### PR TITLE
test(contacts): E2E settlement child 5 — residual relaxation of the cited files

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -50,10 +50,11 @@ function OverdueContactCard({ contact }: { contact: OverdueContact }) {
   }
 
   const getUrgencyIndicator = (daysOverdue: number) => {
-    if (daysOverdue <= 2) return 'bg-yellow-500'
-    if (daysOverdue <= 7) return 'bg-orange-500'
-    return 'bg-red-500'
+    if (daysOverdue <= 2) return { dotClass: 'bg-yellow-500', label: 'Low urgency' }
+    if (daysOverdue <= 7) return { dotClass: 'bg-orange-500', label: 'Medium urgency' }
+    return { dotClass: 'bg-red-500', label: 'High urgency' }
   }
+  const urgency = getUrgencyIndicator(contact.days_overdue)
 
   const formatLastContacted = (lastContacted?: string) => {
     if (!lastContacted) return 'Never contacted'
@@ -86,7 +87,10 @@ function OverdueContactCard({ contact }: { contact: OverdueContact }) {
         <div className="flex-1">
           <div className="flex items-center space-x-3 mb-3">
             <div
-              className={clsx('w-3 h-3 rounded-full', getUrgencyIndicator(contact.days_overdue))}
+              role="img"
+              aria-label={urgency.label}
+              title={urgency.label}
+              className={clsx('w-3 h-3 rounded-full', urgency.dotClass)}
             />
             <h3 className="text-lg font-semibold text-gray-900">{contact.full_name}</h3>
             <span className="text-sm font-medium text-gray-500">({contact.cadence} cadence)</span>
@@ -273,7 +277,7 @@ export default function DashboardPage() {
         {/* Contacts List */}
         <div className="space-y-6">
           {isLoading && (
-            <div className="space-y-6">
+            <div role="status" aria-label="Loading overdue contacts" className="space-y-6">
               {[...Array(3)].map((_, i) => (
                 <div key={i} className="bg-white rounded-lg shadow-sm border p-6 animate-pulse">
                   <div className="h-6 bg-gray-200 rounded w-1/3 mb-3"></div>
@@ -286,7 +290,7 @@ export default function DashboardPage() {
           )}
 
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <div role="alert" className="bg-red-50 border border-red-200 rounded-md p-4">
               <div className="flex">
                 <div className="flex-shrink-0">
                   <AlertCircle className="h-5 w-5 text-red-400" />

--- a/frontend/src/components/contacts/merge-contact-modal.tsx
+++ b/frontend/src/components/contacts/merge-contact-modal.tsx
@@ -170,7 +170,12 @@ export function MergeContactModal({
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <div className="relative top-10 mx-auto p-0 border w-full max-w-xl shadow-lg rounded-lg bg-white mb-10">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Merge Contacts"
+        className="relative top-10 mx-auto p-0 border w-full max-w-xl shadow-lg rounded-lg bg-white mb-10"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 bg-gray-50 border-b rounded-t-lg">
           <div className="flex items-center gap-2">
@@ -200,6 +205,7 @@ export function MergeContactModal({
                     <input
                       ref={nameInputRef}
                       type="text"
+                      aria-label="Merged contact name"
                       value={editedName}
                       onChange={e => setEditedName(e.target.value)}
                       onKeyDown={handleNameKeyDown}
@@ -415,6 +421,7 @@ function FieldToggle({
         <button
           type="button"
           onClick={selected !== 'target' ? onToggle : undefined}
+          aria-pressed={selected === 'target'}
           className={clsx(
             'px-3 py-1.5 text-xs font-medium transition-colors truncate max-w-[140px]',
             selected === 'target'
@@ -428,6 +435,7 @@ function FieldToggle({
         <button
           type="button"
           onClick={selected !== 'source' ? onToggle : undefined}
+          aria-pressed={selected === 'source'}
           className={clsx(
             'px-3 py-1.5 text-xs font-medium transition-colors border-l border-gray-200 truncate max-w-[140px]',
             selected === 'source'

--- a/frontend/src/components/contacts/tasks-section.tsx
+++ b/frontend/src/components/contacts/tasks-section.tsx
@@ -50,7 +50,7 @@ export function TasksSection({
   const hasNoTasks = activeTasks.length === 0 && completedTasks.length === 0
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+    <section aria-label="Tasks" className="bg-white shadow overflow-hidden sm:rounded-lg">
       <div className="px-4 py-5 sm:px-6 border-b border-gray-200 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <ListTodo className="w-5 h-5 text-gray-400" />
@@ -113,7 +113,7 @@ export function TasksSection({
           onClose={() => setShowAddModal(false)}
         />
       )}
-    </div>
+    </section>
   )
 }
 
@@ -163,7 +163,11 @@ function TaskRow({ task, contactId, completed }: TaskRowProps) {
       {completed ? (
         <CheckCircle2 className="w-5 h-5 text-gray-400 flex-shrink-0" />
       ) : task.lifecycle === 'followup_loop' ? (
-        <Clock className="w-5 h-5 text-amber-400 flex-shrink-0" />
+        <Clock
+          role="img"
+          aria-label="Awaiting reply"
+          className="w-5 h-5 text-amber-400 flex-shrink-0"
+        />
       ) : (
         <Circle className="w-5 h-5 text-gray-300 flex-shrink-0" />
       )}

--- a/frontend/src/components/layout/navigation.tsx
+++ b/frontend/src/components/layout/navigation.tsx
@@ -45,6 +45,7 @@ export function Navigation() {
                   <Link
                     key={item.name}
                     href={item.href}
+                    aria-current={isActive ? 'page' : undefined}
                     className={clsx(
                       'inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium',
                       isActive

--- a/frontend/src/components/ui/contact-selector.tsx
+++ b/frontend/src/components/ui/contact-selector.tsx
@@ -191,10 +191,15 @@ export function ContactSelector({
       </div>
 
       {isOpen && !disabled && (
-        <div className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+        <div
+          role="listbox"
+          className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
+        >
           {/* No contact option */}
           {showNoContactOption && (
             <div
+              role="option"
+              aria-selected={value === undefined}
               className={clsx(
                 'relative cursor-pointer select-none py-2 pl-10 pr-4',
                 highlightedIndex === -1
@@ -220,6 +225,8 @@ export function ContactSelector({
             filteredContacts.map((contact, index) => (
               <div
                 key={contact.id}
+                role="option"
+                aria-selected={value === contact.id}
                 className={clsx(
                   'relative cursor-pointer select-none py-2 pl-10 pr-4',
                   highlightedIndex === index

--- a/frontend/tests/e2e/birthdays.spec.ts
+++ b/frontend/tests/e2e/birthdays.spec.ts
@@ -86,6 +86,10 @@ test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
     request,
   }) => {
     // spec: CON-045[3]
+    // spec: KNW-035[0], KNW-035[1]
+    // The list-row and detail-page assertions below prove the year-less
+    // rendering (month/day only, placeholder year never shown) and the
+    // birthdays-card assertions prove the age suppression.
     const birthday = await getCurrentBirthdayDate(request)
     const birthdayDate = new Date(`${birthday}T12:00:00`)
     const expectedListDate = `${birthdayDate.getMonth() + 1}/${birthdayDate.getDate()}`

--- a/frontend/tests/e2e/contact-direction.spec.ts
+++ b/frontend/tests/e2e/contact-direction.spec.ts
@@ -143,57 +143,9 @@ test.describe('Contact Direction Signals @area:contacts', () => {
     await expect(page.getByTitle('Awaiting reply')).not.toBeVisible()
   })
 
-  test('interaction API response includes direction field', async ({ request }) => {
-    const { ids } = await testApi.seedContacts([{ full_name: 'Direction API E2E Test' }])
-    const contactId = ids[0]
-
-    // Create interaction with direction
-    const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString()
-    const createResp = await request.post(
-      `${API_BASE_URL}/api/v1/contacts/${contactId}/interactions`,
-      {
-        headers: API_HEADERS,
-        data: { occurred_at: pastDate, direction: 'inbound' },
-      }
-    )
-    expect(createResp.ok()).toBeTruthy()
-    const createBody = await createResp.json()
-    expect(createBody.data.direction).toBe('inbound')
-
-    // List interactions — should include direction
-    const listResp = await request.get(
-      `${API_BASE_URL}/api/v1/contacts/${contactId}/interactions`,
-      { headers: API_HEADERS }
-    )
-    expect(listResp.ok()).toBeTruthy()
-    const listBody = await listResp.json()
-    expect(listBody.data.length).toBeGreaterThan(0)
-    expect(listBody.data[0].direction).toBe('inbound')
-  })
-
-  test('contact API response includes new direction timestamp fields', async ({ request }) => {
-    const { ids } = await testApi.seedContacts([
-      { full_name: 'Timestamps API E2E Test', cadence: 'monthly' },
-    ])
-    const contactId = ids[0]
-
-    // Record a mutual interaction to populate timestamps
-    const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString()
-    await request.post(`${API_BASE_URL}/api/v1/contacts/${contactId}/interactions`, {
-      headers: API_HEADERS,
-      data: { occurred_at: pastDate, direction: 'mutual' },
-    })
-
-    const resp = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
-      headers: API_HEADERS,
-    })
-    expect(resp.ok()).toBeTruthy()
-    const body = await resp.json()
-
-    expect(body.data).toHaveProperty('last_interaction_at')
-    expect(body.data).toHaveProperty('last_outreach_at')
-    expect(body.data).toHaveProperty('last_response_at')
-    expect(body.data).toHaveProperty('has_pending_followup')
-    expect(body.data.has_pending_followup).toBe(false)
-  })
+  // The interaction/contact wire-shape checks (direction field on POST/list,
+  // direction timestamp fields on GET) that used to live here involved no page
+  // and are owned by the Go API suite: TestInteractionAPI_DirectionInResponse,
+  // TestContactAPI_DirectionTimestamps, and TestContactAPI_HasPendingFollowup
+  // in backend/tests/api/direction_api_test.go.
 })

--- a/frontend/tests/e2e/contact-merge.spec.ts
+++ b/frontend/tests/e2e/contact-merge.spec.ts
@@ -295,9 +295,14 @@ test.describe('Contact Merge @area:contact-merge', () => {
     ).not.toBeVisible()
   })
 
-  test('should dismiss the modal without merging via Escape and backdrop', async ({ page }) => {
+  test('should dismiss the modal without merging via backdrop click', async ({ page }) => {
     // spec: CON-043[6]
-    // Both dismissal affordances leave the flow without performing a merge.
+    // Backdrop click dismisses the modal IN PLACE: no merge fires, the modal
+    // closes, and the user stays on the detail page. The Escape path is NOT
+    // asserted here: the detail page's window-level Escape handler is not
+    // gated on an open modal, so Escape today closes the modal AND navigates
+    // back to the list in the same press — a double-action to fix before an
+    // Escape-dismisses-in-place assertion can hold.
     const { ids } = await testApi.seedContacts([
       {
         full_name: 'Dismiss Modal Test',
@@ -310,19 +315,30 @@ test.describe('Contact Merge @area:contact-merge', () => {
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
     await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
+    const detailUrl = page.url()
 
-    // Escape dismisses
+    // No merge may fire during the dismissal.
+    let mergeFired = false
+    const watchMerge = (req: import('@playwright/test').Request) => {
+      if (req.method() === 'POST' && req.url().endsWith('/merge')) {
+        mergeFired = true
+      }
+    }
+    page.on('request', watchMerge)
+
+    // Backdrop click dismisses: click the overlay ELEMENT itself (the
+    // dialog panel's parent), at a corner outside the centered panel.
     await page.getByRole('button', { name: /Merge/i }).click()
     await expect(mergeModal(page)).toBeVisible()
-    await page.keyboard.press('Escape')
+    const overlay = mergeModal(page).locator('..')
+    await overlay.click({ position: { x: 10, y: 10 } })
     await expect(mergeModal(page)).not.toBeVisible()
 
-    // Backdrop click dismisses (the dialog panel is centered with a top
-    // offset, so the top-left corner is backdrop)
-    await page.getByRole('button', { name: /Merge/i }).click()
-    await expect(mergeModal(page)).toBeVisible()
-    await page.mouse.click(10, 10)
-    await expect(mergeModal(page)).not.toBeVisible()
+    // Dismissal, not navigation and not a merge: still on the detail page.
+    await expect(page).toHaveURL(detailUrl)
+    await expect(page.getByRole('heading', { name: fullName })).toBeVisible()
+    page.off('request', watchMerge)
+    expect(mergeFired).toBe(false)
   })
 
   test('should successfully merge contacts', async ({ page }) => {

--- a/frontend/tests/e2e/contact-merge.spec.ts
+++ b/frontend/tests/e2e/contact-merge.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { APIRequestContext } from '@playwright/test'
+import type { APIRequestContext, Page } from '@playwright/test'
 import { createTestAPI, TestAPI } from './helpers/test-api'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
@@ -31,6 +31,22 @@ async function seedMergeContact(
   return (body.data as { id: string }).id
 }
 
+// The merge modal is a labeled dialog (role="dialog", accessible name
+// "Merge Contacts") — the canonical scope for every in-modal assertion.
+function mergeModal(page: Page) {
+  return page.getByRole('dialog', { name: 'Merge Contacts' })
+}
+
+// Open the source selector, search by the worker prefix, and pick the named
+// source from the selector's listbox options.
+async function selectMergeSource(page: Page, prefix: string, sourceName: string) {
+  await page.getByText('Search for a contact to merge...').click()
+  await page.getByPlaceholder('Search for a contact to merge...').fill(prefix)
+  const sourceOption = page.getByRole('option', { name: sourceName })
+  await expect(sourceOption).toBeVisible({ timeout: 5000 })
+  await sourceOption.click()
+}
+
 test.describe('Contact Merge @area:contact-merge', () => {
   let testApi: TestAPI
 
@@ -40,33 +56,6 @@ test.describe('Contact Merge @area:contact-merge', () => {
 
   test.afterEach(async () => {
     await testApi.cleanup()
-  })
-
-  test('should open merge modal from action menu', async ({ page }) => {
-    // Create a contact to be the merge target
-    const { ids } = await testApi.seedContacts([
-      {
-        full_name: 'Merge Target Contact',
-        location: 'New York',
-        cadence: 'monthly',
-      },
-    ])
-
-    const contactId = ids[0]
-    const fullName = `${testApi.prefix}-Merge Target Contact`
-
-    // Navigate to contact detail page
-    await page.goto(`/contacts/${contactId}`)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
-
-    // Click the Merge button in the action menu
-    await page.getByRole('button', { name: /Merge/i }).click()
-
-    // Verify merge modal opens
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).toBeVisible()
-    await expect(page.getByText('Keeping')).toBeVisible()
-    await expect(page.getByText('Archiving')).toBeVisible()
   })
 
   test('should display target contact as "Keeping"', async ({ page }) => {
@@ -87,10 +76,10 @@ test.describe('Contact Merge @area:contact-merge', () => {
 
     // Open merge modal
     await page.getByRole('button', { name: /Merge/i }).click()
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).toBeVisible()
+    const modal = mergeModal(page)
+    await expect(modal).toBeVisible()
 
     // Verify target contact is shown with "Keeping" badge
-    const modal = page.locator('.fixed.inset-0')
     await expect(modal.getByText(fullName).first()).toBeVisible()
     await expect(modal.getByText('Keeping')).toBeVisible()
   })
@@ -119,85 +108,23 @@ test.describe('Contact Merge @area:contact-merge', () => {
 
     // Open merge modal
     await page.getByRole('button', { name: /Merge/i }).click()
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).toBeVisible()
+    await expect(mergeModal(page)).toBeVisible()
 
-    // Click on the contact selector
+    // Search for the source contact and wait for its option to appear
     await page.getByText('Search for a contact to merge...').click()
-
-    // Search for the source contact
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-
-    // Wait for the source contact to appear in dropdown
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
+    await page.getByPlaceholder('Search for a contact to merge...').fill(testApi.prefix)
+    const sourceOption = page.getByRole('option', { name: sourceName })
     await expect(sourceOption).toBeVisible({ timeout: 5000 })
 
     // The selector excludes the merge target — it appears only as the kept
-    // heading, never as a selectable dropdown candidate (CON-043[0]). Scope to
-    // the dropdown option rows (`select-none`) so the kept-name heading (which
-    // is also cursor-pointer) does not count.
-    const targetOption = page.locator('[class*="select-none"]').filter({ hasText: targetName })
-    await expect(targetOption).toHaveCount(0)
+    // heading, never as a selectable option (CON-043[0]).
+    await expect(page.getByRole('option', { name: targetName })).toHaveCount(0)
 
     // Select the source contact
     await sourceOption.click()
 
     // Verify "Will Be Merged" section appears (a source loads a preview).
     await expect(page.getByText('Will Be Merged')).toBeVisible({ timeout: 5000 })
-  })
-
-  test('should show field conflicts when contacts have different values', async ({ page }) => {
-    // Create contacts with conflicting field values
-    const { ids } = await testApi.seedContacts([
-      {
-        full_name: 'Conflict Target',
-        location: 'New York',
-        cadence: 'monthly',
-      },
-      {
-        full_name: 'Conflict Source',
-        location: 'Los Angeles',
-        cadence: 'weekly',
-      },
-    ])
-
-    const targetId = ids[0]
-    const targetName = `${testApi.prefix}-Conflict Target`
-    const sourceName = `${testApi.prefix}-Conflict Source`
-
-    await page.goto(`/contacts/${targetId}`)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: targetName })).toBeVisible({ timeout: 15000 })
-
-    // Open merge modal
-    await page.getByRole('button', { name: /Merge/i }).click()
-
-    // Select source contact
-    await page.getByText('Search for a contact to merge...').click()
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
-    await expect(sourceOption).toBeVisible({ timeout: 5000 })
-    await sourceOption.click()
-
-    // Wait for preview to load first
-    await expect(page.getByText('Will Be Merged')).toBeVisible({ timeout: 10000 })
-
-    // Check if conflict resolution section appears
-    // Note: Conflicts only show when BOTH contacts have the field set AND values differ
-    const hasConflicts = await page
-      .getByText('Resolve Conflicts')
-      .isVisible()
-      .catch(() => false)
-
-    if (hasConflicts) {
-      // Verify location options are visible as toggle buttons within the conflict section
-      await expect(page.getByRole('button', { name: 'New York' })).toBeVisible()
-      await expect(page.getByRole('button', { name: 'Los Angeles' })).toBeVisible()
-    } else {
-      // If no conflicts section, at least verify the preview is showing
-      await expect(page.getByText('Contact methods')).toBeVisible()
-    }
   })
 
   test('should toggle field selection between source and target', async ({ page, request }) => {
@@ -230,18 +157,14 @@ test.describe('Contact Merge @area:contact-merge', () => {
     await page.getByRole('button', { name: /Merge/i }).click()
 
     // Select source contact
-    await page.getByText('Search for a contact to merge...').click()
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
-    await expect(sourceOption).toBeVisible({ timeout: 5000 })
-    await sourceOption.click()
+    await selectMergeSource(page, testApi.prefix, sourceName)
 
     // Wait for conflicts section
     await expect(page.getByText('Resolve Conflicts')).toBeVisible({ timeout: 5000 })
 
     // Default (before any toggle) keeps the TARGET value selected for EVERY
-    // conflicting field — cadence, location, and birthday. The birthday label is
+    // conflicting field — cadence, location, and birthday. Selection state is
+    // exposed as aria-pressed on the toggle buttons. The birthday label is
     // computed the same way the modal formats it, so the assertion is stable
     // across the runner's timezone.
     const targetBirthdayText = new Date('1990-03-15').toLocaleDateString('en-US', {
@@ -249,23 +172,32 @@ test.describe('Contact Merge @area:contact-merge', () => {
       day: 'numeric',
       year: 'numeric',
     })
-    await expect(page.getByRole('button', { name: 'Monthly' })).toHaveClass(/bg-blue-600/)
+    await expect(page.getByRole('button', { name: 'Monthly' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
     const nyButton = page.getByRole('button', { name: 'New York' })
-    await expect(nyButton).toHaveClass(/bg-blue-600/)
-    await expect(page.getByRole('button', { name: targetBirthdayText })).toHaveClass(/bg-blue-600/)
+    await expect(nyButton).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('button', { name: targetBirthdayText })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
 
     // Each field toggles to its SOURCE value independently — location, cadence,
     // and birthday.
     const sfButton = page.getByRole('button', { name: 'San Francisco' })
     await expect(sfButton).toBeVisible()
     await sfButton.click()
-    await expect(sfButton).toHaveClass(/bg-blue-600/)
-    await expect(nyButton).not.toHaveClass(/bg-blue-600/)
+    await expect(sfButton).toHaveAttribute('aria-pressed', 'true')
+    await expect(nyButton).toHaveAttribute('aria-pressed', 'false')
 
     const weeklyButton = page.getByRole('button', { name: 'Weekly' })
     await weeklyButton.click()
-    await expect(weeklyButton).toHaveClass(/bg-blue-600/)
-    await expect(page.getByRole('button', { name: 'Monthly' })).not.toHaveClass(/bg-blue-600/)
+    await expect(weeklyButton).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('button', { name: 'Monthly' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
 
     const sourceBirthdayText = new Date('1985-07-20').toLocaleDateString('en-US', {
       month: 'short',
@@ -274,9 +206,10 @@ test.describe('Contact Merge @area:contact-merge', () => {
     })
     const sourceBirthdayButton = page.getByRole('button', { name: sourceBirthdayText })
     await sourceBirthdayButton.click()
-    await expect(sourceBirthdayButton).toHaveClass(/bg-blue-600/)
-    await expect(page.getByRole('button', { name: targetBirthdayText })).not.toHaveClass(
-      /bg-blue-600/
+    await expect(sourceBirthdayButton).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('button', { name: targetBirthdayText })).toHaveAttribute(
+      'aria-pressed',
+      'false'
     )
   })
 
@@ -302,13 +235,13 @@ test.describe('Contact Merge @area:contact-merge', () => {
 
     // Open merge modal
     await page.getByRole('button', { name: /Merge/i }).click()
+    const modal = mergeModal(page)
 
     // Click on the name to enter edit mode
-    const modal = page.locator('.fixed.inset-0')
-    await modal.locator('h3').first().click()
+    await modal.getByRole('heading', { level: 3 }).first().click()
 
     // Verify input appears with current name
-    const nameInput = modal.locator('input[type="text"]').first()
+    const nameInput = modal.getByRole('textbox', { name: 'Merged contact name' })
     await expect(nameInput).toBeVisible({ timeout: 5000 })
 
     // Edit the name
@@ -316,11 +249,15 @@ test.describe('Contact Merge @area:contact-merge', () => {
     await nameInput.press('Enter')
 
     // Verify name is updated in the modal header
-    await expect(modal.locator('h3').filter({ hasText: 'Custom Merged Name' })).toBeVisible()
+    await expect(
+      modal.getByRole('heading', { level: 3 }).filter({ hasText: 'Custom Merged Name' })
+    ).toBeVisible()
   })
 
   test('should cancel name edit with Escape', async ({ page }) => {
-    // Create a contact
+    // spec: CON-043[3]
+    // The editable-name contract's discard path: Escape must not adopt the
+    // typed name (no accidental rename baked into the merge).
     const { ids } = await testApi.seedContacts([
       {
         full_name: 'Escape Edit Test',
@@ -336,13 +273,13 @@ test.describe('Contact Merge @area:contact-merge', () => {
 
     // Open merge modal
     await page.getByRole('button', { name: /Merge/i }).click()
+    const modal = mergeModal(page)
 
     // Click on the name to enter edit mode
-    const modal = page.locator('.fixed.inset-0')
-    await modal.locator('h3').first().click()
+    await modal.getByRole('heading', { level: 3 }).first().click()
 
     // Type a new name
-    const nameInput = modal.locator('input[type="text"]').first()
+    const nameInput = modal.getByRole('textbox', { name: 'Merged contact name' })
     await expect(nameInput).toBeVisible({ timeout: 5000 })
     await nameInput.fill('Should Not Save')
 
@@ -350,60 +287,42 @@ test.describe('Contact Merge @area:contact-merge', () => {
     await nameInput.press('Escape')
 
     // Verify original name is restored
-    await expect(modal.locator('h3').filter({ hasText: fullName })).toBeVisible()
-    await expect(modal.locator('h3').filter({ hasText: 'Should Not Save' })).not.toBeVisible()
+    await expect(
+      modal.getByRole('heading', { level: 3 }).filter({ hasText: fullName })
+    ).toBeVisible()
+    await expect(
+      modal.getByRole('heading', { level: 3 }).filter({ hasText: 'Should Not Save' })
+    ).not.toBeVisible()
   })
 
-  test('should close modal when pressing Escape', async ({ page }) => {
-    // Create a contact
+  test('should dismiss the modal without merging via Escape and backdrop', async ({ page }) => {
+    // spec: CON-043[6]
+    // Both dismissal affordances leave the flow without performing a merge.
     const { ids } = await testApi.seedContacts([
       {
-        full_name: 'Escape Close Test',
+        full_name: 'Dismiss Modal Test',
       },
     ])
 
     const contactId = ids[0]
-    const fullName = `${testApi.prefix}-Escape Close Test`
+    const fullName = `${testApi.prefix}-Dismiss Modal Test`
 
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
     await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
 
-    // Open merge modal
+    // Escape dismisses
     await page.getByRole('button', { name: /Merge/i }).click()
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).toBeVisible()
-
-    // Press Escape
+    await expect(mergeModal(page)).toBeVisible()
     await page.keyboard.press('Escape')
+    await expect(mergeModal(page)).not.toBeVisible()
 
-    // Verify modal is closed
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).not.toBeVisible()
-  })
-
-  test('should close modal when clicking backdrop', async ({ page }) => {
-    // Create a contact
-    const { ids } = await testApi.seedContacts([
-      {
-        full_name: 'Backdrop Close Test',
-      },
-    ])
-
-    const contactId = ids[0]
-    const fullName = `${testApi.prefix}-Backdrop Close Test`
-
-    await page.goto(`/contacts/${contactId}`)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
-
-    // Open merge modal
+    // Backdrop click dismisses (the dialog panel is centered with a top
+    // offset, so the top-left corner is backdrop)
     await page.getByRole('button', { name: /Merge/i }).click()
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).toBeVisible()
-
-    // Click on backdrop
-    await page.locator('.fixed.inset-0').click({ position: { x: 10, y: 10 } })
-
-    // Verify modal is closed
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).not.toBeVisible()
+    await expect(mergeModal(page)).toBeVisible()
+    await page.mouse.click(10, 10)
+    await expect(mergeModal(page)).not.toBeVisible()
   })
 
   test('should successfully merge contacts', async ({ page }) => {
@@ -437,12 +356,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
     await page.getByRole('button', { name: /Merge/i }).click()
 
     // Select source contact
-    await page.getByText('Search for a contact to merge...').click()
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
-    await expect(sourceOption).toBeVisible({ timeout: 5000 })
-    await sourceOption.click()
+    await selectMergeSource(page, testApi.prefix, sourceName)
 
     // Wait for preview to load
     await expect(page.getByText('Will Be Merged')).toBeVisible({ timeout: 10000 })
@@ -451,7 +365,6 @@ test.describe('Contact Merge @area:contact-merge', () => {
     const mergeButton = page.getByRole('button', { name: /Merge Contacts/i })
     await expect(mergeButton).toBeEnabled({ timeout: 5000 })
 
-    // Intercept the API call to debug any issues
     const mergeResponse = page.waitForResponse(
       response =>
         response.request().method() === 'POST' &&
@@ -463,31 +376,24 @@ test.describe('Contact Merge @area:contact-merge', () => {
     // Click Merge Contacts button
     await mergeButton.click()
 
-    // Wait for the API response
+    // The merge succeeds
     const response = await mergeResponse
-    const responseStatus = response.status()
+    expect(response.status()).toBe(200)
 
-    // Check if merge was successful (should be 200)
-    if (responseStatus === 200) {
-      // Wait for success notification
-      await expect(page.getByText(/merged successfully/i)).toBeVisible({ timeout: 10000 })
+    // Wait for success notification
+    await expect(page.getByText(/merged successfully/i)).toBeVisible({ timeout: 10000 })
 
-      // Verify we're back on the contact page (modal closed)
-      await expect(page.getByRole('heading', { name: 'Merge Contacts' })).not.toBeVisible()
+    // Verify we're back on the contact page (modal closed)
+    await expect(mergeModal(page)).not.toBeVisible()
 
-      // Verify source contact's phone was added
-      await expect(page.getByText('+1-555-0100')).toBeVisible({ timeout: 5000 })
+    // Verify source contact's phone was added
+    await expect(page.getByText('+1-555-0100')).toBeVisible({ timeout: 5000 })
 
-      // Verify source contact's notes were transferred
-      await expect(page.getByText('Source notes to transfer')).toBeVisible()
+    // Verify source contact's notes were transferred
+    await expect(page.getByText('Source notes to transfer')).toBeVisible()
 
-      // The outcome banner is reported, then auto-dismisses after its timeout.
-      await expect(page.getByText(/merged successfully/i)).not.toBeVisible({ timeout: 10000 })
-    } else {
-      // Log the error for debugging
-      const body = await response.text()
-      throw new Error(`Merge API returned ${responseStatus}: ${body}`)
-    }
+    // The outcome banner is reported, then auto-dismisses after its timeout.
+    await expect(page.getByText(/merged successfully/i)).not.toBeVisible({ timeout: 10000 })
   })
 
   test('should show quick-fill name option when source has different name', async ({ page }) => {
@@ -514,25 +420,22 @@ test.describe('Contact Merge @area:contact-merge', () => {
     await page.getByRole('button', { name: /Merge/i }).click()
 
     // Select source contact
-    await page.getByText('Search for a contact to merge...').click()
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
-    await expect(sourceOption).toBeVisible({ timeout: 5000 })
-    await sourceOption.click()
+    await selectMergeSource(page, testApi.prefix, sourceName)
 
     // Wait for preview
     await expect(page.getByText('Will Be Merged')).toBeVisible({ timeout: 5000 })
 
-    // Verify "use this" link appears for source name
-    await expect(page.getByText('use this')).toBeVisible()
+    // Verify the "use this" quick-fill button appears for the source name
+    const useThis = page.getByRole('button', { name: 'use this' })
+    await expect(useThis).toBeVisible()
 
     // Click "use this" to quick-fill the source name
-    await page.getByText('use this').click()
+    await useThis.click()
 
     // Verify name was updated
-    const modal = page.locator('.fixed.inset-0')
-    await expect(modal.locator('h3').filter({ hasText: sourceName })).toBeVisible()
+    await expect(
+      mergeModal(page).getByRole('heading', { level: 3 }).filter({ hasText: sourceName })
+    ).toBeVisible()
   })
 
   test('should disable merge button when no source selected', async ({ page }) => {
@@ -553,73 +456,11 @@ test.describe('Contact Merge @area:contact-merge', () => {
 
     // Open merge modal
     await page.getByRole('button', { name: /Merge/i }).click()
-    await expect(page.getByRole('heading', { name: 'Merge Contacts' })).toBeVisible()
+    await expect(mergeModal(page)).toBeVisible()
 
     // Verify merge button is disabled
     const mergeButton = page.getByRole('button', { name: /Merge Contacts/i })
     await expect(mergeButton).toBeDisabled()
-  })
-
-  test('should show loading state during merge', async ({ page }) => {
-    // Create contacts
-    const { ids } = await testApi.seedContacts([
-      {
-        full_name: 'Loading Target',
-      },
-      {
-        full_name: 'Loading Source',
-      },
-    ])
-
-    const targetId = ids[0]
-    const targetName = `${testApi.prefix}-Loading Target`
-    const sourceName = `${testApi.prefix}-Loading Source`
-
-    await page.goto(`/contacts/${targetId}`)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: targetName })).toBeVisible({ timeout: 15000 })
-
-    // Open merge modal
-    await page.getByRole('button', { name: /Merge/i }).click()
-
-    // Select source contact
-    await page.getByText('Search for a contact to merge...').click()
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
-    await expect(sourceOption).toBeVisible({ timeout: 5000 })
-    await sourceOption.click()
-
-    // Wait for preview
-    await expect(page.getByText('Will Be Merged')).toBeVisible({ timeout: 10000 })
-
-    // Wait for merge button to be enabled
-    const mergeButton = page.getByRole('button', { name: /Merge Contacts/i })
-    await expect(mergeButton).toBeEnabled({ timeout: 5000 })
-
-    // Intercept the API call
-    const mergeResponse = page.waitForResponse(
-      response =>
-        response.request().method() === 'POST' &&
-        response.url().includes('/api/v1/contacts/') &&
-        response.url().endsWith('/merge'),
-      { timeout: 15000 }
-    )
-
-    // Click merge button
-    await mergeButton.click()
-
-    // Wait for API response
-    const response = await mergeResponse
-
-    if (response.status() === 200) {
-      // Wait for success notification
-      await expect(page.getByText(/merged successfully/i)).toBeVisible({ timeout: 10000 })
-    } else {
-      // Log error for debugging
-      const body = await response.text()
-      throw new Error(`Merge API returned ${response.status()}: ${body}`)
-    }
   })
 
   test('keeps the merge submit disabled while the preview is loading', async ({ page }) => {
@@ -645,12 +486,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
     })
 
     // Select the source.
-    await page.getByText('Search for a contact to merge...').click()
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
-    await expect(sourceOption).toBeVisible({ timeout: 5000 })
-    await sourceOption.click()
+    await selectMergeSource(page, testApi.prefix, sourceName)
 
     // While the preview loads, the submit cannot be pressed.
     const mergeButton = page.getByRole('button', { name: /Merge Contacts/i })
@@ -679,12 +515,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
     await page.getByRole('button', { name: /Merge/i }).click()
 
     // Select the source and wait for the preview to settle.
-    await page.getByText('Search for a contact to merge...').click()
-    const searchInput = page.locator('input[placeholder="Search for a contact to merge..."]')
-    await searchInput.fill(testApi.prefix)
-    const sourceOption = page.locator('[class*="cursor-pointer"]').filter({ hasText: sourceName })
-    await expect(sourceOption).toBeVisible({ timeout: 5000 })
-    await sourceOption.click()
+    await selectMergeSource(page, testApi.prefix, sourceName)
     await expect(page.getByText('Will Be Merged')).toBeVisible({ timeout: 10000 })
 
     const mergeButton = page.getByRole('button', { name: /Merge Contacts/i })

--- a/frontend/tests/e2e/contact-navigation.spec.ts
+++ b/frontend/tests/e2e/contact-navigation.spec.ts
@@ -19,100 +19,6 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     await testApi.cleanup()
   })
 
-  test('should navigate between contacts with arrow keys @smoke', async ({ page }) => {
-    // Create 3 contacts to navigate between
-    const { ids } = await testApi.seedContacts([
-      { full_name: 'Nav Contact A' },
-      { full_name: 'Nav Contact B' },
-      { full_name: 'Nav Contact C' },
-    ])
-
-    const fullNameA = `${testApi.prefix}-Nav Contact A`
-    const fullNameB = `${testApi.prefix}-Nav Contact B`
-    const fullNameC = `${testApi.prefix}-Nav Contact C`
-
-    // Navigate to contacts list first to establish context
-    await page.goto('/contacts')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Click on the middle contact (B) to go to its detail page
-    await page.getByText(fullNameB).click()
-    await page.waitForURL(/\/contacts\/[A-Za-z0-9-]+/)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: fullNameB })).toBeVisible({ timeout: 15000 })
-
-    // Verify navigation bar is visible
-    await expect(page.getByRole('button', { name: 'Previous contact' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Next contact' })).toBeVisible()
-
-    // Press right arrow to go to next contact
-    await page.keyboard.press('ArrowRight')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Should have navigated (the exact contact depends on sort order)
-    // Just verify we're on a different contact or the navigation worked
-    const currentUrl = page.url()
-    expect(currentUrl).toContain('/contacts/')
-  })
-
-  test('should show navigation bar with position indicator', async ({ page }) => {
-    // Create 5 contacts
-    await testApi.seedContacts([
-      { full_name: 'Position Test 1' },
-      { full_name: 'Position Test 2' },
-      { full_name: 'Position Test 3' },
-      { full_name: 'Position Test 4' },
-      { full_name: 'Position Test 5' },
-    ])
-
-    const fullName3 = `${testApi.prefix}-Position Test 3`
-
-    // Go to list first to establish context
-    await page.goto('/contacts')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Click on third contact row
-    await page.getByText(fullName3).click()
-    await page.waitForURL(/\/contacts\/[A-Za-z0-9-]+/)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: fullName3 })).toBeVisible({ timeout: 15000 })
-
-    // Wait for navigation IDs to load, then check for position indicator
-    // The navigation bar shows "N of M" pattern
-    await expect(page.getByText(/\d+ of \d+/)).toBeVisible({ timeout: 10000 })
-
-    // Verify navigation buttons are present
-    await expect(page.getByRole('button', { name: 'Previous contact' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Next contact' })).toBeVisible()
-  })
-
-  test('should disable navigation at boundaries', async ({ page }) => {
-    // Create 2 contacts
-    const { ids } = await testApi.seedContacts([
-      { full_name: 'Boundary First' },
-      { full_name: 'Boundary Last' },
-    ])
-
-    // Go to list first
-    await page.goto('/contacts')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Go to first contact detail via direct URL with sort params
-    await page.goto(
-      `/contacts/${ids[0]}?sort=name&order=asc&search=${encodeURIComponent(testApi.prefix)}`
-    )
-    await page.waitForLoadState('domcontentloaded')
-
-    // Previous button should be disabled at first position
-    const prevButton = page.getByRole('button', { name: 'Previous contact' })
-    await expect(prevButton).toBeVisible()
-    await expect(prevButton).toBeDisabled()
-
-    // Next button should be enabled
-    const nextButton = page.getByRole('button', { name: 'Next contact' })
-    await expect(nextButton).toBeEnabled()
-  })
-
   test('should disable keyboard navigation in edit mode', async ({ page }) => {
     // spec: CON-040[1]
     // Create 2 contacts
@@ -215,6 +121,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('should preserve URL context (sort, search) during navigation', async ({ page }) => {
+    // spec: CON-060[0]
     // Create contacts
     const { ids } = await testApi.seedContacts([
       { full_name: 'Context Test Alpha', location: 'New York' },
@@ -245,12 +152,15 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('should navigate via navigation bar buttons', async ({ page }) => {
-    // Create 3 contacts
+    // spec: CON-059[0], CON-059[1]
+    // Create 3 contacts with a known name-asc order so a pass proves real
+    // movement to the ADJACENT contact, not just "some navigation happened".
     const { ids } = await testApi.seedContacts([
       { full_name: 'Button Nav 1' },
       { full_name: 'Button Nav 2' },
       { full_name: 'Button Nav 3' },
     ])
+    const secondName = `${testApi.prefix}-Button Nav 2`
 
     // Go directly to first contact with sort param and search filter to isolate IDs
     await page.goto(
@@ -258,48 +168,18 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     )
     await page.waitForLoadState('domcontentloaded')
 
-    // Wait for navigation bar to be fully ready with IDs loaded
+    // Wait for navigation bar to be fully ready with IDs loaded; the position
+    // indicator reports the contact's place in the list (CON-059[1]).
     await expect(page.getByRole('button', { name: 'Next contact' })).toBeVisible({ timeout: 10000 })
-    // Wait for the position indicator to show we have navigation data
     await expect(page.getByText(/\d+ of \d+/)).toBeVisible({ timeout: 10000 })
 
-    const initialUrl = page.url()
-
-    // Click next button
+    // Click next: it moves to the ADJACENT contact under the carried
+    // name-asc order — ids[1], "Button Nav 2" (CON-059[0]).
     const nextButton = page.getByRole('button', { name: 'Next contact' })
     await expect(nextButton).toBeEnabled({ timeout: 5000 })
     await nextButton.click()
-    await page.waitForURL(url => url.toString() !== initialUrl)
-    await page.waitForLoadState('domcontentloaded')
-
-    // Should have navigated to a different contact
-    expect(page.url()).not.toBe(initialUrl)
-    expect(page.url()).toContain('/contacts/')
-  })
-
-  test('should handle Escape key to return to list', async ({ page }) => {
-    // spec: CON-040[3]
-    // Create a contact
-    const { ids } = await testApi.seedContacts([{ full_name: 'Escape Test' }])
-
-    const fullName = `${testApi.prefix}-Escape Test`
-
-    // Go to list first
-    await page.goto('/contacts')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Click on contact
-    await page.getByText(fullName).click()
-    await page.waitForURL(/\/contacts\/[A-Za-z0-9-]+/)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
-
-    // Press Escape to return to list
-    await page.keyboard.press('Escape')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Should be back on contacts list
-    await expect(page.getByRole('heading', { name: 'Contacts' })).toBeVisible()
+    await page.waitForURL(u => u.pathname === `/contacts/${ids[1]}`)
+    await expect(page.getByRole('heading', { name: secondName })).toBeVisible({ timeout: 10000 })
   })
 
   test('should restore search and sort state after Escape back to list', async ({ page }) => {
@@ -406,13 +286,12 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     await expect(page.getByRole('button', { name: 'Next contact' })).toBeDisabled()
   })
 
-  test('arrow keys move to the previous/next contact and disable at both boundaries', async ({
+  test('arrow keys move to the previous/next contact and disable at both boundaries @smoke', async ({
     page,
   }) => {
     // spec: CON-040[0]
     // Seed a known name-asc order and isolate the set via search, so a pass
-    // proves real movement to the adjacent contact (the @smoke test only checks
-    // the URL still contains /contacts/).
+    // proves real movement to the adjacent contact.
     const { ids } = await testApi.seedContacts([
       { full_name: 'Kbd Move Alpha' },
       { full_name: 'Kbd Move Bravo' },

--- a/frontend/tests/e2e/contact-navigation.spec.ts
+++ b/frontend/tests/e2e/contact-navigation.spec.ts
@@ -169,17 +169,20 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // Wait for navigation bar to be fully ready with IDs loaded; the position
-    // indicator reports the contact's place in the list (CON-059[1]).
+    // indicator reports the contact's EXACT place in the search-isolated
+    // 3-contact fixture (CON-059[1]) — first under name-asc, so "1 of 3".
     await expect(page.getByRole('button', { name: 'Next contact' })).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText(/\d+ of \d+/)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('1 of 3')).toBeVisible({ timeout: 10000 })
 
     // Click next: it moves to the ADJACENT contact under the carried
-    // name-asc order — ids[1], "Button Nav 2" (CON-059[0]).
+    // name-asc order — ids[1], "Button Nav 2" (CON-059[0]) — and the
+    // position indicator advances with it.
     const nextButton = page.getByRole('button', { name: 'Next contact' })
     await expect(nextButton).toBeEnabled({ timeout: 5000 })
     await nextButton.click()
     await page.waitForURL(u => u.pathname === `/contacts/${ids[1]}`)
     await expect(page.getByRole('heading', { name: secondName })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('2 of 3')).toBeVisible({ timeout: 10000 })
   })
 
   test('should restore search and sort state after Escape back to list', async ({ page }) => {

--- a/frontend/tests/e2e/contact-tasks.spec.ts
+++ b/frontend/tests/e2e/contact-tasks.spec.ts
@@ -81,12 +81,10 @@ async function mockTaskLists(
   })
 }
 
-// The TasksSection card, scoped by its "Tasks" heading; task rows are the
-// TaskRow containers inside it.
+// The TasksSection card is a labeled region (<section aria-label="Tasks">);
+// task rows are the TaskRow containers inside it.
 function tasksSection(page: Page) {
-  return page
-    .locator('div.bg-white.shadow')
-    .filter({ has: page.getByRole('heading', { name: 'Tasks', exact: true }) })
+  return page.getByRole('region', { name: 'Tasks', exact: true })
 }
 test.describe('Contact Tasks @area:contacts @area:tasks', () => {
   let testApi: TestAPI
@@ -121,9 +119,9 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
       await expect(page.getByRole('button', { name: 'Add', exact: true })).toBeVisible()
 
       // A freshly seeded contact has no tasks, so the empty state is
-      // guaranteed: it invites adding a task.
+      // guaranteed: it invites adding a task ("No tasks yet" + the Add button
+      // above are the empty-state observables).
       await expect(page.getByText('No tasks yet')).toBeVisible()
-      await expect(page.getByText('Add a task to track follow-ups for this contact')).toBeVisible()
     })
 
     test('lists follow-up tasks first with a distinct pending indicator, then manual tasks', async ({
@@ -156,11 +154,10 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
       await expect(rows.nth(0)).toContainText('Mock follow-up task')
       await expect(rows.nth(1)).toContainText('Mock manual task')
 
-      // Distinct pending indicator: follow-up rows carry the amber Clock
-      // icon (a CSS-only signal — the class is the observable); the manual
-      // row does not.
-      await expect(rows.nth(0).locator('svg.text-amber-400')).toBeVisible()
-      await expect(rows.nth(1).locator('svg.text-amber-400')).toHaveCount(0)
+      // Distinct pending indicator: follow-up rows carry the labeled
+      // "Awaiting reply" clock; the manual row does not.
+      await expect(rows.nth(0).getByLabel('Awaiting reply')).toBeVisible()
+      await expect(rows.nth(1).getByLabel('Awaiting reply')).toHaveCount(0)
     })
 
     test('derives each task badge from its kind and lifecycle', async ({ page }) => {

--- a/frontend/tests/e2e/contacts.spec.ts
+++ b/frontend/tests/e2e/contacts.spec.ts
@@ -154,8 +154,13 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await page.getByRole('button', { name: 'Log', exact: true }).click()
     const response = await responsePromise
     expect(response.status()).toBe(201)
+
+    // The BACKDATED date travels: the request carries the chosen date (the
+    // modal pins it to UTC midnight) and the stored interaction echoes it.
+    expect(response.request().postDataJSON()?.occurred_at).toBe('2024-01-15T00:00:00.000Z')
     const body = await response.json()
     expect(body.success).toBe(true)
+    expect(body.data.occurred_at).toContain('2024-01-15')
 
     // Modal closes on success.
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 })
@@ -672,7 +677,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(notes)).not.toBeVisible()
   })
 
-  // spec: CON-056[0], CON-056[1]
+  // spec: CON-056[0], CON-056[1], CON-056[2]
   test('should display contact with methods and the primary marked', async ({ page }) => {
     // A slim display proof: seeded methods render with normalized values and
     // exactly one Primary mark. The normalization RULES themselves (per-type
@@ -683,6 +688,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     const personalEmail = `personal-${testApi.prefix}@example.com`
     const telegramHandle = `@@telegram-${testApi.prefix}`
     const normalizedTelegram = telegramHandle.replace(/^@@/, '@')
+    const gchatEmail = `gchat-${testApi.prefix}@example.com`
 
     const { ids } = await testApi.seedContacts([
       {
@@ -690,6 +696,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
         methods: [
           { type: 'email', value: personalEmail },
           { type: 'telegram', value: telegramHandle, is_primary: true },
+          { type: 'gchat', value: gchatEmail },
         ],
       },
     ])
@@ -706,6 +713,54 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     const primaryRow = page.getByText(normalizedTelegram, { exact: true }).locator('..')
     await expect(primaryRow.getByText('Primary')).toBeVisible()
     await expect(page.getByText('Primary')).toHaveCount(1)
+
+    // A gchat identifier has no external link surface: its value renders as
+    // plain text with its type label, NOT as a link (a frontend-only invariant
+    // of getContactMethodHref that the CON-012 Go tests do not cover).
+    const gchatRow = page.getByText(gchatEmail, { exact: true }).locator('..')
+    await expect(gchatRow.getByText('Google Chat', { exact: true })).toBeVisible()
+    await expect(page.getByRole('link', { name: gchatEmail })).toHaveCount(0)
+  })
+
+  // spec: CON-061[0], CON-061[1]
+  test('should render formatted cadence and next-contact values in list rows', async ({ page }) => {
+    // Derived-value display: a contact with a cadence + last-contacted has a
+    // computed contact_by, rendered as a date in the Next Contact column; a
+    // contact without a cadence renders the '-' placeholder there, and the
+    // cadence value renders as its formatted label. Column resolved by its
+    // header position at runtime (no hard-coded cell index).
+    await testApi.seedContacts([
+      { full_name: 'ColDisplay Weekly', cadence: 'weekly', last_contacted_days_ago: 3 },
+      { full_name: 'ColDisplay None' },
+    ])
+
+    await page.goto('/contacts')
+    await page.waitForLoadState('domcontentloaded')
+    const searchInput = page.getByPlaceholder('Search contacts...')
+    await searchInput.fill(`${testApi.prefix}-ColDisplay`)
+    await searchInput.press('Enter')
+
+    const weeklyRow = page.locator('tr', {
+      has: page.getByText(`${testApi.prefix}-ColDisplay Weekly`),
+    })
+    const noneRow = page.locator('tr', {
+      has: page.getByText(`${testApi.prefix}-ColDisplay None`),
+    })
+    await expect(weeklyRow).toBeVisible({ timeout: 15000 })
+    await expect(noneRow).toBeVisible()
+
+    // Formatted cadence label in the seeded row (derived from the stored
+    // 'weekly' value, not raw enum text).
+    await expect(weeklyRow.getByText('Weekly', { exact: true })).toBeVisible()
+
+    // Resolve the Next Contact column by header position.
+    const headerTexts = await page.getByRole('columnheader').allTextContents()
+    const nextIdx = headerTexts.findIndex(t => t.includes('Next Contact'))
+    expect(nextIdx).toBeGreaterThanOrEqual(0)
+
+    // With a cadence: a real date value (contains digits). Without: '-'.
+    await expect(weeklyRow.getByRole('cell').nth(nextIdx)).toHaveText(/\d/)
+    await expect(noneRow.getByRole('cell').nth(nextIdx)).toHaveText('-')
   })
 
   // spec: CON-057[0]
@@ -802,8 +857,13 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await searchInput.press('Enter')
     await searchResponse
 
-    // Page number buttons exist (at least page 1 and 2 in the top control).
+    // BOTH pagination controls render (top + bottom) — this count guards the
+    // sync assertion at the end from vacuously passing when first() and
+    // last() resolve to the same single control.
     const paginationControls = page.locator('[data-testid="pagination"]')
+    await expect(paginationControls).toHaveCount(2)
+
+    // Page number buttons exist (at least page 1 and 2 in the top control).
     const topPagination = paginationControls.first()
     await expect(topPagination.getByRole('button', { name: '1' })).toBeVisible()
     await expect(topPagination.getByRole('button', { name: '2' })).toBeVisible()
@@ -814,12 +874,23 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page1Button).toHaveAttribute('aria-current', 'page')
     await expect(topPagination.getByRole('button', { name: 'Previous' })).toBeDisabled()
 
-    // Click page 2 and verify the current-page mark moves
+    // Click page 2: a page=2 list request fires (the control PAGES the list,
+    // not just restyles itself) and the current-page mark moves.
+    const page2Response = page.waitForResponse(
+      resp =>
+        resp.request().method() === 'GET' &&
+        resp.url().includes('/api/v1/contacts') &&
+        new URL(resp.url()).searchParams.get('page') === '2' &&
+        !new URL(resp.url()).searchParams.has('ids_only')
+    )
     await topPagination.getByRole('button', { name: '2' }).click()
+    await page2Response
     await expect(topPagination.getByRole('button', { name: '2' })).toHaveAttribute(
       'aria-current',
       'page'
     )
+    // The rows changed: 22 seeded contacts at limit 20 leave 2 on page 2.
+    await expect(page.locator('tbody tr')).toHaveCount(2)
 
     // Verify Previous is now enabled and Next is disabled (only 2 pages)
     await expect(topPagination.getByRole('button', { name: 'Previous' })).toBeEnabled()

--- a/frontend/tests/e2e/contacts.spec.ts
+++ b/frontend/tests/e2e/contacts.spec.ts
@@ -20,6 +20,10 @@ test.describe('Contacts - TestAPI Seeded @area:contacts', () => {
     await testApi.cleanup()
   })
 
+  // visual-guard: descender clipping is an already-bitten UI bug (leading-7 +
+  // truncate clips y/g/j/p/q — see the core.md gotcha) with no data or aria
+  // surface; the class assertion is the deliberate, budgeted exception to the
+  // no-CSS-assertion rule (CON visual-guard 1/2).
   test('should use leading-normal on contact name to prevent descender clipping', async ({
     page,
   }) => {
@@ -43,46 +47,7 @@ test.describe('Contacts - TestAPI Seeded @area:contacts', () => {
     await expect(heading).not.toHaveClass(/leading-7/)
   })
 
-  test('should truncate long location with tooltip in contacts table', async ({ page }) => {
-    // Create a very long location that will definitely overflow
-    const longLocation =
-      '1234 Very Long Street Name Boulevard, Extremely Long Neighborhood District, San Francisco, California 94105, United States of America'
-
-    const { ids } = await testApi.seedContacts([
-      {
-        full_name: 'Location Test Contact',
-        location: longLocation,
-      },
-    ])
-
-    const contactId = ids[0]
-    const fullName = `${testApi.prefix}-Location Test Contact`
-
-    // Navigate to contacts list to see the table
-    await page.goto('/contacts')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Find the row with our contact
-    const contactRow = page.locator('tr', { has: page.getByText(fullName) })
-    await expect(contactRow).toBeVisible()
-
-    // Find the location cell with the truncation
-    const locationDiv = contactRow.locator('div[title]', { hasText: longLocation.slice(0, 20) })
-    await expect(locationDiv).toBeVisible()
-
-    // Verify the title attribute contains the full location (for tooltip)
-    await expect(locationDiv).toHaveAttribute('title', longLocation)
-
-    // Verify the text is truncated (has truncate class or text-overflow: ellipsis)
-    const truncatedSpan = locationDiv.locator('span.truncate')
-    await expect(truncatedSpan).toBeVisible()
-
-    // Navigate to contact detail to verify location is displayed fully
-    await page.goto(`/contacts/${contactId}`)
-    await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByRole('heading', { name: fullName })).toBeVisible()
-  })
-
+  // spec: NTS-007[2]
   test('should show expandable notes for long content', async ({ page }) => {
     // Create notes longer than 300 characters to trigger truncation
     const longNotes = `Met at the AI conference in San Francisco, March 2024. Works as a senior ML engineer at a startup focused on personal productivity tools.
@@ -129,6 +94,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(showMoreButton).toBeVisible()
   })
 
+  // spec: NTS-007[2]
   test('should not show expand button for short notes', async ({ page }) => {
     const shortNotes = 'Brief note about this contact.'
 
@@ -155,6 +121,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(page.getByRole('button', { name: 'Show more' })).not.toBeVisible()
   })
 
+  // spec: CON-053[1], CON-053[2]
   test('should log a backdated interaction via the Log Interaction modal', async ({ page }) => {
     // The Log Interaction modal (direction picker + date picker)
     // replaces the previous inline pencil-edit on `last_contacted`.
@@ -194,6 +161,10 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 })
   })
 
+  // visual-guard: the context menu clipping on bottom rows is an already-bitten
+  // UI bug (dropdown rendered inside an overflow container was cut off) with no
+  // data or aria surface; the menuitem-visibility proof on the LAST row is the
+  // deliberate, budgeted exception (CON visual-guard 2/2).
   test('should show context menu without clipping for bottom rows', async ({ page }) => {
     // Create enough contacts to have rows near the bottom of the viewport
     const names = Array.from({ length: 8 }, (_, i) => ({
@@ -281,14 +252,15 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(page).not.toHaveURL(/action=/)
   })
 
+  // spec: CON-053[0], CON-053[2]
   test('should log a mutual interaction via the Log Interaction modal default', async ({
     page,
-    request,
   }) => {
-    // Mutual bumps both last_contacted and last_response_at AND
-    // last_outreach_at, and recomputes contact_by from cadence. This
-    // is the default-direction path of the Log Interaction modal,
-    // preserving the old "I just talked to them" semantic.
+    // The default-direction path of the Log Interaction modal, preserving the
+    // old "I just talked to them" semantic. Which timestamp columns each
+    // direction bumps is CAD-006 (backend-owned) — asserted by
+    // internal/consumer/cadence_updater_test.go and
+    // tests/api/direction_api_test.go, not re-checked through the browser.
     const { ids } = await testApi.seedContacts([
       { full_name: 'Mark Contacted Default', cadence: 'weekly' },
     ])
@@ -313,36 +285,16 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     expect((await response.json()).data.direction).toBe('mutual')
 
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 })
-
-    // Mutual bumps last_response_at + last_outreach_at; both must be
-    // populated after the interaction.
-    const afterResp = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
-      headers: API_HEADERS,
-    })
-    expect(afterResp.ok()).toBeTruthy()
-    const afterContact = (await afterResp.json()).data
-    expect(afterContact.last_response_at).toBeTruthy()
-    expect(afterContact.last_outreach_at).toBeTruthy()
   })
 
-  test('should log an outbound interaction via the Log Interaction modal', async ({
-    page,
-    request,
-  }) => {
-    // Outbound bumps last_outreach_at only — last_contacted stays at
-    // its create-time value (handler sets it to now() on contact create).
+  // spec: CON-053[0]
+  test('should log an outbound interaction via the Log Interaction modal', async ({ page }) => {
+    // The modal's direction picker reaches the API: choosing Outbound posts
+    // direction=outbound. The cadence timestamp effects of each direction are
+    // CAD-006 (backend-owned, Go-covered).
     const { ids } = await testApi.seedContacts([{ full_name: 'Outbound Interaction Test' }])
     const contactId = ids[0]
     const fullName = `${testApi.prefix}-Outbound Interaction Test`
-
-    // Capture last_contacted BEFORE the interaction so we can assert
-    // outbound did not bump it.
-    const beforeResp = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
-      headers: API_HEADERS,
-    })
-    expect(beforeResp.ok()).toBeTruthy()
-    const beforeContact = (await beforeResp.json()).data
-    const lastContactedBefore = beforeContact.last_contacted
 
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
@@ -361,36 +313,16 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     expect(response.status()).toBe(201)
     const body = await response.json()
     expect(body.data.direction).toBe('outbound')
-
-    // Re-fetch the contact and assert direction-aware cadence updates:
-    //   - last_outreach_at advanced (outbound writes this column)
-    //   - last_contacted unchanged (outbound MUST NOT bump it)
-    //   - last_response_at unchanged (no inbound)
-    const afterResp = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
-      headers: API_HEADERS,
-    })
-    expect(afterResp.ok()).toBeTruthy()
-    const afterContact = (await afterResp.json()).data
-    expect(afterContact.last_outreach_at).toBeTruthy()
-    expect(afterContact.last_contacted).toBe(lastContactedBefore)
   })
 
-  test('should log an inbound interaction via the Log Interaction modal', async ({
-    page,
-    request,
-  }) => {
-    // Inbound bumps last_contacted + last_response_at; does NOT bump
-    // last_outreach_at (inbound is the response, not the outreach).
+  // spec: CON-053[0]
+  test('should log an inbound interaction via the Log Interaction modal', async ({ page }) => {
+    // The modal's direction picker reaches the API: choosing Inbound posts
+    // direction=inbound. The cadence timestamp effects of each direction are
+    // CAD-006 (backend-owned, Go-covered).
     const { ids } = await testApi.seedContacts([{ full_name: 'Inbound Interaction Test' }])
     const contactId = ids[0]
     const fullName = `${testApi.prefix}-Inbound Interaction Test`
-
-    const beforeResp = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
-      headers: API_HEADERS,
-    })
-    expect(beforeResp.ok()).toBeTruthy()
-    const beforeContact = (await beforeResp.json()).data
-    const lastOutreachBefore = beforeContact.last_outreach_at ?? null
 
     await page.goto(`/contacts/${contactId}`)
     await page.waitForLoadState('domcontentloaded')
@@ -409,15 +341,6 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     expect(response.status()).toBe(201)
     const body = await response.json()
     expect(body.data.direction).toBe('inbound')
-
-    // last_response_at populated; last_outreach_at unchanged.
-    const afterResp = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
-      headers: API_HEADERS,
-    })
-    expect(afterResp.ok()).toBeTruthy()
-    const afterContact = (await afterResp.json()).data
-    expect(afterContact.last_response_at).toBeTruthy()
-    expect(afterContact.last_outreach_at ?? null).toBe(lastOutreachBefore)
   })
 
   test('defaults the contact list to cadence order, most-frequent-first', async ({ page }) => {
@@ -472,7 +395,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     page,
     request,
   }) => {
-    // spec: CON-042[1], CON-042[2]
+    // spec: CON-042[0], CON-042[1], CON-042[2]
     const { ids } = await testApi.seedContacts([{ full_name: 'Delete Confirm Test' }])
     const contactId = ids[0]
     const fullName = `${testApi.prefix}-Delete Confirm Test`
@@ -490,13 +413,21 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
       }
     }
     page.on('request', watchDelete)
-    page.once('dialog', dialog => dialog.dismiss())
+    // The confirmation copy is captured INSIDE the handler (it cannot be read
+    // after the dialog resolves) and asserted below: the prompt must warn the
+    // action cannot be undone (CON-042[0]).
+    let confirmMessage = ''
+    page.once('dialog', dialog => {
+      confirmMessage = dialog.message()
+      void dialog.dismiss()
+    })
     await page.getByRole('button', { name: 'Delete' }).click()
     // Asserting ABSENCE: there is no positive signal to await on dismiss, so give
     // any (erroneous) DELETE a bounded settle window to appear, then confirm none
     // fired and the contact is still live.
     await page.waitForTimeout(1000)
     expect(deleteFired).toBe(false)
+    expect(confirmMessage).toContain('cannot be undone')
     page.off('request', watchDelete)
     const liveResp = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
       headers: API_HEADERS,
@@ -574,7 +505,7 @@ test.describe('Contacts - Cadence Filter @area:contacts', () => {
   })
 
   test('should filter contacts by cadence status', async ({ page }) => {
-    // spec: DSH-007[0]
+    // spec: DSH-007[0], CON-054[0], CON-054[1]
     // Contact text search is provided through the contact list's search
     // input: the tightened search step below proves typing a term drives a
     // `search=` list request that FILTERS the results (the matching fixtures
@@ -688,6 +619,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await testApi.cleanup()
   })
 
+  // spec: CON-055[0]
   test('should create a contact from the form @smoke', async ({ page }) => {
     const fullName = `${testApi.prefix}-Create Contact`
 
@@ -702,6 +634,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
   })
 
+  // spec: NTS-008[2]
   test('should edit contact notes', async ({ page }) => {
     const notes =
       'Met at a conference in 2024. Works in AI/ML. Very interested in personal CRM tools.'
@@ -739,149 +672,43 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(notes)).not.toBeVisible()
   })
 
-  test('should display contact with all methods and normalized handles', async ({ page }) => {
+  // spec: CON-056[0], CON-056[1]
+  test('should display contact with methods and the primary marked', async ({ page }) => {
+    // A slim display proof: seeded methods render with normalized values and
+    // exactly one Primary mark. The normalization RULES themselves (per-type
+    // handle/phone canonicalization) are CON-012, backend-owned and covered by
+    // internal/identity/normalize_test.go — one spot check here proves the
+    // display path, not the rules.
     const fullName = `${testApi.prefix}-Playwright Contact`
     const personalEmail = `personal-${testApi.prefix}@example.com`
-    const workEmail = `work-${testApi.prefix}@example.com`
-    const phone = '(555) 555-1234'
     const telegramHandle = `@@telegram-${testApi.prefix}`
-    const discordHandle = `@@discord-${testApi.prefix}`
-    const twitterHandle = `@@twitter-${testApi.prefix}`
-    const signal = '+1 555 555 9876'
-    const gchatEmail = `gchat-${testApi.prefix}@example.com`
-
-    const methods = [
-      { type: 'email', value: personalEmail, expected: personalEmail },
-      { type: 'email', value: workEmail, expected: workEmail },
-      { type: 'phone', value: phone, expected: phone },
-      { type: 'telegram', value: telegramHandle, expected: telegramHandle.replace(/^@@/, '@') },
-      { type: 'signal', value: signal, expected: signal },
-      { type: 'discord', value: discordHandle, expected: discordHandle.replace(/^@@/, '@') },
-      { type: 'twitter', value: twitterHandle, expected: twitterHandle.replace(/^@@/, '@') },
-      { type: 'gchat', value: gchatEmail, expected: gchatEmail },
-    ]
+    const normalizedTelegram = telegramHandle.replace(/^@@/, '@')
 
     const { ids } = await testApi.seedContacts([
       {
         full_name: 'Playwright Contact',
         methods: [
           { type: 'email', value: personalEmail },
-          { type: 'email', value: workEmail },
-          { type: 'phone', value: phone },
           { type: 'telegram', value: telegramHandle, is_primary: true },
-          { type: 'signal', value: signal },
-          { type: 'discord', value: discordHandle },
-          { type: 'twitter', value: twitterHandle },
-          { type: 'gchat', value: gchatEmail },
         ],
       },
     ])
 
-    const contactId = ids[0]
-
-    await page.goto(`/contacts/${contactId}`)
+    await page.goto(`/contacts/${ids[0]}`)
     await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
 
-    for (const method of methods) {
-      await expect(page.getByText(method.expected, { exact: true })).toBeVisible()
-    }
+    // Seeded methods display, the handle in its normalized form.
+    await expect(page.getByText(personalEmail, { exact: true })).toBeVisible()
+    await expect(page.getByText(normalizedTelegram, { exact: true })).toBeVisible()
 
-    await expect(page.getByText(telegramHandle, { exact: true })).toHaveCount(0)
-
-    const primaryRow = page.getByText('Telegram', { exact: true }).locator('..')
+    // The primary (telegram) row carries the mark, and it is the ONLY one.
+    // Row scoped from the seeded value (data anchor), not the type label copy.
+    const primaryRow = page.getByText(normalizedTelegram, { exact: true }).locator('..')
     await expect(primaryRow.getByText('Primary')).toBeVisible()
     await expect(page.getByText('Primary')).toHaveCount(1)
-
-    await expect(page.getByText('Google Chat', { exact: true })).toBeVisible()
-    await expect(page.getByRole('link', { name: gchatEmail })).toHaveCount(0)
   })
 
-  test('should display cadence column with formatted values and sort by frequency', async ({
-    page,
-  }) => {
-    // Create contacts with different cadences
-    await testApi.seedContacts([
-      { full_name: 'Cadence Test Weekly', cadence: 'weekly' },
-      { full_name: 'Cadence Test Monthly', cadence: 'monthly' },
-      { full_name: 'Cadence Test Annual', cadence: 'annual' },
-      { full_name: 'Cadence Test None' }, // No cadence
-    ])
-
-    await page.goto('/contacts')
-    await page.waitForLoadState('networkidle')
-
-    // Verify cadence column header exists and is sortable
-    const cadenceHeader = page.locator('th').filter({ hasText: 'Cadence' })
-    await expect(cadenceHeader).toBeVisible()
-
-    // Verify formatted cadence values are displayed (not raw values)
-    // Use .first() since there may be multiple contacts with the same cadence
-    await expect(page.getByText('Weekly', { exact: true }).first()).toBeVisible()
-    await expect(page.getByText('Monthly', { exact: true }).first()).toBeVisible()
-    await expect(page.getByText('Annual', { exact: true }).first()).toBeVisible()
-
-    // Click cadence header to sort - should already be sorted by cadence desc by default
-    // The default is desc (most frequent first), so weekly should be near the top
-    const rows = page.locator('tbody tr')
-    const firstRow = rows.first()
-
-    // First row should contain a contact with cadence (could be weekly if our test data is first)
-    // Just verify the header is clickable and the page doesn't error
-    await cadenceHeader.click()
-    await page.waitForLoadState('networkidle')
-
-    // After clicking (now asc - least frequent first), annual should be before weekly
-    // Verify the sort changed by checking the icon
-    await expect(cadenceHeader.locator('svg')).toBeVisible()
-  })
-
-  test('should display Next Contact column header and render dates', async ({ page }) => {
-    // Create contacts with cadence and last_contacted (so contact_by is calculated)
-    await testApi.seedContacts([
-      {
-        full_name: 'NextContact Weekly',
-        cadence: 'weekly',
-        last_contacted_days_ago: 3,
-      },
-      {
-        full_name: 'NextContact NoCadence',
-      },
-    ])
-
-    await page.goto('/contacts')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Verify "Next Contact" column header exists and is sortable
-    const nextContactHeader = page.getByRole('columnheader').filter({ hasText: 'Next Contact' })
-    await expect(nextContactHeader).toBeVisible()
-
-    // Search for our test contacts
-    const searchInput = page.getByPlaceholder('Search contacts...')
-    await searchInput.fill(`${testApi.prefix}-NextContact`)
-    await searchInput.press('Enter')
-    await page.waitForLoadState('networkidle')
-
-    // Contact with cadence should show a date (not N/A)
-    const weeklyRow = page.locator('tr', {
-      has: page.getByText(`${testApi.prefix}-NextContact Weekly`),
-    })
-    await expect(weeklyRow).toBeVisible()
-    // The Next Contact cell should contain a date (digits with slashes)
-    const weeklyCells = weeklyRow.locator('td')
-    // Next Contact is the 6th column (Name, Cadence, Location, Birthday, Last response, Next Contact, Actions)
-    const weeklyNextContact = weeklyCells.nth(5)
-    await expect(weeklyNextContact).not.toHaveText('-')
-
-    // Contact without cadence should show N/A
-    const noCadenceRow = page.locator('tr', {
-      has: page.getByText(`${testApi.prefix}-NextContact NoCadence`),
-    })
-    await expect(noCadenceRow).toBeVisible()
-    const noCadenceCells = noCadenceRow.locator('td')
-    const noCadenceNextContact = noCadenceCells.nth(5)
-    await expect(noCadenceNextContact).toHaveText('-')
-  })
-
+  // spec: CON-057[0]
   test('should sort by Next Contact column when header clicked', async ({ page }) => {
     await testApi.seedContacts([
       {
@@ -908,9 +735,6 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await nextContactHeader.click()
     await ascResponse
 
-    // Verify sort icon appears
-    await expect(nextContactHeader.locator('svg')).toBeVisible()
-
     // Click again to toggle to descending - verify sort=contact_by&order=desc
     const descResponse = page.waitForResponse(
       resp => resp.url().includes('sort=contact_by') && resp.url().includes('order=desc')
@@ -922,21 +746,14 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(`${testApi.prefix}-SortNext Contact`)).toBeVisible()
   })
 
-  test('should display Last response column header and sort by last_response_at', async ({
-    page,
-  }) => {
+  // spec: CON-057[0]
+  test('should sort by Last response column when header clicked', async ({ page }) => {
     await testApi.seedContacts([{ full_name: 'SortResp Contact' }])
 
     await page.goto('/contacts')
     await page.waitForLoadState('domcontentloaded')
 
-    // Header text matches the new directionally-correct label.
     const lastResponseHeader = page.getByRole('columnheader').filter({ hasText: 'Last response' })
-    await expect(lastResponseHeader).toBeVisible()
-    // The legacy "Last Contact" header is gone.
-    await expect(page.getByRole('columnheader').filter({ hasText: /^Last Contact$/i })).toHaveCount(
-      0
-    )
 
     // Isolate our test contact via search so the sort click reliably
     // produces a fetch we can listen for.
@@ -952,7 +769,6 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     )
     await lastResponseHeader.click()
     await descResponse
-    await expect(lastResponseHeader.locator('svg')).toBeVisible()
 
     // Second click → asc.
     const ascResponse = page.waitForResponse(
@@ -964,6 +780,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(`${testApi.prefix}-SortResp Contact`)).toBeVisible()
   })
 
+  // spec: CON-058[0], CON-058[1]
   test('should show page number buttons and top/bottom pagination when multiple pages exist', async ({
     page,
   }) => {
@@ -985,22 +802,22 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await searchInput.press('Enter')
     await searchResponse
 
-    // Verify top and bottom pagination controls both exist
+    // Page number buttons exist (at least page 1 and 2 in the top control).
     const paginationControls = page.locator('[data-testid="pagination"]')
-    await expect(paginationControls).toHaveCount(2)
-
-    // Verify page number buttons exist (at least page 1 and 2 in top pagination)
     const topPagination = paginationControls.first()
     await expect(topPagination.getByRole('button', { name: '1' })).toBeVisible()
     await expect(topPagination.getByRole('button', { name: '2' })).toBeVisible()
 
-    // Verify page 1 is active (primary variant)
+    // Page 1 is the current page (aria-current marks the active page button).
     const page1Button = topPagination.getByRole('button', { name: '1' })
-    await expect(page1Button).toHaveClass(/bg-blue-600/)
+    await expect(page1Button).toHaveAttribute('aria-current', 'page')
 
-    // Click page 2 and verify it navigates
+    // Click page 2 and verify the current-page mark moves
     await topPagination.getByRole('button', { name: '2' }).click()
-    await expect(topPagination.getByRole('button', { name: '2' })).toHaveClass(/bg-blue-600/)
+    await expect(topPagination.getByRole('button', { name: '2' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
 
     // Verify Previous is now enabled and Next is disabled (only 2 pages)
     await expect(topPagination.getByRole('button', { name: 'Previous' })).toBeEnabled()
@@ -1008,10 +825,16 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
 
     // Click Previous to go back to page 1
     await topPagination.getByRole('button', { name: 'Previous' }).click()
-    await expect(topPagination.getByRole('button', { name: '1' })).toHaveClass(/bg-blue-600/)
+    await expect(topPagination.getByRole('button', { name: '1' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
 
-    // Verify both paginations are in sync (both show page 1 as active)
+    // Both paginations stay in sync (bottom also shows page 1 as current)
     const bottomPagination = paginationControls.last()
-    await expect(bottomPagination.getByRole('button', { name: '1' })).toHaveClass(/bg-blue-600/)
+    await expect(bottomPagination.getByRole('button', { name: '1' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
   })
 })

--- a/frontend/tests/e2e/contacts.spec.ts
+++ b/frontend/tests/e2e/contacts.spec.ts
@@ -808,9 +808,11 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(topPagination.getByRole('button', { name: '1' })).toBeVisible()
     await expect(topPagination.getByRole('button', { name: '2' })).toBeVisible()
 
-    // Page 1 is the current page (aria-current marks the active page button).
+    // Page 1 is the current page (aria-current marks the active page button),
+    // and Previous is disabled at the near boundary.
     const page1Button = topPagination.getByRole('button', { name: '1' })
     await expect(page1Button).toHaveAttribute('aria-current', 'page')
+    await expect(topPagination.getByRole('button', { name: 'Previous' })).toBeDisabled()
 
     // Click page 2 and verify the current-page mark moves
     await topPagination.getByRole('button', { name: '2' }).click()

--- a/frontend/tests/e2e/dashboard.spec.ts
+++ b/frontend/tests/e2e/dashboard.spec.ts
@@ -43,46 +43,10 @@ test.describe('Dashboard @area:dashboard', () => {
     // Wait for page to fully load
     await page.waitForLoadState('domcontentloaded')
 
-    // Should have correct title
-    await expect(page).toHaveTitle(/Personal CRM/)
-
-    // Should show navigation with links (use exact: true to avoid matching "View All Contacts")
-    await expect(page.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Contacts', exact: true })).toBeVisible()
-
-    // Should show "Action Required" heading (the main h2 heading)
+    // The redirect target has render-settled: the main h2 heading is up.
+    // (The nav links themselves are covered per-surface by the DSH-002[0]
+    // loop in navigation.spec.ts.)
     await expect(page.getByRole('heading', { name: 'Action Required', level: 2 })).toBeVisible()
-  })
-
-  test('should navigate to contacts from dashboard', async ({ page }) => {
-    await page.goto('/dashboard')
-
-    // Click on contacts navigation
-    await page.getByRole('link', { name: 'Contacts' }).click()
-
-    // Should navigate to contacts page
-    await expect(page).toHaveURL('/contacts')
-    // Use level: 2 to target the main h2 heading, not the h3 "No contacts"
-    await expect(page.getByRole('heading', { name: 'Contacts', level: 2 })).toBeVisible()
-  })
-
-  test('should show dashboard content when loaded', async ({ page }) => {
-    await page.goto('/dashboard')
-
-    // Wait for content to load
-    await page.waitForLoadState('domcontentloaded')
-
-    // Should show status message (either overdue count or "all caught up")
-    const hasOverdue = await page
-      .getByText('contacts need your attention')
-      .isVisible()
-      .catch(() => false)
-    const hasCaughtUp = await page
-      .getByText("You're all caught up")
-      .isVisible()
-      .catch(() => false)
-
-    expect(hasOverdue || hasCaughtUp).toBeTruthy()
   })
 
   test('caught-up state offers add-contact and view-list paths', async ({ page }) => {
@@ -206,17 +170,17 @@ test.describe('Dashboard - All Caught Up (mocked) @area:dashboard', () => {
 })
 
 test.describe('Dashboard - Card Anatomy (mocked) @area:dashboard', () => {
-  // getUrgencyIndicator boundaries: <=2 yellow, <=7 orange, >7 red. The
-  // fixture pins BOTH SIDES of each boundary — 2|3 (yellow→orange) and 7|8
-  // (orange→red) — so shifting either threshold in either direction flips a
-  // dot class and fails. Mocked rather than seeded: in testing mode a scaled
+  // getUrgencyIndicator boundaries: <=2 low, <=7 medium, >7 high. The
+  // fixture pins BOTH SIDES of each boundary — 2|3 (low→medium) and 7|8
+  // (medium→high) — so shifting either threshold in either direction flips a
+  // tier label and fails. Mocked rather than seeded: in testing mode a scaled
   // "day" is ~17s of wall time, so a seeded boundary value drifts across
   // tiers before the page settles.
   const tierCases = [
-    { name: 'Yellow Boundary Card', days: 2, dot: 'bg-yellow-500' },
-    { name: 'Orange Lower Card', days: 3, dot: 'bg-orange-500' },
-    { name: 'Orange Boundary Card', days: 7, dot: 'bg-orange-500' },
-    { name: 'Red Tier Card', days: 8, dot: 'bg-red-500' },
+    { name: 'Yellow Boundary Card', days: 2, tier: 'Low urgency' },
+    { name: 'Orange Lower Card', days: 3, tier: 'Medium urgency' },
+    { name: 'Orange Boundary Card', days: 7, tier: 'Medium urgency' },
+    { name: 'Red Tier Card', days: 8, tier: 'High urgency' },
   ]
 
   test('each card shows urgency tier, cadence, recency, a reachable method, and the suggested action', async ({
@@ -242,12 +206,12 @@ test.describe('Dashboard - Card Anatomy (mocked) @area:dashboard', () => {
 
     // The clause is per-card ("each card shows ..."): assert ALL FIVE
     // sub-elements on EVERY card, across all three urgency tiers. The tier
-    // dot is CSS-only (no accessible text), so the color class is the
-    // observable signal — the same one the retired verifier graded.
+    // dot carries an accessible label naming its tier, so the label is the
+    // observable signal.
     for (const c of tierCases) {
       await expect(page.getByRole('heading', { name: c.name })).toBeVisible()
       const card = page.locator('div.rounded-lg').filter({ hasText: c.name })
-      await expect(card.locator(`div.rounded-full.${c.dot}`)).toBeVisible()
+      await expect(card.getByLabel(c.tier, { exact: true })).toBeVisible()
       await expect(card.getByText('(weekly cadence)')).toBeVisible()
       // Recency requires a VALUE after "Last contacted", not just the label
       // (formatLastContacted regressing to '' would fail the \S+ match).
@@ -465,14 +429,6 @@ test.describe('Dashboard - With Seeded Data @area:dashboard @area:overdue', () =
       return !entries.some(entry => entry.id === overdueContactId)
     })
 
-    // Page-lifetime sentinel for the "without a page reload" clause: a
-    // window property survives client-side updates but is wiped by any
-    // reload/navigation, so re-reading it after the update proves the same
-    // document handled the whole flow.
-    await page.evaluate(() => {
-      ;(window as unknown as { __noReloadSentinel?: boolean }).__noReloadSentinel = true
-    })
-
     // Click "Mark as Contacted", bracketed by wall-clock reads so the
     // server-assigned timestamp can be bounded. The E2E env runs WITHOUT
     // TIME_ACCELERATION, so the server's accelerated clock IS the wall
@@ -547,13 +503,5 @@ test.describe('Dashboard - With Seeded Data @area:dashboard @area:overdue', () =
         })
       )
       .toBe('header equals cards')
-
-    // No page reload happened: the pre-click window sentinel survived the
-    // whole update (any reload or navigation would have wiped it).
-    expect(
-      await page.evaluate(
-        () => (window as unknown as { __noReloadSentinel?: boolean }).__noReloadSentinel
-      )
-    ).toBe(true)
   })
 })

--- a/frontend/tests/e2e/error-boundary.spec.ts
+++ b/frontend/tests/e2e/error-boundary.spec.ts
@@ -1,34 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { expectAddContactHeader } from './helpers/dashboard'
 
-// API configuration for E2E tests
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
-const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
-const API_HEADERS = {
-  'X-API-Key': API_KEY,
-  'Content-Type': 'application/json',
-}
-
 test.describe('Error Boundary @area:error-boundary', () => {
-  test('backend test error endpoint returns 500', async ({ request }) => {
-    // Test the backend error trigger endpoint
-    const response = await request.post(`${API_BASE_URL}/api/v1/test/trigger-error`, {
-      headers: API_HEADERS,
-      data: {
-        error_type: '500',
-        message: 'Test error for ErrorBoundary',
-      },
-    })
-
-    // The endpoint should return a 500 error
-    expect(response.status()).toBe(500)
-
-    const body = await response.json()
-    expect(body.success).toBe(false)
-    expect(body.error.code).toBe('INTERNAL_ERROR')
-    expect(body.error.details).toBe('Test error for ErrorBoundary')
-  })
-
   test('overdue loading shows placeholder skeletons, not an empty or caught-up state', async ({
     page,
   }) => {
@@ -56,12 +29,10 @@ test.describe('Error Boundary @area:error-boundary', () => {
     await expect(page.getByRole('heading', { name: 'Action Required', level: 2 })).toBeVisible()
 
     // While held (isLoading), assert the discriminating triple the old
-    // verifier used: skeletons present AND no caught-up state AND no overdue
-    // cards. The skeletons are anonymous animate-pulse divs — the class is the
-    // only anchor (the loading branch is dashboard/page.tsx's sole animate-pulse
-    // user); the held route guarantees the loading state, so this cannot
-    // vacuously pass on a fast response.
-    await expect(page.locator('.animate-pulse').first()).toBeVisible()
+    // verifier used: the labeled loading status present AND no caught-up
+    // state AND no overdue cards. The held route guarantees the loading
+    // state, so this cannot vacuously pass on a fast response.
+    await expect(page.getByRole('status', { name: 'Loading overdue contacts' })).toBeVisible()
     await expect(page.getByText('All caught up')).toHaveCount(0)
     await expect(page.getByRole('button', { name: /Mark as Contacted/i })).toHaveCount(0)
 
@@ -77,7 +48,7 @@ test.describe('Error Boundary @area:error-boundary', () => {
   test('overdue failure shows an error state with a reason, not empty or caught-up', async ({
     page,
   }) => {
-    // spec: DSH-004[1], DSH-003[0]
+    // spec: DSH-004[1], DSH-004[2], DSH-003[0]
     // 500 the overdue endpoint (full apiClient failure envelope) BEFORE goto:
     // apiClient throws ApiError on !response.ok, React Query exhausts its
     // retries, and the dashboard renders its error branch.
@@ -95,17 +66,18 @@ test.describe('Error Boundary @area:error-boundary', () => {
     await page.goto('/dashboard')
 
     // React Query retries the failing query 3 times (~7s of backoff) before
-    // surfacing the error, so allow a generous timeout.
-    const errorHeading = page.getByRole('heading', { name: 'Error loading overdue contacts' })
-    await expect(errorHeading).toBeVisible({ timeout: 20000 })
+    // surfacing the error, so allow a generous timeout. The error branch is a
+    // role=alert block containing the heading and the reason.
+    const alert = page.getByRole('alert')
+    await expect(
+      alert.getByRole('heading', { name: 'Error loading overdue contacts' })
+    ).toBeVisible({ timeout: 20000 })
 
-    // A non-empty failure reason is VISIBLY rendered beneath the heading
-    // (toHaveText alone would pass for a hidden node). Whether the reason
-    // FAITHFULLY reflects the actual failure is judge-owned (DSH-004[2]) —
-    // only its visible presence is asserted here.
-    const reason = errorHeading.locator('xpath=following-sibling::p')
-    await expect(reason).toBeVisible()
-    await expect(reason).toHaveText(/\S/)
+    // The shown reason FAITHFULLY reflects the actual failure (DSH-004[2]):
+    // apiClient plumbs the envelope's error.message into ApiError.message and
+    // the dashboard renders error.message, so the mocked failure message is
+    // deterministically the rendered reason.
+    await expect(alert.getByText('Simulated overdue failure')).toBeVisible()
 
     // The error state is distinct: no caught-up text, no overdue cards.
     await expect(page.getByText('All caught up')).toHaveCount(0)

--- a/frontend/tests/e2e/error-boundary.spec.ts
+++ b/frontend/tests/e2e/error-boundary.spec.ts
@@ -1,5 +1,13 @@
 import { test, expect } from '@playwright/test'
 import { expectAddContactHeader } from './helpers/dashboard'
+import type { APIResponse } from '../../src/types/generated/api-envelope'
+
+// The mock envelopes below are typed against the tygo-GENERATED wire type
+// (backend api/response.go → APIResponse), so a backend envelope change
+// regenerates the type and fails tsc here — the mocks cannot silently drift
+// from the real error envelope. The envelope's runtime shape on real error
+// responses is owned by the Go API tests (e.g. contact_validation_test.go
+// asserts success=false + error.code on actual HTTP responses).
 
 test.describe('Error Boundary @area:error-boundary', () => {
   test('overdue loading shows placeholder skeletons, not an empty or caught-up state', async ({
@@ -20,7 +28,7 @@ test.describe('Error Boundary @area:error-boundary', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ success: true, data: [] }),
+        body: JSON.stringify({ success: true, data: [] } satisfies APIResponse),
       })
     })
 
@@ -59,7 +67,7 @@ test.describe('Error Boundary @area:error-boundary', () => {
         body: JSON.stringify({
           success: false,
           error: { code: 'INTERNAL_ERROR', message: 'Simulated overdue failure' },
-        }),
+        } satisfies APIResponse),
       })
     )
 

--- a/frontend/tests/e2e/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation.spec.ts
@@ -41,6 +41,21 @@ test.describe('Navigation @area:navigation', () => {
     }
   })
 
+  test('clicking a nav link navigates to that section', async ({ page }) => {
+    // spec: DSH-002[0]
+    // The href loop above proves the links point at the right routes; this
+    // proves the click-through actually lands on the destination surface.
+    await page.goto('/dashboard')
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.getByRole('navigation').getByRole('link', { name: 'Contacts', exact: true }).click()
+
+    await expect(page).toHaveURL(/\/contacts(\?|$)/)
+    await expect(page.getByRole('heading', { name: 'Contacts', level: 2 })).toBeVisible({
+      timeout: 15000,
+    })
+  })
+
   test('navigation remains visible when scrolling', async ({ page }) => {
     // spec: DSH-002[2]
     // Navigate to contacts page (has enough content to scroll)

--- a/frontend/tests/e2e/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation.spec.ts
@@ -1,61 +1,9 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Navigation @area:navigation', () => {
-  // Note: Sync indicator visual states (gray/green/red) are tested via unit tests for
-  // getAggregateSyncStatus and getSyncIconClasses. Full E2E state testing would require
-  // complex API mocking to simulate sync states, which isn't warranted for this nav indicator.
-  // These E2E tests verify the infrastructure (icon presence, CSS animation) works correctly.
-  test.describe('Sync Status Indicator', () => {
-    test('imports nav item should have an icon element', async ({ page }) => {
-      await page.goto('/dashboard')
-      await page.waitForLoadState('domcontentloaded')
-
-      // Find the Imports link in navigation
-      const importsLink = page.getByRole('link', { name: /Imports/i })
-      await expect(importsLink).toBeVisible()
-
-      // Verify it contains an SVG icon (CloudDownload icon from lucide-react)
-      const icon = importsLink.locator('svg')
-      await expect(icon).toBeVisible()
-      await expect(icon).toHaveClass(/w-4.*h-4|h-4.*w-4/)
-    })
-
-    test('sync-pulse animation is defined in CSS', async ({ page }) => {
-      await page.goto('/dashboard')
-      await page.waitForLoadState('domcontentloaded')
-
-      // Verify the animate-sync-pulse class is available in the stylesheet
-      // by checking that applying it would create an animation
-      const hasAnimation = await page.evaluate(() => {
-        // Create a test element with the class
-        const testEl = document.createElement('div')
-        testEl.className = 'animate-sync-pulse'
-        document.body.appendChild(testEl)
-
-        // Get computed animation
-        const computed = window.getComputedStyle(testEl)
-        const animation = computed.animation || computed.getPropertyValue('animation')
-        document.body.removeChild(testEl)
-
-        // Check if animation is defined (not 'none' or empty)
-        return animation && animation !== 'none' && animation.includes('sync-pulse')
-      })
-
-      expect(hasAnimation).toBe(true)
-    })
-
-    test('imports link should be accessible from all main pages', async ({ page }) => {
-      const pages = ['/dashboard', '/contacts', '/imports', '/settings', '/birthdays']
-
-      for (const pagePath of pages) {
-        await page.goto(pagePath)
-        await page.waitForLoadState('domcontentloaded')
-
-        const importsLink = page.getByRole('link', { name: /Imports/i })
-        await expect(importsLink).toBeVisible()
-      }
-    })
-  })
+  // Note: Sync indicator visual states (gray/green/red) are tested via unit
+  // tests for getAggregateSyncStatus and getSyncIconClasses; icon presence and
+  // the pulse animation are visual quality owned by the judge (Track B).
 
   test('persistent nav links all five sections and marks the current one active', async ({
     page,
@@ -63,11 +11,9 @@ test.describe('Navigation @area:navigation', () => {
     // spec: DSH-002[0], DSH-002[1]
     // On EVERY primary surface, all five section links must be present with
     // their correct hrefs (DSH-002[0]), and the link matching the current
-    // section must carry the active mark — border-blue-500, an aria-invisible
-    // visual-state fact asserted as a class (mirroring the sticky-classes test
-    // below) — while a non-current link does not (DSH-002[1]). Asserting the
-    // active token per route proves the mark follows the pathname rather than
-    // a hard-coded default.
+    // section must carry aria-current="page" while a non-current link does
+    // not (DSH-002[1]). Asserting the active mark per route proves it follows
+    // the pathname rather than a hard-coded default.
     const SECTIONS = [
       { name: 'Dashboard', href: '/dashboard' },
       { name: 'Contacts', href: '/contacts' },
@@ -88,10 +34,10 @@ test.describe('Navigation @area:navigation', () => {
       }
 
       const activeLink = nav.getByRole('link', { name: current.name, exact: true })
-      await expect(activeLink).toHaveClass(/border-blue-500/)
+      await expect(activeLink).toHaveAttribute('aria-current', 'page')
       const other = current.href === SECTIONS[0].href ? SECTIONS[1] : SECTIONS[0]
       const inactiveLink = nav.getByRole('link', { name: other.name, exact: true })
-      await expect(inactiveLink).not.toHaveClass(/border-blue-500/)
+      await expect(inactiveLink).not.toHaveAttribute('aria-current', 'page')
     }
   })
 
@@ -124,17 +70,5 @@ test.describe('Navigation @area:navigation', () => {
     const navBox = await nav.boundingBox()
     expect(navBox).not.toBeNull()
     expect(navBox?.y).toBeLessThanOrEqual(5)
-  })
-
-  test('navigation has correct sticky classes', async ({ page }) => {
-    // spec: DSH-002[2]
-    await page.goto('/dashboard')
-    await page.waitForLoadState('domcontentloaded')
-
-    // Verify the nav element has sticky positioning classes
-    const nav = page.getByRole('navigation')
-    await expect(nav).toHaveClass(/sticky/)
-    await expect(nav).toHaveClass(/top-0/)
-    await expect(nav).toHaveClass(/z-50/)
   })
 })

--- a/frontend/tests/tours/cadence-followup.tour.ts
+++ b/frontend/tests/tours/cadence-followup.tour.ts
@@ -110,9 +110,8 @@ test('cadence-followup tour — contact-detail cadence surfaces', async ({ page,
   })
 
   // --- CAD-030[3] + CAD-033 (skip-listed): the tasks section empty state ---
-  const tasksSection = page
-    .locator('div.bg-white.shadow')
-    .filter({ has: page.getByRole('heading', { name: 'Tasks', level: 3 }) })
+  // The TasksSection card is a labeled region (<section aria-label="Tasks">).
+  const tasksSection = page.getByRole('region', { name: 'Tasks', exact: true })
   await page.getByText('No tasks yet').waitFor({ state: 'visible' })
   await tour.capture(page, {
     behaviors: ['CAD-030', 'CAD-033'],

--- a/frontend/tests/tours/judge/intent-catalog.ts
+++ b/frontend/tests/tours/judge/intent-catalog.ts
@@ -65,7 +65,7 @@ export const INTENT_CATALOG: Record<string, IntentSpec> = {
     statement:
       'moving between the contact list and contact detail feels like traversing one consistent, ordered list — sort, search, and filter context carries across navigation in both directions, with keyboard and mouse as equals',
     status: 'current',
-    servedBy: ['CON-038', 'CON-040', 'CON-041'],
+    servedBy: ['CON-038', 'CON-040', 'CON-041', 'CON-057', 'CON-059', 'CON-060'],
   },
   'CON-052': {
     id: 'CON-052',

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -682,7 +682,8 @@ behaviors:
     then:
       - the contact's methods are displayed with normalized values
       - the primary method is marked, and only one method carries the mark
-    provenance: ["contacts/[id]/page.tsx methods block", getPrimaryAndSecondaryMethods]
+      - a method type without an external link surface (such as Google Chat) renders its value as plain text with its type label, not as a link
+    provenance: ["contacts/[id]/page.tsx methods block", getPrimaryAndSecondaryMethods, getContactMethodHref]
     notes: Identifier normalization rules themselves are CON-012, backend-owned.
 
   - id: CON-057
@@ -735,6 +736,19 @@ behaviors:
     serves: [CON-051]
     provenance: [buildContactDetailUrl, contact detail listContext]
     notes: The current-status half of CON-039, which stays proposed for the tie-determinism claim.
+
+  - id: CON-061
+    title: The list renders derived cadence and next-contact values
+    type: ux
+    status: current
+    surface: ui
+    given: the contact list
+    when: rows render
+    then:
+      - a contact's cadence renders as its formatted label
+      - a contact with a computed next-contact date renders that date, and one without renders a placeholder
+    provenance: [contacts page table cells, formatCadence, contact_by]
+    notes: The contact_by computation itself is backend-owned (CON-001); this row pins only the list's rendering of the derived values.
 
   # --- Intents (judged experience goals — Track B agentic judge only) ---
 

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -548,6 +548,7 @@ behaviors:
       - the merged name is editable, with a quick-fill to adopt the source's name
       - the merge cannot be submitted before a source is selected, while the preview is loading, or while a merge is in flight
       - the outcome is reported and auto-dismissed
+      - the modal can be dismissed without performing a merge
     serves: [CON-050]
     provenance: [merge-contact-modal.tsx, use-merge.ts, contact-merge.spec.ts]
 
@@ -633,6 +634,107 @@ behaviors:
       - the source's primary flags are demoted regardless of method type
     provenance: [DemoteSourcePrimaryMethods, idx_contact_method_primary]
     notes: The unique index is one-primary-per-contact, so demotion keys on the target having any primary, not a same-type one (see CON-027).
+
+  - id: CON-053
+    title: The Log Interaction modal records a directed, optionally backdated interaction
+    type: ux
+    status: current
+    surface: ui
+    given: a contact detail page
+    when: the user logs an interaction through the Log Interaction modal
+    then:
+      - a direction is chosen from outbound, inbound, and mutual, defaulting to mutual
+      - an optional backdated date can be set for the interaction
+      - the interaction is posted with the chosen direction and the modal closes on success
+    provenance: [log-interaction-modal.tsx, contacts.spec.ts Log Interaction tests]
+    notes: Direction-aware cadence timestamp math (which columns each direction bumps) is CAD-006, backend-owned.
+
+  - id: CON-054
+    title: The cadence filter narrows the contact list server-side
+    type: ux
+    status: current
+    surface: ui
+    given: the contact list
+    when: a cadence filter option is selected
+    then:
+      - has-cadence and no-cadence selections drive a cadence_filter list query and only matching rows remain
+      - clearing the filter restores the unfiltered list
+    provenance: [contacts page cadence filter select, ListContacts cadence_filter]
+
+  - id: CON-055
+    title: A contact is created from the new-contact form
+    type: ux
+    status: current
+    surface: ui
+    given: the new-contact form
+    when: it is submitted with a full name
+    then:
+      - the contact is created and the user lands on its detail page
+    provenance: [contacts/new page, useCreateContact]
+
+  - id: CON-056
+    title: The detail page lists contact methods with the primary marked
+    type: ux
+    status: current
+    surface: ui
+    given: a contact with several methods across types
+    when: the detail page renders
+    then:
+      - the contact's methods are displayed with normalized values
+      - the primary method is marked, and only one method carries the mark
+    provenance: ["contacts/[id]/page.tsx methods block", getPrimaryAndSecondaryMethods]
+    notes: Identifier normalization rules themselves are CON-012, backend-owned.
+
+  - id: CON-057
+    title: Column headers drive server-side sorting
+    type: ux
+    status: current
+    surface: ui
+    given: the contact list
+    when: a sortable column header is clicked
+    then:
+      - the list refetches with that column's sort field, toggling the direction on repeated clicks
+    serves: [CON-051]
+    provenance: [contacts page handleSort, ListContacts ORDER BY ladder]
+
+  - id: CON-058
+    title: Pagination controls page the contact list
+    type: ux
+    status: current
+    surface: ui
+    given: a contact list spanning multiple pages
+    when: the pagination controls are used
+    then:
+      - page-number buttons move between pages, with the current page marked
+      - the previous/next controls disable at the list boundaries
+    provenance: [pagination.tsx, contacts page]
+
+  - id: CON-059
+    title: The navigation bar's on-screen buttons traverse the list order
+    type: ux
+    status: current
+    surface: ui
+    given: a contact detail page opened with list context
+    when: the navigation bar's prev/next buttons are clicked
+    then:
+      - the buttons move to the adjacent contact in the carried list order
+      - a position indicator reports the contact's place in the list
+    serves: [CON-051]
+    provenance: [ContactNavigationBar, useContactIDs]
+    notes: The keyboard half of detail traversal is CON-040; this row covers the on-screen buttons so CON-040's then-list (and its citing tests' indexes) stays untouched.
+
+  - id: CON-060
+    title: List context is carried across detail navigation
+    type: ux
+    status: current
+    surface: ui
+    given: a contact detail page opened with sort, order, and search context
+    when: the user moves to an adjacent contact
+    then:
+      - the sort, order, and search context is carried in the destination URL
+    serves: [CON-051]
+    provenance: [buildContactDetailUrl, contact detail listContext]
+    notes: The current-status half of CON-039, which stays proposed for the tie-determinism claim.
 
   # --- Intents (judged experience goals — Track B agentic judge only) ---
 


### PR DESCRIPTION
Child 5 of the E2E surface settlement plan (`.ai/spec/2026-07-15-remaining-e2e-migration-design.md`; work order: `.ai/spec/2026-07-16-e2e-settlement-audit/child-5-residual.md`). The largest child: systematic relaxation of the nine already-cited-but-not-relaxed files from the #659–661 verifier→E2E migration (contacts, contact-navigation, contact-direction, contact-merge, contact-tasks, dashboard, birthdays, navigation, error-boundary). Follows #667/#670/#671/#675.

## Result

`make spec-coverage`: contacts **41 covered / 0 waived / 0 orphaned**, dashboard **12 / 3 / 0**, cadence-followup **25 / 0 / 0** — the CON-042[0] and DSH-004[2] orphans closed (the in-file "judge-owned" comment on the dashboard error reason was stale; the plumbing renders `error.message`, now asserted). 0 invalid citations. Corpus-wide, only TDS-035 remains for the final child.

## What's here

- **96 tests triaged per the audit**: brittle `toHaveClass`/static-copy/count-in-label assertions stripped; ~21 tests deleted or MOVEd — every deletion of a functional affordance documents its surviving coverage (verified by the review pass), pure-presentation deletes are judge-owned handoffs (notably the location-tooltip/truncation test, an explicit Track B handoff).
- **Aria surfaces (semantic-only)**: `aria-current` on nav links, merge-modal `role="dialog"` + `aria-pressed` FieldToggles + name-input label, contact-selector option roles, tasks-clock/urgency-dot labels, `role="status"`/`role="alert"` dashboard states. `pagination.tsx` already had `aria-current="page"` — those tests rewrote with no app change.
- **SSOT mints (CON-053..061)**: real user-facing flows the suite proved but nothing owned — Log Interaction modal, cadence filter, create form, method display, column sorting, pagination, nav buttons, carried context, formatted cadence/next-contact display — plus a dismissal facet appended to CON-043 (end-append; no citation index shifts).
- **Visual guards**: CON 2/2 (leading-normal descender clipping, context-menu clipping) now carry explicit `// visual-guard:` comments; CAD/DSH 0 — aria landed instead.
- **Tour harness kept in lockstep**: the TasksSection `<section>` change re-points `cadence-followup.tour.ts` to the region role (the review caught the stranding before it hit a judged run).
- A high-effort adversarial review ran pre-push; all 10 findings fixed (backdated-date payload assert, restored Next-Contact/cadence display + nav click-through + dual-pagination + gchat-method coverage, exact position-indicator asserts, page-2 request proof, element-based backdrop dismissal, typed error-envelope mocks).

## Known issue filed, not fixed here

#674 — the contact detail page's window-level Escape handler double-acts while a modal is open (closes the modal AND navigates back). Discovered by this PR's dismissal test; CON-043[6] is proven via the backdrop path with an in-test comment until the bug is fixed.

## Verification

- `make spec-lint` — 423 behaviors OK; scanner lines above
- Isolated E2E lane: 78 passed across the nine files
- `bunx tsc --noEmit` (tours included) clean; `bun run lint` clean
