### PR TITLE
feat(qa): cadence gate + deployed-sha assert cores for the QA round

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -535,6 +535,7 @@ test-deploy-scripts:
 	@bash scripts/deploy-staging.test.sh
 	@bash scripts/staging-reset.test.sh
 	@bash scripts/ci/staging-reseed-decision.test.sh
+	@bash scripts/ci/qa-round-cadence-gate.test.sh
 	@bash scripts/staging-deployed-sha.test.sh
 	@bash scripts/staging-reseed.test.sh
 	@bash scripts/admin/setup-staging-reseed-host.sh.test.sh

--- a/scripts/ci/qa-round-cadence-gate.sh
+++ b/scripts/ci/qa-round-cadence-gate.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# qa-round-cadence-gate.sh <BASE> <HEAD> <DAYS_SINCE>
+#
+# Decides whether the nightly QA judge round should run. BASE = the LAST round's
+# deployed sha (persisted by the wrapper); HEAD = the currently-deployed staging
+# sha (read by the wrapper via a staging-deployed-sha.sh-style step); DAYS_SINCE =
+# whole days since the last judge round (wrapper-supplied). Truth table:
+#   1. HEAD == BASE (staging unchanged)                 -> SKIP (run_round=false).
+#   2. else (staging changed):
+#      a. judge-relevant path-filter delta over BASE..HEAD -> RUN (fast path).
+#      b. else DAYS_SINCE >= MAX_STALENESS_DAYS             -> RUN (staleness floor).
+#      c. else                                             -> SKIP.
+#   3. any uncertainty resolving BASE/HEAD/DAYS_SINCE (or filters/git/temp/read)
+#                                                        -> SKIP (run_round=false).
+# Net: zero staging changes -> skip indefinitely; any change -> judged within
+# MAX_STALENESS_DAYS at the latest, sooner if judge-relevant. Emits four flags to
+# stdout (and $GITHUB_ENV when set) for the wrapper / CI:
+#   run_round             true to run (relevant delta OR staleness floor); false to
+#                         skip (unchanged, within-floor, OR any uncertainty).
+#   judge_relevant_change the honest "did the groups change" signal: true/false on a
+#                         clean decision, `unknown` on an uncertain skip. A floor-
+#                         forced run reads run_round=true + judge_relevant_change=false.
+#   base_known            true on a clean, resolved decision (a run, a within-floor
+#                         skip, OR an equal-endpoints skip); false only on an
+#                         uncertain skip.
+#   changed_groups        sorted CSV of which of backend/frontend/seed matched
+#                         (empty when none matched, and empty on any skip).
+#
+# DEGRADE TO SKIP — this advisory, eventual-convergence gate fails toward NOT
+# running (conservative on judge-token spend). The staleness floor bounds how much
+# can slip, and a MANUAL trigger is the backstop, so uncertainty need not force a
+# run. EVERY uncertainty emits run_round=false (+ base_known=false): an unresolvable
+# BASE/HEAD (incl. a force-push that dropped an endpoint), a missing/unreadable
+# path-filters.yml, an unsourceable / absent file_in_group, a temp-file/git/read
+# failure, or an unusable DAYS_SINCE. There is NO filter-validation apparatus: a
+# damaged filter simply fails to match, an unreadable/missing one skips; either way
+# the round is skipped, which is correct here. (The SEPARATE deployed-sha-assert
+# script is an integrity gate and stays FAIL-CLOSED, not degrade-to-skip.)
+#
+# TWO-DOT `git diff BASE HEAD` (direct tree-vs-tree), NOT three-dot (BASE...HEAD,
+# merge-base): the comparison is last-round-tree vs deployed-tree, so a
+# rebase/force-push or non-linear history must NOT shift the base to a merge-base.
+# A resolvable non-linear/divergent BASE+HEAD pair is NOT uncertain — it is diffed
+# with the required two-dot form. The diff is read NUL-delimited (`-z`) so a path
+# with special characters is matched (kept for FAST-path correctness; the floor
+# backstops anything the match still misses).
+#
+# The groups are matched via file_in_group sourced from the pre-push hook — the
+# SAME matcher CI/pre-push use, so the judge-input surface stays single-sourced in
+# path-filters.yml with no second hardcoded prefix. file_in_group reads the global
+# FILTERS_FILE, re-pointed at the real (absolute) path-filters.yml so the group
+# definitions come from THIS checkout while `git diff` runs in the CWD (the deploy
+# checkout in prod; a throwaway fixture repo in the tests).
+#
+# NOTE (vs the reseed decision): a test-only synthetic change (`*_test.go` /
+# `**/testdata/**` under backend/internal/synthetic/**) is NOT the built seed
+# surface, but it DOES match the `backend` group, so it sets run_round=true anyway.
+# We deliberately do NOT special-case it: it is a real judge-input change, so
+# running is correct (the reseed script's exclusion existed only to avoid a
+# destructive wipe, which does not apply to an advisory round).
+#
+# Wrapper contract: BASE = last-round sha (persisted by the wrapper); HEAD =
+# currently-deployed staging sha (read by the wrapper). This script is a pure
+# decision — it never checks out, mutates, reads/re-reads deployed state, or
+# advances any watermark; the wrapper owns all of that.
+
+set -uo pipefail   # NO -e: a failed diff/source/validation must degrade, not abort.
+
+# Sanitize the repo's standard git-location env isolation set so EVERY git call below
+# (the sourced pre-push's rev-parse, plus cat-file/diff) resolves the CWD checkout,
+# not some other repo a caller's env points at. GIT_DIR / GIT_COMMON_DIR /
+# GIT_OBJECT_DIRECTORY redirect object/ref resolution, and GIT_WORK_TREE with a
+# nonexistent-parent path fatals cat-file/diff — all four are load-bearing.
+# GIT_INDEX_FILE is inert for a commit-vs-commit diff but is unset as part of the
+# standard isolation set. The isolation is contract-tested (a fake git that fails on
+# any leaked var).
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+
+emit() {
+  # emit <key> <value>: stdout for humans/tests + $GITHUB_ENV for the workflow.
+  printf '%s=%s\n' "$1" "$2"
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    # In CI the wrapper reads the decision from $GITHUB_ENV, NOT stdout. A failed
+    # append means the decision did not propagate, so fail VISIBLY (non-zero exit +
+    # stderr) rather than exit 0 having emitted only to stdout — a silent success
+    # on a lost decision is exactly the failure mode this gate must avoid.
+    if ! printf '%s=%s\n' "$1" "$2" >> "$GITHUB_ENV"; then
+      printf 'qa-round-cadence-gate: failed to write %s to GITHUB_ENV (%s)\n' "$1" "$GITHUB_ENV" >&2
+      exit 3
+    fi
+  fi
+}
+
+# Uncertain skip: we could NOT confidently decide, so DON'T run (this advisory gate
+# fails toward not running — conservative on judge-token spend, with the floor + a
+# manual trigger as the backstop). Every uncertainty / internal-failure path
+# (unresolvable BASE/HEAD, unsourceable or absent file_in_group, unreadable filters,
+# git/temp/read failure, unusable DAYS_SINCE) ends here. base_known=false marks
+# "decided under uncertainty".
+skip_uncertain() {
+  emit run_round false
+  emit judge_relevant_change unknown
+  emit base_known false
+  emit changed_groups ""
+  exit 0
+}
+
+# The QA round is advisory / eventual-convergence: a missed round is fine because
+# staleness is BOUNDED by this floor and a manual trigger is the backstop. The
+# path-filter match below is the best-effort FAST path (a judge-relevant change runs
+# immediately); the floor ensures any staging change is judged within
+# MAX_STALENESS_DAYS at the latest even if the match misses it. So the filter match
+# does NOT need to be an exhaustively correct negative-prover, and a damaged/unusable
+# filter simply skips (uncertainty -> skip_uncertain) rather than forcing a run.
+MAX_STALENESS_DAYS=7
+
+BASE="${1:-}"
+HEAD="${2:-}"
+# DAYS_SINCE = whole days since the last judge round (wrapper-supplied). Only
+# consulted when staging changed but no judge-relevant delta was found; validated
+# lazily there so a HEAD==BASE skip / judge-relevant run never depends on it.
+DAYS_SINCE="${3:-}"
+
+# Need both endpoints and a resolvable repo root.
+[ -n "$BASE" ] || skip_uncertain
+[ -n "$HEAD" ] || skip_uncertain
+[ -n "$REPO_ROOT" ] || skip_uncertain
+
+# No staging change since the last round -> SKIP, and skip indefinitely regardless
+# of the staleness floor: nothing changed, so there is nothing to judge (don't burn
+# judge tokens). This takes priority over the floor for a VALID equal pair. An
+# INVALID equal pair (two identical unresolvable refs) is an uncertainty, not a
+# confirmed "unchanged", so it skips_uncertain like any other unresolvable endpoint.
+if [ "$BASE" = "$HEAD" ]; then
+  git cat-file -e "${BASE}^{commit}" 2>/dev/null || skip_uncertain
+  emit run_round false
+  emit judge_relevant_change false
+  emit base_known true
+  emit changed_groups ""
+  exit 0
+fi
+
+# file_in_group lives in the pre-push hook; the source-guard keeps the hook body
+# from running on source. Source by absolute path so this is CWD-independent, then
+# re-point FILTERS_FILE at the real path-filters.yml (the matcher reads that global).
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/hooks/pre-push" 2>/dev/null || skip_uncertain
+declare -f file_in_group >/dev/null 2>&1 || skip_uncertain
+FILTERS_FILE="$REPO_ROOT/path-filters.yml"
+{ [ -f "$FILTERS_FILE" ] && [ -r "$FILTERS_FILE" ]; } || skip_uncertain
+
+# Both endpoints must be real commits in the CWD repo (force-push / dropped
+# endpoint -> not resolvable -> skip on uncertainty).
+git cat-file -e "${BASE}^{commit}" 2>/dev/null || skip_uncertain
+git cat-file -e "${HEAD}^{commit}" 2>/dev/null || skip_uncertain
+
+# TWO-DOT diff: last-round tree (BASE) vs deployed tree (HEAD).
+# --no-renames: rename detection collapses a move to only its DESTINATION path, so
+# a judge-relevant source (backend/x.go -> docs/x.go) would be hidden behind an
+# irrelevant destination and silently skip the round. Disabling it surfaces both
+# the deleted source and the added destination.
+# -z: without it, git QUOTES paths containing tabs/newlines/quotes/backslashes (a
+# tab in `backend/a<TAB>b.go` becomes `"backend/a\tb.go"`), which then fails the
+# matcher's `^backend/` anchor -> the change would be missed. -z emits raw
+# NUL-delimited paths, keeping the FAST path correct. A shell variable can't hold
+# NUL, so the list is buffered through a temp file whose creation AND the git write
+# are BOTH status-checked -> any failure (unwritable/full temp, git error) is an
+# uncertainty -> skip. The template is TMPDIR-derived so a broken temp dir fails
+# mktemp instead of silently falling back.
+diff_tmp="$(mktemp "${TMPDIR:-/tmp}/qa-cadence-gate.XXXXXX" 2>/dev/null)" || skip_uncertain
+if ! git diff -z --no-renames --name-only "$BASE" "$HEAD" > "$diff_tmp" 2>/dev/null; then
+  rm -f "$diff_tmp"
+  skip_uncertain
+fi
+
+matched_backend=false
+matched_frontend=false
+matched_seed=false
+# Open the buffered list on fd 3 with a status check: a read-side open failure
+# (temp removed / unreadable) is an uncertainty, not "no changes" -> skip.
+exec 3< "$diff_tmp" || { rm -f "$diff_tmp"; skip_uncertain; }
+# read -r -d '' consumes one NUL-delimited path per iteration verbatim (no word
+# splitting / globbing), so paths with spaces or other special characters stay intact.
+while IFS= read -r -d '' f <&3; do
+  [ -n "$f" ] || continue
+  file_in_group "$f" backend  && matched_backend=true
+  file_in_group "$f" frontend && matched_frontend=true
+  file_in_group "$f" seed     && matched_seed=true
+done
+exec 3<&-
+rm -f "$diff_tmp"
+
+# A matcher failure mid-loop (path-filters.yml deleted/unreadable/replaced WHILE
+# matching) is indistinguishable from a clean non-match inside file_in_group — all
+# groups would stay false and reach a false run_round. Re-check AFTER the loop that
+# the filter is still a readable REGULAR file (the same -f && -r as the pre-loop
+# check): a bare -r would pass for a readable DIRECTORY swapped in mid-match, which
+# file_in_group can't read as a filter. If the check fails, the all-false result is
+# not trustworthy -> skip.
+{ [ -f "$FILTERS_FILE" ] && [ -r "$FILTERS_FILE" ]; } || skip_uncertain
+
+# Build the sorted CSV of matched groups (deterministic: fixed alphabetical order).
+groups=""
+[ "$matched_backend" = true ]  && groups="${groups:+$groups,}backend"
+[ "$matched_frontend" = true ] && groups="${groups:+$groups,}frontend"
+[ "$matched_seed" = true ]     && groups="${groups:+$groups,}seed"
+
+# Decision (staging HAS changed since the last round — HEAD==BASE was handled above):
+#   judge-relevant delta      -> RUN (fast path).
+#   else DAYS_SINCE >= floor   -> RUN (staleness backstop).
+#   else                       -> SKIP.
+# judge_relevant_change stays the honest "did the groups change" signal, so a floor
+# run reads run_round=true + judge_relevant_change=false + empty changed_groups.
+if [ -n "$groups" ]; then
+  emit run_round true
+  emit judge_relevant_change true
+  emit base_known true
+  emit changed_groups "$groups"
+  exit 0
+fi
+
+# Changed but not judge-relevant: the staleness floor decides. An unusable
+# DAYS_SINCE is an uncertainty -> skip. The length cap (<=15 digits) keeps the value
+# well within int64 so the `-ge` comparison below can never overflow (a 19+-digit
+# value errors "number truncated" and would otherwise fall through as a clean skip).
+[[ "$DAYS_SINCE" =~ ^[0-9]{1,15}$ ]] || skip_uncertain
+if [ "$DAYS_SINCE" -ge "$MAX_STALENESS_DAYS" ]; then
+  emit run_round true          # staleness floor forces a run
+else
+  emit run_round false         # within the floor -> skip
+fi
+emit judge_relevant_change false
+emit base_known true
+emit changed_groups ""
+exit 0

--- a/scripts/ci/qa-round-cadence-gate.test.sh
+++ b/scripts/ci/qa-round-cadence-gate.test.sh
@@ -1,0 +1,866 @@
+#!/usr/bin/env bash
+# Tests for qa-round-cadence-gate.sh AND qa-round-deployed-sha-assert.sh — the
+# nightly QA round's cadence decision + deployed-sha pin/manifest assertion.
+#
+# Builds throwaway git fixture repos in a temp dir and COPIES the two scripts, the
+# pre-push hook (for file_in_group), and path-filters.yml into each fixture's own
+# scripts/ci / scripts/hooks layout. Running the FIXTURE copy makes each script
+# resolve its REPO_ROOT to the fixture, so a test can damage the fixture's
+# path-filters.yml / pre-push (missing / unreadable / absent-or-broken required
+# group / absent file_in_group) WITHOUT ever touching the real checkout. The
+# infra files are copied UNTRACKED and each feature commit adds only its own file,
+# so the copied scripts never appear in any diff range.
+#
+# The degrade-to-SKIP contract is load-bearing: for this advisory gate EVERY
+# uncertainty (empty/unresolvable BASE or HEAD, missing/unreadable filters, absent
+# file_in_group, temp-file / git / read failure, unusable DAYS_SINCE) must emit the
+# uncertain-skip tuple (run_round=FALSE, judge_relevant_change=unknown,
+# base_known=false, changed_groups=) and exit 0 — it fails toward NOT running
+# (conservative on judge-token spend; a manual trigger is the backstop). The SEPARATE
+# deployed-sha-assert script stays FAIL-CLOSED (integrity gate, not a skip decision).
+#
+# Portable: no network, no BSD-only flags — this suite runs on Ubuntu CI.
+
+set -uo pipefail
+
+# Sanitize hook-inherited git env BEFORE any git command.
+# Git pre-push hooks export GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE; without unsetting
+# them the fixture's git ops (and the scripts' git cat-file/diff/rev-parse, run in
+# the fixture CWD) would operate against the REAL repo and corrupt it / pollute
+# identity. Unsetting restores cwd-based discovery. (Run directly the vars are
+# absent, so this is a no-op outside the hook.)
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REAL_CADENCE="$REPO_ROOT/scripts/ci/qa-round-cadence-gate.sh"
+REAL_ASSERT="$REPO_ROOT/scripts/ci/qa-round-deployed-sha-assert.sh"
+REAL_PREPUSH="$REPO_ROOT/scripts/hooks/pre-push"
+REAL_FILTERS="$REPO_ROOT/path-filters.yml"
+REAL_GIT="$(command -v git)"
+ABSENT_SHA40="0123456789abcdef0123456789abcdef01234567"  # 40-hex, not in any fixture
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+# ---------------------------------------------------------------------------
+# Fixture construction
+# ---------------------------------------------------------------------------
+
+# require_tmpdir <varname>: mktemp -d into the named var, aborting the WHOLE run if
+# it fails or yields no directory. A silently-empty temp dir would make copy_infra
+# target /scripts and `cd ""` stay in the real checkout, so the fixture's git ops
+# would corrupt the REAL repo — this is the repo's git-fixture hazard, guarded hard.
+require_tmpdir() {
+    local __d
+    __d="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 2; }
+    { [ -n "$__d" ] && [ -d "$__d" ]; } || { echo "FATAL: mktemp -d produced no directory" >&2; exit 2; }
+    printf -v "$1" '%s' "$__d"
+}
+
+copy_infra() {
+    mkdir -p "$FIXTURE/scripts/ci" "$FIXTURE/scripts/hooks"
+    cp "$REAL_CADENCE" "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh"
+    cp "$REAL_ASSERT"  "$FIXTURE/scripts/ci/qa-round-deployed-sha-assert.sh"
+    cp "$REAL_PREPUSH" "$FIXTURE/scripts/hooks/pre-push"
+    cp "$REAL_FILTERS" "$FIXTURE/path-filters.yml"
+}
+
+git_init_fixture() {
+    git init -q
+    git config user.email "ci@example.com"
+    git config user.name "CI"
+    git config commit.gpgsign false
+}
+
+commit_file() {
+    # commit_file <path> <content> <msg>
+    mkdir -p "$(dirname "$1")"
+    printf '%s\n' "$2" > "$1"
+    git add "$1"
+    git commit -q -m "$3"
+    git rev-parse HEAD
+}
+
+# Standard linear fixture: one file per commit across the group surfaces.
+make_fixture() {
+    require_tmpdir FIXTURE
+    GHENV="$FIXTURE/ghenv"
+    copy_infra
+    (
+        cd "$FIXTURE" || exit 1
+        git_init_fixture
+        commit_file README.md "root" "root"                                                    > /dev/null; C0="$(git rev-parse HEAD)"
+        commit_file frontend/src/x.tsx "export const x = 1" "frontend change"                  > /dev/null; C1="$(git rev-parse HEAD)"
+        commit_file backend/internal/service/x.go "package service" "backend change"           > /dev/null; C2="$(git rev-parse HEAD)"
+        commit_file backend/internal/synthetic/profiles.go "package synthetic" "seed change"   > /dev/null; C3="$(git rev-parse HEAD)"
+        # Judge-irrelevant surfaces (docs + spec + mac-daemon) in one commit.
+        mkdir -p docs spec mac-daemon
+        printf 'doc\n' > docs/x.md
+        printf 'spec\n' > spec/x.yaml
+        printf 'swift\n' > mac-daemon/x.swift
+        git add docs/x.md spec/x.yaml mac-daemon/x.swift
+        git commit -q -m "judge-irrelevant change"; C4="$(git rev-parse HEAD)"
+        # Mixed: frontend + docs together.
+        mkdir -p frontend/src docs
+        printf 'export const y = 2\n' > frontend/src/y.tsx
+        printf 'doc y\n' > docs/y.md
+        git add frontend/src/y.tsx docs/y.md
+        git commit -q -m "mixed change"; C5="$(git rev-parse HEAD)"
+        printf '%s\n%s\n%s\n%s\n%s\n%s\n' "$C0" "$C1" "$C2" "$C3" "$C4" "$C5" > shas.txt
+    )
+    { read -r C0; read -r C1; read -r C2; read -r C3; read -r C4; read -r C5; } < "$FIXTURE/shas.txt"
+}
+
+cleanup_fixture() { [ -n "${FIXTURE:-}" ] && rm -rf "$FIXTURE"; }
+
+# ---------------------------------------------------------------------------
+# Runners + assertions
+# ---------------------------------------------------------------------------
+
+# run_cadence <base> <head> [days_since]: runs the FIXTURE copy in the fixture CWD
+# with an isolated GITHUB_ENV; captures stdout/stderr; sets RC. days_since defaults
+# to 0 (< the floor) so a not-judge-relevant change SKIPs unless a test asks for a
+# staler value; a judge-relevant / uncertain-skip case ignores it.
+OUT=""; ERR=""; RC=0
+run_cadence() {
+    # A PRESENT-but-empty 3rd arg must pass through as "" (not default to 0) so the
+    # invalid-DAYS_SINCE skip path is testable; ${3:-0} would collapse "" to 0.
+    local days=0
+    [ "$#" -ge 3 ] && days="$3"
+    : > "$GHENV"
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    ( cd "$FIXTURE" && GITHUB_ENV="$GHENV" bash "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh" "$1" "$2" "$days" ) >"$OUT" 2>"$ERR"
+    RC=$?
+}
+
+run_cadence_fakegit() {
+    : > "$GHENV"
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    ( cd "$FIXTURE" && PATH="$FIXTURE/fakebin:$PATH" GITHUB_ENV="$GHENV" \
+        bash "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh" "$1" "$2" 0 ) >"$OUT" 2>"$ERR"
+    RC=$?
+}
+
+assert_exit0() { if [ "$RC" -eq 0 ]; then ok; else fail "want exit 0, got $RC"; fi; }
+
+# assert_tuple <run_round> <judge_relevant_change> <base_known> <changed_groups>:
+# the STDOUT contract must be EXACTLY these four lines in this order — no missing,
+# duplicated, extra, reordered, or partial-newline lines. Compared BYTE-FOR-BYTE
+# with cmp against an expected file: a `"$(cat)"` string compare strips trailing
+# newlines from both sides, so a missing final terminator or an extra blank 5th
+# line would slip past it.
+assert_tuple() {
+    local expf="$FIXTURE/expected_tuple.txt"
+    printf 'run_round=%s\njudge_relevant_change=%s\nbase_known=%s\nchanged_groups=%s\n' "$1" "$2" "$3" "$4" > "$expf"
+    if cmp -s "$expf" "$OUT"; then ok; else fail "stdout tuple mismatch: $(diff "$expf" "$OUT" 2>&1 | head -5)"; fi
+}
+
+# The uncertain-SKIP tuple (exit 0 + exact four-line block). On any uncertainty the
+# cadence gate fails toward NOT running: run_round=false, base_known=false.
+assert_skip_uncertain() {
+    assert_exit0
+    assert_tuple false unknown false ""
+}
+
+setup_fake_git() {
+    mkdir -p "$FIXTURE/fakebin"
+    cat > "$FIXTURE/fakebin/git" <<EOF
+#!/usr/bin/env bash
+# Delegate to real git for everything EXCEPT diff, which fails — simulating a git
+# diff error after cat-file already resolved both endpoints.
+if [ "\$1" = "diff" ]; then echo "simulated git diff failure" >&2; exit 1; fi
+exec "$REAL_GIT" "\$@"
+EOF
+    chmod +x "$FIXTURE/fakebin/git"
+}
+
+# A fake git that FAILS if ANY git-location var leaked into its environment, else
+# delegates to the real git. Prepended to PATH with all five vars set in the OUTER
+# env, it proves the script UNSET them before calling git (the isolation contract):
+# all cleared -> fake git never trips; drop one from the script's unset -> that var
+# leaks -> fake git exits non-zero -> the script's git call fails. Covers all five
+# uniformly, including inert GIT_INDEX_FILE (tests the contract, not an outcome).
+setup_fake_git_isolation() {
+    mkdir -p "$FIXTURE/fakebin"
+    cat > "$FIXTURE/fakebin/git" <<EOF
+#!/usr/bin/env bash
+for __v in GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY; do
+  if [ -n "\${!__v:-}" ]; then echo "fake-git: leaked \$__v" >&2; exit 77; fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+    chmod +x "$FIXTURE/fakebin/git"
+}
+
+# ===========================================================================
+# Cadence decision — clean cases (full stdout tuple asserted every time).
+# ===========================================================================
+test_frontend_only() {
+    echo "test: frontend-only -> run_round=true, changed_groups=frontend"
+    make_fixture
+    run_cadence "$C0" "$C1"
+    assert_exit0
+    assert_tuple true true true frontend
+    cleanup_fixture
+}
+
+test_backend_only() {
+    echo "test: backend-only -> run_round=true, changed_groups=backend"
+    make_fixture
+    run_cadence "$C1" "$C2"
+    assert_exit0
+    assert_tuple true true true backend
+    cleanup_fixture
+}
+
+test_seed_only() {
+    echo "test: seed-only -> changed_groups=backend,seed (sorted csv, both match)"
+    make_fixture
+    run_cadence "$C2" "$C3"
+    assert_exit0
+    assert_tuple true true true "backend,seed"
+    cleanup_fixture
+}
+
+test_judge_irrelevant() {
+    echo "test: judge-irrelevant (docs+spec+mac-daemon) -> run_round=false, changed_groups empty"
+    make_fixture
+    run_cadence "$C3" "$C4"
+    assert_exit0
+    assert_tuple false false true ""
+    cleanup_fixture
+}
+
+test_base_equals_head() {
+    echo "test: BASE==HEAD (no staging change) -> SKIP regardless of the staleness floor"
+    make_fixture
+    run_cadence "$C1" "$C1"
+    assert_exit0
+    assert_tuple false false true ""
+    # A very stale DAYS_SINCE must NOT force a run when nothing changed.
+    run_cadence "$C1" "$C1" 999
+    assert_exit0
+    assert_tuple false false true ""
+    # An INVALID equal pair (two identical UNRESOLVABLE refs) is NOT a confirmed
+    # "unchanged" -> it must uncertain-skip, not clean-skip.
+    run_cadence "$ABSENT_SHA40" "$ABSENT_SHA40" 5
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_staleness_floor() {
+    echo "test: staleness floor (changed but not judge-relevant) -> DAYS_SINCE decides"
+    make_fixture
+    # C3..C4 is a docs/spec/mac-daemon change: staging changed, but NOT judge-relevant.
+    # DAYS_SINCE < 7 -> skip; >= 7 -> run (floor); invalid -> uncertain skip.
+    run_cadence "$C3" "$C4" 6;  assert_exit0; assert_tuple false false true ""
+    run_cadence "$C3" "$C4" 7;  assert_exit0; assert_tuple true false true ""
+    run_cadence "$C3" "$C4" 8;  assert_exit0; assert_tuple true false true ""
+    run_cadence "$C3" "$C4" 0;  assert_exit0; assert_tuple false false true ""
+    # Invalid / unresolvable DAYS_SINCE while it IS needed (not judge-relevant) ->
+    # uncertain skip.
+    run_cadence "$C3" "$C4" "notaninteger"; assert_skip_uncertain
+    run_cadence "$C3" "$C4" "-1";           assert_skip_uncertain
+    run_cadence "$C3" "$C4" "";             assert_skip_uncertain
+    # Out-of-range (int64-overflowing) DAYS_SINCE: `^[0-9]+$` would accept it but the
+    # `-ge` comparison errors and would fall through as a clean within-floor skip; the
+    # length cap routes it to uncertain-skip instead.
+    run_cadence "$C3" "$C4" "99999999999999999999"; assert_skip_uncertain
+    # A judge-relevant change RUNs regardless of DAYS_SINCE (fast path, floor moot) --
+    # WITH A VALID DAYS_SINCE...
+    run_cadence "$C1" "$C2" 0;  assert_exit0; assert_tuple true true true backend
+    # ...AND with an INVALID/empty DAYS_SINCE: it still RUNs, which proves DAYS_SINCE
+    # is validated LAZILY (only in the not-relevant branch). Eager validation would
+    # wrongly uncertain-skip here.
+    run_cadence "$C1" "$C2" "abc"; assert_exit0; assert_tuple true true true backend
+    run_cadence "$C1" "$C2" "";    assert_exit0; assert_tuple true true true backend
+    cleanup_fixture
+}
+
+test_mixed_frontend_and_docs() {
+    echo "test: mixed (frontend + docs) -> run_round=true, changed_groups=frontend"
+    make_fixture
+    run_cadence "$C4" "$C5"
+    assert_exit0
+    assert_tuple true true true frontend
+    cleanup_fixture
+}
+
+test_rename_to_irrelevant_dest() {
+    echo "test: rename backend->docs surfaces the backend SOURCE (--no-renames) -> run_round=true"
+    require_tmpdir FIXTURE
+    GHENV="$FIXTURE/ghenv"
+    copy_infra
+    (
+        cd "$FIXTURE" || exit 1
+        git_init_fixture
+        commit_file README.md "root" "root" > /dev/null
+        # A backend file with enough content that a pure move is detected as a 100%
+        # rename by git's default detection (which collapses to the destination).
+        mkdir -p backend/internal/service
+        printf 'package service\n// l1\n// l2\n// l3\n// l4\n' > backend/internal/service/ren.go
+        git add backend/internal/service/ren.go
+        git commit -q -m "add backend file"
+        RBASE="$(git rev-parse HEAD)"
+        mkdir -p docs
+        git mv backend/internal/service/ren.go docs/ren.go
+        git commit -q -m "rename backend file to docs"
+        RHEAD="$(git rev-parse HEAD)"
+        printf '%s\n%s\n' "$RBASE" "$RHEAD" > shas.txt
+    )
+    { read -r RBASE; read -r RHEAD; } < "$FIXTURE/shas.txt"
+    run_cadence "$RBASE" "$RHEAD"
+    assert_exit0
+    # Default rename detection would show only docs/ren.go (irrelevant) -> false;
+    # --no-renames surfaces the deleted backend source -> run_round=true.
+    assert_tuple true true true backend
+    cleanup_fixture
+}
+
+# ===========================================================================
+# Uncertainty -> SKIP suite.
+# ===========================================================================
+test_empty_base() {
+    echo "test: empty BASE -> uncertain skip"
+    make_fixture
+    run_cadence "" "$C3"
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_empty_head() {
+    echo "test: empty HEAD -> uncertain skip"
+    make_fixture
+    run_cadence "$C0" ""
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_unresolvable_base() {
+    echo "test: unresolvable BASE sha -> uncertain skip"
+    make_fixture
+    run_cadence "$ABSENT_SHA40" "$C3"
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_unresolvable_head() {
+    echo "test: unresolvable HEAD sha -> uncertain skip"
+    make_fixture
+    run_cadence "$C0" "$ABSENT_SHA40"
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_missing_filters() {
+    echo "test: missing path-filters.yml -> uncertain skip"
+    make_fixture
+    rm -f "$FIXTURE/path-filters.yml"
+    run_cadence "$C3" "$C4"
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_unreadable_filters() {
+    echo "test: unreadable path-filters.yml -> uncertain skip"
+    if [ "$(id -u)" -eq 0 ]; then
+        echo "  SKIP: running as root, chmod 000 stays readable"
+        return
+    fi
+    make_fixture
+    chmod 000 "$FIXTURE/path-filters.yml"
+    run_cadence "$C3" "$C4"
+    assert_skip_uncertain
+    chmod 644 "$FIXTURE/path-filters.yml"
+    cleanup_fixture
+}
+
+test_file_in_group_absent() {
+    echo "test: file_in_group absent (sourceable stub, function missing) -> uncertain skip"
+    make_fixture
+    printf '# stub pre-push without file_in_group\n' > "$FIXTURE/scripts/hooks/pre-push"
+    run_cadence "$C2" "$C3"
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_filter_removed_mid_match() {
+    echo "test: path-filters.yml disappearing DURING matching -> uncertain skip (not a false floor RUN)"
+    make_fixture
+    # A stub file_in_group that deletes the filter file on its first call and returns
+    # no-match: the pre-loop readability check passes, but the post-loop re-check must
+    # catch the disappearance. Not-relevant range + DAYS>=7 so WITHOUT the re-check it
+    # would reach the floor RUN. The single quotes are intentional — $FILTERS_FILE must
+    # land LITERALLY in the stub so the stub expands the gate's global at run time.
+    # shellcheck disable=SC2016
+    printf 'file_in_group() { rm -f "$FILTERS_FILE" 2>/dev/null; return 1; }\n' > "$FIXTURE/scripts/hooks/pre-push"
+    run_cadence "$C3" "$C4" 7
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_filter_replaced_by_dir_mid_match() {
+    echo "test: path-filters.yml replaced by a readable DIRECTORY mid-match -> uncertain skip"
+    make_fixture
+    # A stub file_in_group that replaces the filter FILE with a readable DIRECTORY on
+    # its first call: a bare `-r` post-check would PASS (dirs are readable) and reach
+    # the floor RUN; the `-f && -r` re-check catches that it is no longer a regular file.
+    # shellcheck disable=SC2016
+    printf 'file_in_group() { rm -f "$FILTERS_FILE" 2>/dev/null; mkdir -p "$FILTERS_FILE" 2>/dev/null; return 1; }\n' > "$FIXTURE/scripts/hooks/pre-push"
+    run_cadence "$C3" "$C4" 7
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_require_tmpdir_fails_closed() {
+    echo "test: require_tmpdir aborts (non-zero) when mktemp fails (fixture guard is fail-closed)"
+    # Run in a subshell with mktemp forced to fail; require_tmpdir must exit non-zero
+    # rather than proceed with an empty dir (which would corrupt the real repo).
+    if ( mktemp() { return 1; }; require_tmpdir X ) >/dev/null 2>&1; then
+        fail "require_tmpdir must abort on mktemp failure"
+    else
+        ok
+    fi
+}
+
+test_prepush_unsourceable() {
+    echo "test: pre-push UNSOURCEABLE (parse error) -> uncertain skip (distinct from function-absent)"
+    make_fixture
+    # A parse error makes `source` itself fail (non-zero) before any function is
+    # defined — exercises the `source ... || skip_uncertain` path, not the declare -f one.
+    printf 'file_in_group() {\n  # unterminated function body — parse error\n' > "$FIXTURE/scripts/hooks/pre-push"
+    run_cadence "$C2" "$C3"
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_git_diff_failure() {
+    echo "test: git diff failure (cat-file passes, diff fails) -> uncertain skip"
+    make_fixture
+    setup_fake_git
+    run_cadence_fakegit "$C2" "$C3"
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_github_env_write_success() {
+    echo "test: a successful run writes the SAME decision to \$GITHUB_ENV (not just stdout)"
+    make_fixture
+    run_cadence "$C1" "$C2" 0          # backend -> RUN
+    assert_exit0
+    assert_tuple true true true backend  # stdout contract
+    # The wrapper reads GITHUB_ENV, NOT stdout — assert emit actually wrote the four
+    # key=value lines there, byte-for-byte, on a successful run.
+    local expf="$FIXTURE/expected_ghenv.txt"
+    printf 'run_round=true\njudge_relevant_change=true\nbase_known=true\nchanged_groups=backend\n' > "$expf"
+    if cmp -s "$expf" "$GHENV"; then ok; else fail "GITHUB_ENV mismatch: $(diff "$expf" "$GHENV" 2>&1 | head -5)"; fi
+    cleanup_fixture
+}
+
+test_github_env_write_failure() {
+    echo "test: unwritable GITHUB_ENV -> fail VISIBLY (non-zero), not a silent exit-0"
+    make_fixture
+    # In CI the wrapper reads the decision from GITHUB_ENV; a failed append means the
+    # decision was lost, so the gate must exit non-zero rather than exit 0 having
+    # written only to stdout. Point GITHUB_ENV at a path whose parent doesn't exist.
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    ( cd "$FIXTURE" && GITHUB_ENV="$FIXTURE/no-such-dir/ghenv" \
+        bash "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh" "$C1" "$C2" 0 ) >"$OUT" 2>"$ERR"
+    RC=$?
+    if [ "$RC" -ne 0 ]; then ok; else fail "want non-zero exit on GITHUB_ENV write failure, got $RC"; fi
+    cleanup_fixture
+}
+
+test_unwritable_tmpdir() {
+    echo "test: unusable temp dir must uncertain-SKIP (never a truncated changed-file list -> run_round=false)"
+    make_fixture
+    # The changed-file list is buffered through a TMPDIR-derived mktemp; a broken
+    # temp dir makes mktemp fail -> the status-checked `|| skip_uncertain` fires. Point
+    # TMPDIR at a nonexistent directory so mktemp's template dir doesn't exist (fails
+    # on both macOS and Linux, since the template path is explicit). A backend range
+    # would otherwise RUN normally, so an uncertain skip (base_known=false) proves the temp
+    # failure is caught rather than silently dropping the list.
+    : > "$GHENV"
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    ( cd "$FIXTURE" && TMPDIR="$FIXTURE/nonexistent-tmp-$$" GITHUB_ENV="$GHENV" \
+        bash "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh" "$C1" "$C2" 0 ) >"$OUT" 2>"$ERR"
+    RC=$?
+    assert_skip_uncertain
+    cleanup_fixture
+}
+
+test_special_char_path() {
+    echo "test: a changed path with a TAB is matched (git diff -z, no quoting) -> run_round=true"
+    require_tmpdir FIXTURE
+    GHENV="$FIXTURE/ghenv"
+    copy_infra
+    (
+        cd "$FIXTURE" || exit 1
+        git_init_fixture
+        commit_file README.md "root" "root" > /dev/null
+        TBASE="$(git rev-parse HEAD)"
+        # A real tab character in a backend filename. Without -z, git quotes this to
+        # "backend/.../a\tb.go", which fails the matcher's ^backend/ anchor. Stage
+        # ONLY the tabbed path (NOT `git add -A`) so the copied infra under scripts/**
+        # doesn't independently match backend and mask the -z behavior.
+        mkdir -p backend/internal/service
+        tabpath="$(printf 'backend/internal/service/a\tb.go')"
+        printf 'package service\n' > "$tabpath"
+        git add "$tabpath"
+        git commit -q -m "backend file with a tab in its name"
+        THEAD="$(git rev-parse HEAD)"
+        printf '%s\n%s\n' "$TBASE" "$THEAD" > shas.txt
+    )
+    { read -r TBASE; read -r THEAD; } < "$FIXTURE/shas.txt"
+    run_cadence "$TBASE" "$THEAD"
+    assert_exit0
+    assert_tuple true true true backend
+    cleanup_fixture
+}
+
+# ===========================================================================
+# Two-dot divergent-history proof: two-dot and three-dot yield DIFFERENT
+# changed paths; the script must follow TWO-DOT.
+# ===========================================================================
+test_two_dot_divergent() {
+    echo "test: divergent history -> decision matches TWO-DOT diff (frontend on BASE side)"
+    require_tmpdir FIXTURE
+    GHENV="$FIXTURE/ghenv"
+    copy_infra
+    (
+        cd "$FIXTURE" || exit 1
+        git_init_fixture
+        commit_file README.md "root" "root" > /dev/null
+        root_sha="$(git rev-parse HEAD)"
+        # BASE side: a judge-relevant (frontend) file that exists ONLY on this side.
+        git checkout -q -b base_side
+        commit_file frontend/src/only_base.tsx "export const b = 1" "frontend on base side" > /dev/null
+        DBASE="$(git rev-parse HEAD)"
+        # HEAD side from the same root: a docs-only (irrelevant) file.
+        git checkout -q -b head_side "$root_sha"
+        commit_file docs/only_head.md "head doc" "docs on head side" > /dev/null
+        DHEAD="$(git rev-parse HEAD)"
+        printf '%s\n%s\n' "$DBASE" "$DHEAD" > shas.txt
+    )
+    { read -r DBASE; read -r DHEAD; } < "$FIXTURE/shas.txt"
+    # Two-dot DBASE..DHEAD includes frontend/src/only_base.tsx (a removal) -> RUN.
+    # Three-dot DBASE...DHEAD (merge-base C0 -> DHEAD) is docs-only -> would be false.
+    run_cadence "$DBASE" "$DHEAD"
+    assert_exit0
+    assert_tuple true true true frontend
+    cleanup_fixture
+}
+
+# ===========================================================================
+# Source-guard + git-env isolation.
+# ===========================================================================
+test_source_guard_isolation() {
+    echo "test: sourcing pre-push runs no hook body + leaves the real repo untouched"
+    make_fixture
+    run_cadence "$C0" "$C1"
+    assert_exit0
+    # A clean four-line emit proves the source-guard returned before the hook body.
+    assert_tuple true true true frontend
+    # The hook body (had it executed) would emit its phase/lint/review markers.
+    if grep -Eq '\[lint\]|\[review\]|\[test\]|phase|Running (deploy|lint|tests)' "$OUT" "$ERR"; then
+        fail "hook body appears to have executed (found phase/lint markers)"
+    else
+        ok
+    fi
+    # The real repo's copied assets must be byte-unchanged (tests only touch copies).
+    local dirty
+    dirty="$(git -C "$REPO_ROOT" status --porcelain -- path-filters.yml scripts/hooks/pre-push 2>/dev/null)"
+    if [ -z "$dirty" ]; then ok; else fail "real repo assets modified by tests: $dirty"; fi
+    cleanup_fixture
+}
+
+# ===========================================================================
+# Deployed-SHA assertion suite (same fixture repo).
+# ===========================================================================
+run_assert() {
+    OUT="$FIXTURE/aout.txt"; ERR="$FIXTURE/aerr.txt"
+    ( cd "$FIXTURE" && bash "$FIXTURE/scripts/ci/qa-round-deployed-sha-assert.sh" "$@" ) >"$OUT" 2>"$ERR"
+    RC=$?
+}
+
+# run_assert_from <cwd> <args...>: same, but from an arbitrary cwd — proves the
+# script resolves its repo from its own location, not the caller's cwd.
+run_assert_from() {
+    local cwd="$1"; shift
+    OUT="$FIXTURE/aout.txt"; ERR="$FIXTURE/aerr.txt"
+    ( cd "$cwd" && bash "$FIXTURE/scripts/ci/qa-round-deployed-sha-assert.sh" "$@" ) >"$OUT" 2>"$ERR"
+    RC=$?
+}
+
+# run_assert_gitdir <gitdir> <args...>: run with a poisoned GIT_DIR to prove the
+# script ignores inherited git-location env (resolves its OWN repo, not GIT_DIR's).
+run_assert_gitdir() {
+    local gitdir="$1"; shift
+    OUT="$FIXTURE/aout.txt"; ERR="$FIXTURE/aerr.txt"
+    ( cd "$FIXTURE" && GIT_DIR="$gitdir" bash "$FIXTURE/scripts/ci/qa-round-deployed-sha-assert.sh" "$@" ) >"$OUT" 2>"$ERR"
+    RC=$?
+}
+
+assert_rc_zero()    { if [ "$RC" -eq 0 ]; then ok; else fail "want exit 0, got $RC ($1)"; fi; }
+assert_rc_nonzero() { if [ "$RC" -ne 0 ]; then ok; else fail "want non-zero exit ($1)"; fi; }
+
+upper_sha() { printf '%s' "$1" | tr 'a-f' 'A-F'; }
+
+test_deployed_sha_pin() {
+    echo "test: deployed-sha pre-tour pin — exact HEAD match exits 0; others fail-closed"
+    make_fixture
+    local head; head="$C5"
+    local before after
+
+    run_assert "$head";              assert_rc_zero "exact HEAD"
+    before="$(git -C "$FIXTURE" rev-parse HEAD)"
+    run_assert "$ABSENT_SHA40";      assert_rc_nonzero "different valid sha"
+    after="$(git -C "$FIXTURE" rev-parse HEAD)"
+    if [ "$before" = "$after" ]; then ok; else fail "assert must not change HEAD"; fi
+    # An EXISTING but different commit must also fail — proves equality, not mere
+    # existence/resolvability, is the check (C0 resolves but != HEAD C5).
+    run_assert "$C0";                assert_rc_nonzero "existing but different commit"
+    run_assert "nothex";             assert_rc_nonzero "malformed sha"
+    run_assert "abc123";             assert_rc_nonzero "short sha"
+    run_assert "$(upper_sha "$head")"; assert_rc_nonzero "uppercase sha"
+    run_assert;                      assert_rc_nonzero "zero args"
+    run_assert "$head" x y;          assert_rc_nonzero "three args"
+    # Repo is resolved from the SCRIPT location, not the caller's cwd: an exact match
+    # invoked from a non-repo cwd still passes (a cwd-based resolver would fail here).
+    local nonrepo; require_tmpdir nonrepo
+    run_assert_from "$nonrepo" "$head"; assert_rc_zero "resolves repo from script location, not cwd"
+    rm -rf "$nonrepo"
+    cleanup_fixture
+}
+
+# write_manifest <path> <json>: raw JSON so invalid-JSON cases are expressible.
+write_manifest() { printf '%s' "$2" > "$1"; }
+
+test_deployed_sha_manifest() {
+    echo "test: deployed-sha post-tour manifest — exact .gitSha exits 0; malformed fail-closed"
+    make_fixture
+    local head m; head="$C5"; m="$FIXTURE/manifest.json"
+
+    write_manifest "$m" "{\"gitSha\":\"$head\"}"
+    run_assert "$head" "$m";                     assert_rc_zero "matching manifest"
+
+    run_assert "$head" "$FIXTURE/nope.json";     assert_rc_nonzero "missing manifest"
+
+    write_manifest "$m" "not json"
+    run_assert "$head" "$m";                     assert_rc_nonzero "invalid json"
+
+    write_manifest "$m" "{\"foo\":1}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "missing .gitSha"
+
+    write_manifest "$m" "{\"gitSha\":123}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "non-string .gitSha"
+
+    write_manifest "$m" "{\"gitSha\":\"unknown\"}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "'unknown' .gitSha"
+
+    write_manifest "$m" "{\"gitSha\":\"abc\"}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "short .gitSha"
+
+    write_manifest "$m" "{\"gitSha\":\"$(upper_sha "$head")\"}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "uppercase .gitSha"
+
+    # A trailing newline (or leading space) makes .gitSha NOT exactly 40 hex, but
+    # shell command substitution would strip the trailing newline before a bash
+    # regex saw it — so the format check must live inside jq (anchored \A..\z).
+    write_manifest "$m" "{\"gitSha\":\"${head}\\n\"}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "trailing-newline .gitSha"
+    write_manifest "$m" "{\"gitSha\":\" ${head}\"}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "leading-space .gitSha"
+
+    # A stream of MORE THAN ONE top-level JSON value must be rejected even if a later
+    # value is valid — a jq extract without --slurp would take the last value and pass.
+    write_manifest "$m" "{\"gitSha\":\"unknown\"} {\"gitSha\":\"${head}\"}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "multi-value manifest stream rejected"
+
+    write_manifest "$m" "{\"gitSha\":\"$ABSENT_SHA40\"}"
+    run_assert "$head" "$m";                     assert_rc_nonzero "different valid .gitSha"
+
+    # A matching manifest must NOT mask a stale checkout. Use an EXISTING non-HEAD
+    # commit (C0) as the deployed sha with a manifest that agrees (gitSha=C0): the
+    # checkout check (HEAD=C5 != C0) must still fail. Using an existing commit proves
+    # the gate is HEAD==DEPLOYED, not merely "DEPLOYED resolves + manifest agrees".
+    write_manifest "$m" "{\"gitSha\":\"$C0\"}"
+    run_assert "$C0" "$m";                       assert_rc_nonzero "matching manifest cannot mask stale checkout (existing non-HEAD commit)"
+
+    # A supplied-but-EMPTY manifest arg (two args) must still trigger + fail the
+    # manifest assertion, not silently pass as if no manifest were requested.
+    run_assert "$head" "";                       assert_rc_nonzero "empty manifest arg still asserts"
+
+    # Unreadable manifest fails closed (skip under root: chmod 000 stays readable).
+    if [ "$(id -u)" -ne 0 ]; then
+        write_manifest "$m" "{\"gitSha\":\"$head\"}"
+        chmod 000 "$m"
+        run_assert "$head" "$m";                 assert_rc_nonzero "unreadable manifest"
+        chmod 644 "$m"
+    fi
+
+    # A successful manifest assertion must NOT mutate the manifest file.
+    write_manifest "$m" "{\"gitSha\":\"$head\"}"
+    local before_sum after_sum
+    before_sum="$(cksum < "$m")"
+    run_assert "$head" "$m";                     assert_rc_zero "manifest match (byte-preservation)"
+    after_sum="$(cksum < "$m")"
+    if [ "$before_sum" = "$after_sum" ]; then ok; else fail "assert mutated the manifest"; fi
+    cleanup_fixture
+}
+
+test_deployed_sha_manifest_dash_name() {
+    echo "test: a manifest file named '-' is read as a FILE, not stdin (jq operand injection guard)"
+    make_fixture
+    local head; head="$C5"
+    # Malformed manifest file literally named '-'; a VALID manifest piped on stdin. The
+    # jq OPERAND form (jq ... '-') would read stdin and PASS; the redirect form reads
+    # the malformed file and FAILS. This integrity gate must not be foolable.
+    printf '{"gitSha":"unknown"}' > "$FIXTURE/-"
+    OUT="$FIXTURE/aout.txt"; ERR="$FIXTURE/aerr.txt"
+    ( cd "$FIXTURE" && printf '{"gitSha":"%s"}' "$head" \
+        | bash "$FIXTURE/scripts/ci/qa-round-deployed-sha-assert.sh" "$head" "-" ) >"$OUT" 2>"$ERR"
+    RC=$?
+    if [ "$RC" -ne 0 ]; then ok; else fail "manifest named '-' must be read as a file, not stdin"; fi
+    rm -f "$FIXTURE/-"
+    cleanup_fixture
+}
+
+test_deployed_sha_ignores_poisoned_git_env() {
+    echo "test: poisoned GIT_DIR must not let the assert accept another repo's HEAD"
+    make_fixture   # HEAD = C5
+    local poison psha
+    require_tmpdir poison
+    (
+        cd "$poison" || exit 1
+        git init -q
+        git config user.email "ci@example.com"; git config user.name "CI"; git config commit.gpgsign false
+        printf 'x\n' > f; git add f; git commit -q -m poison
+    )
+    psha="$(git -C "$poison" rev-parse HEAD)"
+    # With GIT_DIR poisoned, asserting the poison repo's HEAD must FAIL (the script
+    # resolves the fixture at C5, not the poison repo) — a buggy git-honoring script
+    # would resolve psha and pass.
+    run_assert_gitdir "$poison/.git" "$psha";        assert_rc_nonzero "poisoned GIT_DIR ignored (checkout)"
+    # A manifest agreeing with the poison sha still can't rescue it.
+    local pm="$FIXTURE/poison_manifest.json"
+    write_manifest "$pm" "{\"gitSha\":\"$psha\"}"
+    run_assert_gitdir "$poison/.git" "$psha" "$pm";  assert_rc_nonzero "poisoned GIT_DIR ignored (manifest)"
+    # Sanity: the fixture's real HEAD still passes under the poison env, proving the
+    # script resolved the fixture (C5), not the poison repo. (Per-var coverage for all
+    # five git-location vars is the isolation-contract test below.)
+    run_assert_gitdir "$poison/.git" "$C5";          assert_rc_zero "correct HEAD passes despite poison env"
+    rm -rf "$poison"
+    cleanup_fixture
+}
+
+test_assert_isolates_git_env() {
+    echo "test: the assert unsets ALL git-location vars before calling git (isolation contract)"
+    make_fixture
+    setup_fake_git_isolation
+    OUT="$FIXTURE/aout.txt"; ERR="$FIXTURE/aerr.txt"
+    # All five vars set in the OUTER env + a fake git that fails on ANY leaked var: the
+    # correct HEAD (C5) must still resolve (rc 0), proving the script cleared them all
+    # before calling git. Dropping any one var from the unset line reddens this.
+    ( cd "$FIXTURE" && PATH="$FIXTURE/fakebin:$PATH" \
+        GIT_DIR=/x GIT_WORK_TREE=/x GIT_INDEX_FILE=/x GIT_COMMON_DIR=/x GIT_OBJECT_DIRECTORY=/x \
+        bash "$FIXTURE/scripts/ci/qa-round-deployed-sha-assert.sh" "$C5" ) >"$OUT" 2>"$ERR"
+    RC=$?
+    if [ "$RC" -eq 0 ]; then ok; else fail "assert leaked a git-location var to git (fake git tripped)"; fi
+    cleanup_fixture
+}
+
+test_cadence_ignores_poisoned_git_env() {
+    echo "test: a poisoned git-location env must not make the cadence gate diff the wrong repo"
+    make_fixture
+    local poison
+    require_tmpdir poison
+    (
+        cd "$poison" || exit 1
+        git init -q
+        git config user.email "ci@example.com"; git config user.name "CI"; git config commit.gpgsign false
+        printf 'x\n' > f; git add f; git commit -q -m poison
+    )
+    # GIT_DIR poisoned with a valid OTHER repo: without the unset, cat-file for the
+    # fixture shas (absent from the poison repo) would fail and the gate would
+    # uncertain-skip (base_known=false). The normal backend tuple (base_known=true)
+    # proves it resolved the FIXTURE repo. (Per-var coverage for all five vars is the
+    # isolation-contract test below.)
+    : > "$GHENV"
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    ( cd "$FIXTURE" && env "GIT_DIR=$poison/.git" GITHUB_ENV="$GHENV" \
+        bash "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh" "$C1" "$C2" 0 ) >"$OUT" 2>"$ERR"
+    RC=$?
+    assert_exit0
+    assert_tuple true true true backend
+    rm -rf "$poison"
+    cleanup_fixture
+}
+
+test_cadence_isolates_git_env() {
+    echo "test: the cadence gate unsets ALL git-location vars before calling git (isolation contract)"
+    make_fixture
+    setup_fake_git_isolation
+    : > "$GHENV"
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    # All five vars set in the OUTER env + a fake git that fails on ANY leaked var: a
+    # relevant backend range must still RUN (true/true/true/backend), proving the gate
+    # cleared them all before calling git. Dropping any one var from the unset reddens.
+    ( cd "$FIXTURE" && PATH="$FIXTURE/fakebin:$PATH" \
+        GIT_DIR=/x GIT_WORK_TREE=/x GIT_INDEX_FILE=/x GIT_COMMON_DIR=/x GIT_OBJECT_DIRECTORY=/x \
+        GITHUB_ENV="$GHENV" bash "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh" "$C1" "$C2" 0 ) >"$OUT" 2>"$ERR"
+    RC=$?
+    assert_exit0
+    assert_tuple true true true backend
+    cleanup_fixture
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_frontend_only
+    test_backend_only
+    test_seed_only
+    test_judge_irrelevant
+    test_base_equals_head
+    test_staleness_floor
+    test_mixed_frontend_and_docs
+    test_rename_to_irrelevant_dest
+    test_special_char_path
+
+    test_empty_base
+    test_empty_head
+    test_unresolvable_base
+    test_unresolvable_head
+    test_missing_filters
+    test_unreadable_filters
+    test_file_in_group_absent
+    test_filter_removed_mid_match
+    test_filter_replaced_by_dir_mid_match
+    test_require_tmpdir_fails_closed
+    test_prepush_unsourceable
+    test_git_diff_failure
+    test_github_env_write_success
+    test_github_env_write_failure
+    test_unwritable_tmpdir
+    test_cadence_ignores_poisoned_git_env
+    test_cadence_isolates_git_env
+
+    test_two_dot_divergent
+    test_source_guard_isolation
+
+    test_deployed_sha_pin
+    test_deployed_sha_manifest
+    test_deployed_sha_manifest_dash_name
+    test_deployed_sha_ignores_poisoned_git_env
+    test_assert_isolates_git_env
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/ci/qa-round-deployed-sha-assert.sh
+++ b/scripts/ci/qa-round-deployed-sha-assert.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# qa-round-deployed-sha-assert.sh <DEPLOYED_SHA> [MANIFEST_PATH]
+#
+# Pure assertion that the repo checkout — and, after tours, the run manifest —
+# exactly match the sha staging is deployed from. A stale checkout runs stale
+# selectors against newer markup and manufactures false failures, so the round
+# MUST pin to the deployed sha; this helper is how the wrapper proves the pin.
+#
+#   <DEPLOYED_SHA>   the full lowercase 40-hex git sha staging is built from (the
+#                    exact output contract of staging-deployed-sha.sh). Only that
+#                    form is accepted; anything else exits non-zero.
+#   [MANIFEST_PATH]  optional run manifest (JSON). When supplied, the file's string
+#                    `.gitSha` must ALSO be full lowercase 40-hex and EXACTLY equal
+#                    to <DEPLOYED_SHA>.
+#
+# Called TWICE by the wrapper: with NO manifest BEFORE tours (the pre-tour pin
+# assertion — checkout HEAD must equal the deployed sha) and WITH the just-written
+# manifest AFTER tours (the post-tour provenance assertion — checkout AND manifest
+# both equal the deployed sha, so a matching manifest cannot mask a stale checkout).
+#
+# Fail-closed: any bad arity, malformed sha, unreadable/missing/invalid manifest,
+# missing/non-string/non-hex/mismatched `.gitSha`, or git error exits non-zero with
+# a targeted message. It NEVER checks out or mutates the repo or the manifest.
+# The wrapper owns reading/re-reading the deployed sha, the checkout, choosing the
+# manifest, and watermark advancement.
+
+set -uo pipefail
+
+# Sanitize the repo's standard git-location env isolation set so `git rev-parse`
+# resolves THIS repo (the one containing the script), not whatever a caller's env
+# points at. A poisoned env would otherwise let the script assert against a different
+# checkout's HEAD (accepting a stale/wrong sha), which a matching manifest could not
+# catch. GIT_DIR / GIT_COMMON_DIR / GIT_OBJECT_DIRECTORY redirect resolution, and
+# GIT_WORK_TREE with a nonexistent-parent path fatals rev-parse — all four are
+# load-bearing. GIT_INDEX_FILE is inert for rev-parse but is unset as part of the
+# standard isolation set. The isolation is contract-tested (a fake git that fails on
+# any leaked var).
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
+
+err() { printf 'qa-round-deployed-sha-assert: %s\n' "$1" >&2; exit 1; }
+
+HEX40='^[0-9a-f]{40}$'
+
+if [ "$#" -ne 1 ] && [ "$#" -ne 2 ]; then
+  err "usage: qa-round-deployed-sha-assert.sh <DEPLOYED_SHA> [MANIFEST_PATH]"
+fi
+
+DEPLOYED="$1"
+
+[[ "$DEPLOYED" =~ $HEX40 ]] || err "DEPLOYED_SHA must be full lowercase 40-hex, got '$DEPLOYED'"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+[ -n "$REPO_ROOT" ] || err "could not resolve repo root from script location"
+
+head="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)" || err "could not resolve HEAD in $REPO_ROOT"
+[ "$head" = "$DEPLOYED" ] || err "checkout HEAD ($head) != deployed sha ($DEPLOYED); pin the checkout before running tours"
+
+# Manifest presence is decided by ARGUMENT COUNT, not by the value: a supplied but
+# empty second arg ("") must still trigger (and fail) the manifest assertion rather
+# than silently pass as if no manifest were requested.
+if [ "$#" -eq 2 ]; then
+  MANIFEST="$2"
+  { [ -f "$MANIFEST" ] && [ -r "$MANIFEST" ]; } || err "manifest not a readable file: $MANIFEST"
+  # Validate ENTIRELY inside jq, with --slurp so a stream of MORE THAN ONE top-level
+  # JSON value is rejected (`length != 1`): a two-value manifest like
+  # `{"gitSha":"unknown"} {"gitSha":"<expected>"}` must NOT pass just because a later
+  # value is valid. The single value's .gitSha must be a string of exactly 40 lowercase
+  # hex, anchored \A..\z so a trailing newline or stray character can't slip past shell
+  # trailing-newline stripping. Empty/invalid JSON -> length 0 or a parse error -> fail.
+  # The manifest is fed via REDIRECTED STDIN, NOT a jq operand: a file literally named
+  # `-` (or a dash-leading name) passed as an operand makes jq read stdin / treat it as
+  # an option, so an attacker could pipe a valid stream and slip a malformed file
+  # named `-` past this fail-closed gate. `< "$MANIFEST"` always reads the file.
+  manifest_sha="$(jq -er --slurp 'if length != 1 then error("manifest must contain exactly one JSON value") else .[0].gitSha | select(type == "string") | select(test("\\A[0-9a-f]{40}\\z")) end' < "$MANIFEST" 2>/dev/null)" \
+    || err "manifest $MANIFEST must be a single JSON object whose .gitSha is full lowercase 40-hex"
+  [ "$manifest_sha" = "$DEPLOYED" ] || err "manifest .gitSha ($manifest_sha) != deployed sha ($DEPLOYED)"
+  printf 'qa-round-deployed-sha-assert: OK checkout + manifest pinned to %s\n' "$DEPLOYED"
+else
+  printf 'qa-round-deployed-sha-assert: OK checkout pinned to %s\n' "$DEPLOYED"
+fi
+exit 0


### PR DESCRIPTION
Arc PR4 of the judge-as-tenant automation (`.ai/log/plan/judge-as-tenant-automation-arc.md`). Arc-independent of PR1/PR2/PR3. CI shell-scripts only — no product runtime code.

## What lands

Two `scripts/ci/` cores that a future (deferred) nightly runner wraps:

- **`qa-round-cadence-gate.sh <BASE> <HEAD> <DAYS_SINCE>`** — decides whether a nightly judge round runs, emitting `run_round`/`judge_relevant_change`/`base_known`/`changed_groups`. Decision: `HEAD==BASE` → skip; else a judge-relevant path-filter delta (backend/frontend/seed groups, two-dot `-z --no-renames` diff) → RUN; else `DAYS_SINCE >= MAX_STALENESS_DAYS (7)` → RUN (staleness floor); else skip.
- **`qa-round-deployed-sha-assert.sh <DEPLOYED_SHA> [MANIFEST]`** — a fail-closed integrity assertion that a tour ran against the expected deployed staging sha.

## Design contract (maintainer-settled)

- **Cadence gate degrades to SKIP on uncertainty** (fail toward *not* running). This is a token-spend optimization for an advisory, eventual-convergence QA system: a missed round is fine and bounded — the 7-day staleness floor guarantees a run within a week whenever staging changed at all, and a manual trigger is the backstop. A silent skip on uncertainty is *intended*, not a bug.
- **The deployed-sha assertion stays fail-closed** (a separate integrity gate): mismatch / malformed / multi-value / unreadable manifest → the assertion fails loudly, never passes. Manifest `.gitSha` is validated inside `jq --slurp` via redirected stdin (no operand injection), anchored to exactly 40 lowercase hex.
- **Git-environment isolation**: both scripts unset the full `GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY` set before any git call (the repo's documented hook-env hazard), so inherited git-location vars can't redirect resolution.

## Review

gpt-5.6-sol (`--effort xhigh`) review loop over multiple rounds → **PASS** (P0=0 P1=0). The loop drove a design pivot: an early validator that tried to *predict* the real matcher's acceptance kept diverging (unbounded silent-skip tail); the maintainer's staleness-floor + degrade-to-skip reframing converted that into a finite, closed problem. Every bug-fix test is mutation-verified (reddens on revert). `make test-deploy-scripts` green (113 assertions), lint + `shellcheck -x` clean.
