### PR TITLE
feat(qa): qa-langfuse-setup script + shared Langfuse client seam (arc PR1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-report prod staging accelerated testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint spec-coverage api-types api-types-check
+.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-report qa-export qa-langfuse-setup prod staging accelerated testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint spec-coverage api-types api-types-check
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -290,6 +290,9 @@ qa-report: ## Render the advisory report over a tours run dir (RUNDIR relative t
 
 qa-export: ## Ship a judge run's GenAI spans (TRACE=<trace.jsonl>, written when the judge runs with QA_JUDGE_TRACE set) to Langfuse, screenshots included. No-op without LANGFUSE_HOST/PUBLIC_KEY/SECRET_KEY.
 	@cd frontend && bun run tests/tours/judge/export/run.ts "$(TRACE)"
+
+qa-langfuse-setup: ## Idempotently provision the standing QA triage queue (ground_truth+disposition dims) + verdict/ground_truth/disposition score configs in Langfuse (obs). Re-runnable; reconciles desired state. Requires LANGFUSE_HOST/PUBLIC_KEY/SECRET_KEY (errors non-zero without them).
+	@cd frontend && bun run tests/tours/judge/export/setup.ts
 
 # Native PostgreSQL (for containerized development without Docker-in-Docker)
 # Symlink the main checkout's gitignored env files (.env, frontend/.env.local,

--- a/frontend/tests/tours/judge/export/langfuse.ts
+++ b/frontend/tests/tours/judge/export/langfuse.ts
@@ -295,8 +295,9 @@ export async function api(
 //              until `page >= totalPages`.
 //   'cursor' — scores v3. Sends/follows `cursor`; meta is `{limit, cursor?}`. The
 //              cursor PROPERTY is ABSENT on the terminal page, INCLUDING a one-page
-//              result — do NOT mistake a valid empty meta for malformed. A present
-//              cursor (even null) that isn't a non-empty string is malformed.
+//              result — do NOT mistake a valid meta with no cursor property for
+//              malformed. A present cursor (even null) that isn't a non-empty string
+//              is malformed.
 //
 // It MERGES its pagination params into whatever query the caller already put on
 // `path` (callers filter by tag/name), never clobbering them. It throws
@@ -336,13 +337,20 @@ export async function apiGetAllPages(
       params.set('cursor', cursor)
     }
     const query = params.toString()
-    const res = await api(cfg, 'GET', query ? `${basePath}?${query}` : basePath)
+    const res: unknown = await api(cfg, 'GET', query ? `${basePath}?${query}` : basePath)
 
-    const data = res.data
+    // A 2xx `null`/scalar/array body is a malformed envelope — raise PaginationError
+    // rather than letting `.data` throw an untyped TypeError.
+    if (res === null || typeof res !== 'object' || Array.isArray(res)) {
+      throw new PaginationError(`${basePath}: response envelope is not a JSON object`)
+    }
+    const envelope = res as Record<string, unknown>
+
+    const data = envelope.data
     if (!Array.isArray(data)) {
       throw new PaginationError(`${basePath}: response missing 'data' array`)
     }
-    const meta = res.meta
+    const meta = envelope.meta
     if (meta === null || typeof meta !== 'object' || Array.isArray(meta)) {
       throw new PaginationError(`${basePath}: missing or malformed 'meta' object`)
     }

--- a/frontend/tests/tours/judge/export/langfuse.ts
+++ b/frontend/tests/tours/judge/export/langfuse.ts
@@ -317,6 +317,15 @@ export async function apiGetAllPages(
   let cursor: string | undefined
   const seenCursors = new Set<string>()
 
+  // Require a schema-mandated integer meta field. A missing / non-integer field means
+  // the read is malformed and must fail closed, NOT terminate as if complete.
+  const reqInt = (v: unknown, name: string, min: number): number => {
+    if (!Number.isInteger(v) || (v as number) < min) {
+      throw new PaginationError(`${basePath}: invalid meta.${name} (${String(v)})`)
+    }
+    return v as number
+  }
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const params = new URLSearchParams(baseParams)
@@ -362,20 +371,18 @@ export async function apiGetAllPages(
       if ('cursor' in m) {
         throw new PaginationError(`${basePath}: page-mode response carries cursor metadata`)
       }
-      const page = m.page
-      const totalPages = m.totalPages
-      if (!Number.isInteger(page) || (page as number) < 1) {
-        throw new PaginationError(`${basePath}: invalid meta.page ${String(page)}`)
-      }
-      if (!Number.isInteger(totalPages) || (totalPages as number) < 0) {
-        throw new PaginationError(`${basePath}: invalid meta.totalPages ${String(totalPages)}`)
-      }
+      // utilsMetaResponse requires ALL of page/limit/totalItems/totalPages as
+      // integers — a response missing any of them is malformed, not terminal.
+      const page = reqInt(m.page, 'page', 1)
+      reqInt(m.limit, 'limit', 1)
+      reqInt(m.totalItems, 'totalItems', 0)
+      const totalPages = reqInt(m.totalPages, 'totalPages', 0)
       if (page !== requestedPage) {
         throw new PaginationError(
           `${basePath}: requested page ${requestedPage} but got ${String(page)}`
         )
       }
-      if ((page as number) >= (totalPages as number)) break
+      if (page >= totalPages) break
       // We are about to request another page; if this one added no new ids the
       // list isn't making progress — refuse rather than loop until totalPages.
       if (added === 0) {
@@ -391,6 +398,9 @@ export async function apiGetAllPages(
       if ('page' in m || 'totalPages' in m || 'totalItems' in m) {
         throw new PaginationError(`${basePath}: cursor-mode response carries page metadata`)
       }
+      // GetScoresV3Meta requires an integer `limit`; validate it before trusting an
+      // absent cursor as terminal, so an empty/malformed `{}` meta fails closed.
+      reqInt(m.limit, 'limit', 1)
       // Terminal state = the cursor PROPERTY is ABSENT (the API omits it when there
       // are no more results, INCLUDING a one-page result). A PRESENT cursor — even
       // `null` — that is not a non-empty string is malformed, never terminal.

--- a/frontend/tests/tours/judge/export/langfuse.ts
+++ b/frontend/tests/tours/judge/export/langfuse.ts
@@ -243,7 +243,34 @@ function authHeader(cfg: LangfuseConfig): string {
   return 'Basic ' + Buffer.from(`${cfg.publicKey}:${cfg.secretKey}`).toString('base64')
 }
 
-async function api(
+// A typed transport error carrying the HTTP status + decoded body, so best-effort
+// callers (PR2's export) can branch on `.status` and fail-closed callers (setup,
+// PR3) can surface a precise message. Extends Error, so existing `catch (err)`
+// paths that only read `.message` are unaffected.
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+    readonly method: string,
+    readonly path: string
+  ) {
+    super(`${method} ${path} -> ${status} ${body.slice(0, 200)}`)
+    this.name = 'ApiError'
+  }
+}
+
+// Thrown by `apiGetAllPages` on ANY structural problem while walking a paginated
+// list — a stale/replayed page, a stalled cursor, missing/malformed metadata, or an
+// item with no id. It is NEVER swallowed into a partial result: silent partial data
+// would let setup create resources it failed to see, or PR3 misreport coverage.
+export class PaginationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PaginationError'
+  }
+}
+
+export async function api(
   cfg: LangfuseConfig,
   method: string,
   path: string,
@@ -255,8 +282,118 @@ async function api(
     body: body ? JSON.stringify(body) : undefined,
   })
   const text = await res.text()
-  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status} ${text.slice(0, 200)}`)
+  if (!res.ok) throw new ApiError(res.status, text, method, path)
   return text ? (JSON.parse(text) as Record<string, unknown>) : {}
+}
+
+// Walk a paginated Langfuse list endpoint to completion and return the accumulated
+// items, deduped by resource `id`. The REQUIRED `protocol` selects one of v3's two
+// incompatible list styles — there is no reliable way to infer it from a response:
+//
+//   'page'   — annotation-queues, queue items, score-configs, traces. Sends
+//              page+limit; meta is `{page, limit, totalItems, totalPages}`. Advances
+//              until `page >= totalPages`.
+//   'cursor' — scores v3. Sends/follows `cursor`; meta is `{limit, cursor?}`. The
+//              cursor PROPERTY is absent (or null) on the terminal page, INCLUDING a
+//              one-page result — do NOT mistake a valid empty meta for malformed.
+//
+// It MERGES its pagination params into whatever query the caller already put on
+// `path` (PR3 filters by tag/name), never clobbering them. It throws
+// `PaginationError` (never returns partial data) on any structural violation, so a
+// short read can't masquerade as "resource absent".
+export async function apiGetAllPages(
+  cfg: LangfuseConfig,
+  path: string,
+  protocol: 'page' | 'cursor'
+): Promise<Record<string, unknown>[]> {
+  const LIMIT = 100
+  const qIdx = path.indexOf('?')
+  const basePath = qIdx === -1 ? path : path.slice(0, qIdx)
+  const baseParams = qIdx === -1 ? '' : path.slice(qIdx + 1)
+
+  const byId = new Map<string, Record<string, unknown>>()
+  let requestedPage = 1
+  let cursor: string | undefined
+  const seenCursors = new Set<string>()
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const params = new URLSearchParams(baseParams)
+    params.set('limit', String(LIMIT))
+    if (protocol === 'page') {
+      params.set('page', String(requestedPage))
+    } else if (cursor !== undefined) {
+      params.set('cursor', cursor)
+    }
+    const query = params.toString()
+    const res = await api(cfg, 'GET', query ? `${basePath}?${query}` : basePath)
+
+    const data = res.data
+    if (!Array.isArray(data)) {
+      throw new PaginationError(`${basePath}: response missing 'data' array`)
+    }
+    const meta = res.meta
+    if (meta === null || typeof meta !== 'object' || Array.isArray(meta)) {
+      throw new PaginationError(`${basePath}: missing or malformed 'meta' object`)
+    }
+    const m = meta as Record<string, unknown>
+
+    // Accumulate BEFORE deciding termination, deduped by id — an overlapping page
+    // (one repeated id + one new id still makes forward progress) must not leak a
+    // phantom duplicate into a caller's uniqueness check.
+    for (const item of data) {
+      if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+        throw new PaginationError(`${basePath}: non-object item in 'data'`)
+      }
+      const id = (item as Record<string, unknown>).id
+      if (typeof id !== 'string' || id.length === 0) {
+        throw new PaginationError(`${basePath}: item lacking a valid string 'id'`)
+      }
+      if (!byId.has(id)) byId.set(id, item as Record<string, unknown>)
+    }
+
+    if (protocol === 'page') {
+      // A cursor property here means we got a scores-v3-shaped body under 'page'.
+      if ('cursor' in m) {
+        throw new PaginationError(`${basePath}: page-mode response carries cursor metadata`)
+      }
+      const page = m.page
+      const totalPages = m.totalPages
+      if (!Number.isInteger(page) || (page as number) < 1) {
+        throw new PaginationError(`${basePath}: invalid meta.page ${String(page)}`)
+      }
+      if (!Number.isInteger(totalPages) || (totalPages as number) < 0) {
+        throw new PaginationError(`${basePath}: invalid meta.totalPages ${String(totalPages)}`)
+      }
+      if (page !== requestedPage) {
+        throw new PaginationError(
+          `${basePath}: requested page ${requestedPage} but got ${String(page)}`
+        )
+      }
+      if ((page as number) >= (totalPages as number)) break
+      requestedPage += 1
+    } else {
+      // Reject page metadata — a utilsMetaResponse under 'cursor' is a protocol mix.
+      if ('page' in m || 'totalPages' in m) {
+        throw new PaginationError(`${basePath}: cursor-mode response carries page metadata`)
+      }
+      // Absent OR null cursor = no more results (the API marks cursor nullable and
+      // "Absent when there are no more results"). A present, non-null value must be
+      // a non-empty string token.
+      const next = m.cursor
+      if (next === undefined || next === null) break
+      if (typeof next !== 'string' || next.length === 0) {
+        throw new PaginationError(`${basePath}: invalid meta.cursor`)
+      }
+      if (seenCursors.has(next)) {
+        throw new PaginationError(`${basePath}: cursor did not advance (repeated ${next})`)
+      }
+      seenCursors.add(next)
+      cursor = next
+    }
+  }
+
+  return [...byId.values()]
 }
 
 // Upload one screenshot and return its media token, or undefined if the file is

--- a/frontend/tests/tours/judge/export/langfuse.ts
+++ b/frontend/tests/tours/judge/export/langfuse.ts
@@ -294,8 +294,9 @@ export async function api(
 //              page+limit; meta is `{page, limit, totalItems, totalPages}`. Advances
 //              until `page >= totalPages`.
 //   'cursor' — scores v3. Sends/follows `cursor`; meta is `{limit, cursor?}`. The
-//              cursor PROPERTY is absent (or null) on the terminal page, INCLUDING a
-//              one-page result — do NOT mistake a valid empty meta for malformed.
+//              cursor PROPERTY is ABSENT on the terminal page, INCLUDING a one-page
+//              result — do NOT mistake a valid empty meta for malformed. A present
+//              cursor (even null) that isn't a non-empty string is malformed.
 //
 // It MERGES its pagination params into whatever query the caller already put on
 // `path` (PR3 filters by tag/name), never clobbering them. It throws
@@ -340,7 +341,10 @@ export async function apiGetAllPages(
 
     // Accumulate BEFORE deciding termination, deduped by id — an overlapping page
     // (one repeated id + one new id still makes forward progress) must not leak a
-    // phantom duplicate into a caller's uniqueness check.
+    // phantom duplicate into a caller's uniqueness check. `added` counts the NEW
+    // ids this page contributed, so a non-terminal page that adds nothing (a
+    // stalled server / fabricated-cursor loop) can be caught below.
+    const sizeBefore = byId.size
     for (const item of data) {
       if (item === null || typeof item !== 'object' || Array.isArray(item)) {
         throw new PaginationError(`${basePath}: non-object item in 'data'`)
@@ -351,6 +355,7 @@ export async function apiGetAllPages(
       }
       if (!byId.has(id)) byId.set(id, item as Record<string, unknown>)
     }
+    const added = byId.size - sizeBefore
 
     if (protocol === 'page') {
       // A cursor property here means we got a scores-v3-shaped body under 'page'.
@@ -371,22 +376,35 @@ export async function apiGetAllPages(
         )
       }
       if ((page as number) >= (totalPages as number)) break
+      // We are about to request another page; if this one added no new ids the
+      // list isn't making progress — refuse rather than loop until totalPages.
+      if (added === 0) {
+        throw new PaginationError(
+          `${basePath}: page ${String(page)} added no new items but more pages remain`
+        )
+      }
       requestedPage += 1
     } else {
       // Reject page metadata — a utilsMetaResponse under 'cursor' is a protocol mix.
       if ('page' in m || 'totalPages' in m) {
         throw new PaginationError(`${basePath}: cursor-mode response carries page metadata`)
       }
-      // Absent OR null cursor = no more results (the API marks cursor nullable and
-      // "Absent when there are no more results"). A present, non-null value must be
-      // a non-empty string token.
+      // Terminal state = the cursor PROPERTY is ABSENT (the API omits it when there
+      // are no more results, INCLUDING a one-page result). A PRESENT cursor — even
+      // `null` — that is not a non-empty string is malformed, never terminal.
+      if (!('cursor' in m)) break
       const next = m.cursor
-      if (next === undefined || next === null) break
       if (typeof next !== 'string' || next.length === 0) {
-        throw new PaginationError(`${basePath}: invalid meta.cursor`)
+        throw new PaginationError(
+          `${basePath}: invalid meta.cursor (must be a non-empty string when present)`
+        )
       }
       if (seenCursors.has(next)) {
         throw new PaginationError(`${basePath}: cursor did not advance (repeated ${next})`)
+      }
+      // A fresh cursor that yields no new ids is a fabricated-continuation loop.
+      if (added === 0) {
+        throw new PaginationError(`${basePath}: continuation cursor but page added no new items`)
       }
       seenCursors.add(next)
       cursor = next

--- a/frontend/tests/tours/judge/export/langfuse.ts
+++ b/frontend/tests/tours/judge/export/langfuse.ts
@@ -244,9 +244,9 @@ function authHeader(cfg: LangfuseConfig): string {
 }
 
 // A typed transport error carrying the HTTP status + decoded body, so best-effort
-// callers (PR2's export) can branch on `.status` and fail-closed callers (setup,
-// PR3) can surface a precise message. Extends Error, so existing `catch (err)`
-// paths that only read `.message` are unaffected.
+// callers can branch on `.status` and fail-closed callers can surface a precise
+// message. Extends Error, so existing `catch (err)` paths that only read `.message`
+// are unaffected.
 export class ApiError extends Error {
   constructor(
     readonly status: number,
@@ -262,7 +262,7 @@ export class ApiError extends Error {
 // Thrown by `apiGetAllPages` on ANY structural problem while walking a paginated
 // list — a stale/replayed page, a stalled cursor, missing/malformed metadata, or an
 // item with no id. It is NEVER swallowed into a partial result: silent partial data
-// would let setup create resources it failed to see, or PR3 misreport coverage.
+// would let setup create resources it failed to see, or a caller misreport coverage.
 export class PaginationError extends Error {
   constructor(message: string) {
     super(message)
@@ -299,7 +299,7 @@ export async function api(
 //              cursor (even null) that isn't a non-empty string is malformed.
 //
 // It MERGES its pagination params into whatever query the caller already put on
-// `path` (PR3 filters by tag/name), never clobbering them. It throws
+// `path` (callers filter by tag/name), never clobbering them. It throws
 // `PaginationError` (never returns partial data) on any structural violation, so a
 // short read can't masquerade as "resource absent".
 export async function apiGetAllPages(
@@ -386,7 +386,9 @@ export async function apiGetAllPages(
       requestedPage += 1
     } else {
       // Reject page metadata — a utilsMetaResponse under 'cursor' is a protocol mix.
-      if ('page' in m || 'totalPages' in m) {
+      // (`limit` is shared by both metas, so it is NOT a discriminator; page/
+      // totalPages/totalItems are page-only.)
+      if ('page' in m || 'totalPages' in m || 'totalItems' in m) {
         throw new PaginationError(`${basePath}: cursor-mode response carries page metadata`)
       }
       // Terminal state = the cursor PROPERTY is ABSENT (the API omits it when there

--- a/frontend/tests/tours/judge/export/setup.test.ts
+++ b/frontend/tests/tours/judge/export/setup.test.ts
@@ -646,6 +646,16 @@ describe('apiGetAllPages — query preservation + dedup + malformed', () => {
     expect(out.map(o => o.id)).toEqual(['a', 'b', 'c'])
   })
 
+  it('throws on a non-object envelope (2xx JSON null / scalar / array)', async () => {
+    for (const json of [null, 7, [{ id: 'a' }]]) {
+      const mock = scripted([{ json }])
+      vi.stubGlobal('fetch', mock.impl)
+      await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+        PaginationError
+      )
+    }
+  })
+
   it('throws on missing data array', async () => {
     const mock = scripted([
       { json: { meta: { page: 1, limit: 100, totalItems: 0, totalPages: 1 } } },

--- a/frontend/tests/tours/judge/export/setup.test.ts
+++ b/frontend/tests/tours/judge/export/setup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { apiGetAllPages, PaginationError, type LangfuseConfig } from './langfuse'
+import { api, ApiError, apiGetAllPages, PaginationError, type LangfuseConfig } from './langfuse'
 import { main } from './setup'
 import {
   SCORE_CONFIGS,
@@ -294,6 +294,32 @@ describe('setup.main — provisioning', () => {
       expect(code).toBe(1)
       expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
     }
+  })
+
+  it('drift — extra category (superset) → non-zero, zero POSTs', async () => {
+    // The 3 correct verdict categories PLUS an extra one — must NOT reconcile clean.
+    const extra = goodConfig(VERDICT_SCORE_NAME)
+    extra.categories = [...extra.categories, { label: 'maybe', value: 2 }]
+    const mock = tenantMock({ configPages: [[extra]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('drift — queue scoreConfigIds contains an EXTRA id (superset) → non-zero, zero POSTs', async () => {
+    // ground_truth + disposition PLUS verdict — a superset must be rejected, not accepted.
+    const configs = SCORE_CONFIGS.map(s => goodConfig(s.name))
+    const queue: QueueObj = {
+      id: 'q1',
+      name: TRIAGE_QUEUE_NAME,
+      scoreConfigIds: ['ground_truth-id', 'disposition-id', 'verdict-id'],
+    }
+    const mock = tenantMock({ configPages: [configs], queuePages: [[queue]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
   })
 
   it('drift — mismatched dataType → non-zero, zero POSTs', async () => {
@@ -640,16 +666,34 @@ describe('apiGetAllPages — query preservation + dedup + malformed', () => {
     }
   })
 
-  it('throws on invalid meta.page / meta.totalPages', async () => {
+  it('throws on any missing / non-integer page-meta field (page/limit/totalItems/totalPages)', async () => {
     const bad = [
       { data: [{ id: 'a' }], meta: { page: 0, limit: 100, totalItems: 1, totalPages: 1 } },
       { data: [{ id: 'a' }], meta: { page: 1, limit: 100, totalItems: 1, totalPages: -1 } },
       { data: [{ id: 'a' }], meta: { page: '1', limit: 100, totalItems: 1, totalPages: 1 } },
+      // limit missing / non-integer (schema-mandated by utilsMetaResponse).
+      { data: [{ id: 'a' }], meta: { page: 1, totalItems: 1, totalPages: 1 } },
+      { data: [{ id: 'a' }], meta: { page: 1, limit: 'x', totalItems: 1, totalPages: 1 } },
+      // totalItems missing / non-integer.
+      { data: [{ id: 'a' }], meta: { page: 1, limit: 100, totalPages: 1 } },
+      { data: [{ id: 'a' }], meta: { page: 1, limit: 100, totalItems: 1.5, totalPages: 1 } },
     ]
     for (const json of bad) {
       const mock = scripted([{ json }])
       vi.stubGlobal('fetch', mock.impl)
       await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+        PaginationError
+      )
+    }
+  })
+
+  it('cursor mode: an empty / limit-less / non-integer-limit meta is NOT terminal (fails closed)', async () => {
+    // scores-v3 GetScoresV3Meta requires an integer `limit`; without a valid one an
+    // absent cursor must NOT be treated as a clean terminal.
+    for (const meta of [{}, { limit: 'x' }, { limit: 1.5 }]) {
+      const mock = scripted([{ json: { data: [{ id: 's1' }], meta } }])
+      vi.stubGlobal('fetch', mock.impl)
+      await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
         PaginationError
       )
     }
@@ -663,6 +707,22 @@ describe('apiGetAllPages — query preservation + dedup + malformed', () => {
         PaginationError
       )
     }
+  })
+})
+
+describe('api — typed ApiError', () => {
+  it('throws ApiError carrying the HTTP status + decoded body (consumed by downstream callers)', async () => {
+    const mock = scripted([{ status: 404, json: 'not found detail' }])
+    vi.stubGlobal('fetch', mock.impl)
+    let caught: unknown
+    try {
+      await api(cfg, 'GET', '/api/public/score-configs')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ApiError)
+    expect((caught as ApiError).status).toBe(404)
+    expect((caught as ApiError).body).toContain('not found detail')
   })
 })
 

--- a/frontend/tests/tours/judge/export/setup.test.ts
+++ b/frontend/tests/tours/judge/export/setup.test.ts
@@ -208,6 +208,33 @@ describe('setup.main — provisioning', () => {
     expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
   })
 
+  it('drift — missing / non-boolean isArchived (strict === false) → non-zero, zero POSTs', async () => {
+    for (const bogus of [undefined, null, 0, 'false']) {
+      const cfgObj = goodConfig(VERDICT_SCORE_NAME)
+      ;(cfgObj as unknown as { isArchived: unknown }).isArchived = bogus
+      const mock = tenantMock({ configPages: [[cfgObj]] })
+      vi.stubGlobal('fetch', mock.impl)
+      const code = await main(creds, silent.log, silent.err)
+      expect(code).toBe(1)
+      expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+    }
+  })
+
+  it('drift — duplicate category label masking a missing one → non-zero, zero POSTs', async () => {
+    // [pass, pass, unsure] is length-3 like verdict's [pass, unsure, fail] but drops fail.
+    const dup = goodConfig(VERDICT_SCORE_NAME)
+    dup.categories = [
+      { label: 'pass', value: 1 },
+      { label: 'pass', value: 1 },
+      { label: 'unsure', value: 0 },
+    ]
+    const mock = tenantMock({ configPages: [[dup]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
   it('drift — wrong queue scoreConfigIds (queue compared on scoreConfigIds only) → non-zero, zero POSTs', async () => {
     const configs = SCORE_CONFIGS.map(s => goodConfig(s.name))
     const queue: QueueObj = {
@@ -324,6 +351,15 @@ describe('apiGetAllPages — page protocol', () => {
     expect(await apiGetAllPages(cfg, '/api/public/annotation-queues', 'page')).toEqual([])
   })
 
+  it('throws when a non-terminal page adds no new ids (no-progress guard)', async () => {
+    // page 1 of 3 = [a]; page 2 of 3 repeats [a] → no new id but more pages remain.
+    const mock = scripted([pageResp([{ id: 'a' }], 1, 3), pageResp([{ id: 'a' }], 2, 3)])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+
   it('throws on a mismatched returned page (stale/replayed page)', async () => {
     const mock = scripted([pageResp([{ id: 'a' }], 1, 3), pageResp([{ id: 'b' }], 1, 3)])
     vi.stubGlobal('fetch', mock.impl)
@@ -362,14 +398,25 @@ describe('apiGetAllPages — cursor protocol (scores v3)', () => {
     ])
   })
 
-  it('treats a null cursor as terminal (API marks cursor nullable)', async () => {
+  it('throws on a PRESENT null cursor (terminal is the property being ABSENT)', async () => {
     const mock = scripted([cursorResp([{ id: 's1' }], null)])
     vi.stubGlobal('fetch', mock.impl)
-    expect(await apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).toHaveLength(1)
+    await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
+      PaginationError
+    )
   })
 
   it('throws on a repeated cursor (no progress)', async () => {
     const mock = scripted([cursorResp([{ id: 's1' }], 'SAME'), cursorResp([{ id: 's2' }], 'SAME')])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+
+  it('throws on a FRESH cursor that adds no new ids (fabricated-continuation loop)', async () => {
+    // Distinct cursors each page, but page 2 repeats page 1's only id → no progress.
+    const mock = scripted([cursorResp([{ id: 's1' }], 'CUR2'), cursorResp([{ id: 's1' }], 'CUR3')])
     vi.stubGlobal('fetch', mock.impl)
     await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
       PaginationError

--- a/frontend/tests/tours/judge/export/setup.test.ts
+++ b/frontend/tests/tours/judge/export/setup.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { apiGetAllPages, PaginationError, type LangfuseConfig } from './langfuse'
 import { main } from './setup'
-import { SCORE_CONFIGS, TRIAGE_QUEUE_NAME, VERDICT_SCORE_NAME } from './triage-config'
+import {
+  SCORE_CONFIGS,
+  TRIAGE_QUEUE_NAME,
+  TRIAGE_QUEUE_SCORE_CONFIGS,
+  VERDICT_SCORE_NAME,
+} from './triage-config'
 
 const cfg: LangfuseConfig = { host: 'http://lf', publicKey: 'p', secretKey: 's' }
 const creds = {
@@ -138,6 +143,49 @@ const silent = { log: () => {}, err: () => {} }
 
 afterEach(() => vi.restoreAllMocks())
 
+describe('triage-config — literal contract', () => {
+  // These assert LITERAL values so a change to the names/labels/encodings in
+  // triage-config.ts is caught here rather than silently tracked by tests that
+  // derive their expectations from SCORE_CONFIGS.
+  it('pins the queue + verdict names', () => {
+    expect(TRIAGE_QUEUE_NAME).toBe('qa-triage')
+    expect(VERDICT_SCORE_NAME).toBe('verdict')
+    expect(TRIAGE_QUEUE_SCORE_CONFIGS).toEqual(['ground_truth', 'disposition'])
+  })
+
+  it('pins the exact score-config matrix (names, dataType, categories + numeric encodings)', () => {
+    expect(SCORE_CONFIGS).toEqual([
+      {
+        name: 'verdict',
+        dataType: 'CATEGORICAL',
+        categories: [
+          { label: 'pass', value: 1 },
+          { label: 'unsure', value: 0 },
+          { label: 'fail', value: -1 },
+        ],
+      },
+      {
+        name: 'ground_truth',
+        dataType: 'CATEGORICAL',
+        categories: [
+          { label: 'should_pass', value: 1 },
+          { label: 'unsure', value: 0 },
+          { label: 'should_fail', value: -1 },
+        ],
+      },
+      {
+        name: 'disposition',
+        dataType: 'CATEGORICAL',
+        categories: [
+          { label: 'acted', value: 1 },
+          { label: 'deferred', value: 0 },
+          { label: 'dismissed', value: -1 },
+        ],
+      },
+    ])
+  })
+})
+
 describe('setup.main — provisioning', () => {
   it('fresh tenant: creates all 3 configs + the queue with ground_truth+disposition dims ONLY', async () => {
     const mock = tenantMock({})
@@ -145,19 +193,47 @@ describe('setup.main — provisioning', () => {
     const code = await main(creds, silent.log, silent.err)
     expect(code).toBe(0)
 
+    // Assert the EXACT POST bodies against LITERAL expected values (not values
+    // derived from SCORE_CONFIGS). This locks the wire contract: a changed name /
+    // encoding OR any added field (INV-D: no new free-text on the wire) fails here.
     const configPosts = postsTo(mock.calls, '/api/public/score-configs')
-    expect(configPosts.map(c => c.body!.name)).toEqual(SCORE_CONFIGS.map(s => s.name))
-    for (const [i, spec] of SCORE_CONFIGS.entries()) {
-      expect(configPosts[i].body!.dataType).toBe('CATEGORICAL')
-      expect(configPosts[i].body!.categories).toEqual(spec.categories)
-    }
+    expect(configPosts.map(c => c.body)).toEqual([
+      {
+        name: 'verdict',
+        dataType: 'CATEGORICAL',
+        categories: [
+          { label: 'pass', value: 1 },
+          { label: 'unsure', value: 0 },
+          { label: 'fail', value: -1 },
+        ],
+      },
+      {
+        name: 'ground_truth',
+        dataType: 'CATEGORICAL',
+        categories: [
+          { label: 'should_pass', value: 1 },
+          { label: 'unsure', value: 0 },
+          { label: 'should_fail', value: -1 },
+        ],
+      },
+      {
+        name: 'disposition',
+        dataType: 'CATEGORICAL',
+        categories: [
+          { label: 'acted', value: 1 },
+          { label: 'deferred', value: 0 },
+          { label: 'dismissed', value: -1 },
+        ],
+      },
+    ])
 
-    const queuePosts = postsTo(mock.calls, '/api/public/annotation-queues')
-    expect(queuePosts).toHaveLength(1)
-    expect(queuePosts[0].body!.name).toBe(TRIAGE_QUEUE_NAME)
     // Creation order is verdict, ground_truth, disposition → new-sc-0/1/2. The queue
-    // references the two HUMAN ids only (new-sc-1, new-sc-2), NOT verdict's new-sc-0.
-    expect(queuePosts[0].body!.scoreConfigIds).toEqual(['new-sc-1', 'new-sc-2'])
+    // body is EXACT: references the two HUMAN ids only (new-sc-1, new-sc-2), NOT
+    // verdict's new-sc-0, and carries no other field.
+    const queuePosts = postsTo(mock.calls, '/api/public/annotation-queues')
+    expect(queuePosts.map(c => c.body)).toEqual([
+      { name: 'qa-triage', scoreConfigIds: ['new-sc-1', 'new-sc-2'] },
+    ])
   })
 
   it('fully-provisioned + matching → ZERO POSTs (idempotency)', async () => {
@@ -218,6 +294,39 @@ describe('setup.main — provisioning', () => {
       expect(code).toBe(1)
       expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
     }
+  })
+
+  it('drift — mismatched dataType → non-zero, zero POSTs', async () => {
+    const wrongType = goodConfig(VERDICT_SCORE_NAME)
+    ;(wrongType as unknown as { dataType: string }).dataType = 'NUMERIC'
+    const mock = tenantMock({ configPages: [[wrongType]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('drift — duplicate qa-triage queue (two distinct ids) → non-zero, zero POSTs', async () => {
+    const configs = SCORE_CONFIGS.map(s => goodConfig(s.name))
+    const q1: QueueObj = {
+      id: 'q-a',
+      name: TRIAGE_QUEUE_NAME,
+      scoreConfigIds: ['ground_truth-id', 'disposition-id'],
+    }
+    const q2: QueueObj = { ...q1, id: 'q-b' }
+    const mock = tenantMock({ configPages: [configs], queuePages: [[q1, q2]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('GET-side ApiError (score-config read returns 500) → non-zero, zero POSTs (fail-closed)', async () => {
+    const mock = scripted([{ status: 500, json: 'boom' }])
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
   })
 
   it('drift — duplicate category label masking a missing one → non-zero, zero POSTs', async () => {
@@ -351,6 +460,30 @@ describe('apiGetAllPages — page protocol', () => {
     expect(await apiGetAllPages(cfg, '/api/public/annotation-queues', 'page')).toEqual([])
   })
 
+  it('ACCEPTS a fully-duplicate TERMINAL page (guard only fires on continuation)', async () => {
+    // page 2 of 2 repeats page 1 entirely — it is terminal, so no-progress does NOT fire.
+    const mock = scripted([
+      pageResp([{ id: 'a' }, { id: 'b' }], 1, 2),
+      pageResp([{ id: 'a' }, { id: 'b' }], 2, 2),
+    ])
+    vi.stubGlobal('fetch', mock.impl)
+    const out = await apiGetAllPages(cfg, '/api/public/score-configs', 'page')
+    expect(out.map(o => o.id)).toEqual(['a', 'b'])
+  })
+
+  it('preserves caller filters on every page request (MERGES page+limit)', async () => {
+    const mock = scripted([pageResp([{ id: 'a' }], 1, 2), pageResp([{ id: 'b' }], 2, 2)])
+    vi.stubGlobal('fetch', mock.impl)
+    await apiGetAllPages(cfg, '/api/public/score-configs?foo=bar&x=1', 'page')
+    for (const c of mock.calls) {
+      expect(c.url).toContain('foo=bar')
+      expect(c.url).toContain('x=1')
+      expect(c.url).toContain('limit=100')
+    }
+    expect(mock.calls[0].url).toContain('page=1')
+    expect(mock.calls[1].url).toContain('page=2')
+  })
+
   it('throws when a non-terminal page adds no new ids (no-progress guard)', async () => {
     // page 1 of 3 = [a]; page 2 of 3 repeats [a] → no new id but more pages remain.
     const mock = scripted([pageResp([{ id: 'a' }], 1, 3), pageResp([{ id: 'a' }], 2, 3)])
@@ -423,6 +556,15 @@ describe('apiGetAllPages — cursor protocol (scores v3)', () => {
     )
   })
 
+  it('ACCEPTS a fully-duplicate TERMINAL cursor page (guard only fires on continuation)', async () => {
+    // page 2 repeats page 1's id but is terminal (no cursor) → no-progress does NOT fire.
+    const mock = scripted([cursorResp([{ id: 's1' }], 'CUR2'), cursorResp([{ id: 's1' }])])
+    vi.stubGlobal('fetch', mock.impl)
+    expect((await apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).map(o => o.id)).toEqual([
+      's1',
+    ])
+  })
+
   it('throws on a present non-string / empty cursor', async () => {
     for (const bad of [123, '']) {
       const mock = scripted([{ json: { data: [{ id: 's1' }], meta: { limit: 100, cursor: bad } } }])
@@ -435,6 +577,16 @@ describe('apiGetAllPages — cursor protocol (scores v3)', () => {
 
   it('rejects page metadata under cursor mode (protocol mix)', async () => {
     const mock = scripted([pageResp([{ id: 's1' }], 1, 1)])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+
+  it('rejects a page-only totalItems under cursor mode (no silent truncation)', async () => {
+    // {limit, totalItems} has no cursor property → would otherwise look terminal, but
+    // totalItems is page-protocol metadata and must be rejected as a protocol mix.
+    const mock = scripted([{ json: { data: [{ id: 's1' }], meta: { limit: 100, totalItems: 1 } } }])
     vi.stubGlobal('fetch', mock.impl)
     await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
       PaginationError
@@ -515,14 +667,25 @@ describe('apiGetAllPages — query preservation + dedup + malformed', () => {
 })
 
 describe('setup.ts — import without side effects', () => {
-  it('importing the module runs no arg-validation / network / process.exit', async () => {
+  it('importing the module runs no network / logging / exit — discriminates the import.meta.main guard', async () => {
+    // If the guard were removed, `void main()` would run on import: with creds absent
+    // main() SYNCHRONOUSLY logs a config error (console.error) before any await; with
+    // creds present it SYNCHRONOUSLY calls fetch before its first await. Asserting
+    // none of those fire (nor process.exit / a changed exitCode) makes this test
+    // actually fail if the guard is dropped — regardless of ambient LANGFUSE_* env.
     vi.resetModules()
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const exitCodeBefore = process.exitCode
     const fetchSpy = vi.fn()
     vi.stubGlobal('fetch', fetchSpy)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
     const mod = await import('./setup')
     expect(typeof mod.main).toBe('function')
     expect(fetchSpy).not.toHaveBeenCalled()
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(errSpy).not.toHaveBeenCalled()
     expect(exitSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(exitCodeBefore)
   })
 })

--- a/frontend/tests/tours/judge/export/setup.test.ts
+++ b/frontend/tests/tours/judge/export/setup.test.ts
@@ -1,0 +1,481 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { apiGetAllPages, PaginationError, type LangfuseConfig } from './langfuse'
+import { main } from './setup'
+import { SCORE_CONFIGS, TRIAGE_QUEUE_NAME, VERDICT_SCORE_NAME } from './triage-config'
+
+const cfg: LangfuseConfig = { host: 'http://lf', publicKey: 'p', secretKey: 's' }
+const creds = {
+  LANGFUSE_HOST: cfg.host,
+  LANGFUSE_PUBLIC_KEY: cfg.publicKey,
+  LANGFUSE_SECRET_KEY: cfg.secretKey,
+}
+
+// ---------- shared fetch-mock plumbing ----------
+
+interface Recorded {
+  url: string
+  method: string
+  body?: Record<string, unknown>
+}
+
+// A response scripted to be returned in call order; running past the end THROWS so a
+// runaway pagination loop surfaces as a test failure instead of hanging.
+function scripted(responses: Array<{ status?: number; json: unknown }>): {
+  impl: typeof fetch
+  calls: Recorded[]
+} {
+  const calls: Recorded[] = []
+  let i = 0
+  const impl = (async (url: string | URL, init?: { method?: string; body?: unknown }) => {
+    calls.push({
+      url: String(url),
+      method: init?.method ?? 'GET',
+      body: init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined,
+    })
+    if (i >= responses.length) throw new Error(`unexpected extra fetch: ${String(url)}`)
+    const r = responses[i++]
+    const status = r.status ?? 200
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => JSON.stringify(r.json),
+    } as Response
+  }) as unknown as typeof fetch
+  return { impl, calls }
+}
+
+const pageResp = (data: unknown[], page: number, totalPages: number): { json: unknown } => ({
+  json: { data, meta: { page, limit: 100, totalItems: data.length, totalPages } },
+})
+
+const cursorResp = (data: unknown[], cursor?: string | null): { json: unknown } => ({
+  json: { data, meta: cursor === undefined ? { limit: 100 } : { limit: 100, cursor } },
+})
+
+// ---------- tenant mock for setup.main ----------
+
+interface ScoreConfigObj {
+  id: string
+  name: string
+  dataType: string
+  isArchived: boolean
+  categories: Array<{ label: string; value: number }>
+}
+interface QueueObj {
+  id: string
+  name: string
+  scoreConfigIds: string[]
+}
+
+function goodConfig(name: string, id = `${name}-id`): ScoreConfigObj {
+  const spec = SCORE_CONFIGS.find(s => s.name === name)
+  if (!spec) throw new Error(`no spec for ${name}`)
+  return {
+    id,
+    name,
+    dataType: 'CATEGORICAL',
+    isArchived: false,
+    categories: spec.categories.map(c => ({ ...c })),
+  }
+}
+
+// A stateful tenant: paginated GETs over the supplied pages, POST-create echoes a
+// fresh object. `failCreate` makes the first matching POST return 500.
+function tenantMock(state: {
+  configPages?: ScoreConfigObj[][]
+  queuePages?: QueueObj[][]
+  failCreate?: 'config' | 'queue'
+}): { impl: typeof fetch; calls: Recorded[] } {
+  const configPages = state.configPages ?? [[]]
+  const queuePages = state.queuePages ?? [[]]
+  const calls: Recorded[] = []
+  let seq = 0
+  const okJson = (obj: unknown, status = 200): Response =>
+    ({ ok: status < 400, status, text: async () => JSON.stringify(obj) }) as Response
+  const pageFrom = (pages: unknown[][], url: string): Response => {
+    const p = Number(new URL(url).searchParams.get('page'))
+    const data = pages[p - 1] ?? []
+    return okJson({
+      data,
+      meta: { page: p, limit: 100, totalItems: pages.flat().length, totalPages: pages.length },
+    })
+  }
+  const impl = (async (url: string | URL, init?: { method?: string; body?: unknown }) => {
+    const u = String(url)
+    const method = init?.method ?? 'GET'
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined
+    calls.push({ url: u, method, body })
+    if (method === 'GET' && u.includes('/api/public/score-configs')) return pageFrom(configPages, u)
+    if (method === 'GET' && u.includes('/api/public/annotation-queues'))
+      return pageFrom(queuePages, u)
+    if (method === 'POST' && u.endsWith('/api/public/score-configs')) {
+      if (state.failCreate === 'config') return okJson('boom', 500)
+      return okJson({
+        id: `new-sc-${seq++}`,
+        name: body!.name,
+        dataType: body!.dataType,
+        isArchived: false,
+        categories: body!.categories,
+      })
+    }
+    if (method === 'POST' && u.endsWith('/api/public/annotation-queues')) {
+      if (state.failCreate === 'queue') return okJson('boom', 500)
+      return okJson({
+        id: `new-q-${seq++}`,
+        name: body!.name,
+        scoreConfigIds: body!.scoreConfigIds,
+      })
+    }
+    throw new Error(`unexpected ${method} ${u}`)
+  }) as unknown as typeof fetch
+  return { impl, calls }
+}
+
+const postsTo = (calls: Recorded[], suffix: string): Recorded[] =>
+  calls.filter(c => c.method === 'POST' && c.url.endsWith(suffix))
+
+const silent = { log: () => {}, err: () => {} }
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('setup.main — provisioning', () => {
+  it('fresh tenant: creates all 3 configs + the queue with ground_truth+disposition dims ONLY', async () => {
+    const mock = tenantMock({})
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(0)
+
+    const configPosts = postsTo(mock.calls, '/api/public/score-configs')
+    expect(configPosts.map(c => c.body!.name)).toEqual(SCORE_CONFIGS.map(s => s.name))
+    for (const [i, spec] of SCORE_CONFIGS.entries()) {
+      expect(configPosts[i].body!.dataType).toBe('CATEGORICAL')
+      expect(configPosts[i].body!.categories).toEqual(spec.categories)
+    }
+
+    const queuePosts = postsTo(mock.calls, '/api/public/annotation-queues')
+    expect(queuePosts).toHaveLength(1)
+    expect(queuePosts[0].body!.name).toBe(TRIAGE_QUEUE_NAME)
+    // Creation order is verdict, ground_truth, disposition → new-sc-0/1/2. The queue
+    // references the two HUMAN ids only (new-sc-1, new-sc-2), NOT verdict's new-sc-0.
+    expect(queuePosts[0].body!.scoreConfigIds).toEqual(['new-sc-1', 'new-sc-2'])
+  })
+
+  it('fully-provisioned + matching → ZERO POSTs (idempotency)', async () => {
+    const configs = SCORE_CONFIGS.map(s => goodConfig(s.name))
+    const queue: QueueObj = {
+      id: 'q1',
+      name: TRIAGE_QUEUE_NAME,
+      scoreConfigIds: ['ground_truth-id', 'disposition-id'],
+    }
+    const mock = tenantMock({ configPages: [configs], queuePages: [[queue]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(0)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('partial (verdict matches, others missing) → creates only the two missing configs', async () => {
+    const mock = tenantMock({ configPages: [[goodConfig(VERDICT_SCORE_NAME, 'v1')]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(0)
+    const configPosts = postsTo(mock.calls, '/api/public/score-configs')
+    expect(configPosts.map(c => c.body!.name)).toEqual(['ground_truth', 'disposition'])
+    // Queue references the two newly-created human ids.
+    const queuePosts = postsTo(mock.calls, '/api/public/annotation-queues')
+    expect(queuePosts[0].body!.scoreConfigIds).toEqual(['new-sc-0', 'new-sc-1'])
+  })
+
+  it('drift — mismatched categories → non-zero, drift message, zero POSTs', async () => {
+    const bad = goodConfig(VERDICT_SCORE_NAME)
+    bad.categories = [{ label: 'pass', value: 1 }] // wrong set
+    const errs: string[] = []
+    const mock = tenantMock({ configPages: [[bad]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, m => errs.push(m))
+    expect(code).toBe(1)
+    expect(errs.join('\n')).toMatch(/DRIFT/)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('drift — archived score-config (isArchived on the CONFIG) → non-zero, zero POSTs', async () => {
+    const archived = goodConfig(VERDICT_SCORE_NAME)
+    archived.isArchived = true
+    const mock = tenantMock({ configPages: [[archived]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('drift — wrong queue scoreConfigIds (queue compared on scoreConfigIds only) → non-zero, zero POSTs', async () => {
+    const configs = SCORE_CONFIGS.map(s => goodConfig(s.name))
+    const queue: QueueObj = {
+      id: 'q1',
+      name: TRIAGE_QUEUE_NAME,
+      scoreConfigIds: ['verdict-id'], // wrong/incomplete
+    }
+    const mock = tenantMock({ configPages: [configs], queuePages: [[queue]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('drift — existing queue while a required human config is absent → non-zero, zero POSTs', async () => {
+    // verdict present, ground_truth/disposition absent, but the queue exists.
+    const queue: QueueObj = { id: 'q1', name: TRIAGE_QUEUE_NAME, scoreConfigIds: ['x', 'y'] }
+    const mock = tenantMock({
+      configPages: [[goodConfig(VERDICT_SCORE_NAME)]],
+      queuePages: [[queue]],
+    })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('drift — duplicate same-named config (two DISTINCT ids, one name) → non-zero, zero POSTs', async () => {
+    const a = goodConfig(VERDICT_SCORE_NAME, 'v-a')
+    const b = goodConfig(VERDICT_SCORE_NAME, 'v-b')
+    const mock = tenantMock({ configPages: [[a, b]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('real API error (create POST 500 → ApiError) → non-zero', async () => {
+    const mock = tenantMock({ failCreate: 'config' })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+  })
+
+  it('no LANGFUSE_* → exits non-zero, zero fetches', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const code = await main({}, silent.log, silent.err)
+    expect(code).toBe(1)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('paginated score-config list (two pages) → all seen, no duplicate create', async () => {
+    const configs = SCORE_CONFIGS.map(s => goodConfig(s.name))
+    const queue: QueueObj = {
+      id: 'q1',
+      name: TRIAGE_QUEUE_NAME,
+      scoreConfigIds: ['ground_truth-id', 'disposition-id'],
+    }
+    const mock = tenantMock({
+      configPages: [[configs[0], configs[1]], [configs[2]]],
+      queuePages: [[queue]],
+    })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(0)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('paginated queue list (qa-triage on page 2) → found, not re-created', async () => {
+    const configs = SCORE_CONFIGS.map(s => goodConfig(s.name))
+    const other: QueueObj = { id: 'q0', name: 'some-other-queue', scoreConfigIds: [] }
+    const queue: QueueObj = {
+      id: 'q1',
+      name: TRIAGE_QUEUE_NAME,
+      scoreConfigIds: ['ground_truth-id', 'disposition-id'],
+    }
+    const mock = tenantMock({ configPages: [configs], queuePages: [[other], [queue]] })
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(0)
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+
+  it('propagates a paginator failure (repeated page) to a non-zero exit (fail-closed)', async () => {
+    // score-configs GET returns page 1 when page 2 was requested → PaginationError.
+    const mock = scripted([pageResp([goodConfig(VERDICT_SCORE_NAME)], 1, 2), pageResp([], 1, 2)])
+    vi.stubGlobal('fetch', mock.impl)
+    const code = await main(creds, silent.log, silent.err)
+    expect(code).toBe(1)
+    // No POSTs after the read failed.
+    expect(mock.calls.filter(c => c.method === 'POST')).toHaveLength(0)
+  })
+})
+
+describe('apiGetAllPages — page protocol', () => {
+  it('walks two pages and returns the union', async () => {
+    const mock = scripted([
+      pageResp([{ id: 'a' }, { id: 'b' }], 1, 2),
+      pageResp([{ id: 'c' }], 2, 2),
+    ])
+    vi.stubGlobal('fetch', mock.impl)
+    const out = await apiGetAllPages(cfg, '/api/public/score-configs', 'page')
+    expect(out.map(o => o.id)).toEqual(['a', 'b', 'c'])
+    // Each request carried the tracked page + limit.
+    expect(mock.calls[0].url).toContain('page=1')
+    expect(mock.calls[1].url).toContain('page=2')
+    expect(mock.calls.every(c => c.url.includes('limit=100'))).toBe(true)
+  })
+
+  it('a single empty page terminates cleanly', async () => {
+    const mock = scripted([pageResp([], 1, 1)])
+    vi.stubGlobal('fetch', mock.impl)
+    expect(await apiGetAllPages(cfg, '/api/public/annotation-queues', 'page')).toEqual([])
+  })
+
+  it('throws on a mismatched returned page (stale/replayed page)', async () => {
+    const mock = scripted([pageResp([{ id: 'a' }], 1, 3), pageResp([{ id: 'b' }], 1, 3)])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+
+  it('rejects cursor metadata under page mode (protocol mix)', async () => {
+    const mock = scripted([{ json: { data: [{ id: 'a' }], meta: { limit: 100, cursor: 'x' } } }])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+})
+
+describe('apiGetAllPages — cursor protocol (scores v3)', () => {
+  it('follows meta.cursor across pages and stops when the property is absent', async () => {
+    const mock = scripted([
+      cursorResp([{ id: 's1' }], 'CUR2'),
+      cursorResp([{ id: 's2' }]), // no cursor property → terminal
+    ])
+    vi.stubGlobal('fetch', mock.impl)
+    const out = await apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')
+    expect(out.map(o => o.id)).toEqual(['s1', 's2'])
+    expect(mock.calls[0].url).not.toContain('cursor=')
+    expect(mock.calls[1].url).toContain('cursor=CUR2')
+  })
+
+  it('a single-page cursor response (valid meta, no cursor property) is NOT malformed', async () => {
+    const mock = scripted([cursorResp([{ id: 's1' }])])
+    vi.stubGlobal('fetch', mock.impl)
+    expect((await apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).map(o => o.id)).toEqual([
+      's1',
+    ])
+  })
+
+  it('treats a null cursor as terminal (API marks cursor nullable)', async () => {
+    const mock = scripted([cursorResp([{ id: 's1' }], null)])
+    vi.stubGlobal('fetch', mock.impl)
+    expect(await apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).toHaveLength(1)
+  })
+
+  it('throws on a repeated cursor (no progress)', async () => {
+    const mock = scripted([cursorResp([{ id: 's1' }], 'SAME'), cursorResp([{ id: 's2' }], 'SAME')])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+
+  it('throws on a present non-string / empty cursor', async () => {
+    for (const bad of [123, '']) {
+      const mock = scripted([{ json: { data: [{ id: 's1' }], meta: { limit: 100, cursor: bad } } }])
+      vi.stubGlobal('fetch', mock.impl)
+      await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
+        PaginationError
+      )
+    }
+  })
+
+  it('rejects page metadata under cursor mode (protocol mix)', async () => {
+    const mock = scripted([pageResp([{ id: 's1' }], 1, 1)])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/v3/scores', 'cursor')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+})
+
+describe('apiGetAllPages — query preservation + dedup + malformed', () => {
+  it('MERGES pagination params without clobbering the caller filters (every page)', async () => {
+    const mock = scripted([cursorResp([{ id: 's1' }], 'CUR2'), cursorResp([{ id: 's2' }])])
+    vi.stubGlobal('fetch', mock.impl)
+    await apiGetAllPages(
+      cfg,
+      '/api/public/v3/scores?name=verdict&dataType=CATEGORICAL&fields=subject',
+      'cursor'
+    )
+    for (const c of mock.calls) {
+      expect(c.url).toContain('name=verdict')
+      expect(c.url).toContain('dataType=CATEGORICAL')
+      expect(c.url).toContain('fields=subject')
+    }
+  })
+
+  it('dedups overlapping pages by id (repeated id appears once, still terminates)', async () => {
+    const mock = scripted([
+      pageResp([{ id: 'a' }, { id: 'b' }], 1, 2),
+      pageResp([{ id: 'b' }, { id: 'c' }], 2, 2), // b repeated + c new
+    ])
+    vi.stubGlobal('fetch', mock.impl)
+    const out = await apiGetAllPages(cfg, '/api/public/score-configs', 'page')
+    expect(out.map(o => o.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('throws on missing data array', async () => {
+    const mock = scripted([
+      { json: { meta: { page: 1, limit: 100, totalItems: 0, totalPages: 1 } } },
+    ])
+    vi.stubGlobal('fetch', mock.impl)
+    await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+      PaginationError
+    )
+  })
+
+  it('throws on missing/malformed meta (null, array, scalar)', async () => {
+    for (const meta of [null, [], 7]) {
+      const mock = scripted([{ json: { data: [], meta } }])
+      vi.stubGlobal('fetch', mock.impl)
+      await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+        PaginationError
+      )
+    }
+  })
+
+  it('throws on invalid meta.page / meta.totalPages', async () => {
+    const bad = [
+      { data: [{ id: 'a' }], meta: { page: 0, limit: 100, totalItems: 1, totalPages: 1 } },
+      { data: [{ id: 'a' }], meta: { page: 1, limit: 100, totalItems: 1, totalPages: -1 } },
+      { data: [{ id: 'a' }], meta: { page: '1', limit: 100, totalItems: 1, totalPages: 1 } },
+    ]
+    for (const json of bad) {
+      const mock = scripted([{ json }])
+      vi.stubGlobal('fetch', mock.impl)
+      await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+        PaginationError
+      )
+    }
+  })
+
+  it('throws on an item lacking a valid string id', async () => {
+    for (const item of [{ name: 'x' }, { id: 42 }, { id: '' }]) {
+      const mock = scripted([pageResp([item], 1, 1)])
+      vi.stubGlobal('fetch', mock.impl)
+      await expect(apiGetAllPages(cfg, '/api/public/score-configs', 'page')).rejects.toBeInstanceOf(
+        PaginationError
+      )
+    }
+  })
+})
+
+describe('setup.ts — import without side effects', () => {
+  it('importing the module runs no arg-validation / network / process.exit', async () => {
+    vi.resetModules()
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const mod = await import('./setup')
+    expect(typeof mod.main).toBe('function')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/tours/judge/export/setup.ts
+++ b/frontend/tests/tours/judge/export/setup.ts
@@ -58,9 +58,13 @@ function groupByName<T extends { name: string }>(objs: T[]): Map<string, T[]> {
 }
 
 // A config matches its spec iff dataType + the exact category set agree AND it is
-// NOT archived (isArchived lives on the score-config, per the v3 response).
+// EXACTLY not-archived. `isArchived` is a REQUIRED boolean on the v3 score-config, so
+// anything other than a literal `false` (missing, null, truthy, non-boolean) is a
+// drifted/malformed config we must NOT silently accept as healthy.
 function scoreConfigDrift(spec: ScoreConfigSpec, actual: ScoreConfig): string | undefined {
-  if (actual.isArchived) return `score-config '${spec.name}' is archived (isArchived=true)`
+  if (actual.isArchived !== false) {
+    return `score-config '${spec.name}' is archived or missing isArchived (isArchived !== false)`
+  }
   if (actual.dataType !== spec.dataType) {
     return `score-config '${spec.name}' dataType ${actual.dataType} != ${spec.dataType}`
   }
@@ -70,17 +74,23 @@ function scoreConfigDrift(spec: ScoreConfigSpec, actual: ScoreConfig): string | 
   return undefined
 }
 
-// Set equality keyed by label→value (order-independent, exact count).
+// EXACT set equality keyed by label→value (order-independent). A duplicate label in
+// `actual` is rejected: without that check an actual `[pass, pass, unsure]` would
+// pass length + membership against desired `[pass, unsure, fail]` while silently
+// dropping `fail`.
 function categoriesMatch(
   desired: ScoreCategory[],
   actual: ScoreCategory[] | null | undefined
 ): boolean {
   if (!Array.isArray(actual) || actual.length !== desired.length) return false
-  const want = new Map(desired.map(c => [c.label, c.value]))
+  const actualByLabel = new Map<string, number>()
   for (const c of actual) {
-    if (!want.has(c.label) || want.get(c.label) !== c.value) return false
+    if (actualByLabel.has(c.label)) return false // duplicate label
+    actualByLabel.set(c.label, c.value)
   }
-  return true
+  // Equal length + no dups + every desired label present with the right value ⇒ a
+  // bijection, i.e. exact set equality.
+  return desired.every(d => actualByLabel.get(d.label) === d.value)
 }
 
 export async function main(

--- a/frontend/tests/tours/judge/export/setup.ts
+++ b/frontend/tests/tours/judge/export/setup.ts
@@ -1,0 +1,245 @@
+// CLI: idempotently provision the standing QA triage substrate in Langfuse.
+//
+//   LANGFUSE_HOST=... LANGFUSE_PUBLIC_KEY=... LANGFUSE_SECRET_KEY=... \
+//     bun run tests/tours/judge/export/setup.ts
+//
+// It reconciles the DESIRED state: the `verdict` / `ground_truth` / `disposition`
+// score configs and the standing `qa-triage` annotation queue (editable dims =
+// ground_truth + disposition). Re-running a correctly-provisioned tenant creates
+// nothing and exits 0.
+//
+// FAIL-CLOSED, unlike qa-export: this is an explicitly-invoked provisioning command
+// whose whole job is to establish a runtime prerequisite, so missing creds or any
+// drift exits NON-ZERO — a silent no-op would manufacture false confidence. It is
+// also OPERATOR-CONTROLLED: it never MUTATES an existing object (Langfuse supports
+// score-config updates, but auto-rewriting shared triage infra is declined) — on any
+// drift it reports the diff and exits non-zero for a human to resolve.
+
+import {
+  ApiError,
+  api,
+  apiGetAllPages,
+  configFromEnv,
+  PaginationError,
+  type LangfuseConfig,
+} from './langfuse'
+import {
+  SCORE_CONFIGS,
+  TRIAGE_QUEUE_NAME,
+  TRIAGE_QUEUE_SCORE_CONFIGS,
+  type ScoreCategory,
+  type ScoreConfigSpec,
+} from './triage-config'
+
+interface ScoreConfig {
+  id: string
+  name: string
+  dataType: string
+  isArchived: boolean
+  categories?: ScoreCategory[] | null
+}
+
+interface AnnotationQueue {
+  id: string
+  name: string
+  scoreConfigIds: string[]
+}
+
+// Group already-deduped-by-id objects by name. More than one DISTINCT id under one
+// name is a prior double-create / hand-made dup → caught as drift by the caller.
+function groupByName<T extends { name: string }>(objs: T[]): Map<string, T[]> {
+  const byName = new Map<string, T[]>()
+  for (const o of objs) {
+    const list = byName.get(o.name)
+    if (list) list.push(o)
+    else byName.set(o.name, [o])
+  }
+  return byName
+}
+
+// A config matches its spec iff dataType + the exact category set agree AND it is
+// NOT archived (isArchived lives on the score-config, per the v3 response).
+function scoreConfigDrift(spec: ScoreConfigSpec, actual: ScoreConfig): string | undefined {
+  if (actual.isArchived) return `score-config '${spec.name}' is archived (isArchived=true)`
+  if (actual.dataType !== spec.dataType) {
+    return `score-config '${spec.name}' dataType ${actual.dataType} != ${spec.dataType}`
+  }
+  if (!categoriesMatch(spec.categories, actual.categories)) {
+    return `score-config '${spec.name}' categories differ from desired`
+  }
+  return undefined
+}
+
+// Set equality keyed by label→value (order-independent, exact count).
+function categoriesMatch(
+  desired: ScoreCategory[],
+  actual: ScoreCategory[] | null | undefined
+): boolean {
+  if (!Array.isArray(actual) || actual.length !== desired.length) return false
+  const want = new Map(desired.map(c => [c.label, c.value]))
+  for (const c of actual) {
+    if (!want.has(c.label) || want.get(c.label) !== c.value) return false
+  }
+  return true
+}
+
+export async function main(
+  env: Record<string, string | undefined> = process.env,
+  log: (msg: string) => void = console.log,
+  errlog: (msg: string) => void = console.error
+): Promise<number> {
+  const cfg = configFromEnv(env)
+  if (!cfg) {
+    errlog(
+      'qa-langfuse-setup: LANGFUSE_HOST / LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set — ' +
+        'cannot provision the triage substrate. Set them and re-run.'
+    )
+    return 1
+  }
+
+  try {
+    // --- read current state (paginated, page protocol) ---
+    const existingConfigs = (await apiGetAllPages(
+      cfg,
+      '/api/public/score-configs',
+      'page'
+    )) as unknown as ScoreConfig[]
+    const existingQueues = (await apiGetAllPages(
+      cfg,
+      '/api/public/annotation-queues',
+      'page'
+    )) as unknown as AnnotationQueue[]
+
+    const configsByName = groupByName(existingConfigs)
+    const queuesByName = groupByName(existingQueues)
+
+    // --- preflight: validate EVERYTHING before the first POST (zero writes on drift) ---
+    const drift: string[] = []
+
+    for (const spec of SCORE_CONFIGS) {
+      const matches = configsByName.get(spec.name) ?? []
+      if (matches.length > 1) {
+        drift.push(
+          `score-config '${spec.name}' has ${matches.length} distinct objects (duplicate name)`
+        )
+        continue
+      }
+      if (matches.length === 1) {
+        const d = scoreConfigDrift(spec, matches[0])
+        if (d) drift.push(d)
+      }
+    }
+
+    const queueMatches = queuesByName.get(TRIAGE_QUEUE_NAME) ?? []
+    if (queueMatches.length > 1) {
+      drift.push(
+        `queue '${TRIAGE_QUEUE_NAME}' has ${queueMatches.length} distinct objects (duplicate name)`
+      )
+    } else if (queueMatches.length === 1) {
+      // The queue can only be validated against the human config ids. If either is
+      // absent, an existing queue necessarily references a missing/wrong id → drift.
+      const humanIds: string[] = []
+      let humanMissing = false
+      for (const name of TRIAGE_QUEUE_SCORE_CONFIGS) {
+        const c = configsByName.get(name) ?? []
+        if (c.length === 1) humanIds.push(c[0].id)
+        else humanMissing = true
+      }
+      if (humanMissing) {
+        drift.push(
+          `queue '${TRIAGE_QUEUE_NAME}' exists but a required editable score config ` +
+            `(${TRIAGE_QUEUE_SCORE_CONFIGS.join(', ')}) is absent/duplicated — cannot reconcile`
+        )
+      } else if (!sameIdSet(queueMatches[0].scoreConfigIds, humanIds)) {
+        drift.push(
+          `queue '${TRIAGE_QUEUE_NAME}' scoreConfigIds ${JSON.stringify(queueMatches[0].scoreConfigIds)} ` +
+            `!= desired ${JSON.stringify(humanIds)} (${TRIAGE_QUEUE_SCORE_CONFIGS.join(', ')})`
+        )
+      }
+    }
+
+    if (drift.length > 0) {
+      errlog('qa-langfuse-setup: DRIFT detected — no changes made. Resolve in the Langfuse UI:')
+      for (const d of drift) errlog(`  - ${d}`)
+      return 1
+    }
+
+    // --- reconcile: create only what's absent (preflight proved matches are clean) ---
+    const configIds = await ensureScoreConfigs(cfg, configsByName, log)
+    const queueId = await ensureQueue(cfg, queuesByName, configIds, log)
+
+    log('qa-langfuse-setup: done.')
+    log(`  queue ${TRIAGE_QUEUE_NAME} = ${queueId}`)
+    for (const spec of SCORE_CONFIGS)
+      log(`  score-config ${spec.name} = ${configIds.get(spec.name)}`)
+    return 0
+  } catch (err) {
+    if (err instanceof ApiError || err instanceof PaginationError) {
+      errlog(`qa-langfuse-setup: ${err.name}: ${err.message}`)
+      return 1
+    }
+    throw err
+  }
+}
+
+// Create absent configs; matching ones log `exists (matches)`. Returns name→id.
+async function ensureScoreConfigs(
+  cfg: LangfuseConfig,
+  configsByName: Map<string, ScoreConfig[]>,
+  log: (msg: string) => void
+): Promise<Map<string, string>> {
+  const ids = new Map<string, string>()
+  for (const spec of SCORE_CONFIGS) {
+    const existing = configsByName.get(spec.name)?.[0]
+    if (existing) {
+      log(`  score-config ${spec.name}: exists (matches)`)
+      ids.set(spec.name, existing.id)
+      continue
+    }
+    const created = (await api(cfg, 'POST', '/api/public/score-configs', {
+      name: spec.name,
+      dataType: spec.dataType,
+      categories: spec.categories,
+    })) as unknown as ScoreConfig
+    log(`  score-config ${spec.name}: created (${created.id})`)
+    ids.set(spec.name, created.id)
+  }
+  return ids
+}
+
+// Find-or-create the queue referencing ONLY the human editable dims.
+async function ensureQueue(
+  cfg: LangfuseConfig,
+  queuesByName: Map<string, AnnotationQueue[]>,
+  configIds: Map<string, string>,
+  log: (msg: string) => void
+): Promise<string> {
+  const scoreConfigIds = TRIAGE_QUEUE_SCORE_CONFIGS.map(name => {
+    const id = configIds.get(name)
+    if (!id) throw new Error(`internal: no id for required score config '${name}'`)
+    return id
+  })
+  const existing = queuesByName.get(TRIAGE_QUEUE_NAME)?.[0]
+  if (existing) {
+    log(`  queue ${TRIAGE_QUEUE_NAME}: exists (matches)`)
+    return existing.id
+  }
+  const created = (await api(cfg, 'POST', '/api/public/annotation-queues', {
+    name: TRIAGE_QUEUE_NAME,
+    scoreConfigIds,
+  })) as unknown as AnnotationQueue
+  log(`  queue ${TRIAGE_QUEUE_NAME}: created (${created.id})`)
+  return created.id
+}
+
+function sameIdSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = new Set(a)
+  return b.every(id => sa.has(id))
+}
+
+if (typeof import.meta !== 'undefined' && (import.meta as ImportMeta).main) {
+  void main().then(code => {
+    process.exitCode = code
+  })
+}

--- a/frontend/tests/tours/judge/export/triage-config.ts
+++ b/frontend/tests/tours/judge/export/triage-config.ts
@@ -1,0 +1,67 @@
+// Single source of truth for the QA triage substrate names + score-config specs.
+//
+// WHY THIS EXISTS (arc contract #2): the setup script, the exporter (PR2), and the
+// backfill CLI (PR3) all reference the SAME triage queue + score names. A name typo
+// split across those call sites would silently bind/emit the wrong score or create a
+// second queue / drop items. Everything downstream imports these constants — nobody
+// spells `'verdict'` / `'qa-triage'` inline.
+
+// The standing annotation queue the judge's fails/traps land in for human triage.
+export const TRIAGE_QUEUE_NAME = 'qa-triage'
+
+// The judge's PROGRAMMATIC verdict score. PR2 emits it on the trace by `configId`;
+// PR3 reads it back. It is deliberately NOT a queue-editable dimension (see
+// TRIAGE_QUEUE_SCORE_CONFIGS) — a second, human-authored `verdict` would overwrite
+// the judge's and destroy the judge-vs-human delta the calibration loop measures.
+export const VERDICT_SCORE_NAME = 'verdict'
+
+export interface ScoreCategory {
+  label: string
+  value: number
+}
+
+export interface ScoreConfigSpec {
+  name: string
+  dataType: 'CATEGORICAL'
+  categories: ScoreCategory[]
+}
+
+// Category VALUE encoding is fixed and load-bearing: pass-ish = 1, unsure = 0,
+// fail-ish = -1 (disposition: acted = 1, deferred = 0, dismissed = -1). The API
+// requires a numeric value per category, but ANALYSIS reads the string LABEL — so
+// the values only need to be stable + documented, which is what this comment is for.
+// Changing a value silently reinterprets every score already recorded under it.
+export const SCORE_CONFIGS: ScoreConfigSpec[] = [
+  {
+    name: VERDICT_SCORE_NAME,
+    dataType: 'CATEGORICAL',
+    categories: [
+      { label: 'pass', value: 1 },
+      { label: 'unsure', value: 0 },
+      { label: 'fail', value: -1 },
+    ],
+  },
+  {
+    name: 'ground_truth',
+    dataType: 'CATEGORICAL',
+    categories: [
+      { label: 'should_pass', value: 1 },
+      { label: 'unsure', value: 0 },
+      { label: 'should_fail', value: -1 },
+    ],
+  },
+  {
+    name: 'disposition',
+    dataType: 'CATEGORICAL',
+    categories: [
+      { label: 'acted', value: 1 },
+      { label: 'deferred', value: 0 },
+      { label: 'dismissed', value: -1 },
+    ],
+  },
+]
+
+// The queue's EDITABLE score dimensions — the two HUMAN dimensions ONLY. `verdict`
+// is excluded on purpose (see VERDICT_SCORE_NAME); it still shows read-only on the
+// trace in the annotation UI as the judge's call the reviewer is adjudicating.
+export const TRIAGE_QUEUE_SCORE_CONFIGS = ['ground_truth', 'disposition'] as const

--- a/frontend/tests/tours/judge/export/triage-config.ts
+++ b/frontend/tests/tours/judge/export/triage-config.ts
@@ -1,18 +1,19 @@
 // Single source of truth for the QA triage substrate names + score-config specs.
 //
-// WHY THIS EXISTS (arc contract #2): the setup script, the exporter (PR2), and the
-// backfill CLI (PR3) all reference the SAME triage queue + score names. A name typo
-// split across those call sites would silently bind/emit the wrong score or create a
-// second queue / drop items. Everything downstream imports these constants — nobody
-// spells `'verdict'` / `'qa-triage'` inline.
+// WHY THIS EXISTS: the setup script, the exporter, and the backfill CLI all
+// reference the SAME triage queue + score names. A name typo split across those call
+// sites would silently bind/emit the wrong score or create a second queue / drop
+// items. Everything downstream imports these constants — nobody spells
+// `'verdict'` / `'qa-triage'` inline.
 
 // The standing annotation queue the judge's fails/traps land in for human triage.
 export const TRIAGE_QUEUE_NAME = 'qa-triage'
 
-// The judge's PROGRAMMATIC verdict score. PR2 emits it on the trace by `configId`;
-// PR3 reads it back. It is deliberately NOT a queue-editable dimension (see
-// TRIAGE_QUEUE_SCORE_CONFIGS) — a second, human-authored `verdict` would overwrite
-// the judge's and destroy the judge-vs-human delta the calibration loop measures.
+// The judge's PROGRAMMATIC verdict score. The exporter emits it on the trace by
+// `configId`; the backfill CLI reads it back. It is deliberately NOT a queue-editable
+// dimension (see TRIAGE_QUEUE_SCORE_CONFIGS) — a second, human-authored `verdict`
+// would overwrite the judge's and destroy the judge-vs-human delta the calibration
+// loop measures.
 export const VERDICT_SCORE_NAME = 'verdict'
 
 export interface ScoreCategory {


### PR DESCRIPTION
## Judge-as-tenant automation — PR1 (pilot)

First PR of the QA judge-as-tenant automation arc (advisory judge → Langfuse triage). This is the **pilot**: it establishes the shared Langfuse client seam that PR2/PR3/PR4 inherit, so its contracts were held to a high bar.

### What it ships
- **`triage-config.ts`** — single-sources the triage queue name, score-config names (incl. `VERDICT_SCORE_NAME`), and the categorical config matrix (`ground_truth` = should_pass/should_fail/unsure; `disposition` = acted/dismissed/deferred). One source of truth so PR2 can't drift.
- **`langfuse.ts`** — exports the shared `api()` seam + typed `ApiError`/`PaginationError`, and adds `apiGetAllPages()` supporting both Langfuse pagination protocols (page+limit for queues; cursor/`meta.cursor` for Scores v3). Query-merging, id-dedup, full schema-mandated metadata validation per protocol, a no-progress guard, and **fail-closed on any malformed envelope (throws `PaginationError`, never returns partial data)** — validated against Langfuse's official OpenAPI spec.
- **`setup.ts`** — idempotent, **fail-closed desired-state reconciler** for the standing triage queue + score configs: a **zero-write drift preflight** that compares full shape (strict `isArchived === false`, exact set equality including supersets) and exits non-zero on drift; creates only what's absent; **never mutates**. Clear non-zero on missing `LANGFUSE_*` creds (a provisioning command, not export's fail-open no-op).
- **Makefile** target + **`setup.test.ts`** (48 tests) that fail-if-broken (literal-pinned, not self-referential).

### Scope
In-arc, spike-independent. The nightly runner/wrapper, personal-ops provisioning, and running this script against the live `obs` tenant are deferred to the provisioning track.

### Review
Plan passed a multi-round adversarial review (Claude→Codex convergence, then a gpt-5.6-sol validation + independent review). Code passed a 4-round gpt-5.6-sol review (P0=4 → 4×P1 → 1×P1+2×P2 → PASS) plus an Opus /review-head at the merge gate. `make lint` / `make test-frontend` (680) / `make test-e2e-diff` green.