### PR TITLE
fix(synthetic): assertion cache refresh in ReplayAssertion (F8)

### DIFF
--- a/backend/internal/consumer/knowledge_cache.go
+++ b/backend/internal/consumer/knowledge_cache.go
@@ -90,7 +90,7 @@ func (u *KnowledgeCacheUpdater) HandleEvent(ctx context.Context, tx pgx.Tx, env 
 	if err := events.Unmarshal(env, &payload); err != nil {
 		return fmt.Errorf("decode assertion event: %w", err)
 	}
-	if !isCacheCutoverPredicate(payload.PredicateKey) {
+	if !IsCacheCutoverPredicate(payload.PredicateKey) {
 		return nil
 	}
 	return u.RefreshTx(ctx, tx, payload.SubjectNodeID, payload.PredicateKey)
@@ -153,9 +153,11 @@ func (u *KnowledgeCacheUpdater) resolveLivesInLabel(ctx context.Context, tx pgx.
 	return &label, nil
 }
 
-// isCacheCutoverPredicate reports whether a predicate key drives one of the
-// derived contact cache columns.
-func isCacheCutoverPredicate(predicateKey string) bool {
+// IsCacheCutoverPredicate reports whether a predicate key drives one of the
+// derived contact cache columns. Exported so cache-writing callers outside this
+// package (e.g. the synthetic replay harness) gate a RefreshTx on the SAME
+// single source of truth, rather than duplicating the predicate set.
+func IsCacheCutoverPredicate(predicateKey string) bool {
 	switch predicateKey {
 	case repository.PredicateLivesIn, repository.PredicateBirthday, repository.PredicateHowMet:
 		return true

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2236,6 +2236,18 @@ type Querier interface {
 	// gate is not vacuously satisfied by a world with no last_outreach_at at all. Caller
 	// passes a BARE prefix.
 	TestCountPureOutboundContactsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
+	// Coherence gate (F8): count the namespace's LIVE contacts that hold a
+	// current-accepted cutover assertion (lives_in / birthday / how_met) whose matching
+	// derived cache column is NULL — a production-impossible state (KnowledgeCacheUpdater
+	// is the sole writer and always populates the column when an accepted assertion
+	// exists). Asserted == 0. "current-accepted" mirrors GetCurrentAccepted: accepted,
+	// knowledge-open, valid-time window contains @now, subject node live, and (for the
+	// lives_in edge) the place object node live. A proposed/pending assertion or one on a
+	// soft-deleted contact is correctly excluded. Single-cardinality predicates mean at
+	// most one current-accepted row per (subject, predicate), so COUNT(*) over this WHERE
+	// is row-equivalent to GetCurrentAccepted's ORDER BY created_at LIMIT 1 per slot.
+	// Caller passes a BARE prefix; '%' appended.
+	TestCountStrandedKnowledgeCacheByNamePrefix(ctx context.Context, arg TestCountStrandedKnowledgeCacheByNamePrefixParams) (int64, error)
 	// Tag-migration test only: count the LIVE accepted `tagged_as` assertions whose
 	// subject is a given node, so a test asserts exactly one per migrated contact_tag
 	// and that an idempotent re-run creates no duplicates.
@@ -2261,6 +2273,11 @@ type Querier interface {
 	// test to prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE
 	// without a sleep/timeout. Production code must NOT call this.
 	TestGetCalendarEventByIDForUpdateNoWait(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error)
+	// F8 target-row proof: return the three derived knowledge-cache columns for one
+	// contact id so the coverage test can assert the ReplayAssertion date-fact birthday's
+	// own contact has a populated birthday cache (proving F8's exact stranded row is now
+	// coherent, not just that SOME cutover cache is populated).
+	TestGetContactCacheColumnsByID(ctx context.Context, id pgtype.UUID) (*TestGetContactCacheColumnsByIDRow, error)
 	// Coherence gate (F4, d-mutual-verify timestamps): return one contact's four cadence
 	// timestamp columns so the test can assert the promoted mutual set them all together
 	// (mutual writes last_contacted / last_interaction_at / last_outreach_at /

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1271,6 +1271,43 @@ WHERE c.full_name LIKE @name_prefix || '%'
   AND ct.lifecycle = 'cadence_due'
   AND ct.state = @state;
 
+-- name: TestCountStrandedKnowledgeCacheByNamePrefix :one
+-- Coherence gate (F8): count the namespace's LIVE contacts that hold a
+-- current-accepted cutover assertion (lives_in / birthday / how_met) whose matching
+-- derived cache column is NULL — a production-impossible state (KnowledgeCacheUpdater
+-- is the sole writer and always populates the column when an accepted assertion
+-- exists). Asserted == 0. "current-accepted" mirrors GetCurrentAccepted: accepted,
+-- knowledge-open, valid-time window contains @now, subject node live, and (for the
+-- lives_in edge) the place object node live. A proposed/pending assertion or one on a
+-- soft-deleted contact is correctly excluded. Single-cardinality predicates mean at
+-- most one current-accepted row per (subject, predicate), so COUNT(*) over this WHERE
+-- is row-equivalent to GetCurrentAccepted's ORDER BY created_at LIMIT 1 per slot.
+-- Caller passes a BARE prefix; '%' appended.
+SELECT COUNT(*)
+FROM assertion a
+JOIN node sn ON sn.id = a.subject_node_id AND sn.deleted_at IS NULL
+JOIN contact c ON c.id = a.subject_node_id AND c.deleted_at IS NULL
+LEFT JOIN node ob ON ob.id = a.object_node_id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND a.predicate_key IN ('lives_in', 'birthday', 'how_met')
+  AND a.status = 'accepted'
+  AND a.knowledge_to IS NULL
+  AND (a.object_node_id IS NULL OR ob.deleted_at IS NULL)
+  AND (a.valid_from IS NULL OR a.valid_from <= @now)
+  AND (a.valid_to IS NULL OR a.valid_to > @now)
+  AND (
+        (a.predicate_key = 'lives_in' AND c.location IS NULL)
+     OR (a.predicate_key = 'birthday' AND c.birthday IS NULL)
+     OR (a.predicate_key = 'how_met'  AND c.how_met IS NULL)
+  );
+
+-- name: TestGetContactCacheColumnsByID :one
+-- F8 target-row proof: return the three derived knowledge-cache columns for one
+-- contact id so the coverage test can assert the ReplayAssertion date-fact birthday's
+-- own contact has a populated birthday cache (proving F8's exact stranded row is now
+-- coherent, not just that SOME cutover cache is populated).
+SELECT location, birthday, how_met FROM contact WHERE id = @id AND deleted_at IS NULL;
+
 -- name: TestGetLiveFollowUpByNamePrefix :one
 -- Coherence gate (F3, Go-side): return the namespace's live managed follow-up loop
 -- task's contact_id, external_task_id, and metadata so the test can decode the

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2411,6 +2411,49 @@ func (q *Queries) TestCountPureOutboundContactsByNamePrefix(ctx context.Context,
 	return count, err
 }
 
+const TestCountStrandedKnowledgeCacheByNamePrefix = `-- name: TestCountStrandedKnowledgeCacheByNamePrefix :one
+SELECT COUNT(*)
+FROM assertion a
+JOIN node sn ON sn.id = a.subject_node_id AND sn.deleted_at IS NULL
+JOIN contact c ON c.id = a.subject_node_id AND c.deleted_at IS NULL
+LEFT JOIN node ob ON ob.id = a.object_node_id
+WHERE c.full_name LIKE $1 || '%'
+  AND a.predicate_key IN ('lives_in', 'birthday', 'how_met')
+  AND a.status = 'accepted'
+  AND a.knowledge_to IS NULL
+  AND (a.object_node_id IS NULL OR ob.deleted_at IS NULL)
+  AND (a.valid_from IS NULL OR a.valid_from <= $2)
+  AND (a.valid_to IS NULL OR a.valid_to > $2)
+  AND (
+        (a.predicate_key = 'lives_in' AND c.location IS NULL)
+     OR (a.predicate_key = 'birthday' AND c.birthday IS NULL)
+     OR (a.predicate_key = 'how_met'  AND c.how_met IS NULL)
+  )
+`
+
+type TestCountStrandedKnowledgeCacheByNamePrefixParams struct {
+	NamePrefix pgtype.Text        `json:"name_prefix"`
+	Now        pgtype.Timestamptz `json:"now"`
+}
+
+// Coherence gate (F8): count the namespace's LIVE contacts that hold a
+// current-accepted cutover assertion (lives_in / birthday / how_met) whose matching
+// derived cache column is NULL — a production-impossible state (KnowledgeCacheUpdater
+// is the sole writer and always populates the column when an accepted assertion
+// exists). Asserted == 0. "current-accepted" mirrors GetCurrentAccepted: accepted,
+// knowledge-open, valid-time window contains @now, subject node live, and (for the
+// lives_in edge) the place object node live. A proposed/pending assertion or one on a
+// soft-deleted contact is correctly excluded. Single-cardinality predicates mean at
+// most one current-accepted row per (subject, predicate), so COUNT(*) over this WHERE
+// is row-equivalent to GetCurrentAccepted's ORDER BY created_at LIMIT 1 per slot.
+// Caller passes a BARE prefix; '%' appended.
+func (q *Queries) TestCountStrandedKnowledgeCacheByNamePrefix(ctx context.Context, arg TestCountStrandedKnowledgeCacheByNamePrefixParams) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountStrandedKnowledgeCacheByNamePrefix, arg.NamePrefix, arg.Now)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const TestCountTaggedAsAssertionsForSubject = `-- name: TestCountTaggedAsAssertionsForSubject :one
 SELECT COUNT(*) FROM assertion
 WHERE subject_node_id = $1
@@ -2455,6 +2498,27 @@ func (q *Queries) TestDeleteTagsByIds(ctx context.Context, tagIds []pgtype.UUID)
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const TestGetContactCacheColumnsByID = `-- name: TestGetContactCacheColumnsByID :one
+SELECT location, birthday, how_met FROM contact WHERE id = $1 AND deleted_at IS NULL
+`
+
+type TestGetContactCacheColumnsByIDRow struct {
+	Location pgtype.Text `json:"location"`
+	Birthday pgtype.Date `json:"birthday"`
+	HowMet   pgtype.Text `json:"how_met"`
+}
+
+// F8 target-row proof: return the three derived knowledge-cache columns for one
+// contact id so the coverage test can assert the ReplayAssertion date-fact birthday's
+// own contact has a populated birthday cache (proving F8's exact stranded row is now
+// coherent, not just that SOME cutover cache is populated).
+func (q *Queries) TestGetContactCacheColumnsByID(ctx context.Context, id pgtype.UUID) (*TestGetContactCacheColumnsByIDRow, error) {
+	row := q.db.QueryRow(ctx, TestGetContactCacheColumnsByID, id)
+	var i TestGetContactCacheColumnsByIDRow
+	err := row.Scan(&i.Location, &i.Birthday, &i.HowMet)
+	return &i, err
 }
 
 const TestGetContactCadenceTimestampsForContact = `-- name: TestGetContactCadenceTimestampsForContact :one

--- a/backend/internal/repository/conversions.go
+++ b/backend/internal/repository/conversions.go
@@ -71,6 +71,15 @@ func pgTimestamptzToTimePtr(t pgtype.Timestamptz) *time.Time {
 	return &u
 }
 
+// pgTextToStringPtr converts a pgtype.Text to *string; invalid/NULL → nil.
+func pgTextToStringPtr(t pgtype.Text) *string {
+	if !t.Valid {
+		return nil
+	}
+	s := t.String
+	return &s
+}
+
 // pgDateToTimePtr converts a pgtype.Date to *time.Time; invalid/NULL → nil.
 // Returned time is normalized to UTC with day precision preserved.
 func pgDateToTimePtr(d pgtype.Date) *time.Time {

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -294,9 +294,10 @@ func (r *SyntheticSupportRepository) CountCadenceDueByStateByNamePrefix(ctx cont
 
 // StrandedKnowledgeCacheCountByNamePrefix counts the namespace's live contacts
 // holding a current-accepted cutover assertion (lives_in / birthday / how_met)
-// whose derived cache column is NULL — the F8 production-impossible state. Asserted
-// == 0. now scopes the assertion valid-time window (anchor-relative — no time.Now()).
-// Caller passes a BARE prefix.
+// whose derived cache column is NULL — the production-impossible state (the cache
+// updater is the sole writer and always populates the column when an accepted
+// assertion exists). Asserted == 0. now scopes the assertion valid-time window
+// (anchor-relative — no time.Now()). Caller passes a BARE prefix.
 func (r *SyntheticSupportRepository) StrandedKnowledgeCacheCountByNamePrefix(ctx context.Context, namePrefix string, now time.Time) (int64, error) {
 	return r.queries.TestCountStrandedKnowledgeCacheByNamePrefix(ctx, db.TestCountStrandedKnowledgeCacheByNamePrefixParams{
 		NamePrefix: pgtype.Text{String: namePrefix, Valid: true},
@@ -313,7 +314,7 @@ type ContactCacheColumns struct {
 }
 
 // GetContactCacheColumns returns a contact's three derived knowledge-cache columns
-// so the coverage gate can assert F8's target row (the ReplayAssertion date-fact
+// so the coverage gate can assert the target row (the ReplayAssertion date-fact
 // birthday's own contact) has a populated birthday cache.
 func (r *SyntheticSupportRepository) GetContactCacheColumns(ctx context.Context, id uuid.UUID) (*ContactCacheColumns, error) {
 	row, err := r.queries.TestGetContactCacheColumnsByID(ctx, uuidToPgUUID(id))

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -292,6 +292,41 @@ func (r *SyntheticSupportRepository) CountCadenceDueByStateByNamePrefix(ctx cont
 	})
 }
 
+// StrandedKnowledgeCacheCountByNamePrefix counts the namespace's live contacts
+// holding a current-accepted cutover assertion (lives_in / birthday / how_met)
+// whose derived cache column is NULL — the F8 production-impossible state. Asserted
+// == 0. now scopes the assertion valid-time window (anchor-relative — no time.Now()).
+// Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) StrandedKnowledgeCacheCountByNamePrefix(ctx context.Context, namePrefix string, now time.Time) (int64, error) {
+	return r.queries.TestCountStrandedKnowledgeCacheByNamePrefix(ctx, db.TestCountStrandedKnowledgeCacheByNamePrefixParams{
+		NamePrefix: pgtype.Text{String: namePrefix, Valid: true},
+		Now:        pgtype.Timestamptz{Time: now, Valid: true},
+	})
+}
+
+// ContactCacheColumns is the derived knowledge-cache projection for one contact
+// (each nil when the column is NULL), returned without leaking generated db.* types.
+type ContactCacheColumns struct {
+	Location *string
+	Birthday *time.Time
+	HowMet   *string
+}
+
+// GetContactCacheColumns returns a contact's three derived knowledge-cache columns
+// so the coverage gate can assert F8's target row (the ReplayAssertion date-fact
+// birthday's own contact) has a populated birthday cache.
+func (r *SyntheticSupportRepository) GetContactCacheColumns(ctx context.Context, id uuid.UUID) (*ContactCacheColumns, error) {
+	row, err := r.queries.TestGetContactCacheColumnsByID(ctx, uuidToPgUUID(id))
+	if err != nil {
+		return nil, err
+	}
+	return &ContactCacheColumns{
+		Location: pgTextToStringPtr(row.Location),
+		Birthday: pgDateToTimePtr(row.Birthday),
+		HowMet:   pgTextToStringPtr(row.HowMet),
+	}, nil
+}
+
 // DeleteContactMethodsByContactIds removes contact_method rows by contact
 // (cleanup step 11).
 func (r *SyntheticSupportRepository) DeleteContactMethodsByContactIds(ctx context.Context, contactIDs []uuid.UUID) (int64, error) {

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -584,6 +584,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		if _, err := h.ReplayAssertion(ctx, catalogContactsWithoutBirthday[0], gen.DateFact("birthday", bday)); err != nil {
 			return res, fmt.Errorf("profile %s: replay date fact: %w", params.Profile, err)
 		}
+		// Record F8's target row so the coverage gate can assert this contact's derived
+		// birthday cache is populated. Pure struct assignment — draws no generator PRNG.
+		h.SetDateFactContactID(catalogContactsWithoutBirthday[0])
 		res.SeededDateFacts++
 	}
 

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -584,8 +584,8 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		if _, err := h.ReplayAssertion(ctx, catalogContactsWithoutBirthday[0], gen.DateFact("birthday", bday)); err != nil {
 			return res, fmt.Errorf("profile %s: replay date fact: %w", params.Profile, err)
 		}
-		// Record F8's target row so the coverage gate can assert this contact's derived
-		// birthday cache is populated. Pure struct assignment — draws no generator PRNG.
+		// Record this contact so the coverage gate can assert its derived birthday cache
+		// is populated (the target row). Pure struct assignment — draws no generator PRNG.
 		h.SetDateFactContactID(catalogContactsWithoutBirthday[0])
 		res.SeededDateFacts++
 	}

--- a/backend/internal/synthetic/replay/assertion.go
+++ b/backend/internal/synthetic/replay/assertion.go
@@ -2,13 +2,16 @@ package replay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 // AssertionResult is the settled outcome of an assertion replay.
@@ -34,6 +37,18 @@ func (h *Harness) assertService() *service.AssertService {
 	)
 }
 
+// knowledgeCacheUpdater builds the KnowledgeCacheUpdater over the harness's graph
+// repos + contact repo — the same wiring harness_setup.go hands ContactService.
+// The repos are cheap thin wrappers, so building per-call (mirroring assertService)
+// keeps the harness struct lean.
+func (h *Harness) knowledgeCacheUpdater() *consumer.KnowledgeCacheUpdater {
+	return consumer.NewKnowledgeCacheUpdater(
+		repository.NewAssertionRepository(h.database.Queries),
+		repository.NewNodeRepository(h.database.Queries),
+		h.contactRepo,
+	)
+}
+
 // ReplayAssertion drives a synthetic fact assertion through the REAL
 // AssertService write path (validation, proposition identity, events) against an
 // existing subject person node. The caller seeds the subject first (e.g. via
@@ -41,12 +56,21 @@ func (h *Harness) assertService() *service.AssertService {
 // provenance carries a namespace-stable source_id so a re-run corroborates
 // (idempotent) rather than duplicating.
 //
+// It runs the same one-tx contract as the production write path
+// (ContactService.knowledge / EnrichmentService.assertInferredKnowledge): AssertTx
+// then, for a cutover predicate, an inline KnowledgeCacheUpdater.RefreshTx in the
+// SAME tx, so a seeded lives_in / birthday / how_met assertion leaves its derived
+// contact cache column current rather than the production-impossible stale/NULL
+// state F8 flagged. A single ReplayAssertion writes one predicate, so it refreshes
+// only that predicate's column (narrower than knowledgeWriter.refreshAll, which
+// covers a multi-field contact edit). Non-cutover predicates skip the refresh —
+// RefreshTx errors on them by design (finding 3), and their columns are not derived.
+//
 // Cleanup: the assertion rows ride on the subject node and are removed by the
 // harness teardown's assertion step (which deletes assertions on every seeded
 // contact node before the person-node delete, since the assertion→node FK is
 // RESTRICT).
-func (h *Harness) ReplayAssertion(ctx context.Context, subjectNodeID uuid.UUID, spec factory.AssertionSpec) (AssertionResult, error) {
-	svc := h.assertService()
+func (h *Harness) ReplayAssertion(ctx context.Context, subjectNodeID uuid.UUID, spec factory.AssertionSpec) (res AssertionResult, err error) {
 	req := service.AssertRequest{
 		SubjectNodeID: subjectNodeID,
 		PredicateKey:  spec.PredicateKey,
@@ -75,10 +99,36 @@ func (h *Harness) ReplayAssertion(ctx context.Context, subjectNodeID uuid.UUID, 
 		value := spec.ValueText
 		req.ValueText = &value
 	}
-	a, err := svc.Assert(ctx, req)
+
+	tx, err := h.database.Pool.Begin(ctx)
+	if err != nil {
+		return AssertionResult{}, fmt.Errorf("replay assertion %s: begin tx: %w", spec.PredicateKey, err)
+	}
+	defer func() {
+		if rb := tx.Rollback(ctx); rb != nil && !errors.Is(rb, pgx.ErrTxClosed) && err == nil {
+			err = rb
+		}
+	}()
+
+	a, err := h.assertService().AssertTx(ctx, tx, req)
 	if err != nil {
 		return AssertionResult{}, fmt.Errorf("replay assertion %s: %w", spec.PredicateKey, err)
 	}
+
+	// Cutover predicate: refresh the derived cache column inline, in the assert tx,
+	// exactly as ContactService.knowledge does. The refresh reads the just-written
+	// current-accepted assertion (same tx) and recomputes the column, so an accepted
+	// assertion populates the cache and a proposed/pending one leaves it NULL.
+	if consumer.IsCacheCutoverPredicate(spec.PredicateKey) {
+		if rerr := h.knowledgeCacheUpdater().RefreshTx(ctx, tx, subjectNodeID, spec.PredicateKey); rerr != nil {
+			return AssertionResult{}, fmt.Errorf("replay assertion %s: refresh cache: %w", spec.PredicateKey, rerr)
+		}
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return AssertionResult{}, fmt.Errorf("replay assertion %s: commit: %w", spec.PredicateKey, err)
+	}
+
 	// Record the source the assertion events published under so Cleanup captures
 	// the root event rows the contact-scoped read misses.
 	h.track(func(c *created) { c.addDirectSource("assertion") })

--- a/backend/internal/synthetic/replay/assertion.go
+++ b/backend/internal/synthetic/replay/assertion.go
@@ -24,8 +24,12 @@ type AssertionResult struct {
 // assertService builds an AssertService over the harness's pool + bus + graph
 // repos. The graph repos are cheap thin wrappers, so building per-call (mirroring
 // the per-source provider construction in the other adapters) keeps the harness
-// struct lean. The bus routes the assertion kinds to no consumer, so no River job
-// is enqueued and the never-started client is fine.
+// struct lean. AssertTx's tx-bound publish enqueues a knowledge_cache_updater river
+// job for accepted/superseded assertions; the harness drains that kind with a no-op
+// worker (knowledgeCacheNoopWorker), so the async job finalizes without writing —
+// the inline RefreshTx in ReplayAssertion is the real cache writer, exactly as the
+// production ContactService path direct-invokes RefreshTx and lets the async job
+// no-op.
 func (h *Harness) assertService() *service.AssertService {
 	return service.NewAssertService(
 		h.database.Pool,
@@ -60,11 +64,12 @@ func (h *Harness) knowledgeCacheUpdater() *consumer.KnowledgeCacheUpdater {
 // (ContactService.knowledge / EnrichmentService.assertInferredKnowledge): AssertTx
 // then, for a cutover predicate, an inline KnowledgeCacheUpdater.RefreshTx in the
 // SAME tx, so a seeded lives_in / birthday / how_met assertion leaves its derived
-// contact cache column current rather than the production-impossible stale/NULL
-// state F8 flagged. A single ReplayAssertion writes one predicate, so it refreshes
-// only that predicate's column (narrower than knowledgeWriter.refreshAll, which
-// covers a multi-field contact edit). Non-cutover predicates skip the refresh —
-// RefreshTx errors on them by design (finding 3), and their columns are not derived.
+// contact cache column current rather than the production-impossible state where a
+// current-accepted assertion exists but its cache column is stale/NULL. A single
+// ReplayAssertion writes one predicate, so it refreshes only that predicate's column
+// (narrower than knowledgeWriter.refreshAll, which covers a multi-field contact
+// edit). Non-cutover predicates skip the refresh — RefreshTx errors on them by
+// design, and their columns are not derived.
 //
 // Cleanup: the assertion rows ride on the subject node and are removed by the
 // harness teardown's assertion step (which deletes assertions on every seeded

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -178,6 +178,15 @@ type Harness struct {
 	// so it must stay off the counts-only, determinism-compared result struct.
 	mutualMessageContactID uuid.UUID
 
+	// dateFactContactID is the contact the profile seeded the toolkit-authored
+	// date-fact birthday on (via ReplayAssertion). A profile sets it via
+	// SetDateFactContactID after the seed; the coverage check reads it via
+	// DateFactContactID to assert F8's exact stranded row — that contact's derived
+	// birthday cache — is now populated. Like mutualMessageContactID it is NOT a
+	// ProfileResult field: the contact id is non-deterministic (uuid_generate_v4),
+	// so it stays off the counts-only, determinism-compared result struct.
+	dateFactContactID uuid.UUID
+
 	created   *created
 	createdMu sync.Mutex
 
@@ -662,6 +671,26 @@ func (h *Harness) MutualMessageContactID() uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return h.mutualMessageContactID
+}
+
+// SetDateFactContactID records the contact the profile seeded the toolkit
+// date-fact birthday on, so the coverage check can resolve it via
+// DateFactContactID. Called by the seeding block (package synthetic) after the
+// date-fact ReplayAssertion — hence exported. Guarded by the ledger mutex for
+// parity with the other tracked ids.
+func (h *Harness) SetDateFactContactID(id uuid.UUID) {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	h.dateFactContactID = id
+}
+
+// DateFactContactID returns the contact the profile seeded the toolkit date-fact
+// birthday on (uuid.Nil if the block did not run). Read by the coverage check to
+// assert that contact's derived birthday cache is populated (F8's target row).
+func (h *Harness) DateFactContactID() uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return h.dateFactContactID
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -181,8 +181,9 @@ type Harness struct {
 	// dateFactContactID is the contact the profile seeded the toolkit-authored
 	// date-fact birthday on (via ReplayAssertion). A profile sets it via
 	// SetDateFactContactID after the seed; the coverage check reads it via
-	// DateFactContactID to assert F8's exact stranded row — that contact's derived
-	// birthday cache — is now populated. Like mutualMessageContactID it is NOT a
+	// DateFactContactID to assert that contact's derived birthday cache — the row
+	// that would otherwise be left stranded — is now populated. Like
+	// mutualMessageContactID it is NOT a
 	// ProfileResult field: the contact id is non-deterministic (uuid_generate_v4),
 	// so it stays off the counts-only, determinism-compared result struct.
 	dateFactContactID uuid.UUID
@@ -686,7 +687,8 @@ func (h *Harness) SetDateFactContactID(id uuid.UUID) {
 
 // DateFactContactID returns the contact the profile seeded the toolkit date-fact
 // birthday on (uuid.Nil if the block did not run). Read by the coverage check to
-// assert that contact's derived birthday cache is populated (F8's target row).
+// assert that contact's derived birthday cache is populated (the target row that
+// exercises the cutover-predicate refresh).
 func (h *Harness) DateFactContactID() uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -229,9 +229,13 @@ func (h *Harness) ReplayTodoist(ctx context.Context, contactIDs []uuid.UUID) (To
 // id into the alphanumeric external id this method matches on (matching on the temp
 // UUID would miss). Namespace scoping: provider.Sync ALWAYS reconciles after
 // processing items (DB-wide), so the provider is built with the same
-// namespace-scoped contact-lister ReplayTodoist uses — the trailing reconcile can
-// only see this harness's contacts, never re-strand a temp id or touch another
-// namespace. The just-unmanaged row survives that reconcile:
+// namespace-scoped contact-lister ReplayTodoist uses (the shared
+// namespaceScopedContactRepo wrapper) — by construction the trailing reconcile
+// enumerates only this harness's contacts, never re-stranding a temp id or touching
+// another namespace. That confinement is regression-guarded by the cross-namespace
+// bystander in TestReplayTodoistRecurringEdit_UnmanagesViaRealPath (an other-namespace
+// reconcile-eligible contact an unscoped reconcile would create a task on).
+// The just-unmanaged row survives that reconcile:
 // GetContactTaskByContactCadenceDue is state-agnostic and reconcile skips a
 // non-managed row, and the partial unique index blocks a duplicate regardless. The
 // task id is already in the cleanup ledger (ReplayTodoist tracked it). Draws no

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -92,7 +92,7 @@ func TestSyntheticProfile_MinimalScopedMatchesSeedAll(t *testing.T) {
 // cohort computed via the production cadence helper (env-robust), the CAD-029
 // tour capacity (four distinct assignable contacts), and no stranded
 // knowledge-cache columns (gate f: every current-accepted cutover assertion has a
-// populated cache column, and — when dateFactID is set — F8's specific target row,
+// populated cache column, and — when dateFactID is set — the specific target row,
 // the ReplayAssertion date-fact birthday's own contact, has a populated birthday
 // cache). Called by both coverage tests. dateFactID is h.DateFactContactID() (the
 // contact the date-fact block seeded; uuid.Nil when that block did not run).
@@ -174,22 +174,24 @@ func assertSeedCoherence(t *testing.T, ctx context.Context, support *repository.
 	require.Equal(t, 4, maxDistinctStateAssignment(flags), "four CAD-029 states must be assignable to four distinct contacts")
 
 	// Gate (f): zero stranded knowledge-cache columns (every current-accepted cutover
-	// assertion on a live contact has its derived cache column populated — the F8
-	// production-impossible state is absent).
+	// assertion on a live contact has its derived cache column populated — the
+	// production-impossible state where an accepted assertion exists but its cache
+	// column is NULL is absent).
 	stranded, err := support.StrandedKnowledgeCacheCountByNamePrefix(ctx, prefix, now)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), stranded, "no live contact may hold a current-accepted cutover assertion (lives_in/birthday/how_met) whose derived cache column is NULL")
 
-	// Gate (f-positive): F8's specific target row is coherent. A generic ">=1 populated
+	// Gate (f-positive): the specific target row is coherent. A generic ">=1 populated
 	// cutover cache" would pass on the contact-create authority-flip bio facts alone, so
 	// target the ReplayAssertion date-fact birthday's OWN contact and assert its birthday
-	// cache is populated — proving the fix reaches F8's exact stranded row, not just that
-	// some cutover cache is populated. (lives_in/how_met non-vacuity rides the existing
-	// ContactsWithLocation/ContactsWithHowMet coverage assertions feeding gate f.)
+	// cache is populated — proving the refresh reaches the exact row that would otherwise
+	// be stranded, not just that some cutover cache is populated. (lives_in/how_met
+	// non-vacuity rides the existing ContactsWithLocation/ContactsWithHowMet coverage
+	// assertions feeding gate f.)
 	if dateFactID != uuid.Nil {
 		cache, err := support.GetContactCacheColumns(ctx, dateFactID)
 		require.NoError(t, err)
-		require.NotNil(t, cache.Birthday, "the ReplayAssertion date-fact birthday's contact must have a populated birthday cache (F8 target row)")
+		require.NotNil(t, cache.Birthday, "the ReplayAssertion date-fact birthday's contact must have a populated birthday cache (target row)")
 	}
 }
 

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -89,9 +89,14 @@ func TestSyntheticProfile_MinimalScopedMatchesSeedAll(t *testing.T) {
 // production-impossible last_contacted (gate a), a non-vacuous interaction-moved
 // cohort (gate a-positive), prod-shaped managed follow-ups (gate c) whose marker
 // decodes and points at the seeded contact (gate c-Go), a cause-driven overdue
-// cohort computed via the production cadence helper (env-robust), and the CAD-029
-// tour capacity (four distinct assignable contacts). Called by both coverage tests.
-func assertSeedCoherence(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, prefix string) {
+// cohort computed via the production cadence helper (env-robust), the CAD-029
+// tour capacity (four distinct assignable contacts), and no stranded
+// knowledge-cache columns (gate f: every current-accepted cutover assertion has a
+// populated cache column, and — when dateFactID is set — F8's specific target row,
+// the ReplayAssertion date-fact birthday's own contact, has a populated birthday
+// cache). Called by both coverage tests. dateFactID is h.DateFactContactID() (the
+// contact the date-fact block seeded; uuid.Nil when that block did not run).
+func assertSeedCoherence(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, prefix string, dateFactID uuid.UUID) {
 	t.Helper()
 	now := accelerated.GetCurrentTime()
 
@@ -167,6 +172,25 @@ func assertSeedCoherence(t *testing.T, ctx context.Context, support *repository.
 	flags, err := support.ListCadenceActivityFlagsByNamePrefix(ctx, prefix)
 	require.NoError(t, err)
 	require.Equal(t, 4, maxDistinctStateAssignment(flags), "four CAD-029 states must be assignable to four distinct contacts")
+
+	// Gate (f): zero stranded knowledge-cache columns (every current-accepted cutover
+	// assertion on a live contact has its derived cache column populated — the F8
+	// production-impossible state is absent).
+	stranded, err := support.StrandedKnowledgeCacheCountByNamePrefix(ctx, prefix, now)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), stranded, "no live contact may hold a current-accepted cutover assertion (lives_in/birthday/how_met) whose derived cache column is NULL")
+
+	// Gate (f-positive): F8's specific target row is coherent. A generic ">=1 populated
+	// cutover cache" would pass on the contact-create authority-flip bio facts alone, so
+	// target the ReplayAssertion date-fact birthday's OWN contact and assert its birthday
+	// cache is populated — proving the fix reaches F8's exact stranded row, not just that
+	// some cutover cache is populated. (lives_in/how_met non-vacuity rides the existing
+	// ContactsWithLocation/ContactsWithHowMet coverage assertions feeding gate f.)
+	if dateFactID != uuid.Nil {
+		cache, err := support.GetContactCacheColumns(ctx, dateFactID)
+		require.NoError(t, err)
+		require.NotNil(t, cache.Birthday, "the ReplayAssertion date-fact birthday's contact must have a populated birthday cache (F8 target row)")
+	}
 }
 
 // maxDistinctStateAssignment returns the size of a maximum matching between the
@@ -380,7 +404,7 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 
 	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
 	support := repository.NewSyntheticSupportRepository(database.Queries)
-	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
+	assertSeedCoherence(t, ctx, support, h.Generator().Prefix(), h.DateFactContactID())
 	// Two-sided message-direction coverage (F4).
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
 	// Notes coverage (F6).
@@ -522,7 +546,7 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, noMethod, 1, "≥1 no-method contact (the no-method bucket exists)")
 
 	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
-	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
+	assertSeedCoherence(t, ctx, support, h.Generator().Prefix(), h.DateFactContactID())
 	// Two-sided message-direction coverage (F4).
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
 	// Notes coverage (F6).

--- a/backend/tests/synthetic_replay_integration_test.go
+++ b/backend/tests/synthetic_replay_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
@@ -141,12 +142,16 @@ func TestSyntheticReplay_SeededSenderSettled(t *testing.T) {
 // (provider.Sync → processItem → handleRecurringDetection), not a raw state write.
 // It seeds two cadence-bearing contacts, reconciles both to `managed` via
 // ReplayTodoist, then runs ReplayTodoistRecurringEdit on ONLY the first. The first
-// task must end `unmanaged`; the second — seeded in the same namespace but outside
-// the recurring edit — must stay `managed`, proving the recurring edit transitioned
-// only the item it matched by external id and the namespace-scoped trailing
-// reconcile left the bystander untouched. It also confirms ReplayTodoist's reconcile
-// finalized the temp id into a Todoist-v1 alphanumeric external id (cleared
-// pending_temp_id) — the id the recurring edit must match on.
+// task must end `unmanaged`; the same-namespace second must stay `managed`, proving
+// (a) the recurring edit transitioned only the item it matched by external id, and
+// (b) the trailing reconcile was non-destructive to an untouched managed sibling. It
+// does NOT prove namespace-scoped confinement — the same-namespace bystander is
+// inside the allow-set, so even an unscoped reconcile would leave its already-managed
+// task managed. That confinement property is guarded separately below by a
+// cross-namespace bystander an unscoped reconcile WOULD visibly mutate. It also
+// confirms ReplayTodoist's reconcile finalized the temp id into a Todoist-v1
+// alphanumeric external id (cleared pending_temp_id) — the id the recurring edit
+// must match on.
 func TestReplayTodoistRecurringEdit_UnmanagesViaRealPath(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -160,6 +165,19 @@ func TestReplayTodoistRecurringEdit_UnmanagesViaRealPath(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = h.ReplayTodoist(ctx, []uuid.UUID{target.ID, bystander.ID})
+	require.NoError(t, err)
+
+	// Cross-namespace confinement guard: seed a reconcile-ELIGIBLE cadence contact in a
+	// SECOND namespace (normal factory + SeedContact populates contact_by), with NO
+	// ReplayTodoist so it has no cadence_due task yet. The recurring edit's trailing Sync
+	// reconciles DB-wide; if the namespace-scoped contact-lister were dropped, that
+	// reconcile would enumerate this contact via ListContactsWithContactBy, find it due
+	// with no task, and CREATE a managed task. Asserting NO task is created is the only
+	// test that catches a regression dropping the scope — a mutation an unscoped run
+	// would perform (unlike the same-namespace bystander, whose already-managed task
+	// stays managed either way).
+	hOther := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+	crossNS, err := hOther.SeedContact(ctx, hOther.Generator().Contact(factory.WithEmail(), factory.WithCadence("weekly")))
 	require.NoError(t, err)
 
 	// Both cadence tasks start managed; the target's temp id is finalized to a
@@ -183,6 +201,86 @@ func TestReplayTodoistRecurringEdit_UnmanagesViaRealPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, repository.ContactTaskStateManaged, bystanderTask.State,
 		"bystander cadence task untouched by the scoped recurring-edit reconcile")
+
+	// Confinement: the cross-namespace contact must have NO cadence_due task — the
+	// DB-wide reconcile did not reach it (namespace scoping held). A dropped scope
+	// would have created one.
+	_, err = taskRepo.GetContactTaskByContactCadenceDue(ctx, crossNS.ID, todoist.SourceName)
+	require.ErrorIs(t, err, db.ErrNotFound,
+		"cross-namespace reconcile-eligible contact must get NO task — the scoped reconcile never enumerated it")
+}
+
+// TestReplayAssertion_RefreshesKnowledgeCache proves ReplayAssertion drives the
+// REAL recompute-from-current-accepted cache path (KnowledgeCacheUpdater.RefreshTx
+// in the assert tx), not a nil-only fill or a raw column write. Three cases:
+//   - fresh: a cutover birthday assertion on a no-birthday contact populates the
+//     derived birthday cache to the asserted value;
+//   - supersession: re-asserting a DIFFERENT current birthday recomputes the cache
+//     to the new value (an only-fills-NULL bug would leave it at the first value —
+//     this is the exact F8 defect class, a cache that must track the current-accepted
+//     assertion, not a one-time write);
+//   - control: a non-cutover text fact returns no error and writes NO cache column,
+//     guarding that a non-cutover predicate never reaches RefreshTx (which errors).
+//
+// Serial (no t.Parallel) to match every sibling in this file — the harness runs a
+// live River client, so DB-wide river_job contention argues against parallelism.
+func TestReplayAssertion_RefreshesKnowledgeCache(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+
+	h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+	gen := h.Generator()
+	anchor := gen.Anchor()
+
+	// Fresh: a no-birthday contact receives a cutover birthday assertion; its derived
+	// birthday cache must populate to the asserted date A.
+	contact, err := h.SeedContact(ctx, gen.Contact(factory.WithEmail()))
+	require.NoError(t, err)
+	require.Nil(t, contact.Birthday, "seeded contact starts with no birthday")
+
+	dateA := time.Date(anchor.Year()-30, time.March, 3, 0, 0, 0, 0, time.UTC)
+	_, err = h.ReplayAssertion(ctx, contact.ID, gen.DateFact("birthday", dateA))
+	require.NoError(t, err)
+
+	got, err := h.ContactRepo().GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Birthday, "cutover birthday assertion populates the derived birthday cache")
+	requireSameDate(t, dateA, *got.Birthday, "fresh birthday cache equals the asserted date A")
+
+	// Supersession: re-assert a DIFFERENT current birthday (date B); birthday is
+	// single-cardinality, so the second assertion supersedes the first and RefreshTx
+	// recomputes the cache from the new current-accepted row. An only-fills-NULL bug
+	// would leave it at date A.
+	dateB := time.Date(anchor.Year()-25, time.September, 9, 0, 0, 0, 0, time.UTC)
+	_, err = h.ReplayAssertion(ctx, contact.ID, gen.DateFact("birthday", dateB))
+	require.NoError(t, err)
+
+	got, err = h.ContactRepo().GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Birthday, "birthday cache stays populated after supersession")
+	requireSameDate(t, dateB, *got.Birthday, "supersession recomputes the birthday cache to date B, not a one-time fill")
+
+	// Control: a non-cutover text fact must NOT reach RefreshTx (which would error) and
+	// must leave every derived cache column NULL.
+	control, err := h.SeedContact(ctx, gen.Contact(factory.WithEmail()))
+	require.NoError(t, err)
+	_, err = h.ReplayAssertion(ctx, control.ID, gen.FactAssertion("job_title"))
+	require.NoError(t, err, "a non-cutover assertion must succeed without touching the cache")
+
+	controlGot, err := h.ContactRepo().GetContact(ctx, control.ID)
+	require.NoError(t, err)
+	require.Nil(t, controlGot.Birthday, "non-cutover assertion leaves birthday cache NULL")
+	require.Nil(t, controlGot.Location, "non-cutover assertion leaves location cache NULL")
+	require.Nil(t, controlGot.HowMet, "non-cutover assertion leaves how_met cache NULL")
+}
+
+// requireSameDate asserts two times fall on the same calendar day (birthday is a
+// DATE column, so only Y/M/D are meaningful).
+func requireSameDate(t *testing.T, want, got time.Time, msg string) {
+	t.Helper()
+	wy, wm, wd := want.Date()
+	gy, gm, gd := got.UTC().Date()
+	require.Equal(t, [3]int{wy, int(wm), wd}, [3]int{gy, int(gm), gd}, msg)
 }
 
 func TestSyntheticReplay_UnknownSenderPending(t *testing.T) {

--- a/backend/tests/synthetic_replay_integration_test.go
+++ b/backend/tests/synthetic_replay_integration_test.go
@@ -217,8 +217,7 @@ func TestReplayTodoistRecurringEdit_UnmanagesViaRealPath(t *testing.T) {
 //     derived birthday cache to the asserted value;
 //   - supersession: re-asserting a DIFFERENT current birthday recomputes the cache
 //     to the new value (an only-fills-NULL bug would leave it at the first value —
-//     this is the exact F8 defect class, a cache that must track the current-accepted
-//     assertion, not a one-time write);
+//     the cache must track the current-accepted assertion, not a one-time write);
 //   - control: a non-cutover text fact returns no error and writes NO cache column,
 //     guarding that a non-cutover predicate never reaches RefreshTx (which errors).
 //


### PR DESCRIPTION
## Summary

Audit finding F8: the seed's assertion replay wrote assertion rows without refreshing the contact's derived knowledge-cache columns (`location`/`birthday`/`how_met`), leaving stranded assertions — a prod-impossible state, since production's sole cache writer is `KnowledgeCacheUpdater` recomputing from current-accepted assertions. This is the final code PR of the synthetic-seed fidelity arc.

## What changed

- **`ReplayAssertion` drives the real path**: `AssertTx` + inline `RefreshTx` in one harness transaction, mirroring `knowledgeWriter`/`assertInferredKnowledge` (single-predicate refresh, deliberately narrower than `refreshAll`), gated on the exported `consumer.IsCacheCutoverPredicate`. `RefreshTx` is verified as the sole cache writer in the synthetic layer (grep enforced in the plan's verification commands).
- **Gate (f)** — assertion↔cache coherence — added to the shared `assertSeedCoherence` (both profile coverage tests): every current-accepted cutover assertion on a live contact has the matching cache column populated (namespace-scoped, mirrors `GetCurrentAccepted` under its single-cardinality guarantee), plus a target-row-specific positive assertion via a new `Harness.DateFactContactID()` accessor (set draw-free — no PRNG shift, no profile reorder).
- **Focused integration test** including the supersession case: an existing birthday cache re-asserted with a different current birthday must update — an only-fills-NULL bug fails it. Serial (live River client), consistent with its siblings.
- **Rider from PR5's review**: the bystander-test comments no longer overclaim namespace-confinement proof (they claim precise external-id matching + reconcile non-destructiveness), and a genuine cross-namespace confinement guard was added — an other-namespace, reconcile-eligible cadence contact with no task must gain NO cadence_due task from the target's Sync; dropping the namespace-scoped repo would create one.

Stale assertions on soft-deleted contacts are untouched — the audit judged them prod-accurate (assertions are retained on soft-delete; the node-level live filter hides them).

## Testing

- `go build ./...`, `go vet`, `make lint`, `make test-unit` (incl. factory draw-order guard)
- Integration: the focused cache-refresh test (incl. supersession), the confinement guard, DevCoversCatalog + ProdShapedCoverageCheck (both run gate f), ProdShapedDeterministic
- Full pre-push gate passed on push; all 4 commits ED25519-signed
- Local Codex: PASS (P0=0 P1=0; two comment-only P2s folded in post-verdict)

Part of the synthetic-seed fidelity arc (audit: `.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md`); follows #643, #644, #646, #649, #650. Completes the code fixes: F1–F4, F6–F8 done; F5 deferred to #647; F9 tracked in #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)