### PR TITLE
refactor(qa): move email/phone scrub into the Langfuse export path (arc PR1)

### DIFF
--- a/frontend/tests/tours/judge/README.md
+++ b/frontend/tests/tours/judge/README.md
@@ -25,9 +25,11 @@ make qa-report RUNDIR=<run dir> JUDGE=1      # + the live judge over residue ite
 
 `make qa-report` groups a run's captures by behavior, grades the judge residue, and renders the markdown roll-up + coverage + skip-list. It files no issues; the judge-layer + fail-precision metrics print `N/A — pending human labels` (see `DEFERRED.md`).
 
+**Live exports are scrubbed at the boundary.** When a run ships spans to Langfuse (`make qa-export`, opt-in on `LANGFUSE_*`), the export path scrubs every free-form / env-sourced string (prompt, response, `metadata.error`, `metadata.model`) through `judge/scrub.ts` before the HTTP call — the single live→Langfuse PII chokepoint. Adding a new free-form trace field without routing it through the scrubber is a leak.
+
 ## The corpus
 
-- `corpus/captures/{contacts,dashboard,cadence-followup}/*.json` — base capture fixtures, curated from a **local `prod-shaped` sweep**, UUID-mapped + host-redacted by the normalizer, then scrubbed (`corpus/scrub.ts`: email/phone → `<email:N>`/`<phone:N>`). Provably synthetic: every contact name carries the `synth-prodshaped-` factory prefix.
+- `corpus/captures/{contacts,dashboard,cadence-followup}/*.json` — base capture fixtures, curated from a **local `prod-shaped` sweep**, UUID-mapped + host-redacted by the normalizer, then scrubbed at curation (`corpus/scrub.ts`'s `scrubCapture`: email/phone → `<email:N>`/`<phone:N>`, sharing the scrubber that now lives in `judge/scrub.ts`). Provably synthetic: every contact name carries the `synth-prodshaped-` factory prefix. (Live-run captures are instead scrubbed in the export path, above.)
 - `corpus/cases/*.json` — clean cases + doctored cases (single-point mutations from `doctor.ts`) that the labeler drafts over; the deterministic eval they once fed has retired with the verifier lane.
 - `corpus/labels/*.draft.json` — draft judge labels (the real stronger-model fill is manual — see `DEFERRED.md`).
 - `corpus/pii-audit.ts` — the mechanical P0 gate over ALL committed artifacts: bans raw UUIDs / real-host URLs / emails / phones / secrets and asserts the `synth-prodshaped-` name prefix. Runs as a vitest (`corpus/pii-audit.test.ts`) over the committed tree AND as a CLI: `bun run tests/tours/judge/corpus/pii-audit.ts corpus`.

--- a/frontend/tests/tours/judge/corpus/pii-audit.ts
+++ b/frontend/tests/tours/judge/corpus/pii-audit.ts
@@ -20,7 +20,7 @@ import {
   REAL_HOST_URL_RE,
   SECRET_RES,
   SYNTH_NAME_PREFIX,
-} from './patterns'
+} from '../pii-patterns'
 
 export interface Violation {
   kind: string

--- a/frontend/tests/tours/judge/corpus/scrub.test.ts
+++ b/frontend/tests/tours/judge/corpus/scrub.test.ts
@@ -1,29 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { createScrubber, scrubCapture, scrubValue } from './scrub'
-import { EMAIL_RE, PHONE_RES } from './patterns'
+import { scrubCapture } from './scrub'
+import { EMAIL_RE, PHONE_RES } from '../pii-patterns'
 
-describe('scrub email/phone → placeholders', () => {
-  it('maps emails to stable <email:N> placeholders (first-seen)', () => {
-    const s = createScrubber()
-    expect(s.scrub('reach synth-prodshaped-brux.dummond-52@synthetic.example now')).toBe(
-      'reach <email:1> now'
-    )
-    expect(s.scrub('a@b.com and synth-prodshaped-brux.dummond-52@synthetic.example')).toBe(
-      '<email:2> and <email:1>'
-    )
-  })
+// The scrubber/pattern assertions live in judge/scrub.test.ts (the scrubber
+// relocated to the export path). Here we cover only the curation-specific
+// scrubCapture wrapper: it scrubs method values AND drops the screenshot key.
 
-  it('maps synthetic + international phones to <phone:N>', () => {
-    const s = createScrubber()
-    expect(s.scrub('call +1-479-555-0100 or (479) 555-0101')).toBe('call <phone:1> or <phone:2>')
-  })
-
-  it('preserves ISO dates and timestamps (NOT phone-shaped)', () => {
-    const s = createScrubber()
-    const kept = 'birthday 1990-05-05 occurred_at 2026-07-12T16:14:34.223608Z'
-    expect(s.scrub(kept)).toBe(kept)
-  })
-
+describe('scrubCapture (curation wrapper)', () => {
   it('deep-scrubs a capture object without mutating the input', () => {
     const capture = {
       aria: { role: 'text', text: 'Keeping synth-x (brux@synthetic.example)' },
@@ -38,12 +21,7 @@ describe('scrub email/phone → placeholders', () => {
     expect(capture.aria.text).toContain('@synthetic.example')
   })
 
-  it('scrubValue leaves non-strings alone', () => {
-    const s = createScrubber()
-    expect(scrubValue({ n: 5, b: true, x: null }, s)).toEqual({ n: 5, b: true, x: null })
-  })
-
-  it('scrubCapture drops the live-run-only screenshot path', () => {
+  it('drops the live-run-only screenshot path', () => {
     const scrubbed = scrubCapture({
       tour: 'dashboard',
       screenshot: 'screenshots/dashboard/001.png',

--- a/frontend/tests/tours/judge/corpus/scrub.ts
+++ b/frontend/tests/tours/judge/corpus/scrub.ts
@@ -1,59 +1,11 @@
-// Corpus-only scrub (design D6a P1): the live-run normalizer host-scrubs URLs +
-// UUID-maps ids, but does NOT redact emails/phones — and the synthetic factory
-// emits real-FORMAT fabricated emails/phones into methods[].value. This scrub
-// maps every email-shaped and phone-shaped string to a stable placeholder
-// (<email:N>/<phone:N>, first-seen like the UUID mapper), applied to every
-// capture AT CURATION on top of the normalizer, so committed fixtures carry no
-// email/phone patterns. Evidence-preserving: no toured behavior's verifier
-// reads a method value (CON-043 uses names, CON-044 the interaction, CON-045
-// birthdays).
-//
-// Pure — no Playwright, no fs. Deep-walks a parsed capture object.
+// Corpus-only curation wrapper (design D6a P1). The scrubber itself now lives in
+// the export path (`judge/scrub.ts`, arc INV-2) — this file keeps ONLY the
+// curation-specific `scrubCapture`, which additionally drops the live-run-only
+// `screenshot` path so committed fixtures stay aria-only. Used at CURATION on
+// top of the normalizer, so committed fixtures carry no email/phone patterns.
+// (Retires with the corpus in a later arc PR.)
 
-import { EMAIL_RE, PHONE_RES } from './patterns'
-
-export interface Scrubber {
-  scrub(value: string): string
-}
-
-// A first-seen map so the same email/phone → the same placeholder across every
-// capture in a curation session (structure-preserving, PII-safe).
-export function createScrubber(): Scrubber {
-  const emails = new Map<string, string>()
-  const phones = new Map<string, string>()
-  const placeholder = (map: Map<string, string>, kind: string, key: string): string => {
-    let p = map.get(key)
-    if (!p) {
-      p = `<${kind}:${map.size + 1}>`
-      map.set(key, p)
-    }
-    return p
-  }
-  return {
-    scrub(value: string): string {
-      let out = value.replace(EMAIL_RE, m => placeholder(emails, 'email', m.toLowerCase()))
-      for (const re of PHONE_RES) {
-        out = out.replace(re, m => placeholder(phones, 'phone', m.replace(/\s+/g, '')))
-      }
-      return out
-    },
-  }
-}
-
-// Deep-walk a JSON value, scrubbing every string. Arrays/objects rebuilt so the
-// input is not mutated.
-export function scrubValue(value: unknown, scrubber: Scrubber): unknown {
-  if (typeof value === 'string') return scrubber.scrub(value)
-  if (Array.isArray(value)) return value.map(v => scrubValue(v, scrubber))
-  if (value !== null && typeof value === 'object') {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = scrubValue(v, scrubber)
-    }
-    return out
-  }
-  return value
-}
+import { createScrubber, scrubValue, type Scrubber } from '../scrub'
 
 // Scrub a parsed capture record (returns a new object). Also drops the
 // live-run-only `screenshot` path: it references a gitignored file that never

--- a/frontend/tests/tours/judge/export/langfuse.test.ts
+++ b/frontend/tests/tours/judge/export/langfuse.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildGenAiSpan } from '../adapter/span'
-import { buildTraceBody, configFromEnv, parseSpanFile, traceIdFor } from './langfuse'
+import { createScrubber } from '../scrub'
+import { buildTraceBody, configFromEnv, exportSpans, parseSpanFile, traceIdFor } from './langfuse'
 
 const baseParams = {
   impl: 'codex-exec',
@@ -70,6 +71,98 @@ describe('buildTraceBody', () => {
     const body = buildTraceBody(span)
     expect(body.metadata.status).toBe('ERROR')
     expect(body.metadata.error).toBe('codex timed out')
+  })
+})
+
+describe('buildTraceBody PII scrub seam (INV-2)', () => {
+  // Distinct sentinel email+phone per free-form / env-sourced branch of the
+  // shipped body: prompt, completion, status.message→metadata.error, and
+  // gen_ai.request.model→metadata.model. None may survive raw.
+  const span = buildGenAiSpan({
+    ...baseParams,
+    model: 'gpt brex@synthetic.example (479) 555-0104',
+    prompt: 'saw brix@synthetic.example and +1-479-555-0100 in aria',
+    response: 'reply to brax@synthetic.example at (479) 555-0101',
+    error: 'threw for brox@synthetic.example calling +1-479-555-0102',
+  })
+
+  it('scrubs every free-form/env-sourced string; no raw sentinel survives', () => {
+    const scrubber = createScrubber()
+    const body = buildTraceBody(span, [], s => scrubber.scrub(s))
+    const shipped = JSON.stringify(body)
+    // No raw email/phone anywhere in the shipped body.
+    expect(shipped).not.toMatch(/@synthetic\.example/)
+    expect(shipped).not.toMatch(/479-555-01\d\d/)
+    expect(shipped).not.toMatch(/\(479\) 555-01\d\d/)
+    // Placeholders present in each branch.
+    expect((body.input as { prompt: string }).prompt).toContain('<email:')
+    expect((body.input as { prompt: string }).prompt).toContain('<phone:')
+    expect(body.output as string).toContain('<email:')
+    expect(body.output as string).toContain('<phone:')
+    expect(String(body.metadata.error)).toContain('<email:')
+    expect(String(body.metadata.error)).toContain('<phone:')
+    expect(String(body.metadata.model)).toContain('<email:')
+    expect(String(body.metadata.model)).toContain('<phone:')
+  })
+
+  it('defaults to identity scrub, so existing callers are unaffected', () => {
+    const body = buildTraceBody(span, [])
+    expect((body.input as { prompt: string }).prompt).toContain('brix@synthetic.example')
+    expect(body.output).toBe('reply to brax@synthetic.example at (479) 555-0101')
+    expect(body.metadata.error).toBe('threw for brox@synthetic.example calling +1-479-555-0102')
+    expect(body.metadata.model).toBe('gpt brex@synthetic.example (479) 555-0104')
+  })
+
+  it('preserves a non-string model attribute via the fallback (scrub only touches strings)', () => {
+    const scrubber = createScrubber()
+    // A non-string model attribute: str() yields undefined, so buildTraceBody
+    // falls back to the raw attribute value rather than scrubbing/crashing.
+    const numericModel = { ...span, attributes: { ...span.attributes, 'gen_ai.request.model': 42 } }
+    expect(buildTraceBody(numericModel, [], s => scrubber.scrub(s)).metadata.model).toBe(42)
+    // Missing entirely → undefined, no throw.
+    const noModel = { ...span, attributes: { ...span.attributes } }
+    delete noModel.attributes['gen_ai.request.model']
+    expect(buildTraceBody(noModel, [], s => scrubber.scrub(s)).metadata.model).toBeUndefined()
+  })
+})
+
+describe('exportSpans shared scrubber', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses ONE scrubber across the run so a shared email maps to the same placeholder', async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init?: { body?: string }) => {
+        if (init?.body) {
+          const parsed = JSON.parse(init.body) as {
+            batch?: Array<{ body?: Record<string, unknown> }>
+          }
+          for (const evt of parsed.batch ?? []) if (evt.body) bodies.push(evt.body)
+        }
+        return { ok: true, status: 200, text: async () => '{}' } as Response
+      })
+    )
+
+    const shared = 'dup@synthetic.example'
+    const spans = [
+      buildGenAiSpan({ ...baseParams, behaviorId: 'CON-001', prompt: `first ${shared}` }),
+      buildGenAiSpan({ ...baseParams, behaviorId: 'CON-002', prompt: `second ${shared}` }),
+    ]
+    const result = await exportSpans({ host: 'http://lf', publicKey: 'p', secretKey: 's' }, spans)
+    expect(result.traces).toBe(2)
+
+    const prompts = bodies
+      .map(b => (b.input as { prompt?: string } | undefined)?.prompt)
+      .filter((p): p is string => typeof p === 'string')
+    expect(prompts).toHaveLength(2)
+    // No raw email shipped, and the SAME placeholder in both (shared scrubber).
+    for (const p of prompts) {
+      expect(p).not.toContain('@synthetic.example')
+      expect(p).toContain('<email:1>')
+    }
   })
 })
 

--- a/frontend/tests/tours/judge/export/langfuse.ts
+++ b/frontend/tests/tours/judge/export/langfuse.ts
@@ -15,6 +15,7 @@
 import * as crypto from 'crypto'
 import * as fs from 'fs'
 import type { GenAiSpan } from '../adapter/span'
+import { createScrubber } from '../scrub'
 
 export interface LangfuseConfig {
   host: string
@@ -55,11 +56,34 @@ const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : und
 // PURE: build the trace body for one span. `mediaTokens` are the Langfuse media
 // references for this span's screenshots (already uploaded), spliced into the input
 // so the reviewer sees exactly what the judge saw.
-export function buildTraceBody(span: GenAiSpan, mediaTokens: string[] = []): TraceBody {
+//
+// PII scrub seam (arc INV-2): `scrub` is applied to every FREE-FORM or
+// ENV-SOURCED string this body ships to Langfuse — the prompt, the completion,
+// `metadata.error` (span.status.message, which is CAUGHT-EXCEPTION text that can
+// embed model output/evidence, so NOT PII-safe), AND `metadata.model`
+// (gen_ai.request.model is an env-configurable string, NOT constrained by
+// construction). The caller (`exportSpans`) injects the run's scrubber; the
+// default identity keeps this pure + leaves existing callers unaffected.
+// Every OTHER string here is identifier/enum-valued BY CONSTRUCTION and is
+// documented as such rather than scrubbed: the trace `name`/`behavior_id` = a
+// spec id (`judge <behavior_id>`), `impl`/`status` = closed enums in our code.
+// POLICY: any NEW free-form string field added to this body MUST route through
+// `scrub` — that is what INV-2 means operationally.
+export function buildTraceBody(
+  span: GenAiSpan,
+  mediaTokens: string[] = [],
+  scrub: (s: string) => string = s => s
+): TraceBody {
   const a = span.attributes
   const behaviorId = String(a['qa.behavior_id'] ?? 'unknown')
-  const prompt = str(a['gen_ai.prompt'])
-  const completion = str(a['gen_ai.completion'])
+  const rawPrompt = str(a['gen_ai.prompt'])
+  const rawCompletion = str(a['gen_ai.completion'])
+  const rawModel = str(a['gen_ai.request.model'])
+  const rawError = span.status.message
+  const prompt = rawPrompt !== undefined ? scrub(rawPrompt) : undefined
+  const completion = rawCompletion !== undefined ? scrub(rawCompletion) : undefined
+  const model = rawModel !== undefined ? scrub(rawModel) : a['gen_ai.request.model']
+  const error = rawError !== undefined ? scrub(rawError) : undefined
   const screenshots = Array.isArray(a['qa.screenshots']) ? (a['qa.screenshots'] as string[]) : []
 
   const input: Record<string, unknown> = {}
@@ -74,12 +98,12 @@ export function buildTraceBody(span: GenAiSpan, mediaTokens: string[] = []): Tra
     metadata: {
       behavior_id: behaviorId,
       impl: a['qa.judge.impl'],
-      model: a['gen_ai.request.model'],
+      model,
       input_tokens: num(a['gen_ai.usage.input_tokens']),
       output_tokens: num(a['gen_ai.usage.output_tokens']),
       tool_rejected: a['qa.tool_rejected'],
       status: span.status.code,
-      error: span.status.message,
+      error,
       duration_ms: Math.round((span.end_time_unix_nano - span.start_time_unix_nano) / 1e6),
       // Honesty: say how many screenshots the judge HAD vs how many made it here.
       // A silent gap between the two would misrepresent the evidence.
@@ -178,6 +202,11 @@ export async function exportSpans(
 ): Promise<ExportResult> {
   const result: ExportResult = { traces: 0, screenshots: 0, failed: 0 }
 
+  // One scrubber for the whole export so the same email/phone maps to the same
+  // placeholder across every span in this run (arc INV-2).
+  const scrubber = createScrubber()
+  const scrub = (s: string): string => scrubber.scrub(s)
+
   for (const span of spans) {
     const traceId = traceIdFor(span)
     try {
@@ -209,7 +238,7 @@ export async function exportSpans(
             id: `evt-${traceId}`,
             type: 'trace-create',
             timestamp: new Date().toISOString(),
-            body: buildTraceBody(span, tokens),
+            body: buildTraceBody(span, tokens, scrub),
           },
         ],
       })

--- a/frontend/tests/tours/judge/pii-patterns.ts
+++ b/frontend/tests/tours/judge/pii-patterns.ts
@@ -1,7 +1,7 @@
-// Shared PII pattern definitions — the SINGLE source used by BOTH the corpus
-// scrub (scrub.ts, which replaces matches) and the PII audit (pii-audit.ts,
-// which bans them). Keeping one source guarantees the audit bans exactly what
-// the scrub removes.
+// Shared PII pattern definitions — the SINGLE source used by BOTH the Langfuse
+// export scrub (scrub.ts, which replaces matches on the way out to Langfuse) and
+// the (soon-retiring) corpus PII audit (corpus/pii-audit.ts, which bans them).
+// Keeping one source guarantees the audit bans exactly what the scrub removes.
 
 // Email addresses.
 export const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g

--- a/frontend/tests/tours/judge/scrub.test.ts
+++ b/frontend/tests/tours/judge/scrub.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { createScrubber, scrubValue } from './scrub'
+import { EMAIL_RE, PHONE_RES } from './pii-patterns'
+
+describe('scrub email/phone → placeholders', () => {
+  it('maps emails to stable <email:N> placeholders (first-seen)', () => {
+    const s = createScrubber()
+    expect(s.scrub('reach synth-prodshaped-brux.dummond-52@synthetic.example now')).toBe(
+      'reach <email:1> now'
+    )
+    expect(s.scrub('a@b.com and synth-prodshaped-brux.dummond-52@synthetic.example')).toBe(
+      '<email:2> and <email:1>'
+    )
+  })
+
+  it('maps synthetic + international + bare 3-3-4 phones to <phone:N>', () => {
+    const s = createScrubber()
+    expect(s.scrub('call +1-479-555-0100 or (479) 555-0101 or 479-555-0102')).toBe(
+      'call <phone:1> or <phone:2> or <phone:3>'
+    )
+  })
+
+  it('preserves ISO dates and timestamps (NOT phone-shaped)', () => {
+    const s = createScrubber()
+    const kept = 'birthday 1990-05-05 occurred_at 2026-07-12T16:14:34.223608Z'
+    expect(s.scrub(kept)).toBe(kept)
+  })
+
+  it('deep-scrubs a nested value without mutating the input', () => {
+    const value = {
+      aria: { role: 'text', text: 'Keeping synth-x (brux@synthetic.example)' },
+      apiResponses: {
+        'GET /x': [{ body: { methods: [{ type: 'phone', value: '+1-479-555-0100' }] } }],
+      },
+    }
+    const scrubbed = scrubValue(value, createScrubber())
+    expect(JSON.stringify(scrubbed)).not.toMatch(EMAIL_RE)
+    for (const re of PHONE_RES) expect(JSON.stringify(scrubbed)).not.toMatch(re)
+    // input untouched
+    expect(value.aria.text).toContain('@synthetic.example')
+  })
+
+  it('scrubValue leaves non-strings alone', () => {
+    expect(scrubValue({ n: 5, b: true, x: null }, createScrubber())).toEqual({
+      n: 5,
+      b: true,
+      x: null,
+    })
+  })
+
+  it('double-scrub is a no-op — placeholders do not re-match the REs (safe anywhere)', () => {
+    const s = createScrubber()
+    const raw = 'reach brux@synthetic.example or call +1-479-555-0100'
+    const once = s.scrub(raw)
+    expect(s.scrub(once)).toBe(once)
+    // and the placeholders survived unchanged
+    expect(once).toBe('reach <email:1> or call <phone:1>')
+  })
+})

--- a/frontend/tests/tours/judge/scrub.ts
+++ b/frontend/tests/tours/judge/scrub.ts
@@ -1,0 +1,57 @@
+// Email/phone scrubber for the Langfuse export path (arc INV-2): every
+// free-form string that leaves for Langfuse is scrubbed HERE, at the export
+// boundary, so live captures never ship real-FORMAT emails/phones (the synthetic
+// factory emits `+1-479-555-0100`, `<name>@…`). Maps every email-shaped and
+// phone-shaped string to a stable first-seen placeholder (<email:N>/<phone:N>).
+//
+// The placeholders (<email:N>/<phone:N>) do NOT match the email/phone REs, so a
+// second scrub pass is a no-op — the seam is safe to sit anywhere without
+// corrupting an already-scrubbed string.
+//
+// Pure — no Playwright, no fs. Deep-walks a parsed value via scrubValue.
+
+import { EMAIL_RE, PHONE_RES } from './pii-patterns'
+
+export interface Scrubber {
+  scrub(value: string): string
+}
+
+// A first-seen map so the same email/phone → the same placeholder across every
+// string in a single scrub session (structure-preserving, PII-safe). One
+// scrubber per export run keeps placeholders stable within that export.
+export function createScrubber(): Scrubber {
+  const emails = new Map<string, string>()
+  const phones = new Map<string, string>()
+  const placeholder = (map: Map<string, string>, kind: string, key: string): string => {
+    let p = map.get(key)
+    if (!p) {
+      p = `<${kind}:${map.size + 1}>`
+      map.set(key, p)
+    }
+    return p
+  }
+  return {
+    scrub(value: string): string {
+      let out = value.replace(EMAIL_RE, m => placeholder(emails, 'email', m.toLowerCase()))
+      for (const re of PHONE_RES) {
+        out = out.replace(re, m => placeholder(phones, 'phone', m.replace(/\s+/g, '')))
+      }
+      return out
+    },
+  }
+}
+
+// Deep-walk a JSON value, scrubbing every string. Arrays/objects rebuilt so the
+// input is not mutated.
+export function scrubValue(value: unknown, scrubber: Scrubber): unknown {
+  if (typeof value === 'string') return scrubber.scrub(value)
+  if (Array.isArray(value)) return value.map(v => scrubValue(v, scrubber))
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = scrubValue(v, scrubber)
+    }
+    return out
+  }
+  return value
+}


### PR DESCRIPTION
**Step-4 corpus-retirement arc — PR1 of 4** (linear chain PR1→PR2→PR3→PR4). Plan: `.ai/log/plan/2026-07-15-corpus-retirement-pr1.md`.

Moves the email/phone PII scrub from curation-time into the Langfuse **export path**, establishing the single live→Langfuse PII chokepoint (arc INV-2) — the same seam #379's input-minimization needs.

## What changes
- Relocate shared PII patterns → `judge/pii-patterns.ts` and the scrubber (`createScrubber`/`scrubValue`) → `judge/scrub.ts`, out of the soon-retiring `corpus/` tree.
- Wire the scrubber into `export/langfuse.ts` so every free-form/env-sourced string in a shipped ingestion body — **prompt, completion, `metadata.error`** (caught-exception text), and **`metadata.model`** (env-configurable) — is scrubbed at the boundary before the HTTP call. Closes the live-run leak where captures shipped unscrubbed.
- `corpus/scrub.ts` keeps only the curation-specific `scrubCapture` wrapper; `pii-audit` re-points its patterns import. No behavior change to the offline report.

## Tests
- New `judge/scrub.test.ts` (relocated + deep-walk + idempotence, all 3 phone formats incl. bare 3-3-4).
- Extended `export/langfuse.test.ts`: scrub coverage for prompt/completion/`metadata.error`/`metadata.model`, plus the non-string model fallback.
- `bun run typecheck` + `make lint` + `make test-frontend` (591) green.

## Review
- Codex (gpt-5.6-sol): PASS, P0=0 P1=0 (2 P2 test-coverage adds folded in).