### PR TITLE
test(seed): distribution realism for overdue ages, cadence mix, spacing

### DIFF
--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -232,9 +232,9 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// The coverage + determinism tests override this down for CI.
 				SeededSignals: 20,
 				// Four settled interactions per dedicated source contact, spread back over
-				// ~9 weeks, so staging shows a prod-like multi-interaction history per
-				// source instead of a single recent message. The coverage + determinism
-				// tests override this down for CI runtime.
+				// a non-uniform, contact-varied span (months-scale), so staging shows a
+				// prod-like multi-interaction history per source instead of a single recent
+				// message. The coverage + determinism tests override this down for CI runtime.
 				MessagesPerContact: 4,
 				// A handful of soft-deleted contacts + merged pairs so staging shows the
 				// tombstoned-contact and merge re-point surfaces. The coverage + determinism
@@ -403,7 +403,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.Contacts++
 		for j := 0; j < messagesPer; j++ {
-			if _, err := h.ReplayGmail(ctx, gmContact.ID, gen.GmailMessage(gmSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+			if _, err := h.ReplayGmail(ctx, gmContact.ID, gen.GmailMessage(gmSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(i, j)))); err != nil {
 				return res, fmt.Errorf("profile %s: replay gmail %d msg %d: %w", params.Profile, i, j, err)
 			}
 			res.SettledInteractions++
@@ -418,7 +418,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.Contacts++
 		for j := 0; j < messagesPer; j++ {
-			if _, err := h.ReplayTelegram(ctx, tgContact.ID, gen.TelegramMessage(tgSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+			if _, err := h.ReplayTelegram(ctx, tgContact.ID, gen.TelegramMessage(tgSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(i, j)))); err != nil {
 				return res, fmt.Errorf("profile %s: replay telegram %d msg %d: %w", params.Profile, i, j, err)
 			}
 			res.SettledInteractions++
@@ -433,7 +433,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.Contacts++
 		for j := 0; j < messagesPer; j++ {
-			if _, err := h.ReplayGCal(ctx, gcContact.ID, gen.GCalEvent(gcSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+			if _, err := h.ReplayGCal(ctx, gcContact.ID, gen.GCalEvent(gcSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(i, j)))); err != nil {
 				return res, fmt.Errorf("profile %s: replay gcal %d msg %d: %w", params.Profile, i, j, err)
 			}
 			res.SettledInteractions++
@@ -448,7 +448,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.Contacts++
 		for j := 0; j < messagesPer; j++ {
-			if _, err := h.ReplayGChat(ctx, gchatContact.ID, gen.GChatMessage(gchatSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+			if _, err := h.ReplayGChat(ctx, gchatContact.ID, gen.GChatMessage(gchatSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(i, j)))); err != nil {
 				return res, fmt.Errorf("profile %s: replay gchat %d msg %d: %w", params.Profile, i, j, err)
 			}
 			res.SettledInteractions++
@@ -463,7 +463,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.Contacts++
 		for j := 0; j < messagesPer; j++ {
-			imageSpec, err := gen.IMessage(imSpec, factory.MatchSeeded, h.MacHostID(), factory.WithMessageAge(interactionSpreadAge(j)))
+			imageSpec, err := gen.IMessage(imSpec, factory.MatchSeeded, h.MacHostID(), factory.WithMessageAge(interactionSpreadAge(i, j)))
 			if err != nil {
 				return res, fmt.Errorf("profile %s: build imessage spec %d msg %d: %w", params.Profile, i, j, err)
 			}
@@ -871,7 +871,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: seed awaiting-reply contact: %w", params.Profile, err)
 		}
 		res.Contacts++
-		if _, err := h.ReplayGCal(ctx, fuContact.ID, gen.GCalEvent(fuSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(0)))); err != nil {
+		if _, err := h.ReplayGCal(ctx, fuContact.ID, gen.GCalEvent(fuSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(0, 0)))); err != nil {
 			return res, fmt.Errorf("profile %s: replay gcal for awaiting-reply contact: %w", params.Profile, err)
 		}
 		res.SettledInteractions++
@@ -1075,14 +1075,43 @@ var catalogSignalKeys = []string{
 // relationship_signal rows so they are identifiable as toolkit-authored.
 const syntheticSignalMethodVersion = "synthetic-seed"
 
-// catalogOverdueAge backdates the overdue catalog cohort ~90 days before the
-// anchor (created_at == last_contacted), far enough that a sub-quarterly cadence
-// reads as overdue. catalogRecentWindow bounds the recently-created cohort within
-// the last ~48h. Both are anchor-relative.
-const (
-	catalogOverdueAge   = 90 * 24 * time.Hour
-	catalogRecentWindow = 48 * time.Hour
+// catalogOverdueLadder is the fixed (cadence, created-age) table the overdue
+// catalog slots rotate over, so the overdue cohort spans a RANGE of days-overdue
+// magnitudes (single-digit / tens / hundreds) and multiple cadences instead of a
+// single monthly / ~60-day monoculture that the dashboard urgency tiers cannot
+// separate. created_at == last_contacted is stamped from one past instant
+// (WithCreatedAge), so days-overdue is (created-age − cadence period). Every pair
+// is genuinely overdue under PRODUCTION cadence durations (weekly 7d / monthly 30d
+// / quarterly 90d — age comfortably exceeds the period), and several keep a
+// >14d-backdated shape so the coherence D1 gate (overdueFloor = now − 14d) holds.
+// Anchor-relative via WithCreatedAge (no time.Now()); indexed by a pure function of
+// the slot, so it draws no PRNG.
+var catalogOverdueLadder = []struct {
+	cadence    string
+	createdAge time.Duration
+}{
+	{"weekly", 12 * 24 * time.Hour},     // ~5 days overdue (weekly period 7d)
+	{"monthly", 40 * 24 * time.Hour},    // ~10 days overdue (monthly period 30d)
+	{"monthly", 96 * 24 * time.Hour},    // ~66 days overdue
+	{"quarterly", 130 * 24 * time.Hour}, // ~40 days overdue (quarterly period 90d)
+	{"weekly", 200 * 24 * time.Hour},    // ~193 days overdue (long-neglected)
+}
+
+// catalogRecentCadences / catalogNeverContactedCadences are the small fixed cadence
+// pools the recent + never-contacted catalog cohorts rotate over (contact-list
+// cadence-mix realism). The first element matches the pre-ladder cadence for each
+// cohort (weekly / quarterly), so the lowest-index representatives are unchanged.
+// All values are migration-005 CHECK cadences. Neither cohort's bucket semantics
+// change: recent stays recent (WithRecentCreation), never-contacted keeps a NULL
+// last_contacted.
+var (
+	catalogRecentCadences         = []string{"weekly", "biweekly"}
+	catalogNeverContactedCadences = []string{"quarterly", "biannual", "annual"}
 )
+
+// catalogRecentWindow bounds the recently-created cohort within the last ~48h
+// (anchor-relative).
+const catalogRecentWindow = 48 * time.Hour
 
 // catalogLocationStems is the small fixed pool the lives_in location rotates over
 // so locations repeat across contacts (prod-like) while staying deterministic. The
@@ -1114,9 +1143,13 @@ var catalogLocationStems = []string{
 func catalogOptionsFor(i, n int, anchor time.Time, prefix string) []factory.ContactOption {
 	var opts []factory.ContactOption
 
-	// The no-method bucket: a cadence-bearing contact with NO contact_method.
+	// The no-method bucket: a cadence-bearing contact with NO contact_method. It
+	// draws its (cadence, created-age) from the same overdue ladder as the general
+	// overdue slots, by the same rotation, so it stays a genuinely overdue,
+	// >14d-backdated contact — just one carrying no method.
 	if i == 3 && n > 3 {
-		opts = append(opts, factory.WithNoMethods(), factory.WithCadence("monthly"), factory.WithCreatedAge(catalogOverdueAge))
+		pair := catalogOverdueLadder[(i/3)%len(catalogOverdueLadder)]
+		opts = append(opts, factory.WithNoMethods(), factory.WithCadence(pair.cadence), factory.WithCreatedAge(pair.createdAge))
 		return opts
 	}
 
@@ -1127,12 +1160,18 @@ func catalogOptionsFor(i, n int, anchor time.Time, prefix string) []factory.Cont
 	// never-contacted (no last_contacted).
 	switch i % 3 {
 	case 0:
-		opts = append(opts, factory.WithCadence("monthly"), factory.WithCreatedAge(catalogOverdueAge))
+		// Overdue: rotate the (cadence, created-age) ladder by overdue-slot index so
+		// the overdue cohort spans distinct days-overdue magnitudes AND cadences,
+		// exercising the dashboard's urgency tiers instead of one uniform card shape.
+		pair := catalogOverdueLadder[(i/3)%len(catalogOverdueLadder)]
+		opts = append(opts, factory.WithCadence(pair.cadence), factory.WithCreatedAge(pair.createdAge))
 	case 1:
-		opts = append(opts, factory.WithCadence("weekly"), factory.WithRecentCreation(catalogRecentWindow))
+		// Recent: rotate the cadence over a small pool for contact-list realism; the
+		// contact stays recent via WithRecentCreation.
+		opts = append(opts, factory.WithCadence(catalogRecentCadences[(i/3)%len(catalogRecentCadences)]), factory.WithRecentCreation(catalogRecentWindow))
 	default:
-		// never-contacted: a cadence but no last_contacted.
-		opts = append(opts, factory.WithCadence("quarterly"))
+		// never-contacted: a cadence (rotated over a small pool) but no last_contacted.
+		opts = append(opts, factory.WithCadence(catalogNeverContactedCadences[(i/3)%len(catalogNeverContactedCadences)]))
 	}
 
 	// One representative of each rendering / data edge case (only when the
@@ -1192,19 +1231,39 @@ func perSourceSettledCount(p Profile) int {
 	return 1
 }
 
-// interactionSpreadInterval is the deterministic gap between successive settled
-// interactions on one contact. It is wider than a day so the messaging-aggregate
-// sources (gchat / messages / telegram), which collapse same-day messages into a
-// single interaction, still yield one interaction per replayed message; ~3 weeks
-// gives a months-scale history at the profile message counts.
-const interactionSpreadInterval = 21 * 24 * time.Hour
+// interactionGapPool is the fixed pool of first-gap sizes the settled-interaction
+// spread rotates over BY CONTACT, so different per-source settled contacts carry
+// different spans even at MessagesPerContact=2 (a single gap). Every value is wider
+// than a day so the messaging-aggregate sources (gchat / messages / telegram),
+// which collapse same-day messages into a single interaction, still yield one
+// interaction per replayed message.
+var interactionGapPool = []time.Duration{
+	9 * 24 * time.Hour,
+	16 * 24 * time.Hour,
+	23 * 24 * time.Hour,
+	34 * 24 * time.Hour,
+}
 
-// interactionSpreadAge is the backward age of the j-th settled message on a
-// contact: 0 for the newest (so it drives last_contacted), then one
-// interactionSpreadInterval older per step. Deterministic (a pure function of j),
-// anchor-relative via the source factories' WithMessageAge (no time.Now()).
-func interactionSpreadAge(j int) time.Duration {
-	return time.Duration(j) * interactionSpreadInterval
+// interactionSpreadStep widens each successive gap on one contact so the spacing is
+// non-uniform WITHIN a contact too (visible at MessagesPerContact>=3), not merely
+// across contacts.
+const interactionSpreadStep = 7 * 24 * time.Hour
+
+// interactionSpreadAge is the backward age of the j-th settled message on the
+// contactIdx-th per-source settled contact: 0 for the newest (j=0, so it drives
+// last_contacted), then the contact's base gap plus a widening step per additional
+// message. It is contact-indexed so the settled history is a non-uniform
+// distribution of spans rather than one uniform interval. Pure function of
+// (contactIdx, j) — no PRNG — anchor-relative via the source factories'
+// WithMessageAge (no time.Now()). Strictly increasing in j with every gap >= 7d, so
+// same-day collapse never merges two of a contact's messages.
+func interactionSpreadAge(contactIdx, j int) time.Duration {
+	base := interactionGapPool[contactIdx%len(interactionGapPool)]
+	var age time.Duration
+	for step := 0; step < j; step++ {
+		age += base + time.Duration(step)*interactionSpreadStep
+	}
+	return age
 }
 
 // Message-age anchors for the two-sided direction block (F4). All are backward

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -2,12 +2,21 @@ package synthetic
 
 import (
 	"testing"
+	"time"
 
+	"personal-crm/backend/internal/cadence"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/stretchr/testify/require"
 )
+
+// validCadences is the migration-005 CHECK constraint's cadence allowlist; the
+// overdue ladder + the recent / never-contacted rotation pools may only draw from it.
+var validCadences = map[string]bool{
+	"weekly": true, "biweekly": true, "monthly": true,
+	"quarterly": true, "biannual": true, "annual": true,
+}
 
 // TestSeedAllowed asserts the prod gate denies the two production aliases and
 // allows every other valid CRM_ENV (the validCRMEnvs set in config.go).
@@ -125,4 +134,137 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.SeededSoftDeleted)
 	require.Equal(t, 0, p.Counts.SeededMerged)
 	require.Equal(t, 0, p.Counts.ImportCandidatesPerSource)
+}
+
+// TestCatalogOverdueLadderWellFormed asserts the overdue ladder is a well-formed
+// urgency distribution: every pair is genuinely overdue under PRODUCTION cadence
+// durations, every cadence is CHECK-valid, the D1 backdated-overdue floor
+// (created_at before now-14d) is robustly satisfiable, and the days-overdue
+// magnitudes span the single-digit / tens / hundreds tiers the dashboard urgency
+// tiers exist to separate (DSH-010). Pure — no DB, no PRNG. The 9-contact bounded
+// integration test only surfaces the first few ladder entries, so this covers the
+// whole table directly. Prod durations are read from the cadence package's own source
+// of truth (not hardcoded) so the test cannot drift from prod semantics.
+func TestCatalogOverdueLadderWellFormed(t *testing.T) {
+	t.Setenv("CRM_ENV", "production")
+
+	const d1Floor = 14 * 24 * time.Hour
+	require.NotEmpty(t, catalogOverdueLadder)
+
+	belowD1Floor := 0
+	overdueMagnitudes := map[time.Duration]bool{}
+	var minOverdue, maxOverdue time.Duration
+	for i, pair := range catalogOverdueLadder {
+		require.True(t, validCadences[pair.cadence], "ladder[%d] cadence %q must be a migration-005 CHECK cadence", i, pair.cadence)
+
+		ct, err := cadence.ParseCadence(pair.cadence)
+		require.NoError(t, err)
+		period := cadence.GetCadenceDuration(ct)
+
+		// Genuinely overdue under prod durations: created-age exceeds the cadence
+		// period, so the computed contact_by has elapsed.
+		require.Greater(t, pair.createdAge, period,
+			"ladder[%d] (%s, age %s) must be overdue under prod durations (age > period %s)", i, pair.cadence, pair.createdAge, period)
+
+		overdue := pair.createdAge - period
+		overdueMagnitudes[overdue] = true
+		if minOverdue == 0 || overdue < minOverdue {
+			minOverdue = overdue
+		}
+		if overdue > maxOverdue {
+			maxOverdue = overdue
+		}
+		if pair.createdAge <= d1Floor {
+			belowD1Floor++
+		}
+	}
+
+	// D1 floor robustly satisfiable: at most one ladder pair sits below now-14d, so any
+	// overdue cohort spanning >=2 rotation slots always surfaces a backdated-overdue
+	// contact for the coherence D1 gate (the single-digit tier below is the only pair
+	// permitted under the floor).
+	require.LessOrEqual(t, belowD1Floor, 1, "at most one ladder pair may sit below the 14d D1 floor (else the D1 gate can be starved)")
+
+	// Distinct days-overdue magnitudes spanning the urgency tiers (DSH-010).
+	require.GreaterOrEqual(t, len(overdueMagnitudes), 3, "ladder must span >=3 distinct days-overdue magnitudes")
+	require.Less(t, minOverdue, 10*24*time.Hour, "ladder must include a single-digit-days-overdue (low-urgency) tier")
+	require.GreaterOrEqual(t, maxOverdue, 100*24*time.Hour, "ladder must include a hundreds-of-days-overdue (high-urgency) tier")
+}
+
+// TestInteractionSpreadAgeShape asserts the settled-interaction spread is a
+// deterministic, non-uniform distribution: age 0 for the newest message, strictly
+// increasing in j, every successive gap >= 7d (so the messaging-aggregate sources
+// never collapse two of a contact's messages), gaps that widen for j>=2 (non-uniform
+// WITHIN a contact — invisible at MessagesPerContact=2, so the bounded integration
+// test cannot cover it), and a first gap that differs across contactIdx (non-uniform
+// ACROSS contacts, giving span variety even at MessagesPerContact=2). Pure — no DB.
+func TestInteractionSpreadAgeShape(t *testing.T) {
+	const minGap = 7 * 24 * time.Hour
+	const contacts = 6
+	const messages = 5
+
+	firstGaps := map[time.Duration]bool{}
+	for c := 0; c < contacts; c++ {
+		require.Zero(t, interactionSpreadAge(c, 0), "j=0 is the newest message (age 0, drives last_contacted)")
+
+		var prevAge, prevGap time.Duration
+		for j := 1; j < messages; j++ {
+			age := interactionSpreadAge(c, j)
+			gap := age - prevAge
+			require.Greater(t, age, prevAge, "contact %d: age must strictly increase in j (j=%d)", c, j)
+			require.GreaterOrEqual(t, gap, minGap, "contact %d: gap at j=%d must be >= 7d", c, j)
+			if j == 1 {
+				firstGaps[gap] = true
+			}
+			if j >= 2 {
+				require.Greater(t, gap, prevGap, "contact %d: gaps must widen for j>=2 (non-uniform within a contact)", c)
+			}
+			prevAge, prevGap = age, gap
+		}
+	}
+	require.GreaterOrEqual(t, len(firstGaps), 2,
+		"the first gap must differ across contactIdx (span variety even at MessagesPerContact=2)")
+}
+
+// TestCatalogCadenceRotation asserts the recent + never-contacted cadence rotation
+// pools each offer >=2 distinct CHECK-valid cadences, and that the rotation actually
+// varies the cadence across the population deterministically (a pure function of the
+// slot index — no PRNG). It exercises catalogOptionsFor end-to-end through the factory
+// (in-memory, no DB). Pure.
+func TestCatalogCadenceRotation(t *testing.T) {
+	for name, pool := range map[string][]string{
+		"recent":         catalogRecentCadences,
+		"neverContacted": catalogNeverContactedCadences,
+	} {
+		distinct := map[string]bool{}
+		for _, c := range pool {
+			require.True(t, validCadences[c], "%s pool cadence %q must be a migration-005 CHECK cadence", name, c)
+			distinct[c] = true
+		}
+		require.GreaterOrEqual(t, len(distinct), 2, "%s cadence pool must offer >=2 distinct cadences", name)
+	}
+
+	const n = 18
+	collect := func() (recent, never map[string]bool) {
+		g := factory.NewGenerator(factory.DefaultSeed, "ladderunit")
+		recent, never = map[string]bool{}, map[string]bool{}
+		for i := 0; i < n; i++ {
+			spec := g.Contact(catalogOptionsFor(i, n, g.Anchor(), g.Prefix())...)
+			switch i % 3 {
+			case 1: // recent cohort
+				require.NotNil(t, spec.Cadence)
+				recent[*spec.Cadence] = true
+			case 2: // never-contacted cohort
+				require.NotNil(t, spec.Cadence)
+				never[*spec.Cadence] = true
+			}
+		}
+		return recent, never
+	}
+	recent1, never1 := collect()
+	recent2, never2 := collect()
+	require.GreaterOrEqual(t, len(recent1), 2, "recent cohort carries >=2 distinct cadences across the population")
+	require.GreaterOrEqual(t, len(never1), 2, "never-contacted cohort carries >=2 distinct cadences across the population")
+	require.Equal(t, recent1, recent2, "recent cadence rotation is deterministic (pure function of i)")
+	require.Equal(t, never1, never2, "never-contacted cadence rotation is deterministic (pure function of i)")
 }

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -152,6 +152,7 @@ func TestCatalogOverdueLadderWellFormed(t *testing.T) {
 	require.NotEmpty(t, catalogOverdueLadder)
 
 	belowD1Floor := 0
+	tensTier := 0 // pairs whose days-overdue lands in [10d, 100d)
 	overdueMagnitudes := map[time.Duration]bool{}
 	var minOverdue, maxOverdue time.Duration
 	for i, pair := range catalogOverdueLadder {
@@ -177,6 +178,9 @@ func TestCatalogOverdueLadderWellFormed(t *testing.T) {
 		if pair.createdAge <= d1Floor {
 			belowD1Floor++
 		}
+		if overdue >= 10*24*time.Hour && overdue < 100*24*time.Hour {
+			tensTier++
+		}
 	}
 
 	// D1 floor robustly satisfiable: at most one ladder pair sits below now-14d, so any
@@ -185,9 +189,12 @@ func TestCatalogOverdueLadderWellFormed(t *testing.T) {
 	// permitted under the floor).
 	require.LessOrEqual(t, belowD1Floor, 1, "at most one ladder pair may sit below the 14d D1 floor (else the D1 gate can be starved)")
 
-	// Distinct days-overdue magnitudes spanning the urgency tiers (DSH-010).
+	// Distinct days-overdue magnitudes spanning ALL THREE urgency tiers (DSH-010): a
+	// single-digit low tier, a tens middle tier, and a hundreds high tier must each be
+	// present (>=3 distinct alone would permit a ladder that skips the middle tier).
 	require.GreaterOrEqual(t, len(overdueMagnitudes), 3, "ladder must span >=3 distinct days-overdue magnitudes")
 	require.Less(t, minOverdue, 10*24*time.Hour, "ladder must include a single-digit-days-overdue (low-urgency) tier")
+	require.GreaterOrEqual(t, tensTier, 1, "ladder must include a tens-of-days-overdue (medium-urgency) tier in [10d, 100d)")
 	require.GreaterOrEqual(t, maxOverdue, 100*24*time.Hour, "ladder must include a hundreds-of-days-overdue (high-urgency) tier")
 }
 

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -477,7 +477,7 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	params.Counts.SeededSignals = 3
 	// Two settled interactions per dedicated source contact (the CI-safe minimum
 	// that still exercises the temporal spread): the second message is one
-	// interactionSpreadInterval (~3 weeks) older, so the per-contact span clears the
+	// contact-indexed spread gap (>= 9 days) older, so the per-contact span clears the
 	// multi-day floor asserted below. Kept small to bound the settle budget.
 	params.Counts.MessagesPerContact = 2
 	// One soft-deleted contact + one merged pair (the CI-safe minimum): enough to

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -547,6 +547,32 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, neverContacted, 1, "≥1 cadence-bearing never-contacted contact (NULL last_contacted survived)")
 	require.GreaterOrEqual(t, noMethod, 1, "≥1 no-method contact (the no-method bucket exists)")
 
+	// Overdue-cohort DIVERSITY (DSH-010): the overdue surface must show a RANGE of
+	// days-overdue and cadences, not a single monthly / ~60-day monoculture the
+	// dashboard urgency tiers cannot separate. Select the backdated cohort
+	// STRUCTURALLY — cadence set, last_contacted == created_at (the backdated creation
+	// stamp), created_at older than a fixed floor (now − 7d, which deterministically
+	// excludes the <48h recent cohort in EVERY env) — so this does NOT depend on the
+	// env-reading cadence helper, which collapses days-overdue under compressed test
+	// durations. Assert ≥3 distinct created-ages AND ≥2 distinct cadences; this is the
+	// assertion that would have caught the pre-change monoculture (all overdue slots
+	// were monthly + 90d), and it is env-independent by construction.
+	diversityFloor := now.Add(-7 * 24 * time.Hour)
+	distinctCreatedAges := map[int64]bool{}
+	distinctOverdueCadences := map[string]bool{}
+	for _, b := range buckets {
+		if b.Cadence == nil || *b.Cadence == "" || b.CreatedAt == nil || b.LastContacted == nil {
+			continue
+		}
+		if !b.LastContacted.Equal(*b.CreatedAt) || !b.CreatedAt.Before(diversityFloor) {
+			continue
+		}
+		distinctCreatedAges[b.CreatedAt.UnixNano()] = true
+		distinctOverdueCadences[*b.Cadence] = true
+	}
+	require.GreaterOrEqual(t, len(distinctCreatedAges), 3, "overdue cohort spans ≥3 distinct created-ages (days-overdue diversity, not a monoculture)")
+	require.GreaterOrEqual(t, len(distinctOverdueCadences), 2, "overdue cohort spans ≥2 distinct cadences")
+
 	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
 	assertSeedCoherence(t, ctx, support, h.Generator().Prefix(), h.DateFactContactID())
 	// Two-sided message-direction coverage (F4).
@@ -735,6 +761,20 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		}
 	}
 	require.True(t, spread, "≥1 settled contact has ≥2 interactions spanning ≥7 days (temporal spread, not one window)")
+
+	// Spacing NON-UNIFORMITY (F9): the settled history must not be one uniform gap
+	// repeated across every contact (the pre-change shape was a fixed 21-day
+	// interval). The spread ladder is contact-indexed, so even at
+	// MessagesPerContact=2 (a single gap) different settled contacts carry different
+	// spans. Assert ≥2 distinct span values across settled contacts with ≥2
+	// interactions — the assertion that would have caught the uniform-spacing shape.
+	distinctSpans := map[time.Duration]bool{}
+	for _, s := range spreads {
+		if s.InteractionCount >= 2 {
+			distinctSpans[s.Span] = true
+		}
+	}
+	require.GreaterOrEqual(t, len(distinctSpans), 2, "≥2 distinct interaction spans across settled contacts (non-uniform spacing, not a single fixed gap)")
 
 	// Merge + soft-delete scenarios (item 12). These are standalone contacts seeded
 	// at full count (independent of the catalog), so the result equals the override.


### PR DESCRIPTION
Part of #642 (does not close it — see scope note).

## Problem

The prod-shaped seed world's overdue surface is a monoculture: every overdue catalog contact is created from the identical `(monthly, 90d)` pair, so every dashboard card reads exactly "60 days overdue / (monthly cadence)". The QA judge correctly fails intent DSH-010 every round ("more urgent relationships do not stand out from less urgent ones") — recurring noise that blocks judge-quality work. Separately, settled interactions are spaced at a perfectly uniform 21 days (audit F9's spacing item).

## Change

- **Overdue cohort:** the single `catalogOverdueAge` constant becomes a fixed `(cadence, created-age)` ladder the overdue slots rotate over — spanning ~5/10/40/66/193 days overdue across weekly/monthly/quarterly. The cause-driven mechanism is unchanged: overdue-ness still comes only from `WithCreatedAge` backdating (`created_at == last_contacted`, the production creation-time shape); no non-creation `last_contacted` is ever written.
- **Cadence mix:** the recent and never-contacted cohorts rotate over small cadence pools (first element preserves the previous behavior for low indices).
- **Message spacing:** `interactionSpreadAge` is now contact-indexed (base gap from a fixed pool by contact index) with a widening per-step increment, replacing uniform `j * 21d`. All gaps ≥ 7d so the existing span gate holds. Pure index arithmetic throughout — no PRNG draws added or reordered.

## Tests

- Coverage-gate additions in `TestSyntheticProfile_ProdShapedCoverageCheck`: overdue diversity (≥3 distinct created-ages AND ≥2 cadences) and spacing non-uniformity (≥2 distinct spans). Both select their cohort structurally (raw timestamp arithmetic) rather than via the env-reading cadence helpers, so they are robust under compressed test durations. Non-vacuity was verified by temporarily reverting the seed change: each assertion fails against the old monoculture shape.
- Pure unit tests over the new tables/functions: full-ladder well-formedness under production durations (every pair genuinely overdue, CHECK-valid cadences, D1-floor satisfiability, single-digit/tens/hundreds tier coverage), spread-shape invariants (strictly increasing, ≥7d gaps, widening, cross-contact variance), and cadence-rotation pools.

## Scope note

Issue #642's literal text is the audit-F9 coverage-absence list. This PR delivers the distribution-realism slice (design-doc step 1, `.ai/spec/2026-07-14-qa-labeling-langfuse-wiring.md`) plus the one overlapping F9 item (uniform spacing). The remaining F9 items (todoist/anarlog/phone interaction rows, gcal multi-attendee fan-out, contact_method type mix) stay parked per the issue's own "expand when a tour/intent needs it" rule.

## Validation

Local: full pre-push gate green (lint + unit + integration + diff-selected E2E). Post-merge: staging reseed → tours + judge round to confirm DSH-010 stops failing on uniform urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETUbFQwweNKprCDdv8aTUs