### PR TITLE
fix(tours): widen contacts uniqueName window to selector's 500

### DIFF
--- a/frontend/tests/tours/contacts.tour.ts
+++ b/frontend/tests/tours/contacts.tour.ts
@@ -33,7 +33,12 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   test.setTimeout(480_000)
 
   // --- Reserve distinct contacts up front, by API query, not list position ---
-  const listResp = await tour.apiCtx.get('/api/v1/contacts?limit=100&sort=cadence&order=desc')
+  // limit MUST cover the merge selector's candidate universe (useContacts({ limit: 500 })
+  // in merge-contact-modal.tsx). uniqueName below is only sound when computed over the
+  // SAME set the selector shows: a smaller window lets a duplicate full_name that lives
+  // outside it pass the guard, then surface twice in the selector — breaking CON-043's
+  // exact-text option click with a strict-mode violation.
+  const listResp = await tour.apiCtx.get('/api/v1/contacts?limit=500&sort=cadence&order=desc')
   const contacts = ((await listResp.json())?.data ?? []) as TourContact[]
   if (contacts.length < 4) {
     throw new Error(`tour: prod-shaped seed too small (${contacts.length} contacts) for the tour`)


### PR DESCRIPTION
## What

The contacts tour's CON-043 merge step selected a source contact by `full_name` and clicked the selector option by exact text. That click is only unambiguous when the source's `full_name` is unique across the merge selector's candidate universe — which is `useContacts({ limit: 500 })` in `merge-contact-modal.tsx` (filtered client-side).

The tour computed `uniqueName` over a `limit=100` sample, so a duplicate name living beyond row 100 passed the guard yet surfaced twice in the selector, tripping a Playwright strict-mode violation (`getByText(..., { exact: true })` → 2 elements). Fix: widen the guard query to `limit=500` so `uniqueName` is computed over the same set the selector shows.

## Root cause (systematic-debugging)

Surfaced by the post-corpus-arc live smoke. The prod-shaped staging seed has **51 duplicate `full_name` values across 171 contacts**, so the `limit=100` window was unsound — the failure only fired when the picked source's name also appeared past row 100. Verified against the live seed: at `limit=500` the guard sees the colliding name twice and correctly rejects it, and a valid cadence-differing unique-named pair still exists (no spurious `seed lacks one` throw).

The cadence-followup failure seen in the same smoke was a **stale-checkout artifact**, not a bug here: commit #676 changed the Tasks card `<div className="bg-white shadow…">` → `<section aria-label="Tasks">` and updated that tour's locator to `getByRole('region', …)` in the same PR; a checkout behind develop ran the old `div.bg-white.shadow` locator against the new markup. No change needed for it.

## Validation

- Live-seed replication of the tour's exact pair-selection logic: `limit=100` → picks the colliding name (would fail); `limit=500` → rejects it, valid pair still found.
- Full tour re-run against staging from this branch: **4/4 tours pass** (contacts 27.4s, cadence-followup 15.0s, dashboard, relationship-loop).
- Pre-push gate: Lint PASS, Tests PASS.

Test-only change (`frontend/tests/tours/`); no app or UI code.