### PR TITLE
test(settings): E2E settlement child 3 — settings/mac/telegram relax + cite

### DIFF
--- a/backend/tests/api/mac_host_get_admin_test.go
+++ b/backend/tests/api/mac_host_get_admin_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// hostDetailView mirrors the MacHostView fields this test asserts on.
+type hostDetailView struct {
+	ID              uuid.UUID  `json:"id"`
+	Hostname        string     `json:"hostname"`
+	APIKeyRevokedAt *time.Time `json:"api_key_revoked_at,omitempty"`
+}
+
+// TestMacHost_GetAdmin_DetailView covers the admin host-detail read:
+// a live host is returned, a revoked host is still returned (the admin
+// view does not filter revocation), and an unknown id is 404.
+// spec: MAC-018[1]
+func TestMacHost_GetAdmin_DetailView(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+	ctx := context.Background()
+	headers := map[string]string{"X-API-Key": env.apiKey}
+
+	// Live host (the singleton index allows one live host at a time).
+	liveName := "get-admin-live-" + uuid.NewString()[:8]
+	live, err := env.hostRepo.SeedHostForTest(ctx, liveName, "0.1.0", 1, "$2a$04$live", nil, nil)
+	require.NoError(t, err)
+
+	w := macHTTP(t, env, http.MethodGet, "/api/v1/host/"+live.ID.String(), headers, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var view hostDetailView
+	readData(t, w, &view)
+	require.Equal(t, live.ID, view.ID)
+	require.Equal(t, liveName, view.Hostname)
+	require.Nil(t, view.APIKeyRevokedAt, "live host must not carry a revocation timestamp")
+
+	// Revoked host: the detail view returns it rather than 404ing.
+	revokedName := "get-admin-revoked-" + uuid.NewString()[:8]
+	revoked, err := env.hostRepo.SeedRevokedHostForTest(ctx, revokedName, "0.1.0", 1, "$2a$04$rvkd")
+	require.NoError(t, err)
+
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+revoked.ID.String(), headers, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	view = hostDetailView{}
+	readData(t, w, &view)
+	require.Equal(t, revoked.ID, view.ID)
+	require.Equal(t, revokedName, view.Hostname)
+	require.NotNil(t, view.APIKeyRevokedAt, "revoked host must carry its revocation timestamp")
+
+	// Unknown id is not-found.
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+uuid.New().String(), headers, nil)
+	require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.String())
+}
+
+// TestMacHost_GetAdmin_BadID_400 confirms the handler rejects a
+// non-UUID path param at validation before touching the service.
+func TestMacHost_GetAdmin_BadID_400(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+	headers := map[string]string{"X-API-Key": env.apiKey}
+	w := macHTTP(t, env, http.MethodGet, "/api/v1/host/not-a-uuid", headers, nil)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+}
+
+// TestMacHost_GetAdmin_Unauthenticated_401 covers the admin-auth path:
+// without the global API key, the detail read is rejected.
+func TestMacHost_GetAdmin_Unauthenticated_401(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+	ctx := context.Background()
+	host, err := env.hostRepo.SeedRevokedHostForTest(ctx,
+		"get-admin-noauth-"+uuid.NewString()[:8], "0.0.0", 1, "$2a$04$nA")
+	require.NoError(t, err)
+
+	w := macHTTP(t, env, http.MethodGet, "/api/v1/host/"+host.ID.String(), nil, nil)
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}

--- a/backend/tests/api/mac_host_source_counts_test.go
+++ b/backend/tests/api/mac_host_source_counts_test.go
@@ -98,6 +98,7 @@ func TestMacHost_GetSourceCounts_HappyPath(t *testing.T) {
 // TestMacHost_GetSourceCounts_UnknownHost_404 covers the host-existence
 // pre-check: an unknown host id returns 404 (not 200 with empty
 // counts).
+// spec: MAC-018[2]
 func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -110,6 +111,7 @@ func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
 // TestMacHost_GetSourceCounts_NoRowsReturnsEmpty asserts that a host
 // with no external_contact rows returns 200 with counts={} rather than
 // 404 or 500.
+// spec: MAC-018[2]
 func TestMacHost_GetSourceCounts_NoRowsReturnsEmpty(t *testing.T) {
 
 	env := setupMacHostEnv(t)

--- a/frontend/src/app/settings/mac/__tests__/cursor-cell.test.ts
+++ b/frontend/src/app/settings/mac/__tests__/cursor-cell.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { renderCursorCell } from '../cursor-cell'
+import { cursorCellState, renderCursorCell } from '../cursor-cell'
 
 describe('renderCursorCell', () => {
   it('renders contact count for icloud_contacts when backfill_complete and counts loaded', () => {
@@ -22,13 +22,20 @@ describe('renderCursorCell', () => {
     expect(out).toBe('—')
   })
 
-  it('renders existing cursor for icloud_contacts when backfill_complete is false', () => {
+  it('never renders the change-token for icloud_contacts while backfill is incomplete', () => {
+    // Mid-backfill with a pushed cursor is the normal state the #327
+    // complaint was about: the change-token must not be displayed.
     const out = renderCursorCell(
       'icloud_contacts',
       { backfill_complete: false, pushed_cursor: 'changeToken123' },
       { icloud_contacts: 99 }
     )
-    expect(out).toBe('changeToken123')
+    expect(out).toBe('—')
+  })
+
+  it('renders the dash for icloud_contacts when backfill_complete is absent', () => {
+    const out = renderCursorCell('icloud_contacts', { pushed_cursor: 'changeToken123' }, undefined)
+    expect(out).toBe('—')
   })
 
   it('renders existing cursor for messages regardless of backfill_complete', () => {
@@ -85,5 +92,34 @@ describe('renderCursorCell', () => {
   it('falls back to raw cursor when phone_calls cursor cannot be parsed', () => {
     const out = renderCursorCell('phone_calls', { pushed_cursor: 'malformed-cursor' }, undefined)
     expect(out).toBe('malformed-cursor')
+  })
+})
+
+describe('cursorCellState', () => {
+  // State and rendering must agree: 'count' iff the count is rendered,
+  // 'pending' iff the backfill-source placeholder is rendered, 'cursor'
+  // for the ordinary cursor/dash rendering.
+  it('is count exactly when the count renders', () => {
+    const entry = { backfill_complete: true }
+    const counts = { icloud_contacts: 3 }
+    expect(cursorCellState('icloud_contacts', entry, counts)).toBe('count')
+    expect(renderCursorCell('icloud_contacts', entry, counts)).toBe('3 contacts ✓')
+  })
+
+  it('is pending with the dash rendered while backfill is incomplete, even with a cursor', () => {
+    const entry = { backfill_complete: false, pushed_cursor: 'changeToken123' }
+    expect(cursorCellState('icloud_contacts', entry, undefined)).toBe('pending')
+    expect(renderCursorCell('icloud_contacts', entry, undefined)).toBe('—')
+  })
+
+  it('is pending with the dash rendered when backfill is complete but counts are missing', () => {
+    const entry = { backfill_complete: true }
+    expect(cursorCellState('icloud_contacts', entry, {})).toBe('pending')
+    expect(renderCursorCell('icloud_contacts', entry, {})).toBe('—')
+  })
+
+  it('is cursor for non-backfill sources', () => {
+    expect(cursorCellState('messages', { pushed_cursor: '123' }, undefined)).toBe('cursor')
+    expect(cursorCellState('messages', {}, undefined)).toBe('cursor')
   })
 })

--- a/frontend/src/app/settings/mac/cursor-cell.ts
+++ b/frontend/src/app/settings/mac/cursor-cell.ts
@@ -51,6 +51,30 @@ function formatPhoneCallsCursor(raw: string): string {
   return match ? match[1] : raw
 }
 
+/**
+ * cursorCellState classifies the Cursor cell for state-based test
+ * assertions (exposed on the td as `data-state`): 'count' when a
+ * backfill-complete source renders its live contact count, 'pending'
+ * when a backfill-progress source has no count to show yet (backfill
+ * incomplete, or counts not loaded), and 'cursor' for every other
+ * source (raw cursor or dash rendering).
+ */
+export type CursorCellState = 'count' | 'pending' | 'cursor'
+
+export function cursorCellState(
+  source: string,
+  entry: SourceHealthEntry,
+  counts: Record<string, number> | undefined
+): CursorCellState {
+  if (BACKFILL_PROGRESS_SOURCES.has(source)) {
+    if (entry.backfill_complete === true && typeof counts?.[source] === 'number') {
+      return 'count'
+    }
+    return 'pending'
+  }
+  return 'cursor'
+}
+
 export function renderCursorCell(
   source: string,
   entry: SourceHealthEntry,

--- a/frontend/src/app/settings/mac/cursor-cell.ts
+++ b/frontend/src/app/settings/mac/cursor-cell.ts
@@ -15,13 +15,14 @@ export interface SourceHealthEntry {
  * renderCursorCell decides what to display in the Cursor column for
  * a single source row (issue #327).
  *
- * The interim fix is narrow: when a source is in
- * `BACKFILL_PROGRESS_SOURCES` and its `backfill_complete` flag is
- * true, swap the dash for `<N> contacts ✓` where `N` is the live
- * external_contact row count for that host+source. Everything else
- * falls through to the previous `pushed_cursor ?? observed_cursor ??
- * '—'` rendering — so messages keeps its rowid, phone_calls renders
- * its own cursor, etc.
+ * Sources in `BACKFILL_PROGRESS_SOURCES` never display their raw
+ * cursor: it is an opaque change-token that misleads the operator
+ * (the original #327 complaint). Once `backfill_complete` is true and
+ * the live count has loaded, the cell shows `<N> contacts ✓`; in every
+ * other state (backfill in progress, or counts not loaded yet) it
+ * shows the neutral dash. All other sources keep the
+ * `pushed_cursor ?? observed_cursor ?? '—'` rendering — messages keeps
+ * its rowid, phone_calls renders its own cursor, etc.
  *
  * Future sources that ship a 'caught up' indicator should add their
  * key to `BACKFILL_PROGRESS_SOURCES` rather than adding more
@@ -56,7 +57,8 @@ function formatPhoneCallsCursor(raw: string): string {
  * assertions (exposed on the td as `data-state`): 'count' when a
  * backfill-complete source renders its live contact count, 'pending'
  * when a backfill-progress source has no count to show yet (backfill
- * incomplete, or counts not loaded), and 'cursor' for every other
+ * incomplete, or counts not loaded — renderCursorCell shows the
+ * neutral dash for exactly these), and 'cursor' for every other
  * source (raw cursor or dash rendering).
  */
 export type CursorCellState = 'count' | 'pending' | 'cursor'
@@ -80,15 +82,18 @@ export function renderCursorCell(
   entry: SourceHealthEntry,
   counts: Record<string, number> | undefined
 ): string {
-  if (BACKFILL_PROGRESS_SOURCES.has(source) && entry.backfill_complete === true) {
-    const n = counts?.[source]
-    if (typeof n === 'number') {
-      return `${n} contacts ✓`
+  if (BACKFILL_PROGRESS_SOURCES.has(source)) {
+    if (entry.backfill_complete === true) {
+      const n = counts?.[source]
+      if (typeof n === 'number') {
+        return `${n} contacts ✓`
+      }
     }
-    // counts not yet loaded / missing — graceful fallback to dash so
-    // the row still renders. We deliberately don't fall through to
-    // the pushed_cursor branch because an iCloud row's cursor is a
-    // change-token, not a number (the whole point of #327).
+    // Backfill in progress, or counts not yet loaded — neutral dash.
+    // We deliberately never fall through to the cursor branch for
+    // these sources: an iCloud row's cursor is a change-token, not a
+    // number, and displaying it misled the operator (the whole point
+    // of #327).
     return '—'
   }
   const cursor = cursorToString(entry.pushed_cursor) ?? cursorToString(entry.observed_cursor)

--- a/frontend/src/app/settings/mac/page.tsx
+++ b/frontend/src/app/settings/mac/page.tsx
@@ -13,7 +13,7 @@ import {
   useMacHosts,
 } from '@/hooks/use-mac-hosts'
 import type { MacHost } from '@/lib/mac-hosts-api'
-import { renderCursorCell, type SourceHealthEntry } from './cursor-cell'
+import { cursorCellState, renderCursorCell, type SourceHealthEntry } from './cursor-cell'
 import { RotateKeyModal } from './rotate-key-modal'
 
 const HEARTBEAT_FRESH_MS = 5 * 60 * 1000
@@ -465,7 +465,11 @@ function SourceHealthTable({ health, hostId }: SourceHealthTableProps) {
                 <td className="px-2 py-1 text-gray-700">
                   {entry.last_pushed_at ? new Date(entry.last_pushed_at).toLocaleString() : '—'}
                 </td>
-                <td className="px-2 py-1 font-mono text-gray-700 truncate max-w-xs">
+                <td
+                  className="px-2 py-1 font-mono text-gray-700 truncate max-w-xs"
+                  data-testid="cursor-cell"
+                  data-state={cursorCellState(source, entry, counts)}
+                >
                   {renderCursorCell(source, entry, counts)}
                 </td>
                 <td className="px-2 py-1 text-red-700">

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -310,7 +310,10 @@ export default function SettingsPage() {
           </section>
 
           {/* System Information */}
-          <section className="bg-white rounded-lg shadow-sm border p-6">
+          <section
+            aria-label="System Information"
+            className="bg-white rounded-lg shadow-sm border p-6"
+          >
             <div className="flex items-center space-x-3 mb-4">
               <Shield className="w-6 h-6 text-purple-600" />
               <h2 className="text-xl font-semibold text-gray-900">System Information</h2>
@@ -319,7 +322,7 @@ export default function SettingsPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
               <div>
                 <p className="text-gray-600">Version</p>
-                <p className="font-medium text-gray-900">
+                <p className="font-medium text-gray-900" data-testid="app-version">
                   {(() => {
                     const version = process.env.NEXT_PUBLIC_BUILD_VERSION
                     const hash = process.env.NEXT_PUBLIC_COMMIT_HASH

--- a/frontend/src/components/settings/google-accounts-section.tsx
+++ b/frontend/src/components/settings/google-accounts-section.tsx
@@ -236,7 +236,7 @@ export function GoogleAccountsSection() {
   const hasAccounts = !isLoading && !error && accounts && accounts.length > 0
 
   return (
-    <section className="bg-white rounded-lg shadow-sm border p-6">
+    <section aria-label="Google Accounts" className="bg-white rounded-lg shadow-sm border p-6">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center space-x-3">
@@ -348,6 +348,7 @@ export function GoogleAccountsSection() {
                     loading={revokeMutation.isPending}
                     variant="ghost"
                     size="sm"
+                    aria-label={`Disconnect ${account.account_id}`}
                     className="text-red-600 hover:text-red-700 hover:bg-red-50"
                   >
                     <Trash2 className="w-4 h-4" />

--- a/frontend/src/components/settings/sync-badge.tsx
+++ b/frontend/src/components/settings/sync-badge.tsx
@@ -31,6 +31,7 @@ export function SyncBadge({ label, syncState, onSync, loading }: SyncBadgeProps)
       <button
         onClick={onSync}
         disabled={loading || isSyncing}
+        aria-label={`Sync ${label}`}
         className="px-2 py-1 text-blue-600 hover:bg-blue-50 border-l border-gray-200 disabled:opacity-50"
       >
         <RefreshCw className={`w-3 h-3 ${loading || isSyncing ? 'animate-spin' : ''}`} />

--- a/frontend/src/components/settings/telegram-section.tsx
+++ b/frontend/src/components/settings/telegram-section.tsx
@@ -150,7 +150,7 @@ export function TelegramSection() {
   }
 
   return (
-    <section className="bg-white rounded-lg shadow-sm border p-6">
+    <section aria-label="Telegram" className="bg-white rounded-lg shadow-sm border p-6">
       {/* Header */}
       <div className="flex items-center space-x-3 mb-2">
         <Send className="w-6 h-6 text-blue-500" />
@@ -481,6 +481,7 @@ function TelegramChatList() {
           </div>
           <select
             value={chat.status}
+            aria-label={`Tracking for ${chat.chat_title || 'Untitled'}`}
             onChange={e =>
               updateStatus.mutate({
                 chatId: chat.telegram_chat_id,

--- a/frontend/src/components/settings/todoist-accounts-section.tsx
+++ b/frontend/src/components/settings/todoist-accounts-section.tsx
@@ -177,7 +177,7 @@ export function TodoistAccountsSection() {
   const isConfigured = settings?.project_id && settings?.label_id
 
   return (
-    <section className="bg-white rounded-lg shadow-sm border p-6">
+    <section aria-label="Todoist" className="bg-white rounded-lg shadow-sm border p-6">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center space-x-3">
@@ -296,6 +296,7 @@ export function TodoistAccountsSection() {
                       loading={revokeMutation.isPending}
                       variant="ghost"
                       size="sm"
+                      aria-label={`Disconnect ${account.account_name || account.account_id}`}
                       className="text-red-600 hover:text-red-700 hover:bg-red-50"
                     >
                       <Trash2 className="w-4 h-4" />
@@ -337,6 +338,7 @@ export function TodoistAccountsSection() {
                       <select
                         value={selectedProjectId}
                         onChange={e => handleProjectChange(e.target.value)}
+                        aria-label="Project"
                         disabled={projectsLoading || updateSettingsMutation.isPending}
                         className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md bg-white appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
                       >
@@ -358,6 +360,7 @@ export function TodoistAccountsSection() {
                       <select
                         value={selectedLabelId}
                         onChange={e => handleLabelChange(e.target.value)}
+                        aria-label="Label"
                         disabled={labelsLoading || updateSettingsMutation.isPending}
                         className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md bg-white appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
                       >

--- a/frontend/src/hooks/use-telegram.ts
+++ b/frontend/src/hooks/use-telegram.ts
@@ -60,6 +60,15 @@ export function useDisconnectTelegram() {
   return useMutation({
     mutationFn: () => telegramApi.disconnect(),
     onSuccess: () => {
+      // Snap the cached status to disconnected before invalidating: the
+      // settings section re-derives its step from the cached status, and
+      // leaving the stale connected payload in place flips the view back
+      // to connected before the refetch lands — after which nothing moves
+      // it to disconnected again.
+      queryClient.setQueryData(telegramKeys.status(), {
+        status: 'disconnected',
+        connected: false,
+      })
       queryClient.invalidateQueries({ queryKey: telegramKeys.status() })
     },
   })

--- a/frontend/tests/e2e/settings-mac.spec.ts
+++ b/frontend/tests/e2e/settings-mac.spec.ts
@@ -45,21 +45,27 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
   // interfere with each other.
   test.describe.configure({ mode: 'serial' })
 
+  // spec: MAC-018[0]
   test('renders empty-state when no Mac hosts are paired', async ({ page, request }) => {
     await deleteAllMacHosts(request)
+    const listPromise = page.waitForResponse(
+      resp => resp.url().endsWith('/api/v1/host') && resp.request().method() === 'GET',
+      { timeout: 15_000 }
+    )
     await page.goto('/settings/mac', { waitUntil: 'domcontentloaded' })
+    const listResp = await listPromise
 
-    await expect(page.getByRole('heading', { name: 'Mac Daemon' })).toBeVisible({
-      timeout: 10_000,
-    })
-    // Pair-new-Mac CTA + back link are always rendered.
-    await expect(page.getByRole('button', { name: 'Pair new Mac' })).toBeVisible()
-    await expect(page.getByRole('link', { name: /Back to Settings/i })).toBeVisible()
+    // The list endpoint reports no live hosts (the zero-facet of "the list
+    // returns the live hosts")…
+    const body = (await listResp.json()) as { data: unknown[] }
+    expect(body.data ?? []).toHaveLength(0)
 
-    // Empty-state messaging.
-    await expect(page.getByText('No Mac hosts paired')).toBeVisible()
+    // …and the page reflects it: empty-state render gate, zero host rows.
+    await expect(page.getByText('No Mac hosts paired')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('mac-host-row')).toHaveCount(0)
   })
 
+  // spec: MAC-018[3]
   test('opens pairing modal with a token when Pair new Mac is clicked', async ({
     page,
     request,
@@ -105,6 +111,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await expect(dialog).not.toBeVisible()
   })
 
+  // spec: MAC-018[0]
   test('renders paired host with permissions and source-health badges', async ({
     page,
     request,
@@ -161,6 +168,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await deleteAllMacHosts(request)
   })
 
+  // spec: MAC-046[0]
   test('renders icloud_contacts contact count when backfill_complete (#327)', async ({
     page,
     request,
@@ -216,14 +224,18 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     const sourceHealth = row.getByTestId('source-health')
     await expect(sourceHealth).toBeVisible()
 
-    // The Cursor cell renders the contact count + checkmark instead of
-    // the misleading change-token / dash.
-    await expect(sourceHealth.getByText('3 contacts ✓')).toBeVisible()
+    // The Cursor cell substitutes the live contact count (3 seeded rows)
+    // for the misleading change-token / dash. The checkmark glyph is
+    // presentation — assert the count and the cell's state instead.
+    const cursorCell = sourceHealth.getByTestId('cursor-cell')
+    await expect(cursorCell).toHaveText(/3 contacts/)
+    await expect(cursorCell).toHaveAttribute('data-state', 'count')
 
     // Cleanup.
     await deleteAllMacHosts(request)
   })
 
+  // spec: MAC-046[1]
   test('renders dash for icloud_contacts when backfill_complete is false (#327)', async ({
     page,
     request,
@@ -255,15 +267,15 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     const sourceHealth = row.getByTestId('source-health')
     await expect(sourceHealth).toBeVisible({ timeout: 10_000 })
 
-    // While backfill is in progress, the cell stays as a dash; no
-    // numeric substitution happens.
-    const rows = sourceHealth.locator('tbody tr')
-    const icloudRow = rows.first()
-    await expect(icloudRow.locator('td').nth(2)).toHaveText('—')
+    // While backfill is in progress, the cell stays in its no-count state;
+    // no numeric substitution happens.
+    await expect(sourceHealth.getByTestId('cursor-cell')).toHaveAttribute('data-state', 'pending')
+    await expect(sourceHealth.getByText(/\d+ contacts/)).toHaveCount(0)
 
     await deleteAllMacHosts(request)
   })
 
+  // spec: MAC-018[3]
   test('opens rotate-key modal with templated CLI command when Rotate Key is clicked', async ({
     page,
     request,
@@ -323,6 +335,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await deleteAllMacHosts(request)
   })
 
+  // spec: MAC-018[3], MAC-018[0]
   test('uninstall flow removes a paired host', async ({ page, request }) => {
     await deleteAllMacHosts(request)
     await seedMacHost(request, { hostname: 'e2e-uninstall-me', protocol_version: 1 })
@@ -348,7 +361,8 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     const deleteResp = await deleteResponsePromise
     expect(deleteResp.status()).toBe(200)
 
-    // Row disappears, empty-state returns.
-    await expect(page.getByText('No Mac hosts paired')).toBeVisible({ timeout: 10_000 })
+    // The removal is reflected in the live list: the host's row is gone.
+    await expect(page.getByTestId('mac-host-row')).toHaveCount(0, { timeout: 10_000 })
+    await expect(page.getByText('e2e-uninstall-me')).toHaveCount(0)
   })
 })

--- a/frontend/tests/e2e/settings-mac.spec.ts
+++ b/frontend/tests/e2e/settings-mac.spec.ts
@@ -45,32 +45,34 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
   // interfere with each other.
   test.describe.configure({ mode: 'serial' })
 
-  // spec: MAC-018[0]
-  test('renders empty-state when no Mac hosts are paired', async ({ page, request }) => {
-    await deleteAllMacHosts(request)
-    const listPromise = page.waitForResponse(
-      resp => resp.url().endsWith('/api/v1/host') && resp.request().method() === 'GET',
-      { timeout: 15_000 }
+  test('renders empty-state when no Mac hosts are paired', async ({ page }) => {
+    // The zero-host rendering branch, driven by mocking the list endpoint:
+    // the shared mac_host singleton table is seeded/reset by parallel
+    // workers (imports-interactions.spec.ts), so asserting real-API global
+    // emptiness is racy and would mean deleting hosts other tests own. The
+    // real-API list facet (MAC-018[0]) is covered by the seeded-host and
+    // uninstall tests below; this test is uncited (the mock replaces the
+    // endpoint the behavior describes).
+    await page.route('**/api/v1/host', route =>
+      route.request().method() === 'GET'
+        ? route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ success: true, data: [] }),
+          })
+        : route.fallback()
     )
+
     await page.goto('/settings/mac', { waitUntil: 'domcontentloaded' })
-    const listResp = await listPromise
 
-    // The list endpoint reports no live hosts (the zero-facet of "the list
-    // returns the live hosts")…
-    const body = (await listResp.json()) as { data: unknown[] }
-    expect(body.data ?? []).toHaveLength(0)
-
-    // …and the page reflects it: empty-state render gate, zero host rows.
     await expect(page.getByText('No Mac hosts paired')).toBeVisible({ timeout: 10_000 })
     await expect(page.getByTestId('mac-host-row')).toHaveCount(0)
   })
 
   // spec: MAC-018[3]
-  test('opens pairing modal with a token when Pair new Mac is clicked', async ({
-    page,
-    request,
-  }) => {
-    await deleteAllMacHosts(request)
+  test('opens pairing modal with a token when Pair new Mac is clicked', async ({ page }) => {
+    // No host seeding or reset needed: the pairing modal works regardless
+    // of how many hosts are listed (parallel workers may own one).
     // Wait for the initial GET /host response BEFORE clicking — this
     // proves React Query has mounted on the page and hydration is
     // complete, otherwise the click handler can fire against an
@@ -81,10 +83,6 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     )
     await page.goto('/settings/mac', { waitUntil: 'domcontentloaded' })
     await initialListPromise
-
-    // Wait for the empty-state to confirm the list query resolved + render
-    // pass completed.
-    await expect(page.getByText('No Mac hosts paired')).toBeVisible({ timeout: 10_000 })
 
     const pairButton = page.getByRole('button', { name: 'Pair new Mac' })
     await expect(pairButton).toBeVisible()
@@ -252,6 +250,9 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
         icloud_contacts: {
           last_pushed_at: '2026-05-01T00:00:00Z',
           backfill_complete: false,
+          // A pushed change-token is the NORMAL mid-backfill state — the
+          // cell must show the placeholder, never this opaque token.
+          pushed_cursor: 'e2e-change-token-xyz',
         },
       },
     })
@@ -267,10 +268,11 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     const sourceHealth = row.getByTestId('source-health')
     await expect(sourceHealth).toBeVisible({ timeout: 10_000 })
 
-    // While backfill is in progress, the cell stays in its no-count state;
-    // no numeric substitution happens.
+    // While backfill is in progress, the cell stays in its no-count state:
+    // no numeric substitution, and the raw change-token is never shown.
     await expect(sourceHealth.getByTestId('cursor-cell')).toHaveAttribute('data-state', 'pending')
     await expect(sourceHealth.getByText(/\d+ contacts/)).toHaveCount(0)
+    await expect(sourceHealth.getByText('e2e-change-token-xyz')).toHaveCount(0)
 
     await deleteAllMacHosts(request)
   })
@@ -361,8 +363,11 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     const deleteResp = await deleteResponsePromise
     expect(deleteResp.status()).toBe(200)
 
-    // The removal is reflected in the live list: the host's row is gone.
-    await expect(page.getByTestId('mac-host-row')).toHaveCount(0, { timeout: 10_000 })
-    await expect(page.getByText('e2e-uninstall-me')).toHaveCount(0)
+    // The removal is reflected in the live list: this test's host row is
+    // gone (scoped to the seeded hostname — a parallel worker may own an
+    // unrelated host at this moment).
+    await expect(
+      page.getByTestId('mac-host-row').filter({ hasText: 'e2e-uninstall-me' })
+    ).toHaveCount(0, { timeout: 10_000 })
   })
 })

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -57,7 +57,6 @@ const todoistRegion = (page: Page) => page.getByRole('region', { name: 'Todoist'
 
 const GMAIL_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly'
 const CALENDAR_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly'
-const CONTACTS_SCOPE = 'https://www.googleapis.com/auth/contacts.readonly'
 const CHAT_SCOPES = [
   'https://www.googleapis.com/auth/chat.spaces.readonly',
   'https://www.googleapis.com/auth/chat.messages.readonly',

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -1,26 +1,16 @@
 import { test, expect, type Page, type Route } from '@playwright/test'
 
 // The provider sections talk to the app's own account/status endpoints, and
-// the sandbox/CI deployment has no GOOGLE_*/TODOIST_* credentials — so every
-// provider-state test here route-mocks those endpoints (the sanctioned
+// the sandbox/CI deployment has no GOOGLE_*/TODOIST_* credentials — so the
+// provider-state tests here route-mock those endpoints (the sanctioned
 // technique) to force each state deterministically, independent of env.
-//
-// The app calls the API cross-origin (frontend :3000 → API :8080) with an
-// X-API-Key header, so fulfilled responses answer the CORS preflight and
-// carry Access-Control-Allow-Origin.
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
-}
+// One live-backend smoke test stays unmocked so a real endpoint-shape
+// regression cannot hide behind the mocks.
 
-function corsFulfill(route: Route, body: unknown, status = 200) {
-  if (route.request().method() === 'OPTIONS') {
-    return route.fulfill({ status: 204, headers: corsHeaders })
-  }
+function fulfillJson(route: Route, body: unknown, status = 200) {
   return route.fulfill({
     status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    contentType: 'application/json',
     body: JSON.stringify(body),
   })
 }
@@ -33,22 +23,22 @@ const notFoundBody = { success: false, error: { code: 'NOT_FOUND', message: 'not
 async function mockGoogleAccounts(page: Page, accounts: unknown[] | null) {
   await page.route('**/api/v1/auth/google/accounts', route =>
     accounts === null
-      ? corsFulfill(route, notFoundBody, 404)
-      : corsFulfill(route, { success: true, data: accounts })
+      ? fulfillJson(route, notFoundBody, 404)
+      : fulfillJson(route, { success: true, data: accounts })
   )
 }
 
 async function mockTodoistAccounts(page: Page, accounts: unknown[] | null) {
   await page.route('**/api/v1/auth/todoist/accounts', route =>
     accounts === null
-      ? corsFulfill(route, notFoundBody, 404)
-      : corsFulfill(route, { success: true, data: accounts })
+      ? fulfillJson(route, notFoundBody, 404)
+      : fulfillJson(route, { success: true, data: accounts })
   )
 }
 
 async function mockSyncStates(page: Page, states: unknown[]) {
   await page.route('**/api/v1/sync/status', route =>
-    corsFulfill(route, { success: true, data: states })
+    fulfillJson(route, { success: true, data: states })
   )
 }
 
@@ -63,9 +53,12 @@ const CHAT_SCOPES = [
   'https://www.googleapis.com/auth/chat.memberships.readonly',
 ]
 
+// The credential row id and the provider account id are DIFFERENT values on
+// the wire (revoke takes the credential id, not the account id) — keep them
+// distinct in fixtures so an id/account_id mix-up is detectable.
 function googleAccount(accountId: string, overrides: Record<string, unknown> = {}) {
   return {
-    id: accountId,
+    id: `cred-${accountId}`,
     account_id: accountId,
     created_at: '2026-01-05T12:00:00Z',
     updated_at: '2026-01-05T12:00:00Z',
@@ -75,6 +68,42 @@ function googleAccount(accountId: string, overrides: Record<string, unknown> = {
 }
 
 test.describe('Settings Page @area:settings', () => {
+  // formatDate renders via toLocaleDateString — pin the browser locale and
+  // timezone so date assertions don't depend on the host machine.
+  test.use({ locale: 'en-US', timezoneId: 'UTC' })
+
+  // Live-backend smoke: deliberately NO route mocks. Whatever the
+  // deployment's provider configuration, the real accounts/status endpoints
+  // must leave every provider section settled — an account state or a
+  // not-connected state, never a hung loader or an error stack. Guards the
+  // real endpoint shapes that the mocked tests in this file replace.
+  test('provider sections settle against the live backend', async ({ page }) => {
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    await expect(
+      google
+        .getByRole('button', { name: /Connect Google Account/i })
+        .or(google.getByRole('button', { name: 'Add Account' }))
+    ).toBeVisible({ timeout: 15_000 })
+
+    const todoist = todoistRegion(page)
+    await expect(
+      todoist
+        .getByRole('button', { name: /Connect Todoist Account/i })
+        .or(todoist.getByRole('button', { name: 'Connect Account' }))
+    ).toBeVisible({ timeout: 15_000 })
+
+    const telegram = page.getByRole('region', { name: 'Telegram' })
+    await expect(
+      telegram
+        .getByRole('button', { name: /Connect Telegram/i })
+        .or(telegram.getByText('Configuration Required'))
+        .or(telegram.getByRole('button', { name: /Disconnect/i }))
+    ).toBeVisible({ timeout: 15_000 })
+  })
+
   // spec: SET-019[0], SET-023[0], SET-023[1]
   test('unconfigured providers collapse to a not-connected state with setup guidance', async ({
     page,
@@ -120,7 +149,8 @@ test.describe('Settings Page @area:settings', () => {
 
     const google = googleRegion(page)
     // The account identity and its connected date (mocked created_at
-    // 2026-01-05, rendered by formatDate) appear on the card.
+    // 2026-01-05, rendered by formatDate under the pinned en-US/UTC
+    // context) appear on the card.
     await expect(google.getByText('e2e-google-user')).toBeVisible({ timeout: 10_000 })
     await expect(google.getByText(/Connected Jan 5, 2026/)).toBeVisible()
 
@@ -135,7 +165,7 @@ test.describe('Settings Page @area:settings', () => {
     // Stub the provider consent screen with a same-origin URL so the
     // whole-page navigation is observable without a live provider.
     await page.route('**/api/v1/auth/google', route =>
-      corsFulfill(route, {
+      fulfillJson(route, {
         success: true,
         data: { url: '/settings?consent-stub=1', state: 'e2e-state' },
       })
@@ -161,11 +191,14 @@ test.describe('Settings Page @area:settings', () => {
   test('a success outcome shows a notification, refreshes accounts, and strips params', async ({
     page,
   }) => {
-    let accountListGets = 0
-    await page.route('**/api/v1/auth/google/accounts', route => {
-      if (route.request().method() === 'GET') accountListGets++
-      return corsFulfill(route, { success: true, data: [googleAccount('e2e-google-user')] })
-    })
+    // The refresh facet is proven by the freshly-connected account being
+    // visible after the success landing. It cannot be pinned to a SECOND
+    // accounts GET: the success handler's refetch() dedupes into the
+    // in-flight mount fetch (React Query collapses them into one request —
+    // verified empirically with a flip-on-second-read mock, which never saw
+    // a second read), and the ?auth=success landing is always a full-page
+    // redirect, so the mount fetch is the refresh on every reachable path.
+    await mockGoogleAccounts(page, [googleAccount('e2e-google-user')])
     await mockSyncStates(page, [])
 
     await page.goto('/settings?auth=success&provider=google')
@@ -175,13 +208,10 @@ test.describe('Settings Page @area:settings', () => {
     await expect(googleRegion(page).getByText(/connected successfully/i)).toBeVisible({
       timeout: 10_000,
     })
-    // …the account list is fetched on the outcome landing and reflects the
-    // connected account. (The success handler's explicit refetch coalesces
-    // with the in-flight initial fetch — React Query dedupe — so asserting
-    // a second GET would over-specify; the observable claim is a fresh
-    // fetch plus the account rendered.)
-    await expect.poll(() => accountListGets, { timeout: 10_000 }).toBeGreaterThanOrEqual(1)
-    await expect(googleRegion(page).getByText('e2e-google-user')).toBeVisible()
+    // …the landing surfaces the newly-connected account…
+    await expect(googleRegion(page).getByText('e2e-google-user')).toBeVisible({
+      timeout: 10_000,
+    })
     // …and the one-time params are stripped so refresh does not re-trigger.
     await expect(page).toHaveURL('/settings', { timeout: 10_000 })
   })
@@ -207,8 +237,8 @@ test.describe('Settings Page @area:settings', () => {
     await mockSyncStates(page, [])
     let revokeCalled = false
     await page.route('**/api/v1/auth/google/accounts/*/revoke', route => {
-      if (route.request().method() !== 'OPTIONS') revokeCalled = true
-      return corsFulfill(route, { success: true, data: { message: 'revoked' } })
+      if (route.request().method() === 'POST') revokeCalled = true
+      return fulfillJson(route, { success: true, data: { message: 'revoked' } })
     })
 
     const dialogMessages: string[] = []
@@ -241,16 +271,16 @@ test.describe('Settings Page @area:settings', () => {
   }) => {
     let accounts: unknown[] = [googleAccount('e2e-google-user')]
     await page.route('**/api/v1/auth/google/accounts', route =>
-      corsFulfill(route, { success: true, data: accounts })
+      fulfillJson(route, { success: true, data: accounts })
     )
     await mockSyncStates(page, [])
     const revokePosts: string[] = []
     await page.route('**/api/v1/auth/google/accounts/*/revoke', route => {
-      if (route.request().method() !== 'OPTIONS') {
+      if (route.request().method() === 'POST') {
         revokePosts.push(route.request().url())
         accounts = []
       }
-      return corsFulfill(route, { success: true, data: { message: 'revoked' } })
+      return fulfillJson(route, { success: true, data: { message: 'revoked' } })
     })
 
     page.on('dialog', dialog => dialog.accept())
@@ -263,9 +293,10 @@ test.describe('Settings Page @area:settings', () => {
     await expect(disconnect).toBeVisible({ timeout: 10_000 })
     await disconnect.click()
 
-    // The revoke request fires for that account…
+    // The revoke request targets the CREDENTIAL id, not the provider
+    // account id…
     await expect
-      .poll(() => revokePosts.some(u => u.includes('/accounts/e2e-google-user/revoke')))
+      .poll(() => revokePosts.some(u => u.includes('/accounts/cred-e2e-google-user/revoke')))
       .toBe(true)
     // …the outcome is reported, and the list reflects the removal.
     await expect(google.getByText(/Disconnected e2e-google-user/)).toBeVisible({
@@ -383,10 +414,10 @@ test.describe('Settings Page @area:settings', () => {
         settingsPatches.push(body)
         settings = { ...settings, ...body }
       }
-      return corsFulfill(route, { success: true, data: settings })
+      return fulfillJson(route, { success: true, data: settings })
     })
     await page.route('**/api/v1/todoist/projects', route =>
-      corsFulfill(route, {
+      fulfillJson(route, {
         success: true,
         data: [
           { id: 'proj-1', name: 'CRM Tasks' },
@@ -395,7 +426,7 @@ test.describe('Settings Page @area:settings', () => {
       })
     )
     await page.route('**/api/v1/todoist/labels', route =>
-      corsFulfill(route, {
+      fulfillJson(route, {
         success: true,
         data: [
           { id: 'label-1', name: 'crm-people' },
@@ -442,30 +473,28 @@ test.describe('Settings Page @area:settings', () => {
     ])
     await mockSyncStates(page, [])
     await page.route('**/api/v1/todoist/settings', route =>
-      corsFulfill(route, { success: true, data: {} })
+      fulfillJson(route, { success: true, data: {} })
     )
     await page.route('**/api/v1/todoist/projects', route =>
-      corsFulfill(route, { success: true, data: [] })
+      fulfillJson(route, { success: true, data: [] })
     )
     await page.route('**/api/v1/todoist/labels', route =>
-      corsFulfill(route, { success: true, data: [] })
+      fulfillJson(route, { success: true, data: [] })
     )
 
     let failMode = false
     const triggerBodies: Record<string, unknown>[] = []
     await page.route('**/api/v1/sync/todoist/trigger', route => {
-      if (route.request().method() === 'OPTIONS') {
-        return route.fulfill({ status: 204, headers: corsHeaders })
-      }
+      if (route.request().method() !== 'POST') return route.fallback()
       triggerBodies.push(route.request().postDataJSON() as Record<string, unknown>)
       if (failMode) {
-        return corsFulfill(
+        return fulfillJson(
           route,
           { success: false, error: { code: 'INTERNAL', message: 'boom' } },
           500
         )
       }
-      return corsFulfill(route, { success: true, data: null })
+      return fulfillJson(route, { success: true, data: null })
     })
 
     await page.goto('/settings')
@@ -510,8 +539,10 @@ test.describe('Settings Page @area:settings', () => {
     const download = await downloadPromise
     expect(download.suggestedFilename()).toMatch(/\.json$/)
 
-    // Import: the affordance accepts a backup file…
+    // Import: the affordance accepts a backup file and is visible to the
+    // user (setInputFiles alone would also work on a hidden input)…
     const fileInput = page.locator('input[type="file"]')
+    await expect(fileInput).toBeVisible()
     await expect(fileInput).toHaveAttribute('accept', '.json')
     await fileInput.setInputFiles({
       name: 'e2e-backup.json',
@@ -529,5 +560,17 @@ test.describe('Settings Page @area:settings', () => {
 
     // The surface communicates that import does not yet modify stored data.
     await expect(page.getByText(/without making changes/i)).toBeVisible()
+  })
+
+  // spec: SET-035[0], SET-035[1]
+  test('the system information section reports a version', async ({ page }) => {
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const sysinfo = page.getByRole('region', { name: 'System Information' })
+    await expect(sysinfo).toBeVisible({ timeout: 10_000 })
+    // A version value is shown; the exact string is build-stamped, so only
+    // non-emptiness is pinned (no dev-fallback copy matching).
+    await expect(sysinfo.getByTestId('app-version')).not.toBeEmpty()
   })
 })

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -1,134 +1,529 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+// The provider sections talk to the app's own account/status endpoints, and
+// the sandbox/CI deployment has no GOOGLE_*/TODOIST_* credentials — so every
+// provider-state test here route-mocks those endpoints (the sanctioned
+// technique) to force each state deterministically, independent of env.
+//
+// The app calls the API cross-origin (frontend :3000 → API :8080) with an
+// X-API-Key header, so fulfilled responses answer the CORS preflight and
+// carry Access-Control-Allow-Origin.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
+}
+
+function corsFulfill(route: Route, body: unknown, status = 200) {
+  if (route.request().method() === 'OPTIONS') {
+    return route.fulfill({ status: 204, headers: corsHeaders })
+  }
+  return route.fulfill({
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const notFoundBody = { success: false, error: { code: 'NOT_FOUND', message: 'not found' } }
+
+// Force a provider into its unconfigured/not-connected state: its account
+// routes 404 exactly as they do on a deployment without the provider's
+// credentials (SET-005).
+async function mockGoogleAccounts(page: Page, accounts: unknown[] | null) {
+  await page.route('**/api/v1/auth/google/accounts', route =>
+    accounts === null
+      ? corsFulfill(route, notFoundBody, 404)
+      : corsFulfill(route, { success: true, data: accounts })
+  )
+}
+
+async function mockTodoistAccounts(page: Page, accounts: unknown[] | null) {
+  await page.route('**/api/v1/auth/todoist/accounts', route =>
+    accounts === null
+      ? corsFulfill(route, notFoundBody, 404)
+      : corsFulfill(route, { success: true, data: accounts })
+  )
+}
+
+async function mockSyncStates(page: Page, states: unknown[]) {
+  await page.route('**/api/v1/sync/status', route =>
+    corsFulfill(route, { success: true, data: states })
+  )
+}
+
+const googleRegion = (page: Page) => page.getByRole('region', { name: 'Google Accounts' })
+const todoistRegion = (page: Page) => page.getByRole('region', { name: 'Todoist' })
+
+const GMAIL_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly'
+const CALENDAR_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly'
+const CONTACTS_SCOPE = 'https://www.googleapis.com/auth/contacts.readonly'
+const CHAT_SCOPES = [
+  'https://www.googleapis.com/auth/chat.spaces.readonly',
+  'https://www.googleapis.com/auth/chat.messages.readonly',
+  'https://www.googleapis.com/auth/chat.memberships.readonly',
+]
+
+function googleAccount(accountId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id: accountId,
+    account_id: accountId,
+    created_at: '2026-01-05T12:00:00Z',
+    updated_at: '2026-01-05T12:00:00Z',
+    scopes: [] as string[],
+    ...overrides,
+  }
+}
 
 test.describe('Settings Page @area:settings', () => {
-  test('should display Todoist accounts section', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'networkidle' })
-    await page.reload({ waitUntil: 'networkidle' })
-
-    // Check Todoist section heading is visible (in the card header)
-    await expect(page.getByRole('heading', { name: 'Todoist', exact: true })).toBeVisible()
-
-    // Check for either Connect button or configuration instructions
-    // (depends on whether backend has TODOIST_* env vars configured)
-    const connectButton = page.getByRole('button', { name: /Connect Todoist/i })
-    const configMessage = page.getByText(/configure your Todoist OAuth credentials/i)
-
-    // One of these should be visible
-    const hasConnectButton = await connectButton.isVisible().catch(() => false)
-    const hasConfigMessage = await configMessage.isVisible().catch(() => false)
-
-    expect(hasConnectButton || hasConfigMessage).toBe(true)
-  })
-
-  test('should display Google Accounts section with optional Gmail sync badge', async ({
+  // spec: SET-019[0], SET-023[0], SET-023[1]
+  test('unconfigured providers collapse to a not-connected state with setup guidance', async ({
     page,
   }) => {
-    await page.goto('/settings', { waitUntil: 'networkidle' })
-    await page.reload({ waitUntil: 'networkidle' })
+    await mockGoogleAccounts(page, null)
+    await mockTodoistAccounts(page, null)
 
-    // Google Accounts section heading should always render
-    await expect(page.getByRole('heading', { name: 'Google Accounts', exact: true })).toBeVisible()
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
 
-    // The Gmail sync badge only appears when an account with the gmail.readonly
-    // scope is connected (depends on backend GOOGLE_* env vars + a real account).
-    // If present, its refresh button must be accessible and not permanently disabled.
-    const gmailBadge = page.locator('div').filter({ hasText: /^Gmail/ })
-    const hasGmailBadge = await gmailBadge
-      .first()
-      .isVisible()
-      .catch(() => false)
+    // Each provider has its own section…
+    const google = googleRegion(page)
+    const todoist = todoistRegion(page)
+    await expect(google).toBeVisible({ timeout: 10_000 })
+    await expect(todoist).toBeVisible()
 
-    if (hasGmailBadge) {
-      const refreshButton = gmailBadge.first().getByRole('button')
-      await expect(refreshButton).toBeVisible()
-      // Button may be transiently disabled while syncing, but not absent/hidden.
-      await expect(refreshButton).toBeEnabled({ timeout: 5000 })
-    }
+    // …showing a not-connected empty state (connect affordance, no error
+    // stack) rather than surfacing the 404.
+    await expect(google.getByRole('button', { name: /Connect Google Account/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(todoist.getByRole('button', { name: /Connect Todoist Account/i })).toBeVisible({
+      timeout: 10_000,
+    })
+
+    // …and listing the configuration the deployment must supply.
+    await expect(google.getByText('GOOGLE_CLIENT_ID')).toBeVisible()
+    await expect(google.getByText('GOOGLE_CLIENT_SECRET')).toBeVisible()
+    await expect(google.getByText('TOKEN_ENCRYPTION_KEY')).toBeVisible()
+    await expect(todoist.getByText('TODOIST_CLIENT_ID')).toBeVisible()
+    await expect(todoist.getByText('TODOIST_CLIENT_SECRET')).toBeVisible()
   })
 
-  test('should display optional Google Chat sync badge or reconnect hint', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'networkidle' })
-    await page.reload({ waitUntil: 'networkidle' })
+  // spec: SET-019[1], SET-019[2]
+  test('a connected account shows its identity, connect date, and manage affordances', async ({
+    page,
+  }) => {
+    await mockGoogleAccounts(page, [googleAccount('e2e-google-user')])
+    await mockSyncStates(page, [])
 
-    await expect(page.getByRole('heading', { name: 'Google Accounts', exact: true })).toBeVisible()
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
 
-    // Per connected Google account, the Chat surface is conditional: a "Chat"
-    // SyncBadge when the account carries chat.spaces.readonly, OR a
-    // "Chat — reconnect required" hint when it does not. Both depend on backend
-    // GOOGLE_* env vars + a real connected account, so this is a
-    // conditional-presence test (like the Gmail-badge test above).
-    const chatBadge = page.locator('div').filter({ hasText: /^Chat/ })
-    const hasChatBadge = await chatBadge
-      .first()
-      .isVisible()
-      .catch(() => false)
+    const google = googleRegion(page)
+    // The account identity and its connected date (mocked created_at
+    // 2026-01-05, rendered by formatDate) appear on the card.
+    await expect(google.getByText('e2e-google-user')).toBeVisible({ timeout: 10_000 })
+    await expect(google.getByText(/Connected Jan 5, 2026/)).toBeVisible()
 
-    if (hasChatBadge) {
-      const refreshButton = chatBadge.first().getByRole('button')
-      await expect(refreshButton).toBeVisible()
-      await expect(refreshButton).toBeEnabled({ timeout: 5000 })
-    } else {
-      // No scoped account: if any Google account is connected, the reconnect
-      // hint may be present. Its visibility is account-dependent, so only assert
-      // it is clickable WHEN present (never required).
-      const reconnectHint = page.getByRole('button', { name: /Chat — reconnect required/ })
-      const hasHint = await reconnectHint
-        .first()
-        .isVisible()
-        .catch(() => false)
-      if (hasHint) {
-        await expect(reconnectHint.first()).toBeEnabled({ timeout: 5000 })
+    // The section offers connect and per-account disconnect affordances.
+    await expect(google.getByRole('button', { name: 'Add Account' })).toBeVisible()
+    await expect(google.getByRole('button', { name: 'Disconnect e2e-google-user' })).toBeVisible()
+  })
+
+  // spec: SET-020[0]
+  test('connecting a provider fetches the auth URL and navigates to it', async ({ page }) => {
+    await mockGoogleAccounts(page, null)
+    // Stub the provider consent screen with a same-origin URL so the
+    // whole-page navigation is observable without a live provider.
+    await page.route('**/api/v1/auth/google', route =>
+      corsFulfill(route, {
+        success: true,
+        data: { url: '/settings?consent-stub=1', state: 'e2e-state' },
+      })
+    )
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const connect = googleRegion(page).getByRole('button', { name: /Connect Google Account/i })
+    await expect(connect).toBeVisible({ timeout: 10_000 })
+
+    const authUrlRequest = page.waitForRequest(
+      req => new URL(req.url()).pathname.endsWith('/api/v1/auth/google') && req.method() === 'GET'
+    )
+    await connect.click()
+    await authUrlRequest
+
+    // The app navigates the whole page to the returned URL.
+    await page.waitForURL('**/settings?consent-stub=1', { timeout: 10_000 })
+  })
+
+  // spec: SET-021[0], SET-021[2]
+  test('a success outcome shows a notification, refreshes accounts, and strips params', async ({
+    page,
+  }) => {
+    let accountListGets = 0
+    await page.route('**/api/v1/auth/google/accounts', route => {
+      if (route.request().method() === 'GET') accountListGets++
+      return corsFulfill(route, { success: true, data: [googleAccount('e2e-google-user')] })
+    })
+    await mockSyncStates(page, [])
+
+    await page.goto('/settings?auth=success&provider=google')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Success indication renders…
+    await expect(googleRegion(page).getByText(/connected successfully/i)).toBeVisible({
+      timeout: 10_000,
+    })
+    // …the account list is refetched (initial load + the success refetch)…
+    await expect.poll(() => accountListGets, { timeout: 10_000 }).toBeGreaterThanOrEqual(2)
+    // …and the one-time params are stripped so refresh does not re-trigger.
+    await expect(page).toHaveURL('/settings', { timeout: 10_000 })
+  })
+
+  // spec: SET-021[1], SET-021[2]
+  test('an error outcome surfaces the failure reason and strips params', async ({ page }) => {
+    await mockGoogleAccounts(page, [])
+    await mockSyncStates(page, [])
+
+    await page.goto('/settings?auth=error&provider=google&message=exchange_failed')
+    await page.waitForLoadState('domcontentloaded')
+
+    // The reason is derived from the redirect's message param — data.
+    await expect(googleRegion(page).getByText(/exchange failed/i)).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page).toHaveURL('/settings', { timeout: 10_000 })
+  })
+
+  // spec: SET-022[0], SET-022[1]
+  test('disconnect asks for confirmation and dismissing revokes nothing', async ({ page }) => {
+    await mockGoogleAccounts(page, [googleAccount('e2e-google-user')])
+    await mockSyncStates(page, [])
+    let revokeCalled = false
+    await page.route('**/api/v1/auth/google/accounts/*/revoke', route => {
+      if (route.request().method() !== 'OPTIONS') revokeCalled = true
+      return corsFulfill(route, { success: true, data: { message: 'revoked' } })
+    })
+
+    const dialogMessages: string[] = []
+    page.on('dialog', dialog => {
+      dialogMessages.push(dialog.message())
+      return dialog.dismiss()
+    })
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    const disconnect = google.getByRole('button', { name: 'Disconnect e2e-google-user' })
+    await expect(disconnect).toBeVisible({ timeout: 10_000 })
+    await disconnect.click()
+
+    // The confirmation identifies the account and warns what is revoked.
+    await expect.poll(() => dialogMessages.length).toBeGreaterThanOrEqual(1)
+    expect(dialogMessages[0]).toContain('e2e-google-user')
+    expect(dialogMessages[0]).toMatch(/revoke/i)
+
+    // Dismissed → no revoke request, account still listed.
+    await expect(google.getByText('e2e-google-user')).toBeVisible()
+    expect(revokeCalled).toBe(false)
+  })
+
+  // spec: SET-022[2]
+  test('confirming a disconnect revokes the account and the list reflects removal', async ({
+    page,
+  }) => {
+    let accounts: unknown[] = [googleAccount('e2e-google-user')]
+    await page.route('**/api/v1/auth/google/accounts', route =>
+      corsFulfill(route, { success: true, data: accounts })
+    )
+    await mockSyncStates(page, [])
+    const revokePosts: string[] = []
+    await page.route('**/api/v1/auth/google/accounts/*/revoke', route => {
+      if (route.request().method() !== 'OPTIONS') {
+        revokePosts.push(route.request().url())
+        accounts = []
       }
-    }
+      return corsFulfill(route, { success: true, data: { message: 'revoked' } })
+    })
+
+    page.on('dialog', dialog => dialog.accept())
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    const disconnect = google.getByRole('button', { name: 'Disconnect e2e-google-user' })
+    await expect(disconnect).toBeVisible({ timeout: 10_000 })
+    await disconnect.click()
+
+    // The revoke request fires for that account…
+    await expect
+      .poll(() => revokePosts.some(u => u.includes('/accounts/e2e-google-user/revoke')))
+      .toBe(true)
+    // …the outcome is reported, and the list reflects the removal.
+    await expect(google.getByText(/Disconnected e2e-google-user/)).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(google.getByRole('button', { name: /Connect Google Account/i })).toBeVisible({
+      timeout: 10_000,
+    })
   })
 
-  test('should display settings page with export and import sections', async ({ page }) => {
+  // spec: SET-024[0]
+  test('per-source sync affordances follow the account scopes', async ({ page }) => {
+    // Gmail + Calendar granted, Contacts omitted.
+    await mockGoogleAccounts(page, [
+      googleAccount('e2e-scoped-user', { scopes: [GMAIL_SCOPE, CALENDAR_SCOPE] }),
+    ])
+    await mockSyncStates(page, [])
+
     await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
 
-    // Check page loads correctly
-    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+    const google = googleRegion(page)
+    await expect(google.getByText('e2e-scoped-user')).toBeVisible({ timeout: 10_000 })
 
-    // Check export section is visible
-    await expect(page.getByRole('heading', { name: 'Export Data' })).toBeVisible()
-    await expect(page.getByRole('button', { name: /Download Backup/i })).toBeVisible()
+    await expect(google.getByRole('button', { name: 'Sync Gmail' })).toBeVisible()
+    await expect(google.getByRole('button', { name: 'Sync Calendar' })).toBeVisible()
+    // The scope the account does not hold gets no affordance.
+    await expect(google.getByRole('button', { name: 'Sync Contacts' })).toHaveCount(0)
+  })
 
-    // Check import section is visible
-    await expect(page.getByRole('heading', { name: 'Import Data' })).toBeVisible()
+  // spec: SET-024[1]
+  test('the Chat affordance appears when all chat scopes are held', async ({ page }) => {
+    await mockGoogleAccounts(page, [
+      googleAccount('e2e-chat-user', { scopes: [GMAIL_SCOPE, ...CHAT_SCOPES] }),
+    ])
+    await mockSyncStates(page, [])
 
-    // Check file input is present
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    await expect(google.getByText('e2e-chat-user')).toBeVisible({ timeout: 10_000 })
+    await expect(google.getByRole('button', { name: 'Sync Chat' })).toBeVisible()
+    await expect(google.getByRole('button', { name: /Chat — reconnect required/ })).toHaveCount(0)
+  })
+
+  // spec: SET-024[1]
+  test('a partial chat grant shows a reconnect prompt instead of the Chat affordance', async ({
+    page,
+  }) => {
+    await mockGoogleAccounts(page, [
+      googleAccount('e2e-partial-chat-user', { scopes: [GMAIL_SCOPE, CHAT_SCOPES[0]] }),
+    ])
+    await mockSyncStates(page, [])
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    await expect(google.getByText('e2e-partial-chat-user')).toBeVisible({ timeout: 10_000 })
+    await expect(google.getByRole('button', { name: /Chat — reconnect required/ })).toBeVisible()
+    await expect(google.getByRole('button', { name: 'Sync Chat' })).toHaveCount(0)
+  })
+
+  // spec: SET-025[0], SET-025[1]
+  test('an auth-errored sync surfaces a reconnect prompt only while the credential is stale', async ({
+    page,
+  }) => {
+    // Account A: sync auth-error NEWER than the credential → reconnect.
+    // Account B: credential refreshed AFTER the same error → suppressed.
+    await mockGoogleAccounts(page, [
+      googleAccount('e2e-stale-user', { updated_at: '2026-01-01T00:00:00Z' }),
+      googleAccount('e2e-fresh-user', { updated_at: '2026-06-15T00:00:00Z' }),
+    ])
+    const errorState = (accountId: string) => ({
+      id: `sync-${accountId}`,
+      source: 'email',
+      account_id: accountId,
+      enabled: true,
+      status: 'error',
+      sync_cursor: null,
+      last_sync_at: null,
+      last_successful_sync_at: null,
+      next_sync_at: null,
+      error_count: 1,
+      error_message: 'oauth token error: invalid_grant',
+      created_at: '2026-06-01T00:00:00Z',
+      updated_at: '2026-06-01T00:00:00Z',
+    })
+    await mockSyncStates(page, [errorState('e2e-stale-user'), errorState('e2e-fresh-user')])
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    await expect(google.getByText('e2e-stale-user')).toBeVisible({ timeout: 10_000 })
+    await expect(google.getByText('e2e-fresh-user')).toBeVisible()
+
+    // Exactly one Reconnect affordance: present for the stale account,
+    // suppressed for the refreshed one. (exact: the per-account chat
+    // "reconnect required" hint would otherwise substring-match.)
+    await expect(google.getByRole('button', { name: 'Reconnect', exact: true })).toHaveCount(1)
+  })
+
+  // spec: SET-026[0], SET-026[1], SET-026[2]
+  test('the Todoist configuration guides selecting a project and label', async ({ page }) => {
+    await mockTodoistAccounts(page, [googleAccount('e2e-todoist-account')])
+    await mockSyncStates(page, [])
+
+    let settings: Record<string, string> = {}
+    const settingsPatches: Record<string, unknown>[] = []
+    await page.route('**/api/v1/todoist/settings', route => {
+      if (route.request().method() === 'PATCH') {
+        const body = route.request().postDataJSON() as Record<string, string>
+        settingsPatches.push(body)
+        settings = { ...settings, ...body }
+      }
+      return corsFulfill(route, { success: true, data: settings })
+    })
+    await page.route('**/api/v1/todoist/projects', route =>
+      corsFulfill(route, {
+        success: true,
+        data: [
+          { id: 'proj-1', name: 'CRM Tasks' },
+          { id: 'proj-2', name: 'Inbox' },
+        ],
+      })
+    )
+    await page.route('**/api/v1/todoist/labels', route =>
+      corsFulfill(route, {
+        success: true,
+        data: [
+          { id: 'label-1', name: 'crm-people' },
+          { id: 'label-2', name: 'someday' },
+        ],
+      })
+    )
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const todoist = todoistRegion(page)
+    await expect(todoist.getByText('e2e-todoist-account')).toBeVisible({ timeout: 10_000 })
+
+    // Pickers are populated from the live provider lists.
+    const projectSelect = todoist.getByRole('combobox', { name: 'Project' })
+    const labelSelect = todoist.getByRole('combobox', { name: 'Label' })
+    await expect(projectSelect.locator('option', { hasText: 'CRM Tasks' })).toHaveCount(1)
+    await expect(projectSelect.locator('option', { hasText: 'Inbox' })).toHaveCount(1)
+    await expect(labelSelect.locator('option', { hasText: 'crm-people' })).toHaveCount(1)
+
+    // Both-required note shows while the pair is incomplete.
+    const bothRequired = todoist.getByText(/both a project and label/i)
+    await expect(bothRequired).toBeVisible()
+
+    // Selecting a project persists the choice and reports the outcome.
+    await projectSelect.selectOption('proj-1')
+    await expect.poll(() => settingsPatches.length).toBeGreaterThanOrEqual(1)
+    expect(settingsPatches[0]).toMatchObject({ project_id: 'proj-1' })
+    await expect(todoist.getByText(/Project updated/i)).toBeVisible({ timeout: 10_000 })
+
+    // Completing the pair clears the both-required note.
+    await labelSelect.selectOption('label-1')
+    await expect.poll(() => settingsPatches.some(p => p.label_id === 'label-1')).toBe(true)
+    await expect(bothRequired).toHaveCount(0, { timeout: 10_000 })
+  })
+
+  // spec: TDS-034[0], TDS-034[1]
+  test('a manual Todoist task sync can be triggered with its outcome indicated', async ({
+    page,
+  }) => {
+    await mockTodoistAccounts(page, [
+      googleAccount('e2e-todoist-account', { scopes: ['data:read_write'] }),
+    ])
+    await mockSyncStates(page, [])
+    await page.route('**/api/v1/todoist/settings', route =>
+      corsFulfill(route, { success: true, data: {} })
+    )
+    await page.route('**/api/v1/todoist/projects', route =>
+      corsFulfill(route, { success: true, data: [] })
+    )
+    await page.route('**/api/v1/todoist/labels', route =>
+      corsFulfill(route, { success: true, data: [] })
+    )
+
+    let failMode = false
+    const triggerBodies: Record<string, unknown>[] = []
+    await page.route('**/api/v1/sync/todoist/trigger', route => {
+      if (route.request().method() === 'OPTIONS') {
+        return route.fulfill({ status: 204, headers: corsHeaders })
+      }
+      triggerBodies.push(route.request().postDataJSON() as Record<string, unknown>)
+      if (failMode) {
+        return corsFulfill(
+          route,
+          { success: false, error: { code: 'INTERNAL', message: 'boom' } },
+          500
+        )
+      }
+      return corsFulfill(route, { success: true, data: null })
+    })
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const todoist = todoistRegion(page)
+    await expect(todoist.getByText('e2e-todoist-account')).toBeVisible({ timeout: 10_000 })
+
+    // The account's read/write permission state is visible (data-derived
+    // from the mocked scopes).
+    await expect(todoist.getByText('Read & Write')).toBeVisible()
+
+    // Trigger the sync: the request targets the todoist source with the
+    // account id, and success is indicated.
+    const syncTasks = todoist.getByRole('button', { name: 'Sync Tasks' })
+    await syncTasks.click()
+    await expect.poll(() => triggerBodies.length).toBeGreaterThanOrEqual(1)
+    expect(triggerBodies[0]).toMatchObject({ account_id: 'e2e-todoist-account' })
+    await expect(todoist.getByText(/Todoist sync started/i)).toBeVisible({ timeout: 10_000 })
+
+    // A failing trigger is indicated as a failure.
+    failMode = true
+    await expect(syncTasks).toBeEnabled()
+    await syncTasks.click()
+    await expect(todoist.getByText(/Failed to start sync/i)).toBeVisible({ timeout: 10_000 })
+  })
+
+  // spec: SET-028[0], SET-028[1], SET-028[2]
+  test('the backup surface exports a JSON download and validates an uploaded backup', async ({
+    page,
+  }) => {
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Export: the affordance streams a JSON backup download (live endpoint).
+    const exportResponse = page.waitForResponse(
+      resp => resp.url().includes('/api/v1/export') && resp.request().method() === 'POST'
+    )
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: /Download Backup/i }).click()
+    expect((await exportResponse).status()).toBe(200)
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toMatch(/\.json$/)
+
+    // Import: the affordance accepts a backup file…
     const fileInput = page.locator('input[type="file"]')
-    await expect(fileInput).toBeVisible()
     await expect(fileInput).toHaveAttribute('accept', '.json')
-  })
+    await fileInput.setInputFiles({
+      name: 'e2e-backup.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify({ version: '1.0', contacts: [] })),
+    })
 
-  test('should have consistent form field styling', async ({ page }) => {
-    await page.goto('/settings')
+    // …and submitting it fires the import request (result alert dismissed).
+    page.on('dialog', dialog => dialog.accept())
+    const importRequest = page.waitForRequest(
+      req => req.url().includes('/api/v1/import') && req.method() === 'POST'
+    )
+    await page.getByRole('button', { name: /Validate/i }).click()
+    await importRequest
 
-    // File input should have consistent styling classes
-    const fileInput = page.locator('input[type="file"]')
-    await expect(fileInput).toHaveClass(/rounded-md/)
-    await expect(fileInput).toHaveClass(/border/)
-    await expect(fileInput).toHaveClass(/shadow-sm/)
-  })
-
-  test('should display system information section with version info', async ({ page }) => {
-    await page.goto('/settings')
-
-    // Check System Information section is visible
-    await expect(page.getByRole('heading', { name: 'System Information' })).toBeVisible()
-
-    // Check Version field exists
-    await expect(page.getByText('Version')).toBeVisible()
-
-    // In test environment without NEXT_PUBLIC_BUILD_VERSION, should show "Personal CRM (dev)"
-    // Note: Testing with a valid version/commit hash is not practical in E2E because:
-    // 1. The env var is baked in at build time, not runtime
-    // 2. We'd need to rebuild the app with specific values for each test run
-    // The fallback logic is verified here.
-    const versionValue = page.locator('p.text-gray-600:has-text("Version")').locator('+ p')
-    await expect(versionValue).toHaveText('Personal CRM (dev)')
-
-    // Verify no GitHub link is rendered when there's no commit hash
-    await expect(versionValue.locator('a')).not.toBeVisible()
+    // The surface communicates that import does not yet modify stored data.
+    await expect(page.getByText(/without making changes/i)).toBeVisible()
   })
 })

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -176,8 +176,13 @@ test.describe('Settings Page @area:settings', () => {
     await expect(googleRegion(page).getByText(/connected successfully/i)).toBeVisible({
       timeout: 10_000,
     })
-    // …the account list is refetched (initial load + the success refetch)…
-    await expect.poll(() => accountListGets, { timeout: 10_000 }).toBeGreaterThanOrEqual(2)
+    // …the account list is fetched on the outcome landing and reflects the
+    // connected account. (The success handler's explicit refetch coalesces
+    // with the in-flight initial fetch — React Query dedupe — so asserting
+    // a second GET would over-specify; the observable claim is a fresh
+    // fetch plus the account rendered.)
+    await expect.poll(() => accountListGets, { timeout: 10_000 }).toBeGreaterThanOrEqual(1)
+    await expect(googleRegion(page).getByText('e2e-google-user')).toBeVisible()
     // …and the one-time params are stripped so refresh does not re-trigger.
     await expect(page).toHaveURL('/settings', { timeout: 10_000 })
   })

--- a/frontend/tests/e2e/telegram-settings.spec.ts
+++ b/frontend/tests/e2e/telegram-settings.spec.ts
@@ -123,7 +123,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByLabel('Verification Code')).toBeVisible()
   })
 
-  // spec: TGM-038[2], TGM-038[4]
+  // spec: TGM-038[2]
   test('auth flow: code → connected transition', async ({ page }) => {
     await mockStatus(page, { status: 'disconnected', connected: false })
 
@@ -172,8 +172,12 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.getByLabel('Verification Code').fill('12345')
     await page.getByRole('button', { name: 'Verify' }).click()
 
-    // Connected state reflects the username from the verify response.
+    // A valid code connects: the success indication carries the verify
+    // response's username, and the view switches to the connected state
+    // (its disconnect affordance appears). The connected VIEW's username
+    // display is TGM-038[4], proven by the pre-connected-status test.
     await expect(page.getByText(/Connected.*@testuser/)).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('button', { name: /Disconnect/i })).toBeVisible()
   })
 
   // spec: TGM-038[2], TGM-038[3]
@@ -242,11 +246,13 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.getByLabel('2FA Password').fill('mypassword')
     await page.getByRole('button', { name: 'Verify' }).click()
 
-    // Should show connected
+    // A valid password connects: success indication plus the view's
+    // disconnect affordance.
     await expect(page.getByText(/Connected.*@testuser2fa/)).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('button', { name: /Disconnect/i })).toBeVisible()
   })
 
-  // spec: TGM-039[0], TGM-039[2]
+  // spec: TGM-038[4], TGM-039[0], TGM-039[2]
   test('shows connected state with username', async ({ page }) => {
     // Mock status as connected
     await mockStatus(page, {
@@ -300,16 +306,6 @@ test.describe('Telegram Settings @area:settings', () => {
                   phone_number: '+15550001111',
                 },
           }),
-        })
-      }
-      if (req.method() === 'OPTIONS') {
-        return route.fulfill({
-          status: 204,
-          headers: {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
-          },
         })
       }
       return route.fallback()

--- a/frontend/tests/e2e/telegram-settings.spec.ts
+++ b/frontend/tests/e2e/telegram-settings.spec.ts
@@ -1,6 +1,24 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
+
+// The telegram section talks to the app's own /api/v1/telegram/* endpoints,
+// which cannot run live in E2E (MTProto needs real credentials and a real
+// account). Every test here route-mocks that boundary — the sanctioned
+// technique — and asserts the real surface branches the mocked states drive.
+
+async function mockStatus(page: Page, data: Record<string, unknown>) {
+  await page.route('**/api/v1/telegram/auth/status', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, data }),
+    })
+  )
+}
+
+const telegramRegion = (page: Page) => page.getByRole('region', { name: 'Telegram' })
 
 test.describe('Telegram Settings @area:settings', () => {
+  // spec: SET-027[0]
   test('shows Telegram section on settings page', async ({ page }) => {
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
@@ -11,39 +29,37 @@ test.describe('Telegram Settings @area:settings', () => {
     })
   })
 
-  test('shows not-configured or disconnected state', async ({ page }) => {
-    await page.goto('/settings')
-    await page.waitForLoadState('domcontentloaded')
-
-    await expect(page.getByRole('heading', { name: 'Telegram', exact: true })).toBeVisible({
-      timeout: 10000,
-    })
-
-    // Scope to the Telegram section
-    const telegramSection = page.locator('section', {
-      has: page.getByRole('heading', { name: 'Telegram', exact: true }),
-    })
-
-    // Wait for loading to finish — either "Configuration Required" or "Connect Telegram" should appear
-    const configRequired = telegramSection.getByText('Configuration Required')
-    const connectButton = telegramSection.getByRole('button', { name: /Connect Telegram/i })
-
-    // Use Playwright's built-in polling instead of instant snapshot
-    await expect(configRequired.or(connectButton)).toBeVisible({ timeout: 10000 })
-  })
-
-  test('auth flow: phone input shows on Connect click', async ({ page }) => {
-    // Intercept status to return disconnected
+  // spec: SET-027[1]
+  test('not-configured backend collapses to configuration guidance', async ({ page }) => {
+    // Force the not-configured branch deterministically: the section keys it
+    // off a 404 from the status endpoint (telegram routes are not registered
+    // when the feature is off, per SET-005).
     await page.route('**/api/v1/telegram/auth/status', route =>
       route.fulfill({
-        status: 200,
+        status: 404,
         contentType: 'application/json',
         body: JSON.stringify({
-          success: true,
-          data: { status: 'disconnected', connected: false },
+          success: false,
+          error: { code: 'NOT_FOUND', message: 'not found' },
         }),
       })
     )
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const section = telegramRegion(page)
+    await expect(section.getByText('Configuration Required')).toBeVisible({ timeout: 10000 })
+    // The behavior mandates naming the configuration the deployment must
+    // supply; match the keys loosely so copy rewording survives.
+    await expect(section.getByText(/ENABLE_TELEGRAM_SYNC/)).toBeVisible()
+    await expect(section.getByText('TELEGRAM_API_ID')).toBeVisible()
+    await expect(section.getByText('TELEGRAM_API_HASH')).toBeVisible()
+  })
+
+  // spec: TGM-038[0]
+  test('auth flow: phone input shows on Connect click', async ({ page }) => {
+    await mockStatus(page, { status: 'disconnected', connected: false })
 
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
@@ -61,18 +77,9 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
   })
 
+  // spec: TGM-038[1]
   test('auth flow: phone input → code input transition', async ({ page }) => {
-    // Mock status as disconnected
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'disconnected', connected: false },
-        }),
-      })
-    )
+    await mockStatus(page, { status: 'disconnected', connected: false })
 
     // Mock start auth
     await page.route('**/api/v1/telegram/auth/start', route =>
@@ -98,30 +105,27 @@ test.describe('Telegram Settings @area:settings', () => {
       timeout: 10000,
     })
 
-    // Start auth flow
+    // Start auth flow, asserting the start request carries the entered phone
+    // (network-param proof that the input is wired to the API).
     await page.getByRole('button', { name: /Connect Telegram/i }).click()
     await page.getByLabel('Phone Number').fill('+15551234567')
+    const startRequest = page.waitForRequest(
+      req => req.url().includes('/api/v1/telegram/auth/start') && req.method() === 'POST'
+    )
     await page.getByRole('button', { name: 'Send Code' }).click()
+    const req = await startRequest
+    expect(req.postDataJSON()).toMatchObject({ phone_number: '+15551234567' })
 
-    // Should show code input
+    // Should show code input, reflecting the mocked delivery channel (app).
     await expect(page.getByText(/code was sent to your Telegram app/i)).toBeVisible({
       timeout: 5000,
     })
     await expect(page.getByLabel('Verification Code')).toBeVisible()
   })
 
+  // spec: TGM-038[2], TGM-038[4]
   test('auth flow: code → connected transition', async ({ page }) => {
-    // Mock status
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'disconnected', connected: false },
-        }),
-      })
-    )
+    await mockStatus(page, { status: 'disconnected', connected: false })
 
     // Mock start auth
     await page.route('**/api/v1/telegram/auth/start', route =>
@@ -168,21 +172,13 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.getByLabel('Verification Code').fill('12345')
     await page.getByRole('button', { name: 'Verify' }).click()
 
-    // Should show connected state
+    // Connected state reflects the username from the verify response.
     await expect(page.getByText(/Connected.*@testuser/)).toBeVisible({ timeout: 5000 })
   })
 
+  // spec: TGM-038[2], TGM-038[3]
   test('auth flow: code → 2FA → connected transition', async ({ page }) => {
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'disconnected', connected: false },
-        }),
-      })
-    )
+    await mockStatus(page, { status: 'disconnected', connected: false })
 
     await page.route('**/api/v1/telegram/auth/start', route =>
       route.fulfill({
@@ -239,9 +235,8 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.getByLabel('Verification Code').fill('12345')
     await page.getByRole('button', { name: 'Verify' }).click()
 
-    // Should show 2FA input
-    await expect(page.getByText(/two-factor authentication/i)).toBeVisible({ timeout: 5000 })
-    await expect(page.getByLabel('2FA Password')).toBeVisible()
+    // Should show 2FA password step (the awaiting_password branch)
+    await expect(page.getByLabel('2FA Password')).toBeVisible({ timeout: 5000 })
 
     // Enter password
     await page.getByLabel('2FA Password').fill('mypassword')
@@ -251,23 +246,15 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByText(/Connected.*@testuser2fa/)).toBeVisible({ timeout: 5000 })
   })
 
+  // spec: TGM-039[0], TGM-039[2]
   test('shows connected state with username', async ({ page }) => {
     // Mock status as connected
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: {
-            status: 'connected',
-            connected: true,
-            username: 'existinguser',
-            phone_number: '+15559876543',
-          },
-        }),
-      })
-    )
+    await mockStatus(page, {
+      status: 'connected',
+      connected: true,
+      username: 'existinguser',
+      phone_number: '+15559876543',
+    })
 
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
@@ -276,30 +263,87 @@ test.describe('Telegram Settings @area:settings', () => {
       timeout: 10000,
     })
 
-    // Should show connected state
+    // Identity from the mocked status is reflected in the section.
     await expect(page.getByText(/Connected.*@existinguser/)).toBeVisible({ timeout: 5000 })
     await expect(page.getByText('+15559876543')).toBeVisible()
     await expect(page.getByRole('button', { name: /Disconnect/i })).toBeVisible()
   })
 
-  // Disconnect E2E test omitted: Playwright's `**/api/v1/telegram/auth` glob matches
-  // `/auth/status` too (LIFO routing means the less-specific handler intercepts status
-  // requests and calls route.continue(), bypassing the status mock). Verified with:
-  // glob patterns, regex patterns, function predicates, and LIFO registration order —
-  // none reliably isolate DELETE /auth from GET /auth/status. The disconnect UI path
-  // is a simple confirm() → mutateAsync() → setStep('disconnected') and is tested manually.
-
-  test('shows error on invalid code', async ({ page }) => {
-    await page.route('**/api/v1/telegram/auth/status', route =>
+  // spec: TGM-039[2]
+  test('disconnect returns the section to the disconnected state', async ({ page }) => {
+    // One handler covers DELETE /auth and GET /auth/status: the glob matches
+    // both, so branch on method + path and route.fallback() anything else.
+    let disconnected = false
+    await page.route('**/api/v1/telegram/auth**', route => {
+      const req = route.request()
+      const path = new URL(req.url()).pathname
+      if (req.method() === 'DELETE' && path.endsWith('/telegram/auth')) {
+        disconnected = true
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { status: 'disconnected' } }),
+        })
+      }
+      if (req.method() === 'GET' && path.endsWith('/auth/status')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: disconnected
+              ? { status: 'disconnected', connected: false }
+              : {
+                  status: 'connected',
+                  connected: true,
+                  username: 'disconnectme',
+                  phone_number: '+15550001111',
+                },
+          }),
+        })
+      }
+      if (req.method() === 'OPTIONS') {
+        return route.fulfill({
+          status: 204,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
+          },
+        })
+      }
+      return route.fallback()
+    })
+    await page.route('**/api/v1/telegram/chats', route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'disconnected', connected: false },
-        }),
+        body: JSON.stringify({ success: true, data: [] }),
       })
     )
+
+    // The disconnect affordance confirms via a native dialog.
+    page.on('dialog', dialog => dialog.accept())
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText(/Connected.*@disconnectme/)).toBeVisible({ timeout: 10000 })
+
+    const deleteRequest = page.waitForRequest(
+      req => req.method() === 'DELETE' && req.url().includes('/api/v1/telegram/auth')
+    )
+    await page.getByRole('button', { name: /Disconnect/i }).click()
+    await deleteRequest
+
+    // The section returns to the disconnected state (connect affordance back).
+    await expect(page.getByRole('button', { name: /Connect Telegram/i })).toBeVisible({
+      timeout: 5000,
+    })
+  })
+
+  // spec: TGM-040[0], TGM-040[1]
+  test('shows error on invalid code', async ({ page }) => {
+    await mockStatus(page, { status: 'disconnected', connected: false })
 
     await page.route('**/api/v1/telegram/auth/start', route =>
       route.fulfill({
@@ -344,21 +388,15 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.getByLabel('Verification Code').fill('99999')
     await page.getByRole('button', { name: 'Verify' }).click()
 
-    // Should show error
+    // The rejection reason (the mocked error payload's message) is surfaced,
+    // and the flow stays on the code step so the user can retry.
     await expect(page.getByText(/Invalid verification code/i)).toBeVisible({ timeout: 5000 })
+    await expect(page.getByLabel('Verification Code')).toBeVisible()
   })
 
+  // spec: TGM-041[0]
   test('group chat management: shows chat list', async ({ page }) => {
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'connected', connected: true, username: 'testuser' },
-        }),
-      })
-    )
+    await mockStatus(page, { status: 'connected', connected: true, username: 'testuser' })
 
     await page.route('**/api/v1/telegram/chats', route =>
       route.fulfill({
@@ -391,26 +429,16 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
 
-    const section = page.locator('section', {
-      has: page.getByRole('heading', { name: 'Telegram', exact: true }),
-    })
+    const section = telegramRegion(page)
     await expect(section.getByText('Close Friends')).toBeVisible({ timeout: 10000 })
     await expect(section.getByText('Work Team')).toBeVisible()
     await expect(section.getByText('5 members').first()).toBeVisible()
     await expect(section.getByText('25 members').first()).toBeVisible()
   })
 
+  // spec: TGM-041[1]
   test('group chat management: empty state', async ({ page }) => {
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'connected', connected: true, username: 'testuser' },
-        }),
-      })
-    )
+    await mockStatus(page, { status: 'connected', connected: true, username: 'testuser' })
 
     await page.route('**/api/v1/telegram/chats', route =>
       route.fulfill({
@@ -423,27 +451,21 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
 
-    await expect(page.getByText(/No group chats discovered yet/i)).toBeVisible({ timeout: 10000 })
+    await expect(telegramRegion(page).getByText(/No group chats/i)).toBeVisible({
+      timeout: 10000,
+    })
   })
 
+  // spec: TGM-039[1]
   test('group chat management: backfill progress', async ({ page }) => {
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: {
-            status: 'connected',
-            connected: true,
-            username: 'testuser',
-            backfill_in_progress: true,
-            backfill_total: 42,
-            backfill_completed: 15,
-          },
-        }),
-      })
-    )
+    await mockStatus(page, {
+      status: 'connected',
+      connected: true,
+      username: 'testuser',
+      backfill_in_progress: true,
+      backfill_total: 42,
+      backfill_completed: 15,
+    })
 
     await page.route('**/api/v1/telegram/chats', route =>
       route.fulfill({
@@ -456,23 +478,16 @@ test.describe('Telegram Settings @area:settings', () => {
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
 
+    // The 15/42 figures are the mocked backfill progress reflected in the UI.
     await expect(page.getByText(/Syncing messages.*15\/42/)).toBeVisible({ timeout: 10000 })
   })
 
+  // spec: TGM-041[2]
   test('group chat management: toggle auto to ignored', async ({ page }) => {
     let currentStatus = 'auto'
     let currentTracked = true
 
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'connected', connected: true, username: 'testuser' },
-        }),
-      })
-    )
+    await mockStatus(page, { status: 'connected', connected: true, username: 'testuser' })
 
     await page.route('**/api/v1/telegram/chats**', route => {
       if (route.request().method() === 'GET') {
@@ -520,30 +535,25 @@ test.describe('Telegram Settings @area:settings', () => {
 
     await expect(page.getByText('Toggle Test Group')).toBeVisible({ timeout: 10000 })
 
-    const select = page.locator('select').first()
+    const select = page.getByRole('combobox', { name: 'Tracking for Toggle Test Group' })
     await expect(select).toHaveValue('auto')
 
-    // Toggle to "Ignored"
+    // Toggle to "Ignored", asserting the persistence request carries the choice.
+    const patchRequest = page.waitForRequest(
+      req => req.method() === 'PATCH' && req.url().includes('/api/v1/telegram/chats/')
+    )
     await select.selectOption('ignored')
+    expect((await patchRequest).postDataJSON()).toMatchObject({ status: 'ignored' })
 
-    // After refetch, tracked indicator should reflect ignored state (gray dot)
-    // The select should update to show "ignored" after the mutation + refetch
+    // After the mutation + refetch the list reflects the persisted choice.
     await expect(select).toHaveValue('ignored', { timeout: 5000 })
   })
 
+  // spec: TGM-041[2]
   test('group chat management: toggle auto to tracked', async ({ page }) => {
     let currentStatus = 'auto'
 
-    await page.route('**/api/v1/telegram/auth/status', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          data: { status: 'connected', connected: true, username: 'testuser' },
-        }),
-      })
-    )
+    await mockStatus(page, { status: 'connected', connected: true, username: 'testuser' })
 
     await page.route('**/api/v1/telegram/chats**', route => {
       if (route.request().method() === 'GET') {
@@ -589,13 +599,17 @@ test.describe('Telegram Settings @area:settings', () => {
 
     await expect(page.getByText('Large Work Group')).toBeVisible({ timeout: 10000 })
 
-    const select = page.locator('select').first()
+    const select = page.getByRole('combobox', { name: 'Tracking for Large Work Group' })
     await expect(select).toHaveValue('auto')
 
-    // Toggle to "Tracked"
+    // Toggle to "Tracked", asserting the persistence request carries the choice.
+    const patchRequest = page.waitForRequest(
+      req => req.method() === 'PATCH' && req.url().includes('/api/v1/telegram/chats/')
+    )
     await select.selectOption('tracked')
+    expect((await patchRequest).postDataJSON()).toMatchObject({ status: 'tracked' })
 
-    // After mutation + refetch, select should show tracked
+    // After mutation + refetch, the list reflects the persisted choice.
     await expect(select).toHaveValue('tracked', { timeout: 5000 })
   })
 })

--- a/spec/mac-host.yaml
+++ b/spec/mac-host.yaml
@@ -245,6 +245,11 @@ behaviors:
       - per-source live counts distinguish a missing host (404) from a host with no rows (an empty count map)
       - an admin can mint a fresh pairing token and revoke a host
     provenance: [MacHostHandler.ListHosts/GetHostAdmin/GetSourceCounts/CreatePairingToken/DeleteHost, RegisterMacHostAdminRoutes]
+    waivers:
+      - then: 1
+        reason: the host detail read (including revoked hosts and the unknown-id 404) is HTTP contract with no browser surface — the settings/mac page consumes only the list endpoint; owned by the Go API test mac_host_get_admin_test.go
+      - then: 2
+        reason: the 404-vs-empty-count-map distinction is response-shape contract invisible in the browser (the UI renders only the happy-path counts); owned by the Go API tests in mac_host_source_counts_test.go (UnknownHost_404, NoRowsReturnsEmpty)
 
   # --- Daemon read endpoints ---
 
@@ -487,3 +492,16 @@ behaviors:
       - re-pair rotates the key in place, and a failure to persist the rotated key prints the plaintext key so the operator can recover
     provenance: [InstallCommand.swift]
     notes: CLI specifics asserted from the surface inventory, not read line-by-line.
+
+  - id: MAC-046
+    title: Source health reports a live contact count once a contacts backfill completes
+    type: ux
+    status: current
+    surface: ui
+    given: a paired host whose source health includes a contacts source
+    when: the source-health view renders that source's cursor state
+    then:
+      - once the source reports backfill complete, the live contact count for the host and source is shown in place of the raw change-token cursor
+      - while backfill is still in progress, a neutral placeholder is shown and no count is substituted
+    provenance: [settings/mac/cursor-cell.ts renderCursorCell/cursorCellState, useMacHostSourceCounts, MacHostHandler.GetSourceCounts]
+    notes: 'The regression guard for issue #327: an iCloud change-token cursor is meaningless to the operator, so the cell swaps to a live count only when the count is trustworthy (backfill complete). The counts endpoint contract is MAC-018.'

--- a/spec/mac-host.yaml
+++ b/spec/mac-host.yaml
@@ -502,6 +502,6 @@ behaviors:
     when: the source-health view renders that source's cursor state
     then:
       - once the source reports backfill complete, the live contact count for the host and source is shown in place of the raw change-token cursor
-      - while backfill is still in progress, a neutral placeholder is shown and no count is substituted
+      - while backfill is still in progress, a neutral placeholder is shown — the raw change-token cursor is never displayed and no count is substituted
     provenance: [settings/mac/cursor-cell.ts renderCursorCell/cursorCellState, useMacHostSourceCounts, MacHostHandler.GetSourceCounts]
-    notes: 'The regression guard for issue #327: an iCloud change-token cursor is meaningless to the operator, so the cell swaps to a live count only when the count is trustworthy (backfill complete). The counts endpoint contract is MAC-018.'
+    notes: 'The regression guard for issue #327: an iCloud change-token cursor is meaningless to the operator, so the cell shows a live count only when the count is trustworthy (backfill complete) and otherwise the neutral placeholder — never the raw change-token. The counts endpoint contract is MAC-018.'

--- a/spec/settings.yaml
+++ b/spec/settings.yaml
@@ -452,3 +452,18 @@ behaviors:
       - a trigger with a well-formed body for a source the account guard does not reject is acknowledged with a 202 whose body carries only an acknowledgement (a message and the source) and no sync result
     provenance: [SyncHandler.TriggerSync, service.AccountIDMissing, service.ErrAccountRequired]
     notes: The trigger is fire-and-forget — acceptance dispatches the sync in a detached goroutine off the request path, so whether/when the sync actually runs is owned by the sync service and worker paths, not this HTTP contract. This behavior pins only the guard (400) and the acknowledgement status+body shape (202). The 400 guard mirrors the service-layer ErrAccountRequired backstop.
+
+  # --- System information ---
+
+  - id: SET-035
+    title: The settings page reports system information
+    type: ux
+    status: current
+    surface: ui
+    given: the settings page
+    when: the system information section renders
+    then:
+      - a system information section is present on the settings surface
+      - a non-empty application version is shown
+    provenance: [settings/page.tsx System Information section]
+    notes: The version string is build-stamped (NEXT_PUBLIC_BUILD_VERSION, with a dev fallback when unstamped); the backend build stamp is covered separately by TestHealthEndpoint_StampedBuildInfo. Pinning the exact fallback copy is deliberately avoided.

--- a/spec/telegram.yaml
+++ b/spec/telegram.yaml
@@ -69,7 +69,7 @@ behaviors:
     title: Starting auth sends a login code
     type: business-logic
     status: current
-    surface: ui
+    surface: none
     given: no connected session and no auth flow in progress
     when: auth is started for a phone number
     then:
@@ -77,12 +77,13 @@ behaviors:
       - a login code is requested and the flow advances to awaiting-code
       - the delivery channel (app, sms, or call; any other sent-code type maps to unknown) and a token with a 5-minute expiry are returned
     provenance: [AuthSessionManager.StartAuth, mapSentCodeType, ErrAlreadyConnected, ErrAuthInProgress]
+    notes: 'Surface is none, not ui: this is AuthSessionManager logic, and E2E necessarily route-mocks the telegram auth endpoints (MTProto cannot run in E2E), so a browser citation would be circular. Owned by Go tests over the manager with a stubbed MTProto client (backfill item — none exist yet). The browser half of the connect flow is TGM-038.'
 
   - id: TGM-005
     title: Verification progresses code then optional password to connected
     type: business-logic
     status: current
-    surface: ui
+    surface: none
     given: an auth flow awaiting a verification step
     when: a verification value is submitted
     then:
@@ -91,6 +92,7 @@ behaviors:
       - a valid password connects the account
       - on connect the session is persisted with the resolved user id and username and marked connected
     provenance: [AuthSessionManager.VerifyCode, AuthSessionManager.VerifyPassword, UpdateUserInfo, UpdateAuthState]
+    notes: 'Surface is none, not ui: session persistence and step gating are AuthSessionManager logic that E2E route-mocks wholesale, so a browser citation would be circular. Owned by Go tests over the manager with a stubbed MTProto client (backfill item — none exist yet). The browser half of the verification flow is TGM-038.'
 
   - id: TGM-006
     title: Auth rejections are retryable while infrastructure errors abort
@@ -152,7 +154,7 @@ behaviors:
     title: Reported status resolves from the live connection then the database
     type: business-logic
     status: current
-    surface: ui
+    surface: none
     given: a request for Telegram status
     when: the status is resolved
     then:
@@ -160,6 +162,7 @@ behaviors:
       - an explicit disconnect reports not-connected without falling back to stale database state
       - otherwise the stored session's connected flag, username, and phone are reported
     provenance: [TelegramManager.Status, enrichStatusFromSyncState]
+    notes: 'Surface is none, not ui: the in-memory-vs-database resolution order is TelegramManager.Status logic that E2E route-mocks replace entirely, so a browser citation would be circular. Owned by Go tests over the manager (backfill item — none exist yet). What the settings surface shows for a connected/disconnected status is TGM-039.'
 
   - id: TGM-033
     title: A dropped connection reconnects with bounded backoff
@@ -478,3 +481,62 @@ behaviors:
       - all unprocessed messages are aggregated into interactions
       - discovery candidates are refreshed for peers over the threshold
     provenance: [TelegramManager.maybeStartBackfill, PeerMatcher.MatchAllUnmatched, AggregationEngine.AggregateAll, PeerMatcher.UpdateDiscoveryCandidates]
+
+  # --- Settings surface (UI) ---
+
+  - id: TGM-038
+    title: The connect flow walks phone, code, and optional password to connected
+    type: ux
+    status: current
+    surface: ui
+    given: the Telegram settings section in a disconnected state
+    when: the user connects an account
+    then:
+      - starting a connect reveals a phone-number entry with submit and cancel affordances
+      - a started flow advances to code entry, reflecting the delivery channel the code was sent through
+      - a valid code either connects the account or, for a two-factor account, advances to a password entry step
+      - a valid password connects the account
+      - the connected state shows the account username
+    provenance: [telegram-section.tsx phone_input/awaiting_code/awaiting_password/connected steps, use-telegram.ts]
+    notes: The browser half of the auth flow; the backend session/step logic it drives is TGM-004/TGM-005 (surface none). E2E proves this against route-mocked auth endpoints — the mock is the external boundary (MTProto cannot run in E2E), the surface branches are real.
+
+  - id: TGM-039
+    title: The connected section reports identity and sync progress
+    type: ux
+    status: current
+    surface: ui
+    given: a connected Telegram account
+    when: the Telegram settings section renders
+    then:
+      - the account username and phone number are shown
+      - while a backfill is in progress, its completed and total counts are shown
+      - a disconnect affordance is offered, and confirming it returns the section to the disconnected state
+    provenance: [telegram-section.tsx connected step, handleDisconnect, backfill progress block]
+    notes: The status values rendered here are resolved by the backend per TGM-010 (surface none).
+
+  - id: TGM-040
+    title: A rejected verification is surfaced and retryable
+    type: ux
+    status: current
+    surface: ui
+    given: an in-progress connect flow awaiting a verification code
+    when: the backend rejects the submitted code
+    then:
+      - the failure reason is shown to the user
+      - the flow stays on the code entry step so the user can retry
+    provenance: [telegram-section.tsx handleVerifyCode error path]
+    notes: Which rejections are retryable versus aborting is backend scope (TGM-006).
+
+  - id: TGM-041
+    title: Group chats are listed with a per-chat tracking control
+    type: ux
+    status: current
+    surface: ui
+    given: a connected Telegram account
+    when: the group-chat list renders
+    then:
+      - discovered group chats are listed with their member counts
+      - before any chats are discovered an empty state is shown
+      - changing a chat's tracking choice persists it and the list reflects the persisted choice
+    provenance: [telegram-section.tsx TelegramChatList, use-telegram.ts useUpdateTelegramChatStatus]
+    notes: How the tracking choice feeds effective tracking is TGM-011 (surface none); the tracked/untracked dot is judge-owned presentation.


### PR DESCRIPTION
Child 3 of the E2E surface settlement plan (`.ai/spec/2026-07-15-remaining-e2e-migration-design.md`; work order: `.ai/spec/2026-07-16-e2e-settlement-audit/child-3-settings.md`). Settings, settings-mac, and telegram-settings relax+cite. Follows #667/#670.

## Result

`make spec-coverage`: settings **26 covered / 0 waived / 0 orphaned**, mac-host **4 / 2 / 0**, telegram **13 / 0 / 0** (todoist's 3 remaining orphans are TDS-035, owned by the residual child). 0 invalid citations corpus-wide.

## ⚠️ Two real product bug fixes included (not test-only)

- **fix(telegram): keep settings section disconnected after disconnect** — the step effect re-derived from the stale cached status and flipped the view back to connected, permanently. Minimal fix in `useDisconnectTelegram` (snap cached status before invalidating). Found because the minted TGM-039[2] test could not truthfully pass without it.
- **fix(mac): never render the backfill change-token cursor** — mid-backfill sources with a pushed cursor rendered the raw change-token (the exact #327 complaint) while `cursorCellState` reported "pending". `renderCursorCell` now agrees with the state fn; 5 new unit tests pin the coherence; the E2E fixture seeds a change-token and asserts it never renders.

## What's here

- **SSOT restructuring (atomic):** TGM-004/005/010 retagged `ui`→`none` (they describe backend auth-session logic; an E2E test route-mocks exactly those endpoints, so citing them would be circular). Minted TGM-038..041 (connect flow, connected status, verification-error retry, chat tracking), MAC-046 (backfill-count guard), SET-035 (system-info surface) as `ux`/`current`; waivers on MAC-018[1]/[2] (HTTP-contract facets, Go-owned — new Go API test `mac_host_get_admin_test.go` covers the host detail read).
- **settings.spec.ts rewritten**: environment-conditional either/or hedges (`isVisible().catch()` — could never fail) replaced with deterministic route-mocked tests covering all 24 SET ui then-items + TDS-034, plus one unmocked live-backend smoke test (provider sections settle against the real endpoints). Locale/timezone pinned.
- **settings-mac.spec.ts / telegram-settings.spec.ts**: citations + targeted relaxations (glyph asserts, positional `td.nth()`, empty-state copy → scoped row assertions).
- **Aria/state surfaces** (semantic-only): SyncBadge `aria-label`, provider section names, telegram chat-select label, mac cursor-cell `data-state`, disconnect/picker labels.
- A high-effort adversarial review pass ran before this PR; its 10 findings (cursor-cell contradiction, cross-worker mac_host race, TZ-dependent asserts, vacuous refetch proof, mis-anchored citation, id/account_id aliasing, dropped live smoke/system-info/file-input coverage, dead CORS scaffolding) are all fixed here.

## Verification

- `make spec-lint` — 414 behaviors OK; `make spec-coverage` — lines above, exit 0
- `PLAYWRIGHT_GREP="settings" make test-e2e-local` — 37 passed
- Go: `TestMacHost_GetAdmin_*` PASS; frontend: lint clean, `tsc --noEmit` clean, 631 unit tests pass
