### PR TITLE
fix(merge): stop minting empty notepad note on every merge winner

### DIFF
--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -1256,19 +1256,9 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 	}
 
 	if sourceNotepad != nil {
-		// Source has a notepad - need to handle it
-		targetNotepad, err := txQueries.GetContactNoteByCategory(ctx, db.GetContactNoteByCategoryParams{
-			ContactID: targetUUID,
-			Category:  notepadCategory,
-		})
-		if err != nil {
-			if !errors.Is(err, pgx.ErrNoRows) {
-				return nil, fmt.Errorf("get target notepad: %w", err)
-			}
-			targetNotepad = nil
-		}
-
-		// Delete source notepad first (so TransferNotes won't create duplicate)
+		// Delete the source notepad first regardless of content — otherwise
+		// TransferNotes repoints it onto the target and collides with the
+		// one-notepad-per-contact unique index when the target has one too.
 		if err := txQueries.DeleteContactNoteByCategory(ctx, db.DeleteContactNoteByCategoryParams{
 			ContactID: sourceUUID,
 			Category:  notepadCategory,
@@ -1276,23 +1266,38 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 			return nil, fmt.Errorf("delete source notepad: %w", err)
 		}
 
-		// Determine combined content
-		var combinedBody string
-		if targetNotepad != nil && targetNotepad.Body != "" {
-			// Both have notepads - combine with separator
-			combinedBody = targetNotepad.Body + "\n\n---\n\n" + sourceNotepad.Body
-		} else {
-			// Only source has notepad
-			combinedBody = sourceNotepad.Body
-		}
+		// An empty-body source notepad (e.g. minted by the pre-fix merge bug)
+		// contributes nothing: leave the target's notepad state untouched.
+		if sourceNotepad.Body != "" {
+			targetNotepad, err := txQueries.GetContactNoteByCategory(ctx, db.GetContactNoteByCategoryParams{
+				ContactID: targetUUID,
+				Category:  notepadCategory,
+			})
+			if err != nil {
+				if !errors.Is(err, pgx.ErrNoRows) {
+					return nil, fmt.Errorf("get target notepad: %w", err)
+				}
+				targetNotepad = nil
+			}
 
-		// Upsert combined content to target
-		if _, err := txQueries.UpsertContactNoteByCategory(ctx, db.UpsertContactNoteByCategoryParams{
-			ContactID: targetUUID,
-			Body:      combinedBody,
-			Category:  notepadCategory,
-		}); err != nil {
-			return nil, fmt.Errorf("upsert merged notepad: %w", err)
+			// Determine combined content
+			var combinedBody string
+			if targetNotepad != nil && targetNotepad.Body != "" {
+				// Both have notepads - combine with separator
+				combinedBody = targetNotepad.Body + "\n\n---\n\n" + sourceNotepad.Body
+			} else {
+				// Only source has notepad content
+				combinedBody = sourceNotepad.Body
+			}
+
+			// Upsert combined content to target
+			if _, err := txQueries.UpsertContactNoteByCategory(ctx, db.UpsertContactNoteByCategoryParams{
+				ContactID: targetUUID,
+				Body:      combinedBody,
+				Category:  notepadCategory,
+			}); err != nil {
+				return nil, fmt.Errorf("upsert merged notepad: %w", err)
+			}
 		}
 	}
 

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -1246,8 +1246,13 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 		ContactID: sourceUUID,
 		Category:  notepadCategory,
 	})
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, fmt.Errorf("get source notepad: %w", err)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("get source notepad: %w", err)
+		}
+		// sqlc :one returns a non-nil pointer even on ErrNoRows; nil it so the
+		// no-notepad case doesn't flow through the combine path below.
+		sourceNotepad = nil
 	}
 
 	if sourceNotepad != nil {
@@ -1256,8 +1261,11 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 			ContactID: targetUUID,
 			Category:  notepadCategory,
 		})
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("get target notepad: %w", err)
+		if err != nil {
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return nil, fmt.Errorf("get target notepad: %w", err)
+			}
+			targetNotepad = nil
 		}
 
 		// Delete source notepad first (so TransferNotes won't create duplicate)

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -199,11 +199,11 @@ func TestContactMerge_Integration(t *testing.T) {
 		assert.Equal(t, "Merge Target Full "+ns, merged.FullName) // target name preserved
 		assert.Equal(t, "Boston", *merged.Location)               // source location selected
 
-		// Verify notepad was transferred
+		// Verify notepad was transferred verbatim (no separator artifacts)
 		mergedNotepad, err := noteRepo.GetContactNotepad(ctx, merged.ID)
 		require.NoError(t, err)
 		require.NotNil(t, mergedNotepad)
-		assert.Contains(t, mergedNotepad.Body, "Important notes")
+		assert.Equal(t, "Important notes", mergedNotepad.Body)
 
 		// Verify methods transferred
 		methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, merged.ID)
@@ -321,15 +321,67 @@ func TestContactMerge_Integration(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Verify notes are combined
+		// Verify notes are combined: target first, then separator, then source
 		mergedNotepad, err := noteRepo.GetContactNotepad(ctx, merged.ID)
 		require.NoError(t, err)
 		require.NotNil(t, mergedNotepad)
-		assert.Contains(t, mergedNotepad.Body, "Target notes here")
-		assert.Contains(t, mergedNotepad.Body, "Source notes here")
+		assert.Equal(t, "Target notes here\n\n---\n\n"+"Source notes here", mergedNotepad.Body)
 
 		// Cleanup
 		_ = contactRepo.HardDeleteContact(ctx, target.ID)
+	})
+
+	t.Run("MergeContacts_NoNotepads_CreatesNone", func(t *testing.T) {
+		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "No Notepad Target " + ns,
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
+
+		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "No Notepad Source " + ns,
+		})
+		require.NoError(t, err)
+
+		merged, err := contactService.MergeContacts(ctx, service.MergeContactsRequest{
+			TargetContactID: target.ID,
+			SourceContactID: source.ID,
+		})
+		require.NoError(t, err)
+
+		// Neither contact had a notepad, so the merge must not mint one
+		mergedNotepad, err := noteRepo.GetContactNotepad(ctx, merged.ID)
+		require.NoError(t, err)
+		assert.Nil(t, mergedNotepad)
+	})
+
+	t.Run("MergeContacts_TargetOnlyNotepad_PreservedVerbatim", func(t *testing.T) {
+		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "Target Notepad Only Target " + ns,
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
+
+		_, err = noteRepo.CreateNotepad(ctx, target.ID, "Target only notes")
+		require.NoError(t, err)
+
+		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "Target Notepad Only Source " + ns,
+		})
+		require.NoError(t, err)
+
+		merged, err := contactService.MergeContacts(ctx, service.MergeContactsRequest{
+			TargetContactID: target.ID,
+			SourceContactID: source.ID,
+		})
+		require.NoError(t, err)
+
+		// Source had no notepad: target's notepad must survive unchanged,
+		// with no separator or empty content appended
+		mergedNotepad, err := noteRepo.GetContactNotepad(ctx, merged.ID)
+		require.NoError(t, err)
+		require.NotNil(t, mergedNotepad)
+		assert.Equal(t, "Target only notes", mergedNotepad.Body)
 	})
 
 	t.Run("MergeContacts_InvalidTargetID", func(t *testing.T) {

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -164,6 +164,7 @@ func TestContactMerge_Integration(t *testing.T) {
 			Cadence:  stringPtr("monthly"),
 		})
 		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
 
 		// Create source contact
 		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
@@ -215,8 +216,6 @@ func TestContactMerge_Integration(t *testing.T) {
 		_, err = contactRepo.GetContact(ctx, source.ID)
 		assert.Error(t, err)
 
-		// Cleanup
-		_ = contactRepo.HardDeleteContact(ctx, target.ID)
 	})
 
 	t.Run("MergeContacts_NameOverride", func(t *testing.T) {
@@ -225,6 +224,7 @@ func TestContactMerge_Integration(t *testing.T) {
 			FullName: "Target Name " + ns,
 		})
 		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
 
 		// Create source contact
 		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
@@ -242,8 +242,6 @@ func TestContactMerge_Integration(t *testing.T) {
 
 		assert.Equal(t, "Custom Merged Name", merged.FullName)
 
-		// Cleanup
-		_ = contactRepo.HardDeleteContact(ctx, target.ID)
 	})
 
 	t.Run("MergeContacts_DeduplicatesMethods", func(t *testing.T) {
@@ -252,6 +250,7 @@ func TestContactMerge_Integration(t *testing.T) {
 			FullName: "Dedup Target " + ns,
 		})
 		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
 
 		// Create source contact
 		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
@@ -289,8 +288,6 @@ func TestContactMerge_Integration(t *testing.T) {
 		assert.Equal(t, "phone", methods[0].Type)
 		assert.True(t, methods[0].IsPrimary) // Target's primary status preserved
 
-		// Cleanup
-		_ = contactRepo.HardDeleteContact(ctx, target.ID)
 	})
 
 	t.Run("MergeContacts_CombinesNotes", func(t *testing.T) {
@@ -299,6 +296,7 @@ func TestContactMerge_Integration(t *testing.T) {
 			FullName: "Notes Target " + ns,
 		})
 		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
 
 		// Create notepad for target
 		_, err = noteRepo.CreateNotepad(ctx, target.ID, "Target notes here")
@@ -327,8 +325,6 @@ func TestContactMerge_Integration(t *testing.T) {
 		require.NotNil(t, mergedNotepad)
 		assert.Equal(t, "Target notes here\n\n---\n\n"+"Source notes here", mergedNotepad.Body)
 
-		// Cleanup
-		_ = contactRepo.HardDeleteContact(ctx, target.ID)
 	})
 
 	t.Run("MergeContacts_NoNotepads_CreatesNone", func(t *testing.T) {
@@ -382,6 +378,69 @@ func TestContactMerge_Integration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, mergedNotepad)
 		assert.Equal(t, "Target only notes", mergedNotepad.Body)
+	})
+
+	t.Run("MergeContacts_EmptyBodySourceNotepad", func(t *testing.T) {
+		// The pre-fix merge bug minted empty-body notepad rows onto merge
+		// winners; when such a contact is later merged as a SOURCE, its empty
+		// notepad must contribute nothing — no note minted on a bare target,
+		// no separator appended to a target with content, and no unique-index
+		// collision from TransferNotes repointing the leftover row.
+		t.Run("BareTarget", func(t *testing.T) {
+			target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+				FullName: "EmptyNotepad Bare Target " + ns,
+			})
+			require.NoError(t, err)
+			defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
+
+			source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+				FullName: "EmptyNotepad Bare Source " + ns,
+			})
+			require.NoError(t, err)
+
+			_, err = noteRepo.CreateNotepad(ctx, source.ID, "")
+			require.NoError(t, err)
+
+			merged, err := contactService.MergeContacts(ctx, service.MergeContactsRequest{
+				TargetContactID: target.ID,
+				SourceContactID: source.ID,
+			})
+			require.NoError(t, err)
+
+			mergedNotepad, err := noteRepo.GetContactNotepad(ctx, merged.ID)
+			require.NoError(t, err)
+			assert.Nil(t, mergedNotepad)
+		})
+
+		t.Run("TargetWithContent", func(t *testing.T) {
+			target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+				FullName: "EmptyNotepad Content Target " + ns,
+			})
+			require.NoError(t, err)
+			defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
+
+			_, err = noteRepo.CreateNotepad(ctx, target.ID, "Keep me")
+			require.NoError(t, err)
+
+			source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+				FullName: "EmptyNotepad Content Source " + ns,
+			})
+			require.NoError(t, err)
+
+			_, err = noteRepo.CreateNotepad(ctx, source.ID, "")
+			require.NoError(t, err)
+
+			merged, err := contactService.MergeContacts(ctx, service.MergeContactsRequest{
+				TargetContactID: target.ID,
+				SourceContactID: source.ID,
+			})
+			require.NoError(t, err)
+
+			mergedNotepad, err := noteRepo.GetContactNotepad(ctx, merged.ID)
+			require.NoError(t, err)
+			require.NotNil(t, mergedNotepad)
+			assert.Equal(t, "Keep me", mergedNotepad.Body)
+		})
 	})
 
 	t.Run("MergeContacts_InvalidTargetID", func(t *testing.T) {
@@ -459,8 +518,6 @@ func TestContactMerge_Integration(t *testing.T) {
 
 		assert.Equal(t, "quarterly", *merged.Cadence)
 
-		// Cleanup
-		_ = contactRepo.HardDeleteContact(ctx, target.ID)
 	})
 
 	t.Run("MergeContacts_FieldSelectionsPreserveTarget", func(t *testing.T) {
@@ -494,8 +551,6 @@ func TestContactMerge_Integration(t *testing.T) {
 		assert.Equal(t, "monthly", *merged.Cadence)
 		assert.Equal(t, "New York", *merged.Location)
 
-		// Cleanup
-		_ = contactRepo.HardDeleteContact(ctx, target.ID)
 	})
 
 	t.Run("MergeContacts_ReturnsFreshStructAfterBulkApply", func(t *testing.T) {

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -314,15 +314,18 @@ behaviors:
     notes: Demotion is per-type while the one-primary rule is per-contact — a cross-type dual-primary pair currently fails the merge; CON-049 proposes the fix.
 
   - id: CON-028
-    title: Merge combines notepad notes and transfers the rest
+    title: Merge combines notepad content and transfers the rest
     type: business-logic
     status: current
-    given: source and target contacts that both have notepad notes
-    when: they are merged
+    given: a merge of a source contact into a target
+    when: notes are merged
     then:
-      - the notepad bodies are combined into the target with a visible separator
+      - when both contacts have notepad content, the bodies are combined into the target with a visible separator, target first
+      - when only the source has notepad content, it transfers to the target verbatim
+      - when the source has no notepad content (no row, or an empty-body row), the target's notepad state is unchanged — a lone target notepad survives verbatim and no note is minted
       - non-notepad notes are transferred to the target
     provenance: [ContactService.MergeContacts notepad step, TransferNotes]
+    notes: An empty-body source notepad row still gets consumed (deleted) by the merge so TransferNotes cannot repoint it into the one-notepad-per-contact unique index.
 
   - id: CON-029
     title: Merge transfers the full interaction history


### PR DESCRIPTION
## Summary
- `MergeContacts` nil-checked the pointer returned by `GetContactNoteByCategory`, but sqlc `:one` queries return a non-nil row pointer even on `pgx.ErrNoRows` — so every merge took the notepad-combination path with a zero-value note
- Winners with no notepad gained a spurious empty one; a winner-only notepad got an empty segment appended after the `---` separator
- Fix: treat `ErrNoRows` as "no notepad" (nil the pointer) for both the source and target fetches before branching
- Audited the other `ErrNoRows`-swallow sites (`repository/sync.go`, `repository/venue.go`): they branch on `err == nil` or discard the row, so the pattern was unique to `MergeContacts`; `repository/note.go` already handles it correctly

## Test plan
- New integration coverage for all four notepad merge cases: neither (asserts no note is minted — red before the fix), winner-only (asserts verbatim body, no separator artifacts — red before the fix), loser-only and both (tightened from `Contains` to exact-body equality)
- `make test` + `make test-e2e-diff` green via the pre-push gate

Fixes #648