### PR TITLE
test(meetings): E2E settlement child 4 — meetings/notepad/knowledge relax + cite

### DIFF
--- a/frontend/src/components/contacts/meetings.tsx
+++ b/frontend/src/components/contacts/meetings.tsx
@@ -49,7 +49,7 @@ function MeetingCard({ event, isPast }: { event: CalendarEvent; isPast: boolean 
   const title = event.title || 'Untitled Meeting'
 
   return (
-    <div className={`px-4 py-4 sm:px-6 ${isPast ? 'opacity-60' : ''}`}>
+    <div role="listitem" className={`px-4 py-4 sm:px-6 ${isPast ? 'opacity-60' : ''}`}>
       <div className="flex items-start justify-between">
         <div className="flex-1 min-w-0">
           <h4 className="text-sm font-medium text-gray-900 truncate flex items-center gap-2">
@@ -143,7 +143,7 @@ export function Meetings({ contactId }: MeetingsProps) {
 
   if (isLoading) {
     return (
-      <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+      <section aria-label="Meetings" className="bg-white shadow overflow-hidden sm:rounded-lg">
         <div className="px-4 py-5 sm:px-6 border-b border-gray-200">
           <h3 className="text-lg leading-6 font-medium text-gray-900 flex items-center">
             <Calendar className="w-5 h-5 mr-2 text-gray-400" />
@@ -156,7 +156,7 @@ export function Meetings({ contactId }: MeetingsProps) {
             <div className="h-4 bg-gray-200 rounded w-1/2"></div>
           </div>
         </div>
-      </div>
+      </section>
     )
   }
 
@@ -175,7 +175,7 @@ export function Meetings({ contactId }: MeetingsProps) {
   ]
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+    <section aria-label="Meetings" className="bg-white shadow overflow-hidden sm:rounded-lg">
       <div className="px-4 py-5 sm:px-6 border-b border-gray-200">
         <div className="flex items-center justify-between">
           <div>
@@ -191,6 +191,7 @@ export function Meetings({ contactId }: MeetingsProps) {
             {filterButtons.map(({ key, label, count }) => (
               <button
                 key={key}
+                aria-pressed={filter === key}
                 onClick={() => {
                   setFilter(key)
                   setDisplayLimit(10)
@@ -207,7 +208,7 @@ export function Meetings({ contactId }: MeetingsProps) {
           </div>
         </div>
       </div>
-      <div className="divide-y divide-gray-200">
+      <div role="list" className="divide-y divide-gray-200">
         {displayedEvents.map(event => (
           <MeetingCard key={event.id} event={event} isPast={isPastEvent(event, currentTime)} />
         ))}
@@ -225,6 +226,6 @@ export function Meetings({ contactId }: MeetingsProps) {
           </Button>
         </div>
       )}
-    </div>
+    </section>
   )
 }

--- a/frontend/tests/e2e/contact-knowledge.spec.ts
+++ b/frontend/tests/e2e/contact-knowledge.spec.ts
@@ -27,6 +27,11 @@ async function createContact(
 }
 
 test.describe('Contact knowledge rows @area:contacts', () => {
+  // The birthday row renders via formatBirthday → toLocaleDateString with the
+  // browser's default locale — pin it so the expectation computed below (with
+  // an explicit 'en-US') matches the browser's rendering.
+  test.use({ locale: 'en-US' })
+
   let testApi: TestAPI
 
   test.beforeEach(async ({ request }, testInfo) => {
@@ -38,6 +43,11 @@ test.describe('Contact knowledge rows @area:contacts', () => {
   })
 
   test('shows a location row only when the location is known', async ({ page, request }) => {
+    // Often the suite's first page load: next dev's on-demand compilation of
+    // the contact-detail route can eat most of the default 30s test budget
+    // before the app even renders — triple it.
+    test.slow()
+
     const location = `${testApi.prefix}-Lisbon`
     const locatedId = await createContact(request, {
       full_name: `${testApi.prefix}-Located Contact`,
@@ -69,9 +79,11 @@ test.describe('Contact knowledge rows @area:contacts', () => {
 
   test('shows a birthday row only when the birthday is known', async ({ page, request }) => {
     const birthday = '1990-04-12'
-    // The same human-readable rendering the detail page computes for a
-    // real-year birthday (month short, day numeric, year numeric).
-    const expectedBirthday = new Date(`${birthday}T12:00:00`).toLocaleDateString('en-US', {
+    // Mirror the component's rendering exactly: parseDateOnly builds a LOCAL
+    // date from the Y-M-D parts (no timezone conversion), and formatBirthday
+    // formats it with year/month/day options in the (pinned en-US) locale.
+    const [year, month, day] = birthday.split('-').map(Number)
+    const expectedBirthday = new Date(year, month - 1, day).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',

--- a/frontend/tests/e2e/contact-knowledge.spec.ts
+++ b/frontend/tests/e2e/contact-knowledge.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, type Page } from '@playwright/test'
+import type { APIRequestContext } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+
+// API configuration for E2E tests
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
+const API_HEADERS = {
+  'X-API-Key': API_KEY,
+  'Content-Type': 'application/json',
+}
+
+// A labeled row in the contact-detail definition list, located by its label.
+const detailRow = (page: Page, label: string) =>
+  page.locator('dl > div').filter({ has: page.getByText(label, { exact: true }) })
+
+async function createContact(
+  request: APIRequestContext,
+  data: { full_name: string; location?: string; birthday?: string }
+): Promise<string> {
+  const response = await request.post(`${API_BASE_URL}/api/v1/contacts`, {
+    headers: API_HEADERS,
+    data,
+  })
+  expect(response.ok()).toBe(true)
+  return ((await response.json()).data as { id: string }).id
+}
+
+test.describe('Contact knowledge rows @area:contacts', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  test('shows a location row only when the location is known', async ({ page, request }) => {
+    const location = `${testApi.prefix}-Lisbon`
+    const locatedId = await createContact(request, {
+      full_name: `${testApi.prefix}-Located Contact`,
+      location,
+    })
+    const unlocatedId = await createContact(request, {
+      full_name: `${testApi.prefix}-Unlocated Contact`,
+    })
+
+    // Known location: a labeled row carrying the seeded value
+    // (30s: this can be the suite's first page load, paying next dev's
+    // on-demand route compilation on top of the data fetch)
+    // spec: KNW-034[0]
+    await page.goto(`/contacts/${locatedId}`)
+    await expect(
+      page.getByRole('heading', { name: `${testApi.prefix}-Located Contact` })
+    ).toBeVisible({ timeout: 30000 })
+    await expect(detailRow(page, 'Location')).toBeVisible()
+    await expect(detailRow(page, 'Location')).toContainText(location)
+
+    // Unknown location: no row renders at all
+    // spec: KNW-034[0]
+    await page.goto(`/contacts/${unlocatedId}`)
+    await expect(
+      page.getByRole('heading', { name: `${testApi.prefix}-Unlocated Contact` })
+    ).toBeVisible({ timeout: 15000 })
+    await expect(detailRow(page, 'Location')).toHaveCount(0)
+  })
+
+  test('shows a birthday row only when the birthday is known', async ({ page, request }) => {
+    const birthday = '1990-04-12'
+    // The same human-readable rendering the detail page computes for a
+    // real-year birthday (month short, day numeric, year numeric).
+    const expectedBirthday = new Date(`${birthday}T12:00:00`).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+
+    const birthdayId = await createContact(request, {
+      full_name: `${testApi.prefix}-Birthday Contact`,
+      birthday,
+    })
+    const plainId = await createContact(request, {
+      full_name: `${testApi.prefix}-No Birthday Contact`,
+    })
+
+    // Known birthday: a labeled row with the human-readable date
+    // spec: KNW-034[1]
+    await page.goto(`/contacts/${birthdayId}`)
+    await expect(
+      page.getByRole('heading', { name: `${testApi.prefix}-Birthday Contact` })
+    ).toBeVisible({ timeout: 15000 })
+    await expect(detailRow(page, 'Birthday')).toBeVisible()
+    await expect(detailRow(page, 'Birthday')).toContainText(expectedBirthday)
+
+    // Unknown birthday: no row renders
+    // spec: KNW-034[1]
+    await page.goto(`/contacts/${plainId}`)
+    await expect(
+      page.getByRole('heading', { name: `${testApi.prefix}-No Birthday Contact` })
+    ).toBeVisible({ timeout: 15000 })
+    await expect(detailRow(page, 'Birthday')).toHaveCount(0)
+  })
+})

--- a/frontend/tests/e2e/helpers/fulfill-json.ts
+++ b/frontend/tests/e2e/helpers/fulfill-json.ts
@@ -1,0 +1,12 @@
+import type { Route } from '@playwright/test'
+
+// Fulfill a route with a JSON body. Playwright exempts fulfilled responses
+// from CORS enforcement, so the app's cross-origin API calls (frontend :3000
+// → API :8080, sent with an X-API-Key header) need no explicit CORS headers.
+export function fulfillJson(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  })
+}

--- a/frontend/tests/e2e/meetings.spec.ts
+++ b/frontend/tests/e2e/meetings.spec.ts
@@ -1,5 +1,7 @@
-import { test, expect, type Page, type Route } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { createTestAPI, TestAPI } from './helpers/test-api'
+import { fulfillJson } from './helpers/fulfill-json'
+import type { CalendarEvent } from '../../src/types/calendar'
 
 // API configuration for E2E tests
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
@@ -9,24 +11,24 @@ const API_HEADERS = {
   'Content-Type': 'application/json',
 }
 
-// The app calls the API cross-origin (frontend :3000 → API :8080) with an
-// X-API-Key header, so route-mocked responses must answer the CORS preflight
-// and carry Access-Control-Allow-Origin.
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
-}
-
-function corsFulfill(route: Route, body: unknown, status = 200) {
-  if (route.request().method() === 'OPTIONS') {
-    return route.fulfill({ status: 204, headers: corsHeaders })
-  }
-  return route.fulfill({
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
+// Freeze the client-side accelerated-time frame to a fixed instant by mocking
+// GET /system/time BEFORE the page loads. `acceleration_factor: 0` pins
+// currentTime at base_time, and the body is the full apiClient envelope.
+// Per-page + pre-navigation, so it is parallel-safe and does not touch the
+// process-wide acceleration state.
+async function mockFrozenSystemTime(page: Page, isoInstant: string): Promise<void> {
+  await page.route('**/api/v1/system/time', route =>
+    fulfillJson(route, {
+      success: true,
+      data: {
+        current_time: isoInstant,
+        base_time: isoInstant,
+        is_accelerated: true,
+        acceleration_factor: 0,
+        environment: 'testing',
+      },
+    })
+  )
 }
 
 // Scope every seeded-title lookup to the Meetings region so parallel workers'
@@ -111,8 +113,8 @@ test.describe('Meetings Component @area:meetings', () => {
     await expect(region.getByText(`${testApi.prefix}-Past Meeting 1`)).not.toBeVisible()
     await expect(region.getByText(`${testApi.prefix}-Past Meeting 2`)).not.toBeVisible()
 
-    // Click All filter to see all events
-    // spec: CAL-025[0]
+    // Click All filter to see all events (no CAL-025 then-item states the
+    // combined view; this block just exercises the third filter's activation)
     await region.getByRole('button', { name: /All \(4\)/i }).click()
     await expect(region.getByRole('button', { name: /All \(4\)/i })).toHaveAttribute(
       'aria-pressed',
@@ -149,9 +151,9 @@ test.describe('Meetings Component @area:meetings', () => {
     await expect(region.getByText(`${testApi.prefix}-Upcoming Event`)).toBeVisible()
     await expect(region.getByText(`${testApi.prefix}-Past Event`)).not.toBeVisible()
 
-    // Click Past filter: the event whose end time precedes the app's
-    // accelerated now is the one classified into the Past bucket
-    // spec: CAL-025[0], CAL-025[2]
+    // Click Past filter: only the past-seeded event shows (the end-time
+    // classification boundary itself is proven by the in-progress test below)
+    // spec: CAL-025[0]
     await region.getByRole('button', { name: /Past \(1\)/i }).click()
     await expect(region.getByRole('button', { name: /Past \(1\)/i })).toHaveAttribute(
       'aria-pressed',
@@ -180,13 +182,68 @@ test.describe('Meetings Component @area:meetings', () => {
 
     await region.getByRole('button', { name: /Past \(3\)/i }).click()
 
-    // Cards render in seeded-data order: days_ago 1, then 5, then 10
+    // Cards render most-recent-first (days_ago 1, then 5, then 10) — a
+    // different order than they were seeded in (10, 1, 5), so this proves
+    // the sort rather than echoing insertion order
     // spec: CAL-025[3]
     const cards = meetingCards(page)
     await expect(cards).toHaveCount(3)
     await expect(cards.nth(0)).toContainText(`${testApi.prefix}-Past Recent`)
     await expect(cards.nth(1)).toContainText(`${testApi.prefix}-Past Middle`)
     await expect(cards.nth(2)).toContainText(`${testApi.prefix}-Past Oldest`)
+  })
+
+  test('should classify a meeting as past only once its end time has passed', async ({ page }) => {
+    // Freeze the app's accelerated clock and mock two events around it: one
+    // IN PROGRESS (started before now, ends after now) and one fully ended.
+    // Only the ended one may classify as past — an in-progress meeting has a
+    // past START time, so this distinguishes end-time classification from
+    // start-time classification against the app's (frozen) accelerated now.
+    const frozenNow = new Date('2026-06-01T12:00:00.000Z')
+    const hour = 60 * 60 * 1000
+    const inProgress: CalendarEvent = {
+      id: 'e2e-in-progress-event',
+      title: 'In Progress Meeting',
+      start_time: new Date(frozenNow.getTime() - 1 * hour).toISOString(),
+      end_time: new Date(frozenNow.getTime() + 1 * hour).toISOString(),
+      status: 'confirmed',
+      attendee_count: 0,
+    }
+    const ended: CalendarEvent = {
+      id: 'e2e-ended-event',
+      title: 'Ended Meeting',
+      start_time: new Date(frozenNow.getTime() - 3 * hour).toISOString(),
+      end_time: new Date(frozenNow.getTime() - 2 * hour).toISOString(),
+      status: 'confirmed',
+      attendee_count: 0,
+    }
+
+    await mockFrozenSystemTime(page, frozenNow.toISOString())
+    await page.route(`**/api/v1/contacts/${contactId}/events**`, route =>
+      fulfillJson(route, { success: true, data: [inProgress, ended] })
+    )
+
+    await page.goto(`/contacts/${contactId}`)
+    await page.waitForLoadState('domcontentloaded')
+    const region = meetingsRegion(page)
+
+    // The live counts split 1/1: the in-progress meeting stays upcoming, the
+    // ended one is past — end time vs the frozen accelerated now decides
+    // spec: CAL-025[2]
+    await expect(region.getByRole('button', { name: /Upcoming \(1\)/i })).toBeVisible()
+    await expect(region.getByRole('button', { name: /Past \(1\)/i })).toBeVisible()
+
+    // Default (Upcoming) view carries the in-progress meeting, unmarked
+    await expect(region.getByText('In Progress Meeting')).toBeVisible()
+    await expect(region.getByText('Ended Meeting')).not.toBeVisible()
+    await expect(
+      meetingCard(page, 'In Progress Meeting').getByText('Past', { exact: true })
+    ).not.toBeVisible()
+
+    // Past view carries only the ended meeting
+    await region.getByRole('button', { name: /Past \(1\)/i }).click()
+    await expect(region.getByText('Ended Meeting')).toBeVisible()
+    await expect(region.getByText('In Progress Meeting')).not.toBeVisible()
   })
 
   test('should summarize time, place, and size on the meeting card', async ({ page, request }) => {
@@ -256,20 +313,16 @@ test.describe('Meetings Component @area:meetings', () => {
     const start = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
     const end = new Date(start.getTime() + 60 * 60 * 1000)
 
+    const untitledEvent: CalendarEvent = {
+      id: 'e2e-untitled-event',
+      title: '',
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      status: 'confirmed',
+      attendee_count: 0,
+    }
     await page.route(`**/api/v1/contacts/${contactId}/events**`, route =>
-      corsFulfill(route, {
-        success: true,
-        data: [
-          {
-            id: 'e2e-untitled-event',
-            title: '',
-            start_time: start.toISOString(),
-            end_time: end.toISOString(),
-            status: 'confirmed',
-            attendee_count: 0,
-          },
-        ],
-      })
+      fulfillJson(route, { success: true, data: [untitledEvent] })
     )
 
     await page.goto(`/contacts/${contactId}`)
@@ -338,7 +391,7 @@ test.describe('Meetings Component @area:meetings', () => {
       { title: 'Hidden Meeting', is_past: false, days_ahead: 3 },
     ])
     await page.route(`**/api/v1/contacts/${contactId}/events**`, route =>
-      corsFulfill(
+      fulfillJson(
         route,
         { success: false, error: { code: 'NOT_FOUND', message: 'not found' } },
         404

--- a/frontend/tests/e2e/meetings.spec.ts
+++ b/frontend/tests/e2e/meetings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page, type Route } from '@playwright/test'
 import { createTestAPI, TestAPI } from './helpers/test-api'
 
 // API configuration for E2E tests
@@ -7,6 +7,50 @@ const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
 const API_HEADERS = {
   'X-API-Key': API_KEY,
   'Content-Type': 'application/json',
+}
+
+// The app calls the API cross-origin (frontend :3000 → API :8080) with an
+// X-API-Key header, so route-mocked responses must answer the CORS preflight
+// and carry Access-Control-Allow-Origin.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
+}
+
+function corsFulfill(route: Route, body: unknown, status = 200) {
+  if (route.request().method() === 'OPTIONS') {
+    return route.fulfill({ status: 204, headers: corsHeaders })
+  }
+  return route.fulfill({
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+// Scope every seeded-title lookup to the Meetings region so parallel workers'
+// data (and other page text) can never collide with these assertions.
+const meetingsRegion = (page: Page) => page.getByRole('region', { name: 'Meetings' })
+const meetingCards = (page: Page) => meetingsRegion(page).getByRole('listitem')
+const meetingCard = (page: Page, title: string) => meetingCards(page).filter({ hasText: title })
+
+// Expected card strings computed with the same Intl options the component
+// uses, from the event timestamps the API actually returned (data-derived,
+// not copied from the UI).
+function expectedDateTime(iso: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(iso))
+}
+
+function expectedTimeRange(startIso: string, endIso: string): string {
+  const fmt = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit' })
+  return `${fmt.format(new Date(startIso))} - ${fmt.format(new Date(endIso))}`
 }
 
 test.describe('Meetings Component @area:meetings', () => {
@@ -46,28 +90,45 @@ test.describe('Meetings Component @area:meetings', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // Verify Meetings section exists
+    // spec: CAL-024[0]
     await expect(page.getByRole('heading', { name: /Meetings/i })).toBeVisible()
+    const region = meetingsRegion(page)
 
-    // Verify filter tabs exist with correct counts
-    await expect(page.getByRole('button', { name: /All \(4\)/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /Upcoming \(2\)/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /Past \(2\)/i })).toBeVisible()
+    // Verify filter tabs exist with live counts derived from the seeded data
+    // spec: CAL-025[0]
+    await expect(region.getByRole('button', { name: /All \(4\)/i })).toBeVisible()
+    await expect(region.getByRole('button', { name: /Upcoming \(2\)/i })).toBeVisible()
+    await expect(region.getByRole('button', { name: /Past \(2\)/i })).toBeVisible()
 
-    // By default (Upcoming tab), only upcoming events should be visible
-    await expect(page.getByText(`${testApi.prefix}-Upcoming Meeting 1`)).toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Upcoming Meeting 2`)).toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Past Meeting 1`)).not.toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Past Meeting 2`)).not.toBeVisible()
+    // By default (Upcoming tab pressed), only upcoming events should be visible
+    // spec: CAL-025[1]
+    await expect(region.getByRole('button', { name: /Upcoming \(2\)/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    await expect(region.getByText(`${testApi.prefix}-Upcoming Meeting 1`)).toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Upcoming Meeting 2`)).toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Past Meeting 1`)).not.toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Past Meeting 2`)).not.toBeVisible()
 
     // Click All filter to see all events
-    await page.getByRole('button', { name: /All \(4\)/i }).click()
-    await expect(page.getByText(`${testApi.prefix}-Upcoming Meeting 1`)).toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Upcoming Meeting 2`)).toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Past Meeting 1`)).toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Past Meeting 2`)).toBeVisible()
+    // spec: CAL-025[0]
+    await region.getByRole('button', { name: /All \(4\)/i }).click()
+    await expect(region.getByRole('button', { name: /All \(4\)/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    await expect(region.getByRole('button', { name: /Upcoming \(2\)/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+    await expect(region.getByText(`${testApi.prefix}-Upcoming Meeting 1`)).toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Upcoming Meeting 2`)).toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Past Meeting 1`)).toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Past Meeting 2`)).toBeVisible()
   })
 
-  test('should filter by upcoming events', async ({ page }) => {
+  test('should filter between upcoming and past events', async ({ page }) => {
     // Seed calendar events
     await testApi.seedCalendarEvents(contactId, [
       { title: 'Upcoming Event', is_past: false, days_ahead: 5 },
@@ -76,38 +137,153 @@ test.describe('Meetings Component @area:meetings', () => {
 
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
+    const region = meetingsRegion(page)
 
-    // Click Upcoming filter
-    await page.getByRole('button', { name: /Upcoming \(1\)/i }).click()
+    // Click Upcoming filter: shows only the upcoming event
+    // spec: CAL-025[0]
+    await region.getByRole('button', { name: /Upcoming \(1\)/i }).click()
+    await expect(region.getByRole('button', { name: /Upcoming \(1\)/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    await expect(region.getByText(`${testApi.prefix}-Upcoming Event`)).toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Past Event`)).not.toBeVisible()
 
-    // Should show only upcoming event
-    await expect(page.getByText(`${testApi.prefix}-Upcoming Event`)).toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Past Event`)).not.toBeVisible()
+    // Click Past filter: the event whose end time precedes the app's
+    // accelerated now is the one classified into the Past bucket
+    // spec: CAL-025[0], CAL-025[2]
+    await region.getByRole('button', { name: /Past \(1\)/i }).click()
+    await expect(region.getByRole('button', { name: /Past \(1\)/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    await expect(region.getByText(`${testApi.prefix}-Past Event`)).toBeVisible()
+    await expect(region.getByText(`${testApi.prefix}-Upcoming Event`)).not.toBeVisible()
+
+    // The past meeting's card carries the past marker (scoped to that card)
+    // spec: CAL-026[3]
+    await expect(
+      meetingCard(page, `${testApi.prefix}-Past Event`).getByText('Past', { exact: true })
+    ).toBeVisible()
   })
 
-  test('should filter by past events', async ({ page }) => {
-    // Seed calendar events
+  test('should order past meetings most-recent-first', async ({ page }) => {
     await testApi.seedCalendarEvents(contactId, [
-      { title: 'Upcoming Event', is_past: false, days_ahead: 5 },
-      { title: 'Past Event', is_past: true, days_ago: 5 },
+      { title: 'Past Oldest', is_past: true, days_ago: 10 },
+      { title: 'Past Recent', is_past: true, days_ago: 1 },
+      { title: 'Past Middle', is_past: true, days_ago: 5 },
     ])
 
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
+    const region = meetingsRegion(page)
 
-    // Click Past filter
-    await page.getByRole('button', { name: /Past \(1\)/i }).click()
+    await region.getByRole('button', { name: /Past \(3\)/i }).click()
 
-    // Should show only past event
-    await expect(page.getByText(`${testApi.prefix}-Past Event`)).toBeVisible()
-    await expect(page.getByText(`${testApi.prefix}-Upcoming Event`)).not.toBeVisible()
+    // Cards render in seeded-data order: days_ago 1, then 5, then 10
+    // spec: CAL-025[3]
+    const cards = meetingCards(page)
+    await expect(cards).toHaveCount(3)
+    await expect(cards.nth(0)).toContainText(`${testApi.prefix}-Past Recent`)
+    await expect(cards.nth(1)).toContainText(`${testApi.prefix}-Past Middle`)
+    await expect(cards.nth(2)).toContainText(`${testApi.prefix}-Past Oldest`)
+  })
 
-    // Past events should have "Past" badge
-    await expect(page.getByText('Past', { exact: true })).toBeVisible()
+  test('should summarize time, place, and size on the meeting card', async ({ page, request }) => {
+    await testApi.seedCalendarEvents(contactId, [
+      {
+        title: 'Detailed Meeting',
+        is_past: false,
+        days_ahead: 3,
+        location: `${testApi.prefix}-Conference Room B`,
+        attendee_emails: [`${testApi.prefix}-a@example.com`, `${testApi.prefix}-b@example.com`],
+      },
+      { title: 'Bare Meeting', is_past: false, days_ahead: 4 },
+    ])
+
+    // Read the seeded events back from the API so the expected date/time
+    // strings are derived from the same data the card renders.
+    const eventsResponse = await request.get(
+      `${API_BASE_URL}/api/v1/contacts/${contactId}/events`,
+      { headers: API_HEADERS }
+    )
+    expect(eventsResponse.ok()).toBe(true)
+    const events = (await eventsResponse.json()).data as Array<{
+      title: string
+      start_time: string
+      end_time: string
+    }>
+    const detailed = events.find(e => e.title === `${testApi.prefix}-Detailed Meeting`)
+    expect(detailed).toBeTruthy()
+
+    await page.goto(`/contacts/${contactId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const detailedCard = meetingCard(page, `${testApi.prefix}-Detailed Meeting`)
+    const bareCard = meetingCard(page, `${testApi.prefix}-Bare Meeting`)
+    await expect(detailedCard).toBeVisible()
+    await expect(bareCard).toBeVisible()
+
+    // Title, date, and start-to-end time range, computed from the API data
+    // spec: CAL-026[0]
+    await expect(detailedCard).toContainText(expectedDateTime(detailed!.start_time))
+    await expect(detailedCard).toContainText(
+      expectedTimeRange(detailed!.start_time, detailed!.end_time)
+    )
+
+    // Location shows only on the meeting that has one
+    // spec: CAL-026[1]
+    await expect(detailedCard.getByText(`${testApi.prefix}-Conference Room B`)).toBeVisible()
+    await expect(bareCard.getByText(`${testApi.prefix}-Conference Room B`)).not.toBeVisible()
+
+    // Attendee count shows only when the meeting has more than one attendee
+    // spec: CAL-026[2]
+    await expect(detailedCard.getByText('2 attendees')).toBeVisible()
+    await expect(bareCard.getByText(/attendees/)).not.toBeVisible()
+  })
+
+  test('should fall back to a label for untitled meetings', async ({ page, request }) => {
+    // The seed endpoint validates title as non-empty (min=1), so the untitled
+    // branch is driven with a route-mocked events response (the sanctioned
+    // technique for states real seeding cannot express).
+    const timeResponse = await request.get(`${API_BASE_URL}/api/v1/system/time`, {
+      headers: API_HEADERS,
+    })
+    expect(timeResponse.ok()).toBe(true)
+    const now = new Date(
+      ((await timeResponse.json()).data as { current_time: string }).current_time
+    )
+    const start = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
+    const end = new Date(start.getTime() + 60 * 60 * 1000)
+
+    await page.route(`**/api/v1/contacts/${contactId}/events**`, route =>
+      corsFulfill(route, {
+        success: true,
+        data: [
+          {
+            id: 'e2e-untitled-event',
+            title: '',
+            start_time: start.toISOString(),
+            end_time: end.toISOString(),
+            status: 'confirmed',
+            attendee_count: 0,
+          },
+        ],
+      })
+    )
+
+    await page.goto(`/contacts/${contactId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    // The untitled event's card renders the fallback label
+    // spec: CAL-026[0]
+    await expect(
+      meetingCards(page).getByRole('heading', { level: 4, name: 'Untitled Meeting' })
+    ).toBeVisible()
   })
 
   test('should display html_link as clickable external link', async ({ page }) => {
-    // Seed event with html_link
+    // Seed one event with html_link and one without
     await testApi.seedCalendarEvents(contactId, [
       {
         title: 'Meeting With Link',
@@ -115,35 +291,68 @@ test.describe('Meetings Component @area:meetings', () => {
         days_ahead: 3,
         html_link: 'https://calendar.google.com/calendar/event?eid=test123',
       },
+      { title: 'Meeting Without Link', is_past: false, days_ahead: 4 },
     ])
 
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
+    const region = meetingsRegion(page)
 
-    // Find the meeting link - it should be a link with the title text
-    const meetingLink = page.getByRole('link', {
+    // The linked meeting's title is a link opening in a new tab
+    // spec: CAL-027[0]
+    const meetingLink = region.getByRole('link', {
       name: new RegExp(`${testApi.prefix}-Meeting With Link`),
     })
     await expect(meetingLink).toBeVisible()
-
-    // Verify it has target="_blank" and correct href
     await expect(meetingLink).toHaveAttribute('target', '_blank')
     await expect(meetingLink).toHaveAttribute(
       'href',
       'https://calendar.google.com/calendar/event?eid=test123'
     )
+
+    // The meeting without a link renders its title as plain text, not a link
+    // spec: CAL-027[1]
+    await expect(region.getByText(`${testApi.prefix}-Meeting Without Link`)).toBeVisible()
+    await expect(
+      region.getByRole('link', { name: new RegExp(`${testApi.prefix}-Meeting Without Link`) })
+    ).toHaveCount(0)
   })
 
-  test('should not show meetings section when no events exist', async ({ page }) => {
+  test('should not show meetings section when no events exist or they fail to load', async ({
+    page,
+  }) => {
     // Don't seed any events - just navigate to the contact
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
 
-    // Meetings section should not be visible
+    // Meetings section should not be visible with no events
+    // spec: CAL-024[1]
+    await expect(
+      page.getByRole('heading', { name: `${testApi.prefix}-Meeting Test Contact` })
+    ).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Meetings/i })).not.toBeVisible()
+
+    // Even with events seeded, a failing events fetch renders nothing
+    // spec: CAL-024[1]
+    await testApi.seedCalendarEvents(contactId, [
+      { title: 'Hidden Meeting', is_past: false, days_ahead: 3 },
+    ])
+    await page.route(`**/api/v1/contacts/${contactId}/events**`, route =>
+      corsFulfill(
+        route,
+        { success: false, error: { code: 'NOT_FOUND', message: 'not found' } },
+        404
+      )
+    )
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await expect(
+      page.getByRole('heading', { name: `${testApi.prefix}-Meeting Test Contact` })
+    ).toBeVisible()
     await expect(page.getByRole('heading', { name: /Meetings/i })).not.toBeVisible()
   })
 
-  test('should show load more button when many events exist', async ({ page }) => {
+  test('should reveal a long meeting list progressively', async ({ page }) => {
     // Seed more than 10 events (the default display limit)
     const events = Array.from({ length: 15 }, (_, i) => ({
       title: `Event ${i + 1}`,
@@ -155,15 +364,24 @@ test.describe('Meetings Component @area:meetings', () => {
 
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
+    const region = meetingsRegion(page)
 
-    // Should show "Load more" button
-    await expect(page.getByRole('button', { name: /Load more/i })).toBeVisible()
+    // Initially 10 of the 15 seeded events show, and the control's accessible
+    // name reports the remainder derived from the data
+    // spec: CAL-028[0]
+    await expect(region.getByRole('button', { name: /Load more \(5 remaining\)/i })).toBeVisible()
+    await expect(meetingCards(page)).toHaveCount(10)
 
-    // Click load more
-    await page.getByRole('button', { name: /Load more/i }).click()
+    // One activation exhausts the list: all 15 show and the control disappears
+    // spec: CAL-028[1]
+    await region.getByRole('button', { name: /Load more \(5 remaining\)/i }).click()
+    await expect(meetingCards(page)).toHaveCount(15)
+    await expect(region.getByRole('button', { name: /Load more/i })).not.toBeVisible()
 
-    // After loading more, all 15 events should be visible
-    // (or the button should update to show fewer remaining)
-    await expect(page.getByRole('button', { name: /Load more/i })).not.toBeVisible()
+    // Switching filters resets the reveal back to the initial page
+    // spec: CAL-028[2]
+    await region.getByRole('button', { name: /All \(15\)/i }).click()
+    await expect(region.getByRole('button', { name: /Load more \(5 remaining\)/i })).toBeVisible()
+    await expect(meetingCards(page)).toHaveCount(10)
   })
 })

--- a/frontend/tests/e2e/notepad.spec.ts
+++ b/frontend/tests/e2e/notepad.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, type Page } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+
+// The Notes row in the contact-detail definition list. Scoped to the row so
+// presence/absence assertions can never collide with other page text.
+const notesRow = (page: Page) =>
+  page.locator('dl > div').filter({ has: page.getByText('Notes', { exact: true }) })
+
+test.describe('Contact notepad @area:contacts', () => {
+  let testApi: TestAPI
+  let contactId: string
+  let fullName: string
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+
+    const { ids } = await testApi.seedContacts([{ full_name: 'Notepad Contact' }])
+    contactId = ids[0]
+    fullName = `${testApi.prefix}-Notepad Contact`
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  test('shows the notepad only with content, preserving line breaks and clamping overflow', async ({
+    page,
+  }) => {
+    // With no note seeded, the detail page renders no Notes row at all
+    // spec: NTS-007[0]
+    await page.goto(`/contacts/${contactId}`)
+    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
+    await expect(notesRow(page)).toHaveCount(0)
+
+    // A short note renders the row with its body, and no expand control
+    // (the control appears only when the content overflows the clamp)
+    // spec: NTS-007[0], NTS-007[2]
+    const shortNote = `${testApi.prefix} short note body`
+    await testApi.seedContactNote(contactId, shortNote)
+    await page.reload()
+    await expect(notesRow(page)).toBeVisible({ timeout: 15000 })
+    await expect(notesRow(page)).toContainText(shortNote)
+    await expect(notesRow(page).getByRole('button', { name: /Show more/i })).not.toBeVisible()
+
+    // A long multi-paragraph note overflows the clamp: the expand control
+    // appears, toggles open and closed, and the expanded body preserves the
+    // seeded blank-line paragraph separation
+    const firstParagraph = `${testApi.prefix} first paragraph with plenty of background context about the contact`
+    const lastParagraph = `${testApi.prefix} closing paragraph noting the follow-up we agreed on`
+    const longNote = [
+      firstParagraph,
+      'Second paragraph adding more detail so the body clearly exceeds the four-line clamp.',
+      'Third paragraph continuing the story with even more detail about shared projects.',
+      'Fourth paragraph covering their preferences, interests, and recent conversations.',
+      lastParagraph,
+    ].join('\n\n')
+    await testApi.seedContactNote(contactId, longNote)
+    await page.reload()
+    await expect(notesRow(page)).toBeVisible({ timeout: 15000 })
+
+    // spec: NTS-007[2]
+    const expand = notesRow(page).getByRole('button', { name: /Show more/i })
+    await expect(expand).toBeVisible()
+    await expand.click()
+    const collapse = notesRow(page).getByRole('button', { name: /Show less/i })
+    await expect(collapse).toBeVisible()
+
+    // spec: NTS-007[1]
+    const body = await notesRow(page).locator('dd > div').first().innerText()
+    expect(body).toContain(firstParagraph)
+    expect(body).toContain(lastParagraph)
+    expect(body).toContain('\n\n')
+
+    await collapse.click()
+    await expect(notesRow(page).getByRole('button', { name: /Show more/i })).toBeVisible()
+  })
+
+  test('saves the notepad as its own operation alongside the contact update', async ({ page }) => {
+    await page.goto(`/contacts/${contactId}`)
+    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
+
+    await page.getByRole('button', { name: 'Edit' }).first().click()
+    await expect(page.getByLabel('Notes')).toBeVisible()
+
+    const renamed = `${testApi.prefix}-Renamed Notepad Contact`
+    const noteBody = `${testApi.prefix} refreshed notepad body`
+    await page.getByLabel('Full Name').fill(renamed)
+    await page.getByLabel('Notes').fill(noteBody)
+
+    // Submitting fires TWO separate PUTs — the contact update and the notepad
+    // save — and both complete before edit mode closes
+    // spec: NTS-008[0]
+    const [contactResponse, notesResponse] = await Promise.all([
+      page.waitForResponse(
+        r => r.url().endsWith(`/api/v1/contacts/${contactId}`) && r.request().method() === 'PUT'
+      ),
+      page.waitForResponse(
+        r =>
+          r.url().endsWith(`/api/v1/contacts/${contactId}/notes`) && r.request().method() === 'PUT'
+      ),
+      page.getByRole('button', { name: 'Update Contact' }).click(),
+    ])
+    expect(contactResponse.ok()).toBe(true)
+    expect(notesResponse.ok()).toBe(true)
+
+    // Edit mode closed and both new values render
+    // spec: NTS-008[2]
+    await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible({
+      timeout: 15000,
+    })
+    await expect(page.getByRole('heading', { name: renamed })).toBeVisible()
+    await expect(notesRow(page)).toContainText(noteBody)
+  })
+
+  test('clearing the notepad removes the note', async ({ page }) => {
+    const disposable = `${testApi.prefix} disposable note body`
+    await testApi.seedContactNote(contactId, disposable)
+
+    await page.goto(`/contacts/${contactId}`)
+    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
+    await expect(notesRow(page)).toContainText(disposable)
+
+    await page.getByRole('button', { name: 'Edit' }).first().click()
+    await expect(page.getByLabel('Notes')).toBeVisible()
+    await page.getByLabel('Notes').fill('')
+
+    // An empty notepad submission deletes the note: the API answers 204
+    // spec: NTS-008[1]
+    const [notesResponse] = await Promise.all([
+      page.waitForResponse(
+        r =>
+          r.url().endsWith(`/api/v1/contacts/${contactId}/notes`) && r.request().method() === 'PUT'
+      ),
+      page.getByRole('button', { name: 'Update Contact' }).click(),
+    ])
+    expect(notesResponse.status()).toBe(204)
+
+    // Back on the detail view, the Notes row is gone
+    // spec: NTS-008[1]
+    await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible({
+      timeout: 15000,
+    })
+    await expect(notesRow(page)).toHaveCount(0)
+  })
+})

--- a/frontend/tests/e2e/notepad.spec.ts
+++ b/frontend/tests/e2e/notepad.spec.ts
@@ -87,27 +87,48 @@ test.describe('Contact notepad @area:contacts', () => {
     await page.getByLabel('Full Name').fill(renamed)
     await page.getByLabel('Notes').fill(noteBody)
 
-    // Submitting fires TWO separate PUTs — the contact update and the notepad
-    // save — and both complete before edit mode closes
-    // spec: NTS-008[0]
-    const [contactResponse, notesResponse] = await Promise.all([
-      page.waitForResponse(
-        r => r.url().endsWith(`/api/v1/contacts/${contactId}`) && r.request().method() === 'PUT'
-      ),
-      page.waitForResponse(
-        r =>
-          r.url().endsWith(`/api/v1/contacts/${contactId}/notes`) && r.request().method() === 'PUT'
-      ),
-      page.getByRole('button', { name: 'Update Contact' }).click(),
-    ])
-    expect(contactResponse.ok()).toBe(true)
-    expect(notesResponse.ok()).toBe(true)
+    // Hold the notepad PUT open at the network layer so the ordering claim is
+    // observable: if edit mode closed after only the contact PUT (a
+    // fire-and-forget notepad save), the still-open assertion below would
+    // catch it. Non-PUT traffic on the notes path passes through untouched.
+    let releaseNotesPut = () => {}
+    const notesGate = new Promise<void>(resolve => {
+      releaseNotesPut = resolve
+    })
+    await page.route(`**/api/v1/contacts/${contactId}/notes`, async route => {
+      if (route.request().method() !== 'PUT') return route.continue()
+      await notesGate
+      return route.continue()
+    })
 
-    // Edit mode closed and both new values render
-    // spec: NTS-008[2]
+    // Submitting fires TWO separate PUTs — the contact update and the notepad
+    // save — and edit mode closes only once BOTH have completed
+    const contactPut = page.waitForResponse(
+      r => r.url().endsWith(`/api/v1/contacts/${contactId}`) && r.request().method() === 'PUT'
+    )
+    const notesPut = page.waitForResponse(
+      r => r.url().endsWith(`/api/v1/contacts/${contactId}/notes`) && r.request().method() === 'PUT'
+    )
+    await page.getByRole('button', { name: 'Update Contact' }).click()
+
+    // The contact update has landed while the notepad save is still held
+    // open — the edit form must still be on screen
+    // spec: NTS-008[0]
+    const contactResponse = await contactPut
+    expect(contactResponse.ok()).toBe(true)
+    await expect(page.getByRole('button', { name: 'Update Contact' })).toBeVisible()
+
+    // Release the notepad save; only now may edit mode close
+    releaseNotesPut()
+    const notesResponse = await notesPut
+    expect(notesResponse.ok()).toBe(true)
+    // spec: NTS-008[0]
     await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible({
       timeout: 15000,
     })
+
+    // Both new values render after the save
+    // spec: NTS-008[2]
     await expect(page.getByRole('heading', { name: renamed })).toBeVisible()
     await expect(notesRow(page)).toContainText(noteBody)
   })

--- a/frontend/tests/e2e/settings-calendar.spec.ts
+++ b/frontend/tests/e2e/settings-calendar.spec.ts
@@ -1,39 +1,26 @@
-import { test, expect, type Page, type Route } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
+import { fulfillJson } from './helpers/fulfill-json'
+import type { SyncState, StalenessBreach } from '../../src/types/sync'
+import type { GoogleAccount } from '../../src/lib/oauth-api'
 
 // The calendar sync control and staleness banner depend on provider state
 // (a connected Google account, watchdog breaches) that the sandbox/CI
 // deployment cannot produce, so these tests route-mock the app's own
 // account/status endpoints — the sanctioned technique — and drive the real
-// settings UI against those states.
-//
-// The app calls the API cross-origin (frontend :3000 → API :8080) with an
-// X-API-Key header, so fulfilled responses answer the CORS preflight and
-// carry Access-Control-Allow-Origin.
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
-}
-
-function corsFulfill(route: Route, body: unknown, status = 200) {
-  if (route.request().method() === 'OPTIONS') {
-    return route.fulfill({ status: 204, headers: corsHeaders })
-  }
-  return route.fulfill({
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-}
+// settings UI against those states. Payloads are typed with the app's wire
+// types so backend DTO drift fails `tsc --noEmit` instead of rotting silently.
 
 const CALENDAR_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly'
 const ACCOUNT_ID = 'e2e-calendar-user'
+// Midday UTC so the rendered calendar date cannot shift across timezones,
+// and old enough that formatSyncTime always takes its date-format branch.
+const LAST_SYNC_AT = '2026-01-01T12:00:00Z'
 
 const googleRegion = (page: Page) => page.getByRole('region', { name: 'Google Accounts' })
 
-function calendarAccount() {
+function calendarAccount(): GoogleAccount {
   return {
-    id: ACCOUNT_ID,
+    id: 'e2e-google-credential-row',
     account_id: ACCOUNT_ID,
     created_at: '2026-01-05T12:00:00Z',
     updated_at: '2026-01-05T12:00:00Z',
@@ -41,7 +28,7 @@ function calendarAccount() {
   }
 }
 
-function gcalSyncState(overrides: Record<string, unknown> = {}) {
+function gcalSyncState(overrides: Partial<SyncState> = {}): SyncState {
   return {
     id: 'e2e-gcal-sync-state',
     source: 'gcal',
@@ -49,40 +36,63 @@ function gcalSyncState(overrides: Record<string, unknown> = {}) {
     enabled: true,
     status: 'idle',
     sync_cursor: null,
-    last_sync_at: '2026-01-01T00:00:00Z',
-    last_successful_sync_at: '2026-01-01T00:00:00Z',
+    last_sync_at: LAST_SYNC_AT,
+    last_successful_sync_at: LAST_SYNC_AT,
     next_sync_at: null,
     error_count: 0,
     error_message: null,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
+    created_at: LAST_SYNC_AT,
+    updated_at: LAST_SYNC_AT,
     ...overrides,
+  }
+}
+
+function gcalBreach(): StalenessBreach {
+  return {
+    id: 'e2e-gcal-breach',
+    source: 'gcal',
+    account_id: ACCOUNT_ID,
+    breach_type: 'sync_stale',
+    stale_since: LAST_SYNC_AT,
+    threshold_seconds: 3600,
+    details: 'no successful sync in 2h',
+    detected_at: '2026-01-01T14:00:00Z',
+    last_observed_at: '2026-01-01T14:00:00Z',
   }
 }
 
 async function mockCalendarAccount(page: Page) {
   await page.route('**/api/v1/auth/google/accounts', route =>
-    corsFulfill(route, { success: true, data: [calendarAccount()] })
+    fulfillJson(route, { success: true, data: [calendarAccount()] })
   )
 }
 
-async function mockStaleness(page: Page, breaches: unknown[]) {
+async function mockSyncStates(page: Page, states: SyncState[]) {
+  await page.route('**/api/v1/sync/status', route =>
+    fulfillJson(route, { success: true, data: states })
+  )
+}
+
+async function mockStaleness(page: Page, breaches: StalenessBreach[]) {
   await page.route('**/api/v1/sync/staleness', route =>
-    corsFulfill(route, { success: true, data: breaches })
+    fulfillJson(route, { success: true, data: breaches })
   )
 }
 
 test.describe('Settings calendar sync @area:settings', () => {
+  // The badge's last-sync text renders via toLocaleDateString with the
+  // browser defaults — pin locale and timezone so the expectation computed
+  // below matches the browser's rendering on any host.
+  test.use({ locale: 'en-US', timezoneId: 'UTC' })
+
   // spec: CAL-029[0]
   test('the calendar badge shows the sync state and triggers a sync for the account', async ({
     page,
   }) => {
     await mockCalendarAccount(page)
-    await page.route('**/api/v1/sync/status', route =>
-      corsFulfill(route, { success: true, data: [gcalSyncState()] })
-    )
+    await mockSyncStates(page, [gcalSyncState()])
     await page.route('**/api/v1/sync/gcal/trigger', route =>
-      corsFulfill(route, { success: true, data: null }, 202)
+      fulfillJson(route, { success: true, data: null }, 202)
     )
 
     await page.goto('/settings')
@@ -92,9 +102,14 @@ test.describe('Settings calendar sync @area:settings', () => {
     await expect(google.getByText(ACCOUNT_ID)).toBeVisible({ timeout: 10_000 })
 
     // The badge reports the state derived from the mocked
-    // last_successful_sync_at (2026-01-01 → "Jan 1" via formatSyncTime).
+    // last_successful_sync_at, rendered the same way formatSyncTime does.
+    const expectedLastSync = new Date(LAST_SYNC_AT).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    })
     await expect(google.getByText('Calendar', { exact: true })).toBeVisible()
-    await expect(google.getByText('Jan 1', { exact: true })).toBeVisible()
+    await expect(google.getByText(expectedLastSync, { exact: true })).toBeVisible()
 
     // Triggering the sync posts to the gcal trigger endpoint with the
     // account the badge belongs to.
@@ -118,14 +133,14 @@ test.describe('Settings calendar sync @area:settings', () => {
     // post-trigger refetch observes the in-progress state.
     let syncing = false
     await page.route('**/api/v1/sync/status', route =>
-      corsFulfill(route, {
+      fulfillJson(route, {
         success: true,
         data: [gcalSyncState(syncing ? { status: 'syncing' } : {})],
       })
     )
     await page.route('**/api/v1/sync/gcal/trigger', route => {
       syncing = true
-      return corsFulfill(route, { success: true, data: null }, 202)
+      return fulfillJson(route, { success: true, data: null }, 202)
     })
 
     await page.goto('/settings')
@@ -148,22 +163,8 @@ test.describe('Settings calendar sync @area:settings', () => {
   // spec: CAL-030[0]
   test('a stalled calendar sync is named on the staleness banner', async ({ page }) => {
     await mockCalendarAccount(page)
-    await page.route('**/api/v1/sync/status', route =>
-      corsFulfill(route, { success: true, data: [gcalSyncState()] })
-    )
-    await mockStaleness(page, [
-      {
-        id: 'e2e-gcal-breach',
-        source: 'gcal',
-        account_id: ACCOUNT_ID,
-        breach_type: 'sync_stale',
-        stale_since: '2026-01-01T00:00:00Z',
-        threshold_seconds: 3600,
-        details: 'no successful sync in 2h',
-        detected_at: '2026-01-01T02:00:00Z',
-        last_observed_at: '2026-01-01T02:00:00Z',
-      },
-    ])
+    await mockSyncStates(page, [gcalSyncState()])
+    await mockStaleness(page, [gcalBreach()])
 
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
@@ -180,9 +181,7 @@ test.describe('Settings calendar sync @area:settings', () => {
   // spec: CAL-030[1]
   test('the staleness banner stays quiet when nothing is stalled', async ({ page }) => {
     await mockCalendarAccount(page)
-    await page.route('**/api/v1/sync/status', route =>
-      corsFulfill(route, { success: true, data: [gcalSyncState()] })
-    )
+    await mockSyncStates(page, [gcalSyncState()])
     await mockStaleness(page, [])
 
     await page.goto('/settings')

--- a/frontend/tests/e2e/settings-calendar.spec.ts
+++ b/frontend/tests/e2e/settings-calendar.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+// The calendar sync control and staleness banner depend on provider state
+// (a connected Google account, watchdog breaches) that the sandbox/CI
+// deployment cannot produce, so these tests route-mock the app's own
+// account/status endpoints — the sanctioned technique — and drive the real
+// settings UI against those states.
+//
+// The app calls the API cross-origin (frontend :3000 → API :8080) with an
+// X-API-Key header, so fulfilled responses answer the CORS preflight and
+// carry Access-Control-Allow-Origin.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type,X-API-Key',
+}
+
+function corsFulfill(route: Route, body: unknown, status = 200) {
+  if (route.request().method() === 'OPTIONS') {
+    return route.fulfill({ status: 204, headers: corsHeaders })
+  }
+  return route.fulfill({
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const CALENDAR_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly'
+const ACCOUNT_ID = 'e2e-calendar-user'
+
+const googleRegion = (page: Page) => page.getByRole('region', { name: 'Google Accounts' })
+
+function calendarAccount() {
+  return {
+    id: ACCOUNT_ID,
+    account_id: ACCOUNT_ID,
+    created_at: '2026-01-05T12:00:00Z',
+    updated_at: '2026-01-05T12:00:00Z',
+    scopes: [CALENDAR_SCOPE],
+  }
+}
+
+function gcalSyncState(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'e2e-gcal-sync-state',
+    source: 'gcal',
+    account_id: ACCOUNT_ID,
+    enabled: true,
+    status: 'idle',
+    sync_cursor: null,
+    last_sync_at: '2026-01-01T00:00:00Z',
+    last_successful_sync_at: '2026-01-01T00:00:00Z',
+    next_sync_at: null,
+    error_count: 0,
+    error_message: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+async function mockCalendarAccount(page: Page) {
+  await page.route('**/api/v1/auth/google/accounts', route =>
+    corsFulfill(route, { success: true, data: [calendarAccount()] })
+  )
+}
+
+async function mockStaleness(page: Page, breaches: unknown[]) {
+  await page.route('**/api/v1/sync/staleness', route =>
+    corsFulfill(route, { success: true, data: breaches })
+  )
+}
+
+test.describe('Settings calendar sync @area:settings', () => {
+  // spec: CAL-029[0]
+  test('the calendar badge shows the sync state and triggers a sync for the account', async ({
+    page,
+  }) => {
+    await mockCalendarAccount(page)
+    await page.route('**/api/v1/sync/status', route =>
+      corsFulfill(route, { success: true, data: [gcalSyncState()] })
+    )
+    await page.route('**/api/v1/sync/gcal/trigger', route =>
+      corsFulfill(route, { success: true, data: null }, 202)
+    )
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    await expect(google.getByText(ACCOUNT_ID)).toBeVisible({ timeout: 10_000 })
+
+    // The badge reports the state derived from the mocked
+    // last_successful_sync_at (2026-01-01 → "Jan 1" via formatSyncTime).
+    await expect(google.getByText('Calendar', { exact: true })).toBeVisible()
+    await expect(google.getByText('Jan 1', { exact: true })).toBeVisible()
+
+    // Triggering the sync posts to the gcal trigger endpoint with the
+    // account the badge belongs to.
+    const syncButton = google.getByRole('button', { name: 'Sync Calendar' })
+    const [triggerRequest] = await Promise.all([
+      page.waitForRequest(
+        r => r.url().includes('/api/v1/sync/gcal/trigger') && r.method() === 'POST'
+      ),
+      syncButton.click(),
+    ])
+    expect(triggerRequest.postDataJSON()).toMatchObject({ account_id: ACCOUNT_ID })
+  })
+
+  // spec: CAL-029[1]
+  test('a triggered sync reports it started and the badge reflects the polled progress', async ({
+    page,
+  }) => {
+    await mockCalendarAccount(page)
+
+    // The status mock flips to syncing once the trigger lands, so the
+    // post-trigger refetch observes the in-progress state.
+    let syncing = false
+    await page.route('**/api/v1/sync/status', route =>
+      corsFulfill(route, {
+        success: true,
+        data: [gcalSyncState(syncing ? { status: 'syncing' } : {})],
+      })
+    )
+    await page.route('**/api/v1/sync/gcal/trigger', route => {
+      syncing = true
+      return corsFulfill(route, { success: true, data: null }, 202)
+    })
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    const google = googleRegion(page)
+    const syncButton = google.getByRole('button', { name: 'Sync Calendar' })
+    await expect(syncButton).toBeVisible({ timeout: 10_000 })
+    await syncButton.click()
+
+    // The section reports the sync started…
+    await expect(google.getByText('Calendar sync started!')).toBeVisible({ timeout: 10_000 })
+
+    // …and once the state poll returns syncing, the badge reflects it and
+    // the trigger control is held disabled.
+    await expect(google.getByText('Syncing...')).toBeVisible({ timeout: 10_000 })
+    await expect(syncButton).toBeDisabled()
+  })
+
+  // spec: CAL-030[0]
+  test('a stalled calendar sync is named on the staleness banner', async ({ page }) => {
+    await mockCalendarAccount(page)
+    await page.route('**/api/v1/sync/status', route =>
+      corsFulfill(route, { success: true, data: [gcalSyncState()] })
+    )
+    await mockStaleness(page, [
+      {
+        id: 'e2e-gcal-breach',
+        source: 'gcal',
+        account_id: ACCOUNT_ID,
+        breach_type: 'sync_stale',
+        stale_since: '2026-01-01T00:00:00Z',
+        threshold_seconds: 3600,
+        details: 'no successful sync in 2h',
+        detected_at: '2026-01-01T02:00:00Z',
+        last_observed_at: '2026-01-01T02:00:00Z',
+      },
+    ])
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    // The banner names Google Calendar (label derived from the breach's
+    // source datum) and carries the watchdog's details.
+    const banner = page.getByTestId('sync-staleness-banner')
+    await expect(banner).toBeVisible({ timeout: 10_000 })
+    await expect(banner).toHaveAttribute('role', 'status')
+    await expect(banner).toContainText('Google Calendar')
+    await expect(banner).toContainText('no successful sync in 2h')
+  })
+
+  // spec: CAL-030[1]
+  test('the staleness banner stays quiet when nothing is stalled', async ({ page }) => {
+    await mockCalendarAccount(page)
+    await page.route('**/api/v1/sync/status', route =>
+      corsFulfill(route, { success: true, data: [gcalSyncState()] })
+    )
+    await mockStaleness(page, [])
+
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Wait for the page to settle (the account section has rendered its
+    // data) before asserting the banner's settled-state absence.
+    await expect(googleRegion(page).getByText(ACCOUNT_ID)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('sync-staleness-banner')).toHaveCount(0)
+  })
+})

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -84,6 +84,18 @@
     "tags": ["@area:settings"]
   },
   {
+    "pattern": "^frontend/tests/e2e/settings-calendar\\.spec\\.ts$",
+    "tags": ["@area:settings"]
+  },
+  {
+    "pattern": "^frontend/tests/e2e/notepad\\.spec\\.ts$",
+    "tags": ["@area:contacts"]
+  },
+  {
+    "pattern": "^frontend/tests/e2e/contact-knowledge\\.spec\\.ts$",
+    "tags": ["@area:contacts"]
+  },
+  {
     "pattern": "^frontend/tests/e2e/settings-mac\\.spec\\.ts$",
     "tags": ["@area:settings"]
   },

--- a/spec/calendar.yaml
+++ b/spec/calendar.yaml
@@ -346,8 +346,9 @@ behaviors:
       - it shows the title (a fallback label when untitled), the date, and the start-to-end time range
       - it shows a location when the meeting has one
       - it shows an attendee count only when the meeting has more than one attendee
-      - a past meeting is visually de-emphasized and carries a past marker
+      - a past meeting carries a past marker
     provenance: [components/contacts/meetings.tsx MeetingCard]
+    notes: The visual de-emphasis of past cards (reduced opacity) is presentation quality owned by the agentic judge, deliberately not pinned as a then-item.
 
   - id: CAL-027
     title: A meeting with a source link opens it externally


### PR DESCRIPTION
Child 4 of the E2E surface settlement plan (`.ai/spec/2026-07-15-remaining-e2e-migration-design.md`; work order: `.ai/spec/2026-07-16-e2e-settlement-audit/child-4-notes-meetings-knowledge.md`). Meetings, notepad, contact-knowledge, and settings-calendar surfaces. Follows #667/#670/#671.

## Result

`make spec-coverage`: calendar **22 covered / 0 waived / 0 orphaned** (was 3/0/19), notes-meetings **6 / 0 / 0** (was 0/0/6), knowledge KNW-034 covered (KNW-035's citations land with the remaining-specs child). 0 invalid citations corpus-wide.

## What's here

- **meetings.spec.ts settled**: already KEEP-grade per the audit — gained per-then-item citations (CAL-024..028), region-scoped drivers, and extensions: past ordering, card-content facets, an in-progress meeting fixture proving end-time-vs-accelerated-now classification (CAL-025[2]), untitled-fallback via route mock, fail-to-load branch, reveal reset.
- **Three new spec files** (+ test-map entries): `notepad.spec.ts` (NTS-007/008 — including a delayed-PUT gate proving edit mode waits for both saves before closing), `contact-knowledge.spec.ts` (KNW-034 — location/birthday rows render only when known), `settings-calendar.spec.ts` (CAL-029/030 via typed route mocks).
- **Aria (semantic-only)**: `aria-pressed` on the meetings filter buttons, a named Meetings region, list/listitem roles on meeting cards.
- **SSOT**: CAL-026[3] reworded in place to pin the past marker; the opacity de-emphasis is recorded as judge-owned (Track B) in `notes:` — no citation indexes shifted.
- A high-effort adversarial review ran pre-push; all 9 findings fixed (TZ/locale pinning + midday-UTC timestamps, honest citations, typed mocks so DTO drift fails tsc, corrected comments, shared `fulfillJson` helper extracted to `frontend/tests/e2e/helpers/`).

## Verification

- `make spec-lint` — 414 behaviors OK; `make spec-coverage` — lines above
- Isolated E2E lane: 19 passed (includes the new classification + notepad-ordering tests)
- `bunx tsc --noEmit` clean; `bun run lint` clean
