### PR TITLE
test(e2e): size Playwright workers to cgroup CPU quota

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,54 @@
 import { defineConfig, devices } from '@playwright/test'
 import os from 'os'
+import { readFileSync } from 'fs'
+
+// Effective CPU budget = the cgroup CFS quota when present, else the visible
+// core count. A container can be capped far below os.cpus(): our dev sandbox
+// reports 10 cores but cpu.max limits it to 2. Sizing the worker pool to the
+// visible cores oversubscribes such a box, which measured SLOWER than matching
+// the quota (full suite: 4 workers on a 2-CPU cap = 562s vs 440s at 2 workers).
+// Falls back to os.cpus() on macOS / cgroup v1 / unlimited quota.
+function readCgroupV2CpuMax(): string | null {
+  // The applicable cpu.max lives at this process's cgroup-v2 path, which is
+  // NOT always the root (nested systemd scopes put it deeper); reading the root
+  // there returns "max" and misses the cap. Resolve the path from
+  // /proc/self/cgroup ("0::/<path>"), then fall back to the root.
+  const paths: string[] = []
+  try {
+    const line = readFileSync('/proc/self/cgroup', 'utf8')
+      .split('\n')
+      .find(l => l.startsWith('0::'))
+    if (line) paths.push(`/sys/fs/cgroup${line.slice(3).trim()}/cpu.max`)
+  } catch {
+    // /proc/self/cgroup unreadable — fall through to the root path
+  }
+  paths.push('/sys/fs/cgroup/cpu.max')
+  for (const p of paths) {
+    try {
+      const raw = readFileSync(p, 'utf8').trim()
+      if (raw && raw !== 'max') return raw
+    } catch {
+      // try the next candidate path
+    }
+  }
+  return null
+}
+
+function effectiveCpuBudget(): number {
+  const cores = os.cpus().length || 1
+  const raw = readCgroupV2CpuMax()
+  if (raw) {
+    const [quotaStr, periodStr] = raw.split(/\s+/)
+    const quota = Number(quotaStr)
+    const period = Number(periodStr)
+    if (quota > 0 && period > 0) {
+      // Clamp to >=1: a sub-one-CPU quota floors to 0, but the pool still needs
+      // at least one worker (and must not fall back to all visible cores).
+      return Math.min(cores, Math.max(1, Math.floor(quota / period)))
+    }
+  }
+  return cores
+}
 
 const frontendPort = process.env.E2E_FRONTEND_PORT || '3000'
 const backendPort = process.env.E2E_BACKEND_PORT || '8080'
@@ -24,21 +73,18 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  // Allow safe parallelism; override with PLAYWRIGHT_WORKERS if needed
-  // Pi (arm64) runs faster with 1 worker due to resource contention
+  // Size the worker pool to the effective CPU budget (cgroup quota, not just
+  // visible cores); override with PLAYWRIGHT_WORKERS. This replaces the former
+  // arm64-linux=1 special-case: that was a proxy for "CPU-constrained", but the
+  // real signal is the quota, and it wrongly pinned any capable arm64 Linux box
+  // to 1 while missing x86 containers that are also capped.
   workers: (() => {
     const configured = Number.parseInt(process.env.PLAYWRIGHT_WORKERS || '', 10)
     if (Number.isFinite(configured) && configured > 0) {
       return configured
     }
 
-    // Raspberry Pi (Linux arm64): 1 worker is faster than parallel due to memory/CPU contention
-    // Apple Silicon Macs (darwin arm64) are fast enough for parallel
-    if (os.arch() === 'arm64' && os.platform() === 'linux') {
-      return 1
-    }
-
-    const cpuCount = os.cpus().length || 1
+    const cpuCount = effectiveCpuBudget()
     const maxWorkers = cpuCount >= 8 ? 4 : cpuCount >= 4 ? 3 : 2
     return Math.max(1, Math.min(maxWorkers, cpuCount))
   })(),


### PR DESCRIPTION
Closes the remaining piece of #425.

## What
Replace the `os.arch() === 'arm64' && os.platform() === 'linux' → 1 worker` special-case in `playwright.config.ts` with a **cgroup-CPU-quota-aware** worker heuristic. The arm64 pin was a crude proxy for "CPU-constrained"; the real signal is the cgroup CFS quota.

`effectiveCpuBudget()` reads the process's cgroup-v2 `cpu.max` (resolved from `/proc/self/cgroup`, falling back to the root path), computes `floor(quota/period)` clamped to `[1, os.cpus()]`, and falls back to `os.cpus()` on macOS / cgroup v1 / unlimited / unreadable. `PLAYWRIGHT_WORKERS` still overrides (CI sets it explicitly, so CI is unaffected).

Computed worker counts: sandbox (2-CPU cap) → 2, 4-CPU → 3, 8-CPU → 4, Mac (12 cores, no cgroup) → 4.

## Why (measured, not assumed)
Benchmarked the full suite across three environments (2-CPU-capped sandbox, 12-CPU Mac, CI) with per-test Playwright JSON timing + cgroup CPU/throttle accounting. The suite is **CPU-bound**; sizing the pool to visible cores **oversubscribes** a capped container and runs *slower*:

| workers (sandbox, 2-CPU cap) | full-suite exec | throttled CPU-s |
|---|---|---|
| 1 | 486s | 489 |
| 2 | **440s (optimal)** | 1,254 |
| 4 | 562s (worst) | 3,080 |

A single worker's process tree already draws ~1.65 CPUs, so 2 workers saturate a 2-CPU cap and 4 just thrash. The naive "unpin to `nproc` formula" plan would have read 10 cores on this sandbox → picked 4 → regressed to the worst case. This heuristic picks the measured optimum and **auto-scales** if the container's CPU allocation is raised — no future code change needed.

Note: the separate infra win (raising the sandbox 2→4 CPUs, ~2× faster) is a host-level change tracked outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)