### PR TITLE
feat(synthetic): cadence_due task coherence (F7)

### DIFF
--- a/.ai/patterns/synthetic-seed-toolkit.md
+++ b/.ai/patterns/synthetic-seed-toolkit.md
@@ -4,6 +4,10 @@ The synthetic-seed toolkit produces **prod-shaped, PII-free, deterministic** syn
 
 The defining capability is that it doesn't just write terminal domain rows — it injects synthetic sync-source inputs (e.g. fake Gmail, GChat, GCal, Telegram, iMessage, Mac-Contacts, or Todoist payloads) and drives them through provider normalization → matching → dedup → event bus → River consumers → downstream graph, so the full sync flow is exercised without live credentials.
 
+## Why the seed drives services and provider replay, not the HTTP API
+
+A natural question is whether seeding should go through the public HTTP API instead, so data propagates via "the application's actual logic." That principle — seed the cause, not the endpoint — is exactly what the toolkit enforces, but deliberately one layer below the handlers. First, most prod data has no API surface: interactions, external contacts, sync state, and enrichment assertions originate from sync pipelines in production, so for that data the app's actual logic *is* the provider replay path, and routing it through invented API endpoints would fake the sync result rather than reproduce its cause. Second, a prod-shaped world requires things the API correctly forbids — contacts created months ago, interactions backdated across cadence windows, deterministic PRNG, per-test namespacing; in prod those shapes come from time passing, which can't be replayed through a public API, so the seed injects timestamps at the service/repo layer while still driving the real causal chain from there down. Third, the layer skipped (handler → service) is the thinnest one — DTO validation and auth — and it is validated where it matters: the E2E suite and QA tours exercise the real API against the seeded world. The corollary trade-off: a bug living only in a handler won't corrupt the seeded world and won't be caught by seeding; it surfaces in E2E/tours instead. Bugs in service-layer logic, by contrast, do surface here because seeding runs the real services — the post-seed coherence gates then assert the world contains only prod-reachable states.
+
 ## Layers
 
 | Layer | Package | What it is |

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1821,13 +1821,6 @@ type Querier interface {
 	// a positive guard so a future reader does not "fix" a perceived gap by re-seeding
 	// the legacy table. Caller passes a BARE prefix; '%' is appended here.
 	SyntheticCountContactTagsByContactNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
-	// Profile coverage test only: count contact_task rows in a given state whose
-	// contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
-	// each surface state (managed/unmanaged/completed/dismissed) has ≥1 representative
-	// scoped to its own namespace on the shared test DB. contact_task has no
-	// deleted_at; the contact soft-delete filter scopes to live catalog contacts.
-	// Caller passes a BARE prefix; '%' appended.
-	SyntheticCountContactTasksByStateAndNamePrefix(ctx context.Context, arg SyntheticCountContactTasksByStateAndNamePrefixParams) (int64, error)
 	// Contact→node dual-write test support: count contacts with an exact full_name
 	// (namespace-prefixed names are unique per test), so a rollback test asserts a
 	// failed-tx contact did not survive without paging the whole contact list.
@@ -2164,6 +2157,14 @@ type Querier interface {
 	// list by the test before it reaches here; format() with %I quotes the
 	// identifier so it can never be an injection vector.
 	TestCountAllRows(ctx context.Context, tableName string) (int64, error)
+	// Coherence gate (F7, positive): count the namespace's cadence_due contact_tasks in
+	// a given state, so the coverage check can assert BOTH prod-reachable persistent
+	// states are present — `managed` (>= 1, the reconcile default) and `unmanaged`
+	// (>= 1, reached only via the real recurring edit). Scoped to the namespace so the
+	// shared test DB's other rows do not count. contact_task has no deleted_at; the
+	// contact soft-delete filter scopes to live catalog contacts. Caller passes a BARE
+	// prefix; '%' appended.
+	TestCountCadenceDueByStateAndNamePrefix(ctx context.Context, arg TestCountCadenceDueByStateAndNamePrefixParams) (int64, error)
 	// Coverage gate (F6): count the namespace's LIVE contacts that carry a NON-EMPTY
 	// NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
 	// The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
@@ -2176,6 +2177,17 @@ type Querier interface {
 	// has NO deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
 	// predicate on the join. Caller passes a BARE prefix.
 	TestCountContactsWithNotepadByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
+	// Coherence gate (F7): count the namespace's cadence_due contact_tasks in a
+	// prod-impossible shape. Asserted == 0. Two incoherence classes:
+	//   - state: `dismissed` is unreachable for cadence_due (a skip routes to a managed
+	//     replacement, never to dismissed), and a persistent `completed` row is deleted
+	//     by the next reconcile — so neither state can persist on this lifecycle.
+	//   - external id: must be a FINALIZED Todoist-v1 alphanumeric id. The strict
+	//     '^[A-Za-z0-9]+$' rejects empty, a raw UUID (hyphens), and any punctuation; a
+	//     lingering pending_temp_id metadata key means the temp→real finalize never ran.
+	// contact_task has no deleted_at; the contact soft-delete filter scopes to live
+	// catalog contacts. Caller passes a BARE prefix; '%' appended.
+	TestCountIncoherentCadenceDueByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Coherence gate: count the namespace's contacts whose non-creation last_contacted
 	// is NOT backed by a live inbound/mutual interaction at the same occurred_at, or
 	// whose last_interaction_at is not in lockstep with last_contacted. Asserted == 0.

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -307,20 +307,6 @@ SELECT id FROM contact_task WHERE provider = @provider;
 -- created (the before/after diff from SyntheticListContactTaskIdsByProvider).
 DELETE FROM contact_task WHERE id = ANY(@task_ids::uuid[]);
 
--- name: SyntheticCountContactTasksByStateAndNamePrefix :one
--- Profile coverage test only: count contact_task rows in a given state whose
--- contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
--- each surface state (managed/unmanaged/completed/dismissed) has ≥1 representative
--- scoped to its own namespace on the shared test DB. contact_task has no
--- deleted_at; the contact soft-delete filter scopes to live catalog contacts.
--- Caller passes a BARE prefix; '%' appended.
-SELECT COUNT(*)
-FROM contact_task ct
-JOIN contact c ON ct.contact_id = c.id
-WHERE c.full_name LIKE @name_prefix || '%'
-  AND ct.state = @state
-  AND c.deleted_at IS NULL;
-
 -- name: SyntheticCountLiveFollowUpsByNamePrefix :one
 -- Profile coverage test only: count LIVE follow-up loops (the "awaiting reply" state
 -- behind has_pending_followup) on ns-prefixed contacts. Mirrors FindPendingFollowUp's
@@ -1244,6 +1230,46 @@ WHERE c.full_name LIKE @name_prefix || '%'
      OR COALESCE(ct.metadata->>'content','')     NOT LIKE 'Follow up:%(awaiting reply)'
      OR COALESCE(ct.metadata->>'marker_json','')  NOT LIKE '%followup_loop%'
   );
+
+-- name: TestCountIncoherentCadenceDueByNamePrefix :one
+-- Coherence gate (F7): count the namespace's cadence_due contact_tasks in a
+-- prod-impossible shape. Asserted == 0. Two incoherence classes:
+--   - state: `dismissed` is unreachable for cadence_due (a skip routes to a managed
+--     replacement, never to dismissed), and a persistent `completed` row is deleted
+--     by the next reconcile — so neither state can persist on this lifecycle.
+--   - external id: must be a FINALIZED Todoist-v1 alphanumeric id. The strict
+--     '^[A-Za-z0-9]+$' rejects empty, a raw UUID (hyphens), and any punctuation; a
+--     lingering pending_temp_id metadata key means the temp→real finalize never ran.
+-- contact_task has no deleted_at; the contact soft-delete filter scopes to live
+-- catalog contacts. Caller passes a BARE prefix; '%' appended.
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'cadence_due'
+  AND (
+        ct.state IN ('completed', 'dismissed')
+     OR ct.external_task_id IS NULL
+     OR ct.external_task_id !~ '^[A-Za-z0-9]+$'
+     OR (ct.metadata ? 'pending_temp_id')
+  );
+
+-- name: TestCountCadenceDueByStateAndNamePrefix :one
+-- Coherence gate (F7, positive): count the namespace's cadence_due contact_tasks in
+-- a given state, so the coverage check can assert BOTH prod-reachable persistent
+-- states are present — `managed` (>= 1, the reconcile default) and `unmanaged`
+-- (>= 1, reached only via the real recurring edit). Scoped to the namespace so the
+-- shared test DB's other rows do not count. contact_task has no deleted_at; the
+-- contact soft-delete filter scopes to live catalog contacts. Caller passes a BARE
+-- prefix; '%' appended.
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'cadence_due'
+  AND ct.state = @state;
 
 -- name: TestGetLiveFollowUpByNamePrefix :one
 -- Coherence gate (F3, Go-side): return the namespace's live managed follow-up loop

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -917,33 +917,6 @@ func (q *Queries) SyntheticCountContactTagsByContactNamePrefix(ctx context.Conte
 	return count, err
 }
 
-const SyntheticCountContactTasksByStateAndNamePrefix = `-- name: SyntheticCountContactTasksByStateAndNamePrefix :one
-SELECT COUNT(*)
-FROM contact_task ct
-JOIN contact c ON ct.contact_id = c.id
-WHERE c.full_name LIKE $1 || '%'
-  AND ct.state = $2
-  AND c.deleted_at IS NULL
-`
-
-type SyntheticCountContactTasksByStateAndNamePrefixParams struct {
-	NamePrefix pgtype.Text `json:"name_prefix"`
-	State      string      `json:"state"`
-}
-
-// Profile coverage test only: count contact_task rows in a given state whose
-// contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
-// each surface state (managed/unmanaged/completed/dismissed) has ≥1 representative
-// scoped to its own namespace on the shared test DB. contact_task has no
-// deleted_at; the contact soft-delete filter scopes to live catalog contacts.
-// Caller passes a BARE prefix; '%' appended.
-func (q *Queries) SyntheticCountContactTasksByStateAndNamePrefix(ctx context.Context, arg SyntheticCountContactTasksByStateAndNamePrefixParams) (int64, error) {
-	row := q.db.QueryRow(ctx, SyntheticCountContactTasksByStateAndNamePrefix, arg.NamePrefix, arg.State)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
 const SyntheticCountContactsByFullName = `-- name: SyntheticCountContactsByFullName :one
 SELECT COUNT(*) FROM contact WHERE full_name = $1 AND deleted_at IS NULL
 `
@@ -2173,6 +2146,35 @@ func (q *Queries) TestCountAllRows(ctx context.Context, tableName string) (int64
 	return column_1, err
 }
 
+const TestCountCadenceDueByStateAndNamePrefix = `-- name: TestCountCadenceDueByStateAndNamePrefix :one
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'cadence_due'
+  AND ct.state = $2
+`
+
+type TestCountCadenceDueByStateAndNamePrefixParams struct {
+	NamePrefix pgtype.Text `json:"name_prefix"`
+	State      string      `json:"state"`
+}
+
+// Coherence gate (F7, positive): count the namespace's cadence_due contact_tasks in
+// a given state, so the coverage check can assert BOTH prod-reachable persistent
+// states are present — `managed` (>= 1, the reconcile default) and `unmanaged`
+// (>= 1, reached only via the real recurring edit). Scoped to the namespace so the
+// shared test DB's other rows do not count. contact_task has no deleted_at; the
+// contact soft-delete filter scopes to live catalog contacts. Caller passes a BARE
+// prefix; '%' appended.
+func (q *Queries) TestCountCadenceDueByStateAndNamePrefix(ctx context.Context, arg TestCountCadenceDueByStateAndNamePrefixParams) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountCadenceDueByStateAndNamePrefix, arg.NamePrefix, arg.State)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const TestCountContactsWithNotepadByNamePrefix = `-- name: TestCountContactsWithNotepadByNamePrefix :one
 SELECT COUNT(DISTINCT c.id)
 FROM contact c
@@ -2195,6 +2197,39 @@ WHERE c.full_name LIKE $1 || '%'
 // predicate on the join. Caller passes a BARE prefix.
 func (q *Queries) TestCountContactsWithNotepadByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
 	row := q.db.QueryRow(ctx, TestCountContactsWithNotepadByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const TestCountIncoherentCadenceDueByNamePrefix = `-- name: TestCountIncoherentCadenceDueByNamePrefix :one
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'cadence_due'
+  AND (
+        ct.state IN ('completed', 'dismissed')
+     OR ct.external_task_id IS NULL
+     OR ct.external_task_id !~ '^[A-Za-z0-9]+$'
+     OR (ct.metadata ? 'pending_temp_id')
+  )
+`
+
+// Coherence gate (F7): count the namespace's cadence_due contact_tasks in a
+// prod-impossible shape. Asserted == 0. Two incoherence classes:
+//   - state: `dismissed` is unreachable for cadence_due (a skip routes to a managed
+//     replacement, never to dismissed), and a persistent `completed` row is deleted
+//     by the next reconcile — so neither state can persist on this lifecycle.
+//   - external id: must be a FINALIZED Todoist-v1 alphanumeric id. The strict
+//     '^[A-Za-z0-9]+$' rejects empty, a raw UUID (hyphens), and any punctuation; a
+//     lingering pending_temp_id metadata key means the temp→real finalize never ran.
+//
+// contact_task has no deleted_at; the contact soft-delete filter scopes to live
+// catalog contacts. Caller passes a BARE prefix; '%' appended.
+func (q *Queries) TestCountIncoherentCadenceDueByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountIncoherentCadenceDueByNamePrefix, namePrefix)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -265,24 +265,31 @@ func (r *SyntheticSupportRepository) DeleteContactTasksByIds(ctx context.Context
 	return r.queries.SyntheticDeleteContactTasksByIds(ctx, pgUUIDs(taskIDs))
 }
 
-// CountContactTasksByStateAndNamePrefix counts contact_task rows in a given state
-// whose contact's full_name is ns-prefixed, so the prod-shaped coverage test can
-// assert each surface state (managed/unmanaged/completed/dismissed) has ≥1
-// representative scoped to its own namespace on the shared test DB. Caller passes
-// a BARE prefix.
-func (r *SyntheticSupportRepository) CountContactTasksByStateAndNamePrefix(ctx context.Context, state, namePrefix string) (int64, error) {
-	return r.queries.SyntheticCountContactTasksByStateAndNamePrefix(ctx, db.SyntheticCountContactTasksByStateAndNamePrefixParams{
-		NamePrefix: pgtype.Text{String: namePrefix, Valid: true},
-		State:      state,
-	})
-}
-
 // CountLiveFollowUpsByNamePrefix counts LIVE follow-up loops — the "awaiting reply"
 // state behind has_pending_followup — on ns-prefixed contacts. Mirrors
 // FindPendingFollowUp's predicate, so the coverage test asserts the state the API
 // actually surfaces. Caller passes a BARE prefix.
 func (r *SyntheticSupportRepository) CountLiveFollowUpsByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
 	return r.queries.SyntheticCountLiveFollowUpsByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// IncoherentCadenceDueCountByNamePrefix returns the number of the namespace's
+// cadence_due contact_tasks in a prod-impossible shape (F7): a completed/dismissed
+// state, or a non-finalized external id (empty, a raw UUID, punctuation, or a
+// lingering pending_temp_id key). Asserted == 0. Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) IncoherentCadenceDueCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountIncoherentCadenceDueByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// CountCadenceDueByStateByNamePrefix counts the namespace's cadence_due
+// contact_tasks in a given state, so the coverage check can assert both
+// prod-reachable persistent states are present (managed / unmanaged). Caller
+// passes a BARE prefix.
+func (r *SyntheticSupportRepository) CountCadenceDueByStateByNamePrefix(ctx context.Context, state, namePrefix string) (int64, error) {
+	return r.queries.TestCountCadenceDueByStateAndNamePrefix(ctx, db.TestCountCadenceDueByStateAndNamePrefixParams{
+		NamePrefix: pgtype.Text{String: namePrefix, Valid: true},
+		State:      state,
+	})
 }
 
 // DeleteContactMethodsByContactIds removes contact_method rows by contact

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -168,7 +168,8 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				SeededRelationships: 2,
 				// Enable cadence-task seeding (>0 gate). The dev catalog is all
 				// cadence-bearing, so reconcile creates a managed task on each and
-				// three are transitioned for surface coverage.
+				// one is driven to `unmanaged` via the real recurring-edit path
+				// (completed/dismissed are unreachable for cadence_due).
 				SeededTasks: 1,
 				// Small entity pool (1 org + 1 topic + 1 tag) + a few person→entity
 				// edges so the dev graph surfaces show works_at/interested_in/tagged_as.
@@ -215,8 +216,9 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				SeededRelationships: 12,
 				// Enable cadence-task seeding (>0 gate). The prod-shaped catalog is
 				// all cadence-bearing, so reconcile creates a managed cadence task on
-				// each (catalog-wide, like prod) and three are transitioned to the
-				// completed/dismissed/unmanaged surface states.
+				// each (catalog-wide, like prod) and one is driven to `unmanaged` via
+				// the real recurring-edit path (completed/dismissed are unreachable
+				// for cadence_due).
 				SeededTasks: 1,
 				// Small org/topic/tag pool (3 each) + ~1/5 of the catalog carrying a
 				// person→entity edge (works_at/interested_in/tagged_as), drawn from the

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -68,11 +68,12 @@ type ProfileResult struct {
 	// pages are not near-empty — a judge touring an empty page reads it as a broken
 	// feature. Counts-only / no PII.
 	ContactsWithNotes int
-	// SeededTasks counts the contact_task rows the profile seeded — one `managed`
-	// cadence task per cadence-bearing catalog contact (via ReplayTodoist's
-	// reconcile), a deterministic three of which are then transitioned to the
-	// completed/dismissed/unmanaged surface states. The state-transitions do not
-	// change the row count, so this is the total cadence-task population.
+	// SeededTasks counts the contact_task rows the profile seeded: one `managed`
+	// cadence_due task per cadence-bearing catalog contact (via ReplayTodoist's
+	// reconcile, one of which is then driven to `unmanaged` via the recurring-edit
+	// path — a state change, not a row change) PLUS the one seeded follow-up loop
+	// (SeedPendingFollowUp increments it). It is therefore NOT a pure cadence_due row
+	// count; a future exact-count gate must account for the follow-up too.
 	SeededTasks int
 	// SeededPendingFollowUps counts the LIVE followup_loop rows seeded — the "awaiting
 	// reply" state (has_pending_followup). A seeded world cannot reach this state through
@@ -714,28 +715,27 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// drives the REAL CadenceSyncProvider reconcile, which reads
 	// ListContactsWithContactBy (contact_by auto-computed from cadence by
 	// CreateContact) and creates one `managed` cadence-due task per cadence-bearing
-	// contact — the live cadence-task state. It draws NO generator PRNG (it only
-	// READS the seeded contacts), so it runs after the gen.X() assertion spread above
-	// without shifting the deterministic id sequence the earlier replays depend on.
+	// contact, finalizing each task's temp id into a prod-shaped alphanumeric external
+	// id within the same Sync. It draws NO generator PRNG (it only READS the seeded
+	// contacts), so it runs after the gen.X() assertion spread above without shifting
+	// the deterministic id sequence the earlier replays depend on.
 	//
-	// The empty fake-Todoist sync produces only `managed` rows, so the remaining
-	// surface states are seeded by transitioning a deterministic three of the
-	// just-created tasks via the production UpdateContactTaskState path:
-	// completed / dismissed / unmanaged. pending_remote_create (a transient
-	// create-in-flight state) is out of scope.
+	// cadence_due has exactly two prod-reachable persistent states: `managed` (the
+	// reconcile default) and `unmanaged` (reached ONLY when the Todoist task is edited
+	// to recur). So one task is driven to `unmanaged` through the REAL recurring-edit
+	// path (ReplayTodoistRecurringEdit → handleRecurringDetection), after the reconcile
+	// finalized its external id. `completed`/`dismissed` are prod-impossible for this
+	// lifecycle (a completed cadence row is deleted by the next reconcile; a skip routes
+	// to a managed replacement, never to dismissed), so they are not seeded here.
 	if params.Counts.SeededTasks > 0 && len(cadenceBearingCatalogIDs) > 0 {
 		if _, err := h.ReplayTodoist(ctx, cadenceBearingCatalogIDs); err != nil {
 			return res, fmt.Errorf("profile %s: replay todoist: %w", params.Profile, err)
 		}
-		// Each transition flips one managed task's state; the row count is unchanged,
-		// so res.SeededTasks (the cadence-bearing population) still reflects every row.
-		for idx, state := range nonManagedTaskStates {
-			if idx >= len(cadenceBearingCatalogIDs) {
-				break
-			}
-			if _, err := h.TransitionTodoistCadenceTaskState(ctx, cadenceBearingCatalogIDs[idx], state); err != nil {
-				return res, fmt.Errorf("profile %s: transition cadence task %d: %w", params.Profile, idx, err)
-			}
+		// Drive ONE task to `unmanaged` via the real recurring edit; the row count is
+		// unchanged, so res.SeededTasks (the cadence-bearing population) still reflects
+		// every row. The len>0 guard above makes index 0 safe.
+		if err := h.ReplayTodoistRecurringEdit(ctx, cadenceBearingCatalogIDs[0]); err != nil {
+			return res, fmt.Errorf("profile %s: unmanage cadence task via recurring edit: %w", params.Profile, err)
 		}
 		res.SeededTasks = len(cadenceBearingCatalogIDs)
 
@@ -999,17 +999,6 @@ const (
 // follow-up loop only opens for a contact that HAS a cadence (CAD-011/CAD-012), so the
 // scenario cannot express the state without one.
 const followUpScenarioCadence = "monthly"
-
-// nonManagedTaskStates is the deterministic spread of non-`managed` contact_task
-// surface states the profile transitions cadence tasks into (one each), so staging
-// shows every state the cadence-task UI renders. `managed` is the reconcile
-// default (the remaining, un-transitioned tasks); pending_remote_create is a
-// transient create-in-flight state and is out of scope.
-var nonManagedTaskStates = []repository.ContactTaskState{
-	repository.ContactTaskStateCompleted,
-	repository.ContactTaskStateDismissed,
-	repository.ContactTaskStateUnmanaged,
-}
 
 // catalogTextFactPredicates is the predicate cycle the Phase-4 assertion spread
 // walks. health_condition (always-confirm → proposed) leads so any non-zero

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -46,19 +46,43 @@ func (syntheticTodoistOAuth) GetAccessToken(_ context.Context, _ string) (string
 }
 func (syntheticTodoistOAuth) HasAnyAccount(_ context.Context) bool { return true }
 
-// fakeTodoistClient is a Client returning an empty incremental Sync (no inbound
-// items). The Todoist provider has no inbound interaction graph; "settled" =
-// the provider's own DB writes (task reconciliation for the seeded contacts)
-// complete inside Sync. MatchIntent is n/a for Todoist.
-type fakeTodoistClient struct{}
+// fakeTodoistClient is the Client the Todoist replay drives instead of the real
+// Sync API. It has no inbound interaction graph; "settled" = the provider's own DB
+// writes (task reconciliation for the seeded contacts) complete inside Sync.
+// MatchIntent is n/a for Todoist. Two behaviors, both always on:
+//
+//   - It ALWAYS finalizes item_add commands. For each command carrying a TempID
+//     (only item_add sets one), Sync returns TempIDMap[TempID] = a prod-shaped
+//     alphanumeric id, so the provider's inline processTempIDMappings swaps the
+//     temp UUID for a finalized Todoist-v1 id WITHIN the same Sync call — leaving
+//     every reconcile-created cadence_due row with an alphanumeric external_task_id
+//     and a cleared pending_temp_id, exactly as production's temp→real handoff does.
+//   - It returns the configured `items` as the incremental Sync response. Empty for
+//     the plain reconcile-only replay (ReplayTodoist); the recurring-edit replay
+//     (ReplayTodoistRecurringEdit) configures one recurring item so processItem
+//     drives the real handleRecurringDetection path.
+type fakeTodoistClient struct {
+	items []todoist.SyncItem
+}
 
 func (fakeTodoistClient) QuickAdd(_ context.Context, _ string, _ string) (*todoist.QuickAddTask, error) {
 	return &todoist.QuickAddTask{}, nil
 }
 
-func (fakeTodoistClient) Sync(_ context.Context, _ string, _ []string, _ []todoist.SyncCommand) (*todoist.SyncResponse, error) {
-	// Empty incremental response: no items, fresh sync token.
-	return &todoist.SyncResponse{SyncToken: "synthetic-sync-token", FullSync: true}, nil
+func (c fakeTodoistClient) Sync(_ context.Context, _ string, _ []string, commands []todoist.SyncCommand) (*todoist.SyncResponse, error) {
+	resp := &todoist.SyncResponse{SyncToken: "synthetic-sync-token", FullSync: true, Items: c.items}
+	for _, cmd := range commands {
+		// Only item_add carries a TempID; finalize each so the reconcile's inline
+		// processTempIDMappings resolves temp→real within this same tick.
+		if cmd.TempID == "" {
+			continue
+		}
+		if resp.TempIDMap == nil {
+			resp.TempIDMap = make(map[string]string)
+		}
+		resp.TempIDMap[cmd.TempID] = finalizeTempID(cmd.TempID)
+	}
+	return resp, nil
 }
 
 // namespaceScopedContactRepo wraps the real contact repository for the Todoist
@@ -93,36 +117,28 @@ func (r *namespaceScopedContactRepo) ListContactsWithContactBy(ctx context.Conte
 	return scoped, nil
 }
 
-// ReplayTodoist drives the REAL CadenceSyncProvider with a fake Client (no
-// OAuth/HTTP). It exercises cadence task reconciliation; there is no inbound
-// sender or pending equivalent, so MatchIntent is ignored. "Settled" = Sync's
-// own DB writes complete + any enqueued jobs drain.
-//
-// Namespace scoping: the provider's reconcile lists ALL cadence-bearing contacts
-// DB-wide (ListContactsWithContactBy) and may create/update/close contact_task
-// rows on any of them. To keep the replay non-destructive on the shared test DB
-// (where the real internal/todoist cadence tests run concurrently), the adapter
-// injects a namespace-scoped contact-lister wrapper so the reconcile only ever
-// sees THIS harness's seeded contacts — it can never touch another namespace's
-// (or a real) contact. The before/after contact_task id-delta is still tracked
-// into the cleanup ledger as belt-and-suspenders. contactIDs is the caller's
-// seeded set, returned for assertion convenience.
-func (h *Harness) ReplayTodoist(ctx context.Context, contactIDs []uuid.UUID) (TodoistResult, error) {
+// newScopedTodoistProvider builds the REAL CadenceSyncProvider wired to the fake
+// Client, with the namespace-scoped contact-lister BOTH Todoist replays share so
+// the scoping cannot drift between them. The provider's reconcile lists ALL
+// cadence-bearing contacts DB-wide (ListContactsWithContactBy) and may
+// create/update/close contact_task rows on any of them; the wrapper filters that
+// enumeration to this harness's seeded contacts (the ledger ∪ extra) so a replay
+// in one namespace can never touch another namespace's (or a real) contact on the
+// shared test DB. clientItems is the inbound incremental Sync response — nil for
+// the reconcile-only replay, one recurring item for the recurring-edit replay.
+func (h *Harness) newScopedTodoistProvider(clientItems []todoist.SyncItem, extra []uuid.UUID) *todoist.CadenceSyncProvider {
 	syncRepo := repository.NewSyncRepositoryWithPool(h.database.Queries, h.database.Pool)
 
-	// Build the namespace-scoped allow-set: every contact this harness seeded
-	// (the ledger) plus the caller's explicit set, so the reconcile is confined
-	// to the namespace regardless of which contacts carry cadence + contact_by.
 	allowed := make(map[uuid.UUID]struct{})
 	for _, id := range h.snapshotContactIDs() {
 		allowed[id] = struct{}{}
 	}
-	for _, id := range contactIDs {
+	for _, id := range extra {
 		allowed[id] = struct{}{}
 	}
 	scopedContacts := &namespaceScopedContactRepo{real: h.contactRepo, allowed: allowed}
 
-	provider := todoist.NewCadenceSyncProvider(
+	return todoist.NewCadenceSyncProvider(
 		syntheticTodoistOAuth{},
 		repository.NewContactTaskRepository(h.database.Queries),
 		scopedContacts,
@@ -131,13 +147,28 @@ func (h *Harness) ReplayTodoist(ctx context.Context, contactIDs []uuid.UUID) (To
 		h.bus,
 		h.cadenceUpdater,
 		h.database.Pool,
-		func(string) todoist.Client { return fakeTodoistClient{} },
-		// Temp-ID finalize deps: the fake client returns an empty sync (no
-		// temp_id_mapping), so the state-aware finalize never runs here.
-		// remoteCloseEnabled=false mirrors the harness's follow-up mode (off).
+		func(string) todoist.Client { return fakeTodoistClient{items: clientItems} },
+		// Temp-ID finalize deps: the fake client always finalizes item_add
+		// commands via its TempIDMap, and reconcile-created cadence rows are
+		// `managed`, so finalizeTempIDMappingTx takes the managed branch (no
+		// riverInserter / remoteClose). remoteCloseEnabled=false mirrors the
+		// harness's follow-up mode (off).
 		nil,
 		false,
 	)
+}
+
+// ReplayTodoist drives the REAL CadenceSyncProvider with a fake Client (no
+// OAuth/HTTP). It exercises cadence task reconciliation; there is no inbound
+// sender or pending equivalent, so MatchIntent is ignored. "Settled" = Sync's
+// own DB writes complete + any enqueued jobs drain. The provider is built with the
+// namespace-scoped contact-lister (see newScopedTodoistProvider) so the reconcile
+// only touches this harness's contacts on the shared test DB. The before/after
+// contact_task id-delta is still tracked into the cleanup ledger as belt-and-
+// suspenders. contactIDs is the caller's seeded set, returned for assertion
+// convenience.
+func (h *Harness) ReplayTodoist(ctx context.Context, contactIDs []uuid.UUID) (TodoistResult, error) {
+	provider := h.newScopedTodoistProvider(nil, contactIDs)
 
 	// Snapshot todoist contact_task ids before the (globally-scoped) reconcile.
 	before, err := h.support.ListContactTaskIdsByProvider(ctx, todoist.SourceName)
@@ -185,26 +216,60 @@ func (h *Harness) ReplayTodoist(ctx context.Context, contactIDs []uuid.UUID) (To
 	return TodoistResult{ContactIDs: contactIDs}, nil
 }
 
-// TransitionTodoistCadenceTaskState fetches the seeded contact's managed Todoist
-// cadence-due task (created by ReplayTodoist's reconcile) and transitions it to
-// the target state via the production UpdateContactTaskState path, returning the
-// task id. The prod-shaped profile uses it to cover the non-managed contact_task
-// surface states (completed/dismissed/unmanaged) that the empty fake-Todoist sync
-// never produces — reconcile alone creates only `managed` rows. The task id is
-// already in the cleanup ledger (ReplayTodoist tracked it), so no extra tracking
-// is needed. Errors (rather than no-ops) if the contact has no cadence-due Todoist
-// task, so a mis-wired seed fails loudly.
-func (h *Harness) TransitionTodoistCadenceTaskState(ctx context.Context, contactID uuid.UUID, state repository.ContactTaskState) (uuid.UUID, error) {
+// ReplayTodoistRecurringEdit drives the contact's managed cadence_due task to the
+// `unmanaged` surface state through the REAL production path — the only way prod
+// reaches it. It feeds the CadenceSyncProvider one inbound Todoist item: the task's
+// own (finalized, alphanumeric) external id, now marked recurring. processItem
+// matches it by external id and routes through handleRecurringDetection, exactly as
+// production does when a user edits the Todoist task to repeat. This replaces the
+// former raw UpdateContactTaskState write, which forged a state the lifecycle would
+// never otherwise hold.
+//
+// Ordering contract: call AFTER ReplayTodoist, whose reconcile finalizes the temp
+// id into the alphanumeric external id this method matches on (matching on the temp
+// UUID would miss). Namespace scoping: provider.Sync ALWAYS reconciles after
+// processing items (DB-wide), so the provider is built with the same
+// namespace-scoped contact-lister ReplayTodoist uses — the trailing reconcile can
+// only see this harness's contacts, never re-strand a temp id or touch another
+// namespace. The just-unmanaged row survives that reconcile:
+// GetContactTaskByContactCadenceDue is state-agnostic and reconcile skips a
+// non-managed row, and the partial unique index blocks a duplicate regardless. The
+// task id is already in the cleanup ledger (ReplayTodoist tracked it). Draws no
+// generator PRNG (reads a seeded contact + its task), so it is safe after the
+// deterministic id sequence the earlier replays depend on.
+func (h *Harness) ReplayTodoistRecurringEdit(ctx context.Context, contactID uuid.UUID) error {
 	taskRepo := repository.NewContactTaskRepository(h.database.Queries)
 	task, err := taskRepo.GetContactTaskByContactCadenceDue(ctx, contactID, todoist.SourceName)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("get cadence-due task for contact %s: %w", contactID, err)
+		return fmt.Errorf("get cadence-due task for contact %s: %w", contactID, err)
 	}
-	updated, err := taskRepo.UpdateContactTaskState(ctx, task.ID, state)
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("transition contact_task %s to %s: %w", task.ID, state, err)
+
+	// One inbound item: the task's finalized external id, edited to recur.
+	recurringItem := todoist.SyncItem{
+		ID:  task.ExternalTaskID,
+		Due: &todoist.SyncDue{IsRecurring: true},
 	}
-	return updated.ID, nil
+	provider := h.newScopedTodoistProvider([]todoist.SyncItem{recurringItem}, []uuid.UUID{contactID})
+
+	accountID := h.gen.Prefix() + "todoist"
+	state := &repository.SyncState{
+		Source:    repository.InteractionSourceTodoist,
+		AccountID: &accountID,
+		Metadata: map[string]any{
+			todoist.MetadataKeyProjectID: h.gen.Prefix() + "project",
+			todoist.MetadataKeyLabelID:   h.gen.Prefix() + "label",
+		},
+	}
+	if _, err := provider.Sync(ctx, state, nil); err != nil {
+		return fmt.Errorf("todoist recurring-edit sync for contact %s: %w", contactID, err)
+	}
+
+	// Settle Gate B over the seeded contacts (no domain predicate — the recurring
+	// detection's state write is synchronous within Sync).
+	if err := h.Settle(ctx, nil, ""); err != nil {
+		return err
+	}
+	return nil
 }
 
 // SeedPendingFollowUp gives a contact a LIVE follow-up loop — the "awaiting reply"
@@ -283,6 +348,27 @@ func (h *Harness) SeedPendingFollowUp(ctx context.Context, contactID uuid.UUID, 
 // shape (alphanumeric strings, not UUIDs) and is unique per contact, so it never
 // collides on the global partial-unique follow-up index.
 func externalTaskIDForContact(contactID uuid.UUID) string {
-	id := contactID
+	return base62UUID(contactID)
+}
+
+// base62UUID renders a UUID's 16 bytes as base62 (0-9a-zA-Z) — the Todoist-v1 id
+// shape (alphanumeric, not a hyphenated UUID). Bijective on the bytes, so the
+// result is globally unique and satisfies the strict '^[A-Za-z0-9]+$' finalized-id
+// coherence gate.
+func base62UUID(id uuid.UUID) string {
 	return new(big.Int).SetBytes(id[:]).Text(62)
+}
+
+// finalizeTempID maps an item_add command's temp id to the prod-shaped
+// alphanumeric id the fake Sync returns for it (mirroring the temp→real handoff
+// the real Todoist Sync API performs). The provider mints temp ids via
+// uuid.New().String(), so the normal path parses + base62-encodes the UUID to
+// match PR1's follow-up-id convention; a non-UUID temp id (never emitted by the
+// provider) falls back to base62 of the raw bytes so the result stays alphanumeric
+// and unique regardless.
+func finalizeTempID(tempID string) string {
+	if u, err := uuid.Parse(tempID); err == nil {
+		return base62UUID(u)
+	}
+	return new(big.Int).SetBytes([]byte(tempID)).Text(62)
 }

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -103,8 +103,9 @@ type Counts struct {
 	// SeededTasks is a >0 GATE (not a hard cap) for Todoist cadence-task seeding:
 	// when non-zero the profile runs ReplayTodoist, whose reconcile creates one
 	// `managed` cadence task per cadence-bearing catalog contact (catalog-wide, like
-	// prod), then transitions a deterministic three to completed/dismissed/unmanaged
-	// for surface coverage. ProfileResult.SeededTasks reports the actual rows. 0
+	// prod), then drives ONE to `unmanaged` via the real recurring-edit path — the
+	// two states cadence_due can hold in prod (completed/dismissed are unreachable
+	// for this lifecycle). ProfileResult.SeededTasks reports the actual rows. 0
 	// disables (minimal-scoped stays task-free / byte-stable).
 	SeededTasks int
 	// SeededEntities is the size of the org/topic/tag entity pool the profile

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -436,8 +436,9 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	params.Counts.SeededBoolFacts = 3
 	params.Counts.SeededRelationships = 3
 	// Enable cadence-task seeding (>0 gate). The 9-contact catalog is all
-	// cadence-bearing, so reconcile creates 9 `managed` tasks and three are
-	// transitioned to completed/dismissed/unmanaged — every surface state present.
+	// cadence-bearing, so reconcile creates 9 `managed` tasks and one is driven to
+	// `unmanaged` via the real recurring-edit path — the two states cadence_due can
+	// hold in prod (completed/dismissed are unreachable for this lifecycle).
 	params.Counts.SeededTasks = 1
 	// Entity pool of 3 (1 org + 1 topic + 1 tag) + one full person→entity edge cycle
 	// (works_at/interested_in/tagged_as) so every entity subtype + edge type is

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -319,8 +319,24 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	require.GreaterOrEqual(t, res.ContactsWithHowMet, 1, "dev profile seeds how_met bio facts")
 	// Cadence tasks: the dev catalog is cadence-bearing, so ReplayTodoist seeds a
 	// managed task per contact (res.SeededTasks is the actual rows, a catalog-wide
-	// count, not the >0 gate value in Counts.SeededTasks).
+	// count, not the >0 gate value in Counts.SeededTasks), and one is driven to
+	// `unmanaged` via the real recurring edit. Same F7 coherence gate as the
+	// prod-shaped profile: both prod-reachable states present, zero prod-impossible
+	// (completed/dismissed or non-finalized external id) cadence_due rows.
 	require.GreaterOrEqual(t, res.SeededTasks, 1, "dev profile seeds cadence tasks")
+	{
+		cadenceSupport := repository.NewSyntheticSupportRepository(database.Queries)
+		devPrefix := h.Generator().Prefix()
+		managedCadence, err := cadenceSupport.CountCadenceDueByStateByNamePrefix(ctx, string(repository.ContactTaskStateManaged), devPrefix)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, managedCadence, int64(1), "≥1 managed cadence_due task (reconcile default)")
+		unmanagedCadence, err := cadenceSupport.CountCadenceDueByStateByNamePrefix(ctx, string(repository.ContactTaskStateUnmanaged), devPrefix)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, unmanagedCadence, int64(1), "≥1 unmanaged cadence_due task (real recurring-edit path)")
+		incoherentCadence, err := cadenceSupport.IncoherentCadenceDueCountByNamePrefix(ctx, devPrefix)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), incoherentCadence, "no cadence_due task may be completed/dismissed or carry a non-finalized external id")
+	}
 	// Value-type + edge graph rows: the dev catalog (18) far exceeds the small
 	// dev knob counts, so the seeded counts are exact (no catalog-size bounding),
 	// and the bool-fact gate produces exactly one toolkit date fact.
@@ -624,23 +640,25 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, signalsLanded, int64(1), "≥1 relationship_signal row present for the seeded nodes")
 
-	// Cadence tasks: ReplayTodoist seeds a `managed` cadence task on each
-	// cadence-bearing catalog contact, and the profile transitions a deterministic
-	// three to completed/dismissed/unmanaged. Assert ≥1 row in EACH state the seed
-	// produces (namespace-scoped), so every cadence-task surface the staging UI
-	// renders has content. pending_remote_create is out of scope (a transient
-	// create-in-flight state the seed does not produce).
+	// Cadence tasks: ReplayTodoist seeds a `managed` cadence_due task on each
+	// cadence-bearing catalog contact, and ReplayTodoistRecurringEdit drives one to
+	// `unmanaged` through the real recurring-edit path. cadence_due has exactly two
+	// prod-reachable persistent states — `managed` and `unmanaged` — so assert BOTH
+	// are present (namespace-scoped) and that NO cadence_due row is in a prod-
+	// impossible shape (gate e): `completed`/`dismissed` states (a completed row is
+	// deleted by the next reconcile; a skip routes to a managed replacement, never to
+	// dismissed) or a non-finalized external id (a raw UUID / lingering
+	// pending_temp_id instead of a Todoist-v1 alphanumeric).
 	require.GreaterOrEqual(t, res.SeededTasks, 1, "cadence tasks seeded")
-	for _, state := range []repository.ContactTaskState{
-		repository.ContactTaskStateManaged,
-		repository.ContactTaskStateUnmanaged,
-		repository.ContactTaskStateCompleted,
-		repository.ContactTaskStateDismissed,
-	} {
-		count, err := support.CountContactTasksByStateAndNamePrefix(ctx, string(state), prefix)
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, count, int64(1), "≥1 contact_task in state %q", state)
-	}
+	managedCadence, err := support.CountCadenceDueByStateByNamePrefix(ctx, string(repository.ContactTaskStateManaged), prefix)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, managedCadence, int64(1), "≥1 managed cadence_due task (reconcile default)")
+	unmanagedCadence, err := support.CountCadenceDueByStateByNamePrefix(ctx, string(repository.ContactTaskStateUnmanaged), prefix)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, unmanagedCadence, int64(1), "≥1 unmanaged cadence_due task (real recurring-edit path)")
+	incoherentCadence, err := support.IncoherentCadenceDueCountByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), incoherentCadence, "no cadence_due task may be completed/dismissed or carry a non-finalized external id")
 
 	// The "awaiting reply" state (has_pending_followup). REGRESSION GUARD, not a nicety:
 	// a seeded world cannot reach this state through the production path (FollowUpManager

--- a/backend/tests/synthetic_replay_integration_test.go
+++ b/backend/tests/synthetic_replay_integration_test.go
@@ -8,8 +8,10 @@ import (
 
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/synthetic"
 	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/todoist"
 	"personal-crm/backend/tests/testsupport"
 
 	"github.com/google/uuid"
@@ -132,6 +134,55 @@ func TestSyntheticReplay_SeededSenderSettled(t *testing.T) {
 		_, err = h.ReplayTodoist(ctx, []uuid.UUID{contact.ID})
 		require.NoError(t, err)
 	})
+}
+
+// TestReplayTodoistRecurringEdit_UnmanagesViaRealPath proves the seed reaches the
+// cadence_due `unmanaged` state through the PRODUCTION recurring-edit path
+// (provider.Sync → processItem → handleRecurringDetection), not a raw state write.
+// It seeds two cadence-bearing contacts, reconciles both to `managed` via
+// ReplayTodoist, then runs ReplayTodoistRecurringEdit on ONLY the first. The first
+// task must end `unmanaged`; the second — seeded in the same namespace but outside
+// the recurring edit — must stay `managed`, proving the recurring edit transitioned
+// only the item it matched by external id and the namespace-scoped trailing
+// reconcile left the bystander untouched. It also confirms ReplayTodoist's reconcile
+// finalized the temp id into a Todoist-v1 alphanumeric external id (cleared
+// pending_temp_id) — the id the recurring edit must match on.
+func TestReplayTodoistRecurringEdit_UnmanagesViaRealPath(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+
+	h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+	gen := h.Generator()
+
+	target, err := h.SeedContact(ctx, gen.Contact(factory.WithEmail(), factory.WithCadence("weekly")))
+	require.NoError(t, err)
+	bystander, err := h.SeedContact(ctx, gen.Contact(factory.WithEmail(), factory.WithCadence("weekly")))
+	require.NoError(t, err)
+
+	_, err = h.ReplayTodoist(ctx, []uuid.UUID{target.ID, bystander.ID})
+	require.NoError(t, err)
+
+	// Both cadence tasks start managed; the target's temp id is finalized to a
+	// Todoist-v1 alphanumeric external id (the id the recurring edit matches on).
+	taskRepo := repository.NewContactTaskRepository(database.Queries)
+	targetTask, err := taskRepo.GetContactTaskByContactCadenceDue(ctx, target.ID, todoist.SourceName)
+	require.NoError(t, err)
+	require.Equal(t, repository.ContactTaskStateManaged, targetTask.State, "target starts managed")
+	require.Regexp(t, "^[A-Za-z0-9]+$", targetTask.ExternalTaskID, "reconcile finalized the temp id to a Todoist-v1 alphanumeric id")
+	require.NotContains(t, targetTask.Metadata, todoist.MetadataKeyPendingTempID, "finalize cleared pending_temp_id")
+
+	// Edit the target's Todoist task to recur — drives the REAL path to unmanaged.
+	require.NoError(t, h.ReplayTodoistRecurringEdit(ctx, target.ID))
+
+	targetTask, err = taskRepo.GetContactTaskByContactCadenceDue(ctx, target.ID, todoist.SourceName)
+	require.NoError(t, err)
+	require.Equal(t, repository.ContactTaskStateUnmanaged, targetTask.State,
+		"recurring edit unmanaged the target via handleRecurringDetection")
+
+	bystanderTask, err := taskRepo.GetContactTaskByContactCadenceDue(ctx, bystander.ID, todoist.SourceName)
+	require.NoError(t, err)
+	require.Equal(t, repository.ContactTaskStateManaged, bystanderTask.State,
+		"bystander cadence task untouched by the scoped recurring-edit reconcile")
 }
 
 func TestSyntheticReplay_UnknownSenderPending(t *testing.T) {


### PR DESCRIPTION
## Summary

Audit finding F7: seeded `cadence_due` contact_tasks reached prod-impossible states — every row carried a raw-UUID `external_task_id` (prod ids are Todoist alphanumerics), and the state variants (dismissed, persistent completed) were forced via a raw state write that production has no path to. This PR makes every seeded cadence_due row reach its state through the real task lifecycle, and gates the shape.

## What changed

- **Temp-id finalize through the real path**: the fake Todoist client now returns a `TempIDMap` for its `item_add` commands, so the reconcile's inline `processTempIDMappings` finalize runs during seeding — every cadence_due row ends with a prod-shaped alphanumeric `external_task_id` and cleared `pending_temp_id` (previously all ~150 rows kept raw UUIDs forever).
- **Unmanaged via the real recurring-edit path**: new `ReplayTodoistRecurringEdit` drives a `Due.IsRecurring` item through `handleRecurringDetection`, replacing the raw `UpdateContactTaskState` write. The recurring-edit's trailing reconcile reuses the namespace-scoped contact-repo guard (shared provider-construction helper) so it cannot touch other namespaces or re-strand temp ids; a focused test proves the real path and that an out-of-scope cadence contact stays untouched.
- **Prod-impossible states dropped**: `dismissed` is unreachable for cadence_due (skip routes through `handleSkipTrigger` and leaves the task managed) and a persistent `completed` is deleted by the next reconcile — so `TransitionTodoistCadenceTaskState` is deleted entirely, and the reachability model (managed via reconcile, unmanaged via recurring-edit only) is verified against every `UpdateContactTaskState` producer.
- **Gate (e)** in both profile coverage tests: zero dismissed/completed cadence_due rows, all external ids alphanumeric, plus managed/unmanaged positive assertions.
- **Rider**: `.ai/patterns/synthetic-seed-toolkit.md` gains a user-requested "Why the seed drives services and provider replay, not the HTTP API" section documenting the seeding-layer rationale.

F7 reuses existing catalog contacts (no new contacts or notes), so PR4's exact F6 notepad count is untouched.

## Testing

- `go build ./...`, `go vet`, `make lint`, full `make test-unit` (incl. the factory draw-order guard)
- Integration: DevCoversCatalog + ProdShapedCoverageCheck (both run gate e), ProdShapedDeterministic, SeededSenderSettled, and the new `TestReplayTodoistRecurringEdit_UnmanagesViaRealPath`
- Full pre-push gate passed on push
- Local Codex: PASS (P0=0 P1=0; one comment-only P2 folded in post-verdict)

Part of the synthetic-seed fidelity arc (audit: `.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md`); follows #643, #644, #646, #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)