### PR TITLE
fix(todoist): clear user-set due date on follow-up deadline refresh

### DIFF
--- a/backend/internal/consumer/todoist_op_worker.go
+++ b/backend/internal/consumer/todoist_op_worker.go
@@ -331,6 +331,12 @@ type opUpdateVerb struct {
 
 // deadlineUpdateVerb pushes the row's current `due_date` metadata as a
 // Todoist deadline. Fingerprint is the deadline string itself.
+//
+// The item_update also clears the task's Todoist due date (`due: null`):
+// the CRM only ever writes deadlines on follow-ups, so any due date is
+// user-set (Todoist's quick-reschedule/postpone edits the due field, not
+// the deadline). Left in place, a postponed task would keep surfacing as
+// due-today even though the reply window just restarted.
 func deadlineUpdateVerb() opUpdateVerb {
 	return opUpdateVerb{
 		op: consumerjobs.TaskOpUpdateDeadline,
@@ -339,7 +345,10 @@ func deadlineUpdateVerb() opUpdateVerb {
 			if !ok || due == "" {
 				return "", nil, false
 			}
-			return due, map[string]any{"deadline": map[string]string{"date": due}}, true
+			return due, map[string]any{
+				"deadline": map[string]string{"date": due},
+				"due":      nil,
+			}, true
 		},
 		fingerprint: func(value string) string { return value },
 	}

--- a/backend/internal/consumer/todoist_op_worker_test.go
+++ b/backend/internal/consumer/todoist_op_worker_test.go
@@ -328,6 +328,30 @@ func TestOpWorker_UpdateDeadline_ManagedPushesCurrentValue(t *testing.T) {
 		"command UUID must carry the pushed-value fingerprint")
 }
 
+func TestOpWorker_UpdateDeadline_ClearsUserSetDueDate(t *testing.T) {
+	// The CRM only ever writes Todoist deadlines on follow-ups, but a user
+	// postponing the task in Todoist sets a due date. The deadline refresh
+	// must clear that due date in the same item_update, otherwise the task
+	// keeps surfacing as due-today after the follow-up window restarts.
+	taskID := uuid.New()
+	repo := newFakeOpTaskRepo(&repository.ContactTask{
+		ID:             taskID,
+		State:          repository.ContactTaskStateManaged,
+		ExternalTaskID: "remote-42",
+		Metadata:       map[string]any{"due_date": "2026-08-06"},
+	})
+	client := &fakeOpClient{}
+	w := newOpWorker(repo, client, &recordingInserter{})
+
+	err := w.Work(context.Background(), opJob(taskID, consumerjobs.TaskOpUpdateDeadline))
+	require.NoError(t, err)
+	require.Len(t, client.commands, 1)
+	cmd := client.commands[0]
+	due, present := cmd.Args["due"]
+	require.True(t, present, "item_update must carry due to clear a user-set due date")
+	require.Nil(t, due, "due must be null so Todoist removes the due date")
+}
+
 func TestOpWorker_UpdateDeadline_ManagedEmptyExternalID_Errors(t *testing.T) {
 	taskID := uuid.New()
 	repo := newFakeOpTaskRepo(&repository.ContactTask{

--- a/spec/cadence-followup.yaml
+++ b/spec/cadence-followup.yaml
@@ -146,9 +146,9 @@ behaviors:
       - a contact without a cadence gets no follow-up
       - an automated outbound older than the follow-up window is skipped as backdated; manual outbounds are exempt
       - an outbound that already has a later response is skipped as out of order
-      - an existing live follow-up is refreshed (deadline updated) instead of duplicated
+      - an existing live follow-up is refreshed instead of duplicated — the remote deadline is updated and any user-set remote due date is cleared, so a previously postponed task stops surfacing once the reply window restarts
       - if the remote task provider is unconfigured, the interaction still records and the follow-up is skipped with a warning
-    provenance: [FollowUpManager creation guards, HasResponseAfterTx, FindPendingFollowUpTx]
+    provenance: [FollowUpManager creation guards, HasResponseAfterTx, FindPendingFollowUpTx, deadlineUpdateVerb]
 
   - id: CAD-013
     title: At most one live follow-up per contact and provider


### PR DESCRIPTION
## Problem

When an outbound outreach is detected while a live follow-up exists, the follow-up is refreshed in place (CAD-012): the `update_deadline` op pushes the new deadline (outreach day + watchdog window) to the same Todoist task. But the CRM only ever writes Todoist *deadlines* on follow-ups — any *due date* on the task is user-set, via Todoist's postpone/quick-reschedule. The refresh left that due date untouched, so a previously postponed follow-up kept surfacing as due-today even though the reply window had just restarted.

Observed in prod 2026-07-16: two follow-up tasks refreshed to an Aug 6 deadline after telegram outreach both kept their user-set due-today date, reading as "new tasks due today" from the Todoist side.

## Fix

`deadlineUpdateVerb`'s `item_update` now also sends `due: null`, clearing the user-set due date in the same command that moves the deadline. Single change point — both the op executor and the legacy refresh adapter route through this verb, and the verb is only ever used for follow-up refreshes. Verify-after-push fingerprint semantics unchanged (still the deadline string).

## Spec

CAD-012's refresh bullet extended to cover the due-date clear (`make spec-lint` green).

## Testing

- New unit test `TestOpWorker_UpdateDeadline_ClearsUserSetDueDate` (watched fail before the fix)
- Full `make test` green locally; pre-push gate (lint + unit + frontend + integration + e2e-diff) passed

Related deferred finding from the same investigation: #680 (follow-up dismissal resurrects cadence task at stale contact_by).