### PR TITLE
fix(merge): demote source primary regardless of method type

### DIFF
--- a/backend/internal/db/contact_merge.sql.go
+++ b/backend/internal/db/contact_merge.sql.go
@@ -111,8 +111,8 @@ SET is_primary = false,
     updated_at = NOW()
 WHERE cm_source.contact_id = $1
   AND cm_source.is_primary = true
-  AND cm_source.type IN (
-    SELECT cm_target.type FROM contact_method cm_target
+  AND EXISTS (
+    SELECT 1 FROM contact_method cm_target
     WHERE cm_target.contact_id = $2
       AND cm_target.is_primary = true
   )
@@ -123,8 +123,11 @@ type DemoteSourcePrimaryMethodsParams struct {
 	TargetContactID pgtype.UUID `json:"target_contact_id"`
 }
 
-// Demote source's primary contact methods when target already has a primary for that type
-// This prevents violation of the unique partial index on (contact_id, type) WHERE is_primary = true
+// Demote source's primary contact methods when the target already has a primary.
+// The one-primary rule is per contact — idx_contact_method_primary is a unique
+// partial index on (contact_id) WHERE is_primary = TRUE — so the source's primary
+// must be demoted regardless of method type before TransferContactMethods, or a
+// cross-type dual-primary pair violates the index and fails the merge.
 func (q *Queries) DemoteSourcePrimaryMethods(ctx context.Context, arg DemoteSourcePrimaryMethodsParams) error {
 	_, err := q.db.Exec(ctx, DemoteSourcePrimaryMethods, arg.SourceContactID, arg.TargetContactID)
 	return err

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -513,8 +513,11 @@ type Querier interface {
 	DeleteTelegramMessagesByPeerUserID(ctx context.Context, peerUserID pgtype.Int8) (int64, error)
 	DeleteTelegramSession(ctx context.Context) error
 	DeleteTelegramUpdateState(ctx context.Context, userID int64) error
-	// Demote source's primary contact methods when target already has a primary for that type
-	// This prevents violation of the unique partial index on (contact_id, type) WHERE is_primary = true
+	// Demote source's primary contact methods when the target already has a primary.
+	// The one-primary rule is per contact — idx_contact_method_primary is a unique
+	// partial index on (contact_id) WHERE is_primary = TRUE — so the source's primary
+	// must be demoted regardless of method type before TransferContactMethods, or a
+	// cross-type dual-primary pair violates the index and fails the merge.
 	DemoteSourcePrimaryMethods(ctx context.Context, arg DemoteSourcePrimaryMethodsParams) error
 	ExistsCalendarEvent(ctx context.Context, id pgtype.UUID) (bool, error)
 	// Write-time existence validation: confirm a content source row exists before

--- a/backend/internal/db/queries/contact_merge.sql
+++ b/backend/internal/db/queries/contact_merge.sql
@@ -132,15 +132,18 @@ WHERE cm_source.contact_id = sqlc.arg(source_contact_id)
   );
 
 -- name: DemoteSourcePrimaryMethods :exec
--- Demote source's primary contact methods when target already has a primary for that type
--- This prevents violation of the unique partial index on (contact_id, type) WHERE is_primary = true
+-- Demote source's primary contact methods when the target already has a primary.
+-- The one-primary rule is per contact — idx_contact_method_primary is a unique
+-- partial index on (contact_id) WHERE is_primary = TRUE — so the source's primary
+-- must be demoted regardless of method type before TransferContactMethods, or a
+-- cross-type dual-primary pair violates the index and fails the merge.
 UPDATE contact_method cm_source
 SET is_primary = false,
     updated_at = NOW()
 WHERE cm_source.contact_id = sqlc.arg(source_contact_id)
   AND cm_source.is_primary = true
-  AND cm_source.type IN (
-    SELECT cm_target.type FROM contact_method cm_target
+  AND EXISTS (
+    SELECT 1 FROM contact_method cm_target
     WHERE cm_target.contact_id = sqlc.arg(target_contact_id)
       AND cm_target.is_primary = true
   );

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -1223,8 +1223,10 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 		return nil, fmt.Errorf("delete duplicate contact methods: %w", err)
 	}
 
-	// 1b. Demote source's primary methods when target already has primaries for those types
-	// This prevents violation of the unique partial index on (contact_id, type) WHERE is_primary = true
+	// 1b. Demote the source's primary methods when the target already has a
+	// primary, regardless of method type — idx_contact_method_primary is a
+	// unique partial index on (contact_id) WHERE is_primary = true, so an
+	// undemoted source primary of any type would collide on transfer.
 	if err := txQueries.DemoteSourcePrimaryMethods(ctx, db.DemoteSourcePrimaryMethodsParams{
 		SourceContactID: sourceUUID,
 		TargetContactID: targetUUID,

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -293,6 +293,58 @@ func TestContactMerge_Integration(t *testing.T) {
 		_ = contactRepo.HardDeleteContact(ctx, target.ID)
 	})
 
+	t.Run("MergeContacts_CrossTypeDualPrimaries", func(t *testing.T) {
+		// CON-049: source and target each hold a primary of a DIFFERENT method
+		// type. The one-primary rule is per contact (idx_contact_method_primary
+		// on (contact_id) WHERE is_primary), so the source's primary must be
+		// demoted regardless of type or the transfer violates the index.
+		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "CrossType Target " + ns,
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
+
+		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "CrossType Source " + ns,
+		})
+		require.NoError(t, err)
+
+		// Target: primary email. Source: primary phone (different type).
+		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: target.ID,
+			Type:      "email",
+			Value:     "crosstype-target@example.com",
+			IsPrimary: true,
+		})
+		require.NoError(t, err)
+
+		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: source.ID,
+			Type:      "phone",
+			Value:     "+1-555-0177",
+			IsPrimary: true,
+		})
+		require.NoError(t, err)
+
+		// The merge must succeed, not fail on the unique partial index
+		merged, err := contactService.MergeContacts(ctx, service.MergeContactsRequest{
+			TargetContactID: target.ID,
+			SourceContactID: source.ID,
+		})
+		require.NoError(t, err)
+
+		// Target's existing primary is preserved; the source's arrives demoted
+		methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, merged.ID)
+		require.NoError(t, err)
+		require.Len(t, methods, 2)
+		byType := map[string]bool{}
+		for _, m := range methods {
+			byType[m.Type] = m.IsPrimary
+		}
+		assert.True(t, byType["email"], "target's primary email preserved")
+		assert.False(t, byType["phone"], "source's phone transferred demoted")
+	})
+
 	t.Run("MergeContacts_CombinesNotes", func(t *testing.T) {
 		// Create target contact
 		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -304,14 +304,14 @@ behaviors:
     title: Merge transfers source methods, skipping duplicates
     type: business-logic
     status: current
-    given: a merge of a source contact into a target, where source and target do not hold primaries of different method types
+    given: a merge of a source contact into a target
     when: contact methods are merged
     then:
       - source methods whose type and normalized value already exist on the target are dropped
-      - source primary flags are demoted where the target already has a primary of the same type
+      - source primary flags are demoted whenever the target already has a primary, regardless of method type
       - remaining source methods are repointed to the target
     provenance: [DeleteDuplicateContactMethods, DemoteSourcePrimaryMethods, TransferContactMethods]
-    notes: Demotion is per-type while the one-primary rule is per-contact — a cross-type dual-primary pair currently fails the merge; CON-049 proposes the fix.
+    notes: Primary-collision semantics are pinned in CON-049.
 
   - id: CON-028
     title: Merge combines notepad notes and transfers the rest
@@ -573,7 +573,7 @@ behaviors:
   - id: CON-049
     title: Merge resolves primary-method collisions without failing
     type: business-logic
-    status: proposed
+    status: current
     given: a source and target that each have a primary contact method of different types
     when: they are merged
     then:
@@ -581,7 +581,7 @@ behaviors:
       - the target's existing primary is preserved
       - the source's primary flags are demoted regardless of method type
     provenance: [DemoteSourcePrimaryMethods, idx_contact_method_primary]
-    notes: 'Proposed: demotion is currently per-type while the unique index is one-primary-per-contact, so a cross-type dual-primary merge fails with a constraint violation today (see CON-027).'
+    notes: The unique index is one-primary-per-contact, so demotion keys on the target having any primary, not a same-type one (see CON-027).
 
   # --- Intents (judged experience goals — Track B agentic judge only) ---
 


### PR DESCRIPTION
## Summary
- `DemoteSourcePrimaryMethods` only demoted source primaries where the target had a primary of the **same type**, but `idx_contact_method_primary` is one-primary-per-**contact** — so a cross-type dual-primary pair survived demotion and `TransferContactMethods` hit the unique partial index, failing the whole merge with a 500
- Demotion now keys on the target having **any** primary (`EXISTS`), regardless of method type; the target's existing primary is preserved
- Fixed the query comment that misstated the index as `(contact_id, type)`
- Spec kept in lockstep: CON-049 flipped `proposed` → `current`; CON-027's `given`/`notes` updated to drop the now-fixed caveat

## Test plan
- New integration test `MergeContacts_CrossTypeDualPrimaries` (source: primary phone, target: primary email): red before the fix with the exact reported unique violation (`23505` on `idx_contact_method_primary`), green after; asserts the merge succeeds, the target's primary is preserved, and the source's arrives demoted
- `make spec-lint` green; full suite green via the pre-push gate

Fixes #584