### PR TITLE
feat(qa): qa-fn-backfill false-negative recall helper (arc PR3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-report qa-export qa-langfuse-setup prod staging accelerated testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint spec-coverage api-types api-types-check
+.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-report qa-export qa-langfuse-setup qa-fn-backfill prod staging accelerated testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint spec-coverage api-types api-types-check
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -294,6 +294,10 @@ qa-export: ## Ship a judge run's GenAI spans (TRACE=<trace.jsonl>, written when 
 qa-langfuse-setup: ## Idempotently provision the standing QA triage queue (ground_truth+disposition dims) + verdict/ground_truth/disposition score configs in Langfuse (obs). Re-runnable; reconciles desired state. Requires LANGFUSE_HOST/PUBLIC_KEY/SECRET_KEY (errors non-zero without them).
 	@cd frontend && bun run tests/tours/judge/export/setup.ts
 
+qa-fn-backfill: ## False-negative recall helper. BEHAVIOR=<id> lists covering-PASS candidate traces (deep-links + cite/critique); add ROUND=<runId|gitSha> to narrow. BEHAVIOR=<id> TRACE=<traceId> enqueues that proven candidate into the qa-triage queue for should_fail scoring. Fail-closed (non-zero on any error); reports, never mutates, an already-triaged item. Requires LANGFUSE_HOST/PUBLIC_KEY/SECRET_KEY; LANGFUSE_PROJECT_ID resolves deep-links (else the key's sole project).
+	@if [ -n "$(TRACE)" ] && [ -n "$(ROUND)" ]; then echo "qa-fn-backfill: TRACE (enqueue) and ROUND (list narrow) are mutually exclusive — pass only one." >&2; exit 2; fi
+	@cd frontend && bun run tests/tours/judge/export/backfill.ts "$(BEHAVIOR)" $(if $(TRACE),"$(TRACE)",$(if $(ROUND),--round "$(ROUND)",))
+
 # Native PostgreSQL (for containerized development without Docker-in-Docker)
 # Symlink the main checkout's gitignored env files (.env, frontend/.env.local,
 # ...) into the current worktree. Normally automatic via the post-checkout git
@@ -536,6 +540,7 @@ test-deploy-scripts:
 	@bash scripts/staging-reset.test.sh
 	@bash scripts/ci/staging-reseed-decision.test.sh
 	@bash scripts/ci/qa-round-cadence-gate.test.sh
+	@bash scripts/ci/qa-fn-backfill-guard.test.sh
 	@bash scripts/staging-deployed-sha.test.sh
 	@bash scripts/staging-reseed.test.sh
 	@bash scripts/admin/setup-staging-reseed-host.sh.test.sh

--- a/frontend/tests/tours/judge/export/backfill.test.ts
+++ b/frontend/tests/tours/judge/export/backfill.test.ts
@@ -1,0 +1,824 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { main } from './backfill'
+import { TRIAGE_QUEUE_NAME, VERDICT_SCORE_NAME } from './triage-config'
+
+// --- fixtures ---------------------------------------------------------------
+
+const ENV = {
+  LANGFUSE_HOST: 'http://lf',
+  LANGFUSE_PUBLIC_KEY: 'p',
+  LANGFUSE_SECRET_KEY: 's',
+}
+
+type Verdict = 'pass' | 'fail' | 'unsure'
+
+interface TraceObj {
+  id: string
+  tags: string[]
+  output?: unknown
+}
+interface ScoreObj {
+  id: string
+  name: string
+  value: string
+  dataType: string
+  subject: { kind: string; id: string }
+}
+interface QueueObj {
+  id: string
+  name: string
+}
+
+// A graded item-trace's output shape (PerItemVerdict).
+const verdictOutput = (verdict: Verdict, citation = 'c', critique = 'k'): unknown => ({
+  itemIndex: 0,
+  verdict,
+  citation,
+  critique,
+})
+
+const trace = (id: string, tags: string[], output?: unknown): TraceObj => ({ id, tags, output })
+
+// A trace-level verdict score: the trace id lives in `subject.id` (kind === 'trace').
+const traceScore = (traceId: string, value: string): ScoreObj => ({
+  id: `sc-${traceId}-${value}`,
+  name: VERDICT_SCORE_NAME,
+  value,
+  dataType: 'CATEGORICAL',
+  subject: { kind: 'trace', id: traceId },
+})
+
+const triageQueue: QueueObj = { id: 'q-triage', name: TRIAGE_QUEUE_NAME }
+
+interface MockOpts {
+  traces?: TraceObj[]
+  tracesPerPage?: number
+  tracesError?: boolean
+  tracesMalformed?: boolean
+  // scores/items accept raw shapes so a test can inject a spec-invalid row.
+  scores?: unknown[]
+  scoresPerPage?: number
+  scoresError?: boolean
+  projects?: { id: string }[]
+  projectsError?: boolean
+  queues?: QueueObj[]
+  queuesPerPage?: number
+  queueError?: boolean
+  items?: unknown[]
+  itemsPerPage?: number
+  itemsError?: boolean
+  itemsMalformed?: boolean
+  failItemPost?: boolean
+}
+
+function mock(opts: MockOpts = {}): {
+  fetchImpl: typeof fetch
+  tracesReqs: URLSearchParams[]
+  scoresReqs: URLSearchParams[]
+  // The EXACT POST bodies (to prove INV-D: identifier/enum-only wire fields) + their queues.
+  itemPosts: Array<Record<string, unknown>>
+  postQueueIds: string[]
+  calls: number
+} {
+  const tracesReqs: URLSearchParams[] = []
+  const scoresReqs: URLSearchParams[] = []
+  const itemPosts: Array<Record<string, unknown>> = []
+  const postQueueIds: string[] = []
+  const state = { calls: 0 }
+
+  const okText = (obj: unknown): Response =>
+    ({ ok: true, status: 200, text: async () => JSON.stringify(obj) }) as Response
+  const err = (status: number, msg: string): Response =>
+    ({ ok: false, status, text: async () => msg }) as Response
+
+  // Page protocol: slice `all` to the requested page, emit utilsMetaResponse.
+  const page = (all: unknown[], q: URLSearchParams, per: number): Response => {
+    const requested = Number(q.get('page') ?? '1')
+    const totalPages = Math.max(1, Math.ceil(all.length / per))
+    const start = (requested - 1) * per
+    return okText({
+      data: all.slice(start, start + per),
+      meta: { page: requested, limit: per, totalItems: all.length, totalPages },
+    })
+  }
+  // Cursor protocol: `cursor` query is a numeric offset; omit meta.cursor on the last page.
+  const cursorPage = (all: unknown[], q: URLSearchParams, per: number): Response => {
+    const offset = Number(q.get('cursor') ?? '0')
+    const slice = all.slice(offset, offset + per)
+    const next = offset + per
+    const meta: Record<string, unknown> = { limit: per }
+    if (next < all.length) meta.cursor = String(next)
+    return okText({ data: slice, meta })
+  }
+
+  const fetchImpl = (async (url: string | URL, init?: { method?: string; body?: unknown }) => {
+    state.calls++
+    const u = String(url)
+    const method = init?.method ?? 'GET'
+    const parsed = new URL(u)
+    const pathname = parsed.pathname
+    const q = parsed.searchParams
+    const json = (): Record<string, unknown> =>
+      JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    if (pathname === '/api/public/traces' && method === 'GET') {
+      tracesReqs.push(new URLSearchParams(q))
+      if (opts.tracesError === true) return err(500, 'traces boom')
+      if (opts.tracesMalformed === true)
+        return okText({ meta: { page: 1, limit: 100, totalItems: 0, totalPages: 1 } })
+      const wanted = q.getAll('tags')
+      const all = (opts.traces ?? []).filter(t => wanted.every(w => t.tags.includes(w)))
+      return page(all, q, opts.tracesPerPage ?? 100)
+    }
+    if (pathname === '/api/public/v3/scores' && method === 'GET') {
+      scoresReqs.push(new URLSearchParams(q))
+      if (opts.scoresError === true) return err(500, 'scores boom')
+      return cursorPage(opts.scores ?? [], q, opts.scoresPerPage ?? 100)
+    }
+    if (pathname === '/api/public/projects' && method === 'GET') {
+      if (opts.projectsError === true) return err(500, 'projects boom')
+      return okText({ data: opts.projects ?? [{ id: 'proj-1' }] })
+    }
+    if (pathname === '/api/public/annotation-queues' && method === 'GET') {
+      if (opts.queueError === true) return err(500, 'queue boom')
+      return page(opts.queues ?? [triageQueue], q, opts.queuesPerPage ?? 100)
+    }
+    const itemsMatch = /^\/api\/public\/annotation-queues\/([^/]+)\/items$/.exec(pathname)
+    if (itemsMatch) {
+      if (method === 'GET') {
+        if (opts.itemsError === true) return err(500, 'items boom')
+        if (opts.itemsMalformed === true)
+          return okText({ meta: { page: 1, limit: 100, totalItems: 0, totalPages: 1 } })
+        return page(opts.items ?? [], q, opts.itemsPerPage ?? 100)
+      }
+      if (method === 'POST') {
+        const b = json()
+        itemPosts.push(b)
+        postQueueIds.push(itemsMatch[1])
+        if (opts.failItemPost === true) return err(500, 'post boom')
+        return okText({ id: 'new-item', ...b, status: 'PENDING' })
+      }
+    }
+    // Any route/method the CLI is NOT expected to touch (e.g. a PATCH reopen or a direct
+    // score write) reddens the test — a silent 200 would make the no-write tests toothless.
+    throw new Error(`unexpected fetch: ${method} ${pathname}`)
+  }) as unknown as typeof fetch
+
+  return {
+    fetchImpl,
+    tracesReqs,
+    scoresReqs,
+    itemPosts,
+    postQueueIds,
+    get calls() {
+      return state.calls
+    },
+  }
+}
+
+// Capture stdout/stderr lines a run emits.
+function sinks(): {
+  log: (m: string) => void
+  errlog: (m: string) => void
+  out: string[]
+  er: string[]
+} {
+  const out: string[] = []
+  const er: string[] = []
+  return { log: m => out.push(m), errlog: m => er.push(m), out, er }
+}
+
+const RUN_ID = '20260717T151639Z'
+
+afterEach(() => vi.restoreAllMocks())
+
+// --- list: covering-PASS candidates + deep-links ----------------------------
+
+describe('list — covering-PASS candidates + deep-links', () => {
+  it('lists only covering-PASS traces with a resolvable deep-link, paginating traces AND scores', async () => {
+    // t1: scored pass → candidate; t2: scored fail → excluded; t3: zero-score output-PASS
+    // → candidate (fallback). Force multi-page traces AND cursor-paged scores.
+    const traces = [
+      trace('t1', ['behavior:CON-042'], verdictOutput('pass', 'row gone', 'looks right')),
+      trace('t2', ['behavior:CON-042'], verdictOutput('fail')),
+      trace('t3', ['behavior:CON-042'], verdictOutput('pass', 'cite3', 'crit3')),
+    ]
+    const scores = [traceScore('t1', 'pass'), traceScore('t2', 'fail')]
+    const m = mock({ traces, tracesPerPage: 1, scores, scoresPerPage: 1 })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    const shipped = s.out.join('\n')
+    // Candidates t1 + t3; NOT t2.
+    expect(shipped).toContain('t1')
+    expect(shipped).toContain('t3')
+    expect(shipped).not.toMatch(/(^|\s)t2(\s|$)/)
+    // Deep-link uses the resolved project id.
+    expect(shipped).toContain('http://lf/project/proj-1/traces/t1')
+    expect(shipped).toContain('cite: row gone')
+    expect(shipped).toContain('critique: looks right')
+    // Traces were paginated (3 requests over pages 1..3) and asked for output via fields=core,io.
+    expect(m.tracesReqs.length).toBeGreaterThanOrEqual(3)
+    expect(m.tracesReqs[0].get('fields')).toBe('core,io')
+    expect(m.tracesReqs[0].getAll('tags')).toContain('behavior:CON-042')
+    // EVERY scores request retained name/dataType/fields=subject and carried NO value filter.
+    expect(m.scoresReqs.length).toBeGreaterThanOrEqual(2)
+    for (const q of m.scoresReqs) {
+      expect(q.get('name')).toBe(VERDICT_SCORE_NAME)
+      expect(q.get('dataType')).toBe('CATEGORICAL')
+      expect(q.get('fields')).toBe('subject')
+      expect(q.has('value')).toBe(false)
+    }
+  })
+
+  it('ignores a non-trace (observation) score subject even when its id collides with a trace', async () => {
+    // t1 output FAIL → only an OBSERVATION-subject pass score references its id. If that
+    // were wrongly joined, t1 would look like one scored pass → candidate. Correct: the
+    // observation score is ignored, t1 stays scoreless → output FAIL → NOT a candidate.
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('fail'))],
+      scores: [
+        {
+          id: 'sc-obs',
+          name: VERDICT_SCORE_NAME,
+          value: 'pass',
+          dataType: 'CATEGORICAL',
+          subject: { kind: 'observation', id: 't1', traceId: 't1' },
+        },
+      ],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(4) // no covering pass
+  })
+})
+
+// --- enqueue happy path -----------------------------------------------------
+
+describe('enqueue — happy path', () => {
+  it('enqueues a valid candidate with EXACTLY {objectId, objectType:TRACE} and exits 0', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    // The wire body is identifier/enum-only — no free-text, no extra fields (INV-D).
+    expect(m.itemPosts).toEqual([{ objectId: 't1', objectType: 'TRACE' }])
+    expect(m.postQueueIds).toEqual(['q-triage'])
+    expect(s.out.join('\n')).toContain('enqueued t1')
+  })
+})
+
+// --- enqueue refuses a non-member -------------------------------------------
+
+describe('enqueue — refuses a non-member trace', () => {
+  it('refuses a traceId not in the candidate set (wrong behavior) and does NOT POST', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 'not-a-real-trace'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+    expect(s.er.join('\n')).toMatch(/not a covering-PASS candidate/)
+  })
+
+  it('refuses a trace that covers the behavior but is currently NON-pass', async () => {
+    const m = mock({
+      traces: [trace('t9', ['behavior:CON-042'], verdictOutput('fail'))],
+      scores: [traceScore('t9', 'fail')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't9'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+  })
+})
+
+// --- three distinct not-found outcomes --------------------------------------
+
+describe('three distinct outcomes: unknown / zero-traces / no-covering-pass', () => {
+  it('unknown behavior (not in registry) → distinct message + code 2, no query', async () => {
+    const m = mock()
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['ZZZ-999'], ENV, s.log, s.errlog)
+    expect(code).toBe(2)
+    expect(s.er.join('\n')).toMatch(/unknown behavior/)
+    expect(m.calls).toBe(0) // rejected before any API call
+  })
+
+  it('resolves an INTENT_CATALOG id (DSH-010), proving the intent half of the registry', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:DSH-010'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['DSH-010'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    expect(s.out.join('\n')).toContain('t1')
+  })
+
+  it('valid behavior, zero traces → distinct message + code 3', async () => {
+    const m = mock({ traces: [] })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['DSH-004'], ENV, s.log, s.errlog)
+    expect(code).toBe(3)
+    expect(s.er.join('\n')).toMatch(/no traces tagged behavior:DSH-004/)
+    expect(s.er.join('\n')).toMatch(/coverage gap/)
+  })
+
+  it('valid behavior, traces but no covering PASS → distinct message + code 4', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('fail'))],
+      scores: [traceScore('t1', 'fail')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(4)
+    expect(s.er.join('\n')).toMatch(/none is a covering PASS/)
+  })
+})
+
+// --- enqueue duplicate-safe on an existing PENDING item ---------------------
+
+describe('enqueue — duplicate-safe on an existing PENDING item', () => {
+  it('a trace already queued and PENDING is a no-op "already queued (pending)", exit 0, no POST', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [{ id: 'e1', objectId: 't1', objectType: 'TRACE', status: 'PENDING' }],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+    expect(s.out.join('\n')).toMatch(/already queued \(pending\)/)
+  })
+
+  it('finds an existing PENDING item on a LATER item page (paginated dedup), no dup POST', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [
+        { id: 'e0', objectId: 'zzz', objectType: 'TRACE', status: 'PENDING' },
+        { id: 'e1', objectId: 't1', objectType: 'TRACE', status: 'PENDING' }, // on page 2
+      ],
+      itemsPerPage: 1,
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+  })
+
+  it('a same-id OBSERVATION item does NOT satisfy the TRACE check → still POSTs', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [{ id: 'e1', objectId: 't1', objectType: 'OBSERVATION', status: 'PENDING' }],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    expect(m.itemPosts).toHaveLength(1)
+  })
+})
+
+// --- --round dispatch + strict arity ----------------------------------------
+
+describe('--round dispatch + strict arity', () => {
+  it('a valid runId narrows the trace query by the runId: tag', async () => {
+    const m = mock({
+      traces: [
+        trace('t1', ['behavior:CON-042', `runId:${RUN_ID}`], verdictOutput('pass')),
+        trace('t2', ['behavior:CON-042'], verdictOutput('pass')), // other round
+      ],
+      scores: [traceScore('t1', 'pass'), traceScore('t2', 'pass')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', '--round', RUN_ID], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    expect(m.tracesReqs[0].getAll('tags')).toEqual(
+      expect.arrayContaining(['behavior:CON-042', `runId:${RUN_ID}`])
+    )
+    const shipped = s.out.join('\n')
+    expect(shipped).toContain('t1')
+    expect(shipped).not.toMatch(/(^|\s)t2(\s|$)/)
+  })
+
+  it('a valid gitSha narrows the trace query by the gitSha: tag', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042', 'gitSha:abc1234'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', '--round', 'abc1234'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    expect(m.tracesReqs[0].getAll('tags')).toContain('gitSha:abc1234')
+  })
+
+  it('a --round value that is neither a run-id nor a git sha → usage error, no query', async () => {
+    for (const bad of ['20269999T999999Z', 'not-a-sha!', 'GHIJKLM']) {
+      const m = mock()
+      vi.stubGlobal('fetch', m.fetchImpl)
+      const s = sinks()
+      const code = await main(['CON-042', '--round', bad], ENV, s.log, s.errlog)
+      expect(code).toBe(2)
+      expect(m.calls).toBe(0)
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('--round with no value → usage error, no query', async () => {
+    const m = mock()
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', '--round'], ENV, s.log, s.errlog)
+    expect(code).toBe(2)
+    expect(m.calls).toBe(0)
+  })
+
+  it('rejects any invocation that is not exactly a recognized form, before any query', async () => {
+    const malformed = [
+      ['CON-042', '--round', 'abc1234', 'extra'], // trailing arg after --round
+      ['CON-042', 't1', '--round', 'abc1234'], // enqueue + round mixed
+      ['CON-042', 't1', 'extra'], // enqueue with a trailing arg
+      ['CON-042', '--unknown-flag'], // unknown flag in the enqueue slot
+    ]
+    for (const argv of malformed) {
+      const m = mock()
+      vi.stubGlobal('fetch', m.fetchImpl)
+      const s = sinks()
+      const code = await main(argv, ENV, s.log, s.errlog)
+      expect(code, `argv=${argv.join(' ')}`).toBe(2)
+      expect(m.calls, `argv=${argv.join(' ')}`).toBe(0)
+      vi.restoreAllMocks()
+    }
+  })
+})
+
+// --- mixed-population score-presence classification -------------------------
+
+describe('mixed-population score-presence classification', () => {
+  it('candidates are exactly {scored-pass, scoreless output-PASS}; scored fail/unsure excluded despite output PASS', async () => {
+    const traces = [
+      trace('scored-pass', ['behavior:CON-042'], verdictOutput('pass', 'a', 'aa')),
+      trace('scoreless-pass', ['behavior:CON-042'], verdictOutput('pass', 'b', 'bb')),
+      trace('scored-fail', ['behavior:CON-042'], verdictOutput('pass', 'c', 'cc')), // output PASS...
+      trace('scored-unsure', ['behavior:CON-042'], verdictOutput('pass', 'd', 'dd')), // ...but scored
+      trace('scoreless-fail', ['behavior:CON-042'], verdictOutput('fail', 'e', 'ee')),
+    ]
+    const scores = [
+      traceScore('scored-pass', 'pass'),
+      traceScore('scored-fail', 'fail'),
+      traceScore('scored-unsure', 'unsure'),
+    ]
+    const m = mock({ traces, scores })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    const shipped = s.out.join('\n')
+    expect(shipped).toContain('scored-pass')
+    expect(shipped).toContain('scoreless-pass')
+    expect(shipped).not.toContain('scored-fail')
+    expect(shipped).not.toContain('scored-unsure')
+    expect(shipped).not.toContain('scoreless-fail')
+    expect(shipped).toMatch(/2 covering-PASS candidate/)
+  })
+
+  it('a trace with MULTIPLE verdict scores → ambiguous: reports the trace id, exits non-zero, lists nothing', async () => {
+    const m = mock({
+      traces: [trace('t-amb', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t-amb', 'pass'), traceScore('t-amb', 'fail')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(s.er.join('\n')).toMatch(/ambiguous/)
+    expect(s.er.join('\n')).toContain('t-amb')
+    expect(s.out.join('\n')).not.toMatch(/covering-PASS candidate/)
+  })
+
+  it('ambiguity also blocks enqueue (never picks one)', async () => {
+    const m = mock({
+      traces: [trace('t-amb', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t-amb', 'pass'), traceScore('t-amb', 'unsure')],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't-amb'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(0)
+  })
+})
+
+// --- existing-item report — no PATCH/reopen ---------------------------------
+
+describe('existing-item report — no PATCH/reopen', () => {
+  it('an existing COMPLETED item → reported "reopen in UI" + non-zero, no POST, no ground-truth label', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [{ id: 'e1', objectId: 't1', objectType: 'TRACE', status: 'COMPLETED' }],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+    const er = s.er.join('\n')
+    expect(er).toMatch(/already triaged \(COMPLETED\)/)
+    expect(er).toMatch(/reopen it in the Langfuse/)
+    // The CLI never queries or prints a ground_truth label.
+    expect((s.out.join('\n') + er).toLowerCase()).not.toContain('should_fail')
+  })
+
+  it('MULTIPLE matching items (mixed statuses) → all reported + non-zero, never picks one', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [
+        { id: 'e1', objectId: 't1', objectType: 'TRACE', status: 'PENDING' },
+        { id: 'e2', objectId: 't1', objectType: 'TRACE', status: 'COMPLETED' },
+      ],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+    const er = s.er.join('\n')
+    expect(er).toMatch(/2 matching queue items/)
+    expect(er).toContain('e1')
+    expect(er).toContain('e2')
+  })
+})
+
+// --- deep-link resolution ---------------------------------------------------
+
+describe('deep-link resolution', () => {
+  const candidate = {
+    traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+    scores: [traceScore('t1', 'pass')],
+  }
+
+  it('LANGFUSE_PROJECT_ID env → used directly, no projects call', async () => {
+    const m = mock(candidate)
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(
+      ['CON-042'],
+      { ...ENV, LANGFUSE_PROJECT_ID: 'env-proj' },
+      s.log,
+      s.errlog
+    )
+    expect(code).toBe(0)
+    expect(s.out.join('\n')).toContain('http://lf/project/env-proj/traces/t1')
+  })
+
+  it('no env → the API sole project is used', async () => {
+    const m = mock({ ...candidate, projects: [{ id: 'only-1' }] })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(0)
+    expect(s.out.join('\n')).toContain('http://lf/project/only-1/traces/t1')
+  })
+
+  it('zero projects → fail-closed', async () => {
+    const m = mock({ ...candidate, projects: [] })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+    expect(s.er.join('\n')).toMatch(/LANGFUSE_PROJECT_ID/)
+  })
+
+  it('multiple projects → fail-closed', async () => {
+    const m = mock({ ...candidate, projects: [{ id: 'a' }, { id: 'b' }] })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+  })
+
+  it('a projects API error → fail-closed', async () => {
+    const m = mock({ ...candidate, projectsError: true })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+  })
+
+  it('missing creds → fail-closed usage exit', async () => {
+    const m = mock(candidate)
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], {}, s.log, s.errlog)
+    expect(code).toBe(2)
+    expect(m.calls).toBe(0)
+  })
+})
+
+// --- fail-closed write failures ---------------------------------------------
+
+describe('fail-closed write failures', () => {
+  const cand = {
+    traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+    scores: [traceScore('t1', 'pass')],
+  }
+
+  it('missing qa-triage queue → non-zero, no POST', async () => {
+    const m = mock({ ...cand, queues: [] })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+    expect(s.er.join('\n')).toMatch(/expected exactly 1/)
+  })
+
+  it('ambiguous (multiple) qa-triage queue → non-zero, no POST', async () => {
+    const m = mock({ ...cand, queues: [triageQueue, { id: 'q2', name: TRIAGE_QUEUE_NAME }] })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).not.toBe(0)
+    expect(m.itemPosts).toHaveLength(0)
+  })
+
+  it('a queue-list GET error → non-zero', async () => {
+    const m = mock({ ...cand, queueError: true })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(0)
+  })
+
+  it('an existing-items GET error → non-zero', async () => {
+    const m = mock({ ...cand, itemsError: true })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(0)
+  })
+
+  it('a PaginationError listing candidate traces → non-zero (no list)', async () => {
+    const m = mock({ ...cand, tracesMalformed: true })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(s.er.join('\n')).toMatch(/PaginationError/)
+  })
+
+  it('a PaginationError reading existing items → non-zero (no POST)', async () => {
+    const m = mock({ ...cand, itemsMalformed: true })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(0)
+  })
+
+  it('the item POST itself failing → non-zero, no completion reported', async () => {
+    const m = mock({ ...cand, failItemPost: true })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(1) // attempted
+    expect(s.out.join('\n')).not.toMatch(/enqueued/)
+  })
+})
+
+// --- spec-invalid wire rows fail CLOSED (never dropped to "absent") ----------
+
+describe('spec-invalid wire rows fail closed', () => {
+  it('a malformed verdict-score row for an otherwise-scoreless trace → fail closed, NOT a fallback candidate', async () => {
+    // t1 output PASS would be a fallback candidate IF it read as scoreless. The malformed
+    // score (trace-kind, no subject.id) must fail closed rather than be dropped to absent.
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [
+        {
+          id: 'sc-bad',
+          name: VERDICT_SCORE_NAME,
+          value: 'pass',
+          dataType: 'CATEGORICAL',
+          subject: { kind: 'trace' },
+        },
+      ],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(s.er.join('\n')).toMatch(/BackfillDataError/)
+    expect(s.out.join('\n')).not.toMatch(/covering-PASS candidate/)
+  })
+
+  it('a verdict-score row with a non-{pass,fail,unsure} value → fail closed', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [
+        {
+          id: 'sc-bad',
+          name: VERDICT_SCORE_NAME,
+          value: 'garbage',
+          dataType: 'CATEGORICAL',
+          subject: { kind: 'trace', id: 't1' },
+        },
+      ],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+  })
+
+  it('a malformed existing queue-item → fail closed, NOT a duplicate POST', async () => {
+    // The item has objectId===t1 but a malformed (non-string) objectType. Silently ignoring
+    // it would let the enqueue duplicate a queued trace; it must fail closed instead.
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [{ id: 'e-bad', objectId: 't1', objectType: 42 }],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(0)
+    expect(s.er.join('\n')).toMatch(/objectType/)
+  })
+
+  it('a MISSING or UNKNOWN subject.kind on an otherwise-scoreless trace → fail closed, not admitted', async () => {
+    // Both are corrupt rows: a KNOWN non-trace variant would be legitimately ignored, but a
+    // missing/unknown kind that vanishes would let t1 (output PASS) sneak in via the fallback.
+    for (const subject of [{ id: 't1' } as unknown, { kind: 'bogus', id: 't1' } as unknown]) {
+      const m = mock({
+        traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+        scores: [
+          { id: 'sc-x', name: VERDICT_SCORE_NAME, value: 'pass', dataType: 'CATEGORICAL', subject },
+        ],
+      })
+      vi.stubGlobal('fetch', m.fetchImpl)
+      const s = sinks()
+      const code = await main(['CON-042'], ENV, s.log, s.errlog)
+      expect(code).toBe(1)
+      expect(s.er.join('\n')).toMatch(/subject\.kind/)
+      expect(s.out.join('\n')).not.toMatch(/covering-PASS candidate/)
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('an existing item objectType of the wrong case ("trace") → fail closed, NOT a silent dup POST', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [{ id: 'e-bad', objectId: 't1', objectType: 'trace', status: 'PENDING' }],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(0)
+    expect(s.er.join('\n')).toMatch(/objectType/)
+  })
+
+  it('a matching item with an unknown status → fail closed, NOT a dup POST', async () => {
+    const m = mock({
+      traces: [trace('t1', ['behavior:CON-042'], verdictOutput('pass'))],
+      scores: [traceScore('t1', 'pass')],
+      items: [{ id: 'e1', objectId: 't1', objectType: 'TRACE', status: 'ARCHIVED' }],
+    })
+    vi.stubGlobal('fetch', m.fetchImpl)
+    const s = sinks()
+    const code = await main(['CON-042', 't1'], ENV, s.log, s.errlog)
+    expect(code).toBe(1)
+    expect(m.itemPosts).toHaveLength(0)
+    expect(s.er.join('\n')).toMatch(/status/)
+  })
+})

--- a/frontend/tests/tours/judge/export/backfill.ts
+++ b/frontend/tests/tours/judge/export/backfill.ts
@@ -1,0 +1,472 @@
+// CLI: qa-fn-backfill — turn a downstream bug discovery into recall signal.
+//
+//   list:    bun run tests/tours/judge/export/backfill.ts <behavior_id> [--round <runId|gitSha>]
+//   enqueue: bun run tests/tours/judge/export/backfill.ts <behavior_id> <traceId>
+//
+// The list form prints the covering-PASS candidate traces for a behavior — a deep
+// link plus the judge's cite/critique — so a maintainer can eyeball the one that
+// covers the bug they found elsewhere. The enqueue form adds a proven candidate to
+// the standing `qa-triage` queue, where it is scored `should_fail` in the normal
+// flow. That queue is the ONLY write path (no direct score) so the human-triage
+// boundary is never bypassed.
+//
+// FAIL-CLOSED (opposite of qa-export's best-effort): because it writes into the
+// false-negative ground-truth pool, EVERY failure — a missing/ambiguous queue, any
+// list GET / pagination error, an ambiguous verdict, a non-member traceId, an
+// unknown behavior, an unresolvable deep-link project, or the item POST itself —
+// exits NON-ZERO and never reports the backfill as done. It is a REPORTER, not a
+// status-mutator: an already-triaged item is reported for a manual UI reopen, never
+// PATCHed.
+
+import {
+  ApiError,
+  PaginationError,
+  api,
+  apiGetAllPages,
+  configFromEnv,
+  type LangfuseConfig,
+} from './langfuse'
+import { validGitSha, validRunId } from './run'
+import { TRIAGE_QUEUE_NAME, VERDICT_SCORE_NAME } from './triage-config'
+import { SPEC_CATALOG } from '../spec-catalog'
+import { INTENT_CATALOG } from '../intent-catalog'
+
+type Verdict = 'pass' | 'fail' | 'unsure'
+
+// A spec-invalid 2xx wire row (a verdict score or queue item the API returned but that
+// violates its own schema — a malformed subject, a non-enum value). A fail-CLOSED
+// writer must NOT silently drop such a row to "absent" — that would fail OPEN (a
+// malformed score makes a trace look scoreless → the output-PASS fallback admits it;
+// a malformed existing item makes a queued trace look un-queued → a duplicate POST).
+// Thrown so the caller exits non-zero rather than acting on an untrustworthy read.
+class BackfillDataError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BackfillDataError'
+  }
+}
+
+// Distinct exit codes so the three not-found list outcomes are separable by a
+// script/human. FAIL is the single fail-closed operational code; USAGE covers bad
+// args + an unknown behavior (a typo/coverage error, caught before any query).
+const EXIT = { OK: 0, FAIL: 1, USAGE: 2, NO_TRACES: 3, NO_COVERING_PASS: 4 } as const
+
+// Langfuse v3 closed variant/enum sets (from the deployed OpenAPI: ScoreSubjectV3,
+// AnnotationQueueObjectType, AnnotationQueueStatus). For every closed discriminator on a
+// 2xx row, a value OUTSIDE its set — INCLUDING missing — is spec-invalid and fails CLOSED;
+// only a genuinely-valid-but-not-our-target value (e.g. an observation-kind score, a
+// SESSION item) is legitimately skipped. A silently-ignored corrupt row fails OPEN (the
+// row vanishes → a scored trace looks scoreless / a queued trace looks un-queued).
+const SUBJECT_KINDS: ReadonlySet<string> = new Set([
+  'trace',
+  'observation',
+  'session',
+  'experiment',
+])
+const QUEUE_OBJECT_TYPES: ReadonlySet<string> = new Set(['TRACE', 'OBSERVATION', 'SESSION'])
+const QUEUE_ITEM_STATUSES: ReadonlySet<string> = new Set(['PENDING', 'COMPLETED'])
+
+// The behavior/intent registry — the SAME catalogs the judge + tours use, so a trace
+// tagged `behavior:<id>` (the tag comes from `qa.behavior_id`, which is a behavior id
+// for residue behaviors and an intent id for intent judgments). This is what makes
+// "unknown behavior" (id absent — a typo) distinguishable from "valid behavior, zero
+// traces" (a coverage gap): Langfuse data alone cannot tell them apart.
+const BEHAVIOR_REGISTRY: ReadonlySet<string> = new Set([
+  ...Object.keys(SPEC_CATALOG),
+  ...Object.keys(INTENT_CATALOG),
+])
+
+const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e))
+
+const asVerdict = (v: unknown): Verdict | undefined =>
+  v === 'pass' || v === 'fail' || v === 'unsure' ? v : undefined
+
+// A graded item-trace's output is its PerItemVerdict ({verdict, citation, critique});
+// a content-light trace's output is a string/undefined (no verdict).
+function outputVerdict(output: unknown): Verdict | undefined {
+  if (output !== null && typeof output === 'object' && !Array.isArray(output)) {
+    return asVerdict((output as { verdict?: unknown }).verdict)
+  }
+  return undefined
+}
+
+function citeCritique(output: unknown): { citation?: string; critique?: string } {
+  if (output !== null && typeof output === 'object' && !Array.isArray(output)) {
+    const o = output as { citation?: unknown; critique?: unknown }
+    return {
+      citation: typeof o.citation === 'string' ? o.citation : undefined,
+      critique: typeof o.critique === 'string' ? o.critique : undefined,
+    }
+  }
+  return {}
+}
+
+// Closed, fail-safe per-trace classification from its verdict scores + output:
+//   >1 verdict scores → ambiguous (never choose one; fail closed)
+//    1 verdict score  → `pass` qualifies; `fail`/`unsure`/other excludes even if the
+//                       trace OUTPUT says pass (the bound score wins)
+//    0 verdict scores → fall back to output PASS (a legacy trace or a failed score
+//                       request has none; keyed on zero PRESENCE, never on absence
+//                       from a pass-filtered query)
+type Classification = 'candidate' | 'excluded' | 'ambiguous'
+function classify(verdictScores: Verdict[], output: unknown): Classification {
+  if (verdictScores.length > 1) return 'ambiguous'
+  if (verdictScores.length === 1) return verdictScores[0] === 'pass' ? 'candidate' : 'excluded'
+  return outputVerdict(output) === 'pass' ? 'candidate' : 'excluded'
+}
+
+interface Candidate {
+  traceId: string
+  citation?: string
+  critique?: string
+}
+interface CandidateSet {
+  traceCount: number
+  candidates: Candidate[]
+  ambiguous: string[]
+}
+
+// Build a behavior's candidate set: traces tagged `behavior:<id>` (+ an optional round
+// tag, AND-combined), each classified against ALL verdict scores. Throws ApiError /
+// PaginationError on any list/pagination failure (fail-closed at the call site).
+async function buildCandidateSet(
+  cfg: LangfuseConfig,
+  behaviorId: string,
+  roundTag: string | undefined
+): Promise<CandidateSet> {
+  // Traces filtered by tag — `tags` is an AND filter, so behavior + round both apply.
+  // `fields=core,io` returns `output` (the verdict/cite/critique) alongside the id/tags.
+  const tParams = new URLSearchParams()
+  tParams.append('tags', `behavior:${behaviorId}`)
+  if (roundTag) tParams.append('tags', roundTag)
+  tParams.set('fields', 'core,io')
+  const traces = await apiGetAllPages(cfg, `/api/public/traces?${tParams.toString()}`, 'page')
+
+  // ALL verdict scores (no `value` filter — a pass-only query cannot tell a hidden
+  // fail/unsure from a missing score). `fields=subject` is required because core score
+  // rows omit the trace association. Scores v3 is CURSOR-paginated.
+  const sParams = new URLSearchParams()
+  sParams.set('name', VERDICT_SCORE_NAME)
+  sParams.set('dataType', 'CATEGORICAL')
+  sParams.set('fields', 'subject')
+  const scores = await apiGetAllPages(cfg, `/api/public/v3/scores?${sParams.toString()}`, 'cursor')
+
+  // Join by the trace-level subject. Langfuse v3 puts the trace id in `subject.id` when
+  // `subject.kind === 'trace'` (only OBSERVATION-level subjects carry `subject.traceId`),
+  // so a trace-bound verdict score joins on `subject.id`. Non-trace subjects (observation/
+  // session/experiment) are legitimately IGNORED — they are not this trace's verdict. But a
+  // TRACE-kind row that is spec-invalid (no `subject.id`, or a value outside the config's
+  // {pass,fail,unsure}) is a corrupt read → fail CLOSED, never dropped to "scoreless".
+  const byTrace = new Map<string, Verdict[]>()
+  for (const s of scores) {
+    const subject = (s as { subject?: unknown }).subject
+    if (subject === null || typeof subject !== 'object' || Array.isArray(subject)) {
+      throw new BackfillDataError(
+        `verdict score '${String((s as { id?: unknown }).id)}' has no subject`
+      )
+    }
+    const sub = subject as { kind?: unknown; id?: unknown }
+    if (sub.kind !== 'trace') {
+      // A VALID non-trace variant (observation/session/experiment) is legitimately not
+      // this trace's verdict; a MISSING or UNKNOWN kind is a corrupt row → fail closed.
+      if (typeof sub.kind === 'string' && SUBJECT_KINDS.has(sub.kind)) continue
+      throw new BackfillDataError(
+        `verdict score '${String((s as { id?: unknown }).id)}' has a missing/unknown ` +
+          `subject.kind (${String(sub.kind)})`
+      )
+    }
+    if (typeof sub.id !== 'string' || sub.id.length === 0) {
+      throw new BackfillDataError(
+        `trace-level verdict score '${String((s as { id?: unknown }).id)}' has no subject.id`
+      )
+    }
+    const value = asVerdict((s as { value?: unknown }).value)
+    if (!value) {
+      throw new BackfillDataError(
+        `verdict score for trace ${sub.id} has a non-{pass,fail,unsure} value ` +
+          `(${String((s as { value?: unknown }).value)})`
+      )
+    }
+    const arr = byTrace.get(sub.id) ?? []
+    arr.push(value)
+    byTrace.set(sub.id, arr)
+  }
+
+  const candidates: Candidate[] = []
+  const ambiguous: string[] = []
+  for (const t of traces) {
+    // The paginator guarantees a string id on every item.
+    const traceId = t.id as string
+    const output = (t as { output?: unknown }).output
+    const c = classify(byTrace.get(traceId) ?? [], output)
+    if (c === 'ambiguous') ambiguous.push(traceId)
+    else if (c === 'candidate') candidates.push({ traceId, ...citeCritique(output) })
+  }
+  return { traceCount: traces.length, candidates, ambiguous }
+}
+
+// The UI project id for a trace deep link. Deterministic + fail-closed: env override,
+// else the key's SOLE project; zero/multiple/error → throw (never guess a link).
+async function resolveProjectId(
+  cfg: LangfuseConfig,
+  env: Record<string, string | undefined>
+): Promise<string> {
+  const fromEnv = env.LANGFUSE_PROJECT_ID
+  if (fromEnv) return fromEnv
+  const res = await api(cfg, 'GET', '/api/public/projects')
+  const data = (res as { data?: unknown }).data
+  if (!Array.isArray(data) || data.length !== 1) {
+    throw new Error(`expected exactly 1 project, found ${Array.isArray(data) ? data.length : 0}`)
+  }
+  const id = (data[0] as { id?: unknown }).id
+  if (typeof id !== 'string' || id.length === 0) throw new Error('project has no id')
+  return id
+}
+
+async function runList(
+  cfg: LangfuseConfig,
+  env: Record<string, string | undefined>,
+  behaviorId: string,
+  roundTag: string | undefined,
+  log: (msg: string) => void,
+  errlog: (msg: string) => void
+): Promise<number> {
+  const set = await buildCandidateSet(cfg, behaviorId, roundTag)
+  if (set.ambiguous.length > 0) {
+    errlog(
+      `qa-fn-backfill: multiple verdict scores for trace(s) ${set.ambiguous.join(', ')} — ` +
+        'ambiguous; resolve in the Langfuse UI. Not listing candidates.'
+    )
+    return EXIT.FAIL
+  }
+  const round = roundTag ? ` (${roundTag})` : ''
+  if (set.traceCount === 0) {
+    errlog(
+      `qa-fn-backfill: no traces tagged behavior:${behaviorId}${round} — coverage gap ` +
+        '(extend the tour), not a judge miss.'
+    )
+    return EXIT.NO_TRACES
+  }
+  if (set.candidates.length === 0) {
+    errlog(
+      `qa-fn-backfill: ${set.traceCount} trace(s) for ${behaviorId}${round} but none is a ` +
+        'covering PASS — nothing to backfill.'
+    )
+    return EXIT.NO_COVERING_PASS
+  }
+
+  let projectId: string
+  try {
+    projectId = await resolveProjectId(cfg, env)
+  } catch (err) {
+    errlog(
+      `qa-fn-backfill: cannot resolve a deep-link project (${errMsg(err)}) — ` +
+        'set LANGFUSE_PROJECT_ID.'
+    )
+    return EXIT.FAIL
+  }
+
+  log(`${set.candidates.length} covering-PASS candidate(s) for ${behaviorId}${round}:`)
+  for (const c of set.candidates) {
+    log(`  ${c.traceId}`)
+    log(`    ${cfg.host}/project/${projectId}/traces/${c.traceId}`)
+    if (c.citation) log(`    cite: ${c.citation}`)
+    if (c.critique) log(`    critique: ${c.critique}`)
+  }
+  log(`\nto backfill one: qa-fn-backfill ${behaviorId} <traceId>`)
+  return EXIT.OK
+}
+
+async function runEnqueue(
+  cfg: LangfuseConfig,
+  behaviorId: string,
+  traceId: string,
+  log: (msg: string) => void,
+  errlog: (msg: string) => void
+): Promise<number> {
+  // Membership proof: the trace must cover this behavior AND be a current covering PASS.
+  // Built WITHOUT a round narrow (membership is round-agnostic).
+  const set = await buildCandidateSet(cfg, behaviorId, undefined)
+  if (set.ambiguous.length > 0) {
+    errlog(
+      `qa-fn-backfill: multiple verdict scores for trace(s) ${set.ambiguous.join(', ')} — ` +
+        'ambiguous; resolve in the Langfuse UI. Not enqueuing.'
+    )
+    return EXIT.FAIL
+  }
+  if (!set.candidates.some(c => c.traceId === traceId)) {
+    errlog(
+      `qa-fn-backfill: trace ${traceId} is not a covering-PASS candidate for ${behaviorId} — ` +
+        'refusing to enqueue (guards the false-negative ground-truth pool).'
+    )
+    return EXIT.FAIL
+  }
+
+  // Resolve the standing queue (exactly one) — fail closed on missing/ambiguous.
+  const queues = await apiGetAllPages(cfg, '/api/public/annotation-queues', 'page')
+  const matches = queues.filter(q => q.name === TRIAGE_QUEUE_NAME)
+  if (matches.length !== 1 || typeof matches[0].id !== 'string') {
+    errlog(
+      `qa-fn-backfill: expected exactly 1 '${TRIAGE_QUEUE_NAME}' queue, found ${matches.length} — ` +
+        'cannot enqueue.'
+    )
+    return EXIT.FAIL
+  }
+  const queueId = matches[0].id as string
+
+  // Existing items keyed by (objectType, objectId): queue-item POST has no server dedup,
+  // so REPORT rather than blindly re-POST. A correct dedup read requires EVERY item's
+  // identity to be well-formed — a malformed objectType/objectId would let a real match
+  // slip through and duplicate the POST, so a spec-invalid item fails CLOSED.
+  const items = await apiGetAllPages(cfg, `/api/public/annotation-queues/${queueId}/items`, 'page')
+  for (const it of items) {
+    const objectType = (it as { objectType?: unknown }).objectType
+    const objectId = (it as { objectId?: unknown }).objectId
+    if (typeof objectId !== 'string') {
+      throw new BackfillDataError(
+        `queue item '${String((it as { id?: unknown }).id)}' has a malformed objectId`
+      )
+    }
+    // objectType must be a KNOWN enum member: a wrong-case 'trace' or garbage would let a
+    // real TRACE match slip through → a duplicate POST. Fail closed instead.
+    if (typeof objectType !== 'string' || !QUEUE_OBJECT_TYPES.has(objectType)) {
+      throw new BackfillDataError(
+        `queue item '${String((it as { id?: unknown }).id)}' has a missing/unknown ` +
+          `objectType (${String(objectType)})`
+      )
+    }
+  }
+  const matching = items.filter(
+    it => (it as { objectType: string }).objectType === 'TRACE' && it.objectId === traceId
+  )
+  if (matching.length > 1) {
+    const detail = matching
+      .map(it => `${String(it.id)}:${String((it as { status?: unknown }).status)}`)
+      .join(', ')
+    errlog(
+      `qa-fn-backfill: trace ${traceId} has ${matching.length} matching queue items (${detail}) — ` +
+        'ambiguous; resolve in the Langfuse UI. Not enqueuing.'
+    )
+    return EXIT.FAIL
+  }
+  if (matching.length === 1) {
+    const rawStatus = (matching[0] as { status?: unknown }).status
+    // status is a closed enum {PENDING, COMPLETED}: a missing/unknown value is spec-invalid,
+    // not "neither pending nor completed" → fail closed.
+    if (typeof rawStatus !== 'string' || !QUEUE_ITEM_STATUSES.has(rawStatus)) {
+      throw new BackfillDataError(
+        `queue item for trace ${traceId} has a missing/unknown status (${String(rawStatus)})`
+      )
+    }
+    const status = rawStatus
+    if (status === 'PENDING') {
+      log(`qa-fn-backfill: trace ${traceId} already queued (pending) in ${TRIAGE_QUEUE_NAME}.`)
+      return EXIT.OK
+    }
+    errlog(
+      `qa-fn-backfill: trace ${traceId} already triaged (${status}); reopen it in the Langfuse ` +
+        'UI to re-triage. Not re-enqueuing.'
+    )
+    return EXIT.FAIL
+  }
+
+  // Zero existing → POST. A non-2xx throws ApiError → caught by main → non-zero.
+  await api(cfg, 'POST', `/api/public/annotation-queues/${queueId}/items`, {
+    objectId: traceId,
+    objectType: 'TRACE',
+  })
+  log(`qa-fn-backfill: enqueued ${traceId} into ${TRIAGE_QUEUE_NAME}.`)
+  return EXIT.OK
+}
+
+export async function main(
+  argv: string[],
+  env: Record<string, string | undefined> = process.env,
+  log: (msg: string) => void = console.log,
+  errlog: (msg: string) => void = console.error
+): Promise<number> {
+  const cfg = configFromEnv(env)
+  if (!cfg) {
+    errlog(
+      'qa-fn-backfill: LANGFUSE_HOST / LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set — ' +
+        'cannot reach Langfuse.'
+    )
+    return EXIT.USAGE
+  }
+
+  const usage =
+    'usage: qa-fn-backfill <behavior_id> [--round <runId|gitSha>]   (list)\n' +
+    '       qa-fn-backfill <behavior_id> <traceId>                 (enqueue)'
+
+  const behaviorId = argv[0]
+  if (!behaviorId) {
+    errlog(usage)
+    return EXIT.USAGE
+  }
+
+  // Format-dispatch + STRICT arity BEFORE any query — a fail-closed writer rejects any
+  // invocation that is not EXACTLY a recognized form (no ignored trailing args, no
+  // list+enqueue mix). Recognized:
+  //   list:    <behavior>                   (rest = [])
+  //   list:    <behavior> --round <value>   (rest = ['--round', value])
+  //   enqueue: <behavior> <traceId>         (rest = [traceId])
+  const rest = argv.slice(1)
+  let roundTag: string | undefined
+  let traceIdArg: string | undefined
+  if (rest.length === 0) {
+    // list, no round
+  } else if (rest[0] === '--round') {
+    if (rest.length !== 2) {
+      errlog(`qa-fn-backfill: --round takes exactly one value and no other arguments.\n${usage}`)
+      return EXIT.USAGE
+    }
+    const r = rest[1]
+    if (validRunId(r)) roundTag = `runId:${r}`
+    else if (validGitSha(r)) roundTag = `gitSha:${r}`
+    else {
+      errlog(
+        `qa-fn-backfill: --round '${r}' is neither a run-id (YYYYMMDDTHHMMSSZ) nor a ` +
+          'git sha (7-40 hex).'
+      )
+      return EXIT.USAGE
+    }
+  } else if (rest.length === 1 && !rest[0].startsWith('--')) {
+    traceIdArg = rest[0]
+  } else {
+    errlog(`qa-fn-backfill: unrecognized arguments.\n${usage}`)
+    return EXIT.USAGE
+  }
+
+  // An unknown behavior is a typo/coverage error — reject before any query.
+  if (!BEHAVIOR_REGISTRY.has(behaviorId)) {
+    errlog(
+      `qa-fn-backfill: unknown behavior '${behaviorId}' — not in the behavior/intent catalog ` +
+        '(a typo, or a behavior the judge does not cover).'
+    )
+    return EXIT.USAGE
+  }
+
+  try {
+    return traceIdArg === undefined
+      ? await runList(cfg, env, behaviorId, roundTag, log, errlog)
+      : await runEnqueue(cfg, behaviorId, traceIdArg, log, errlog)
+  } catch (err) {
+    if (
+      err instanceof ApiError ||
+      err instanceof PaginationError ||
+      err instanceof BackfillDataError
+    ) {
+      errlog(`qa-fn-backfill: ${err.name}: ${err.message}`)
+      return EXIT.FAIL
+    }
+    throw err
+  }
+}
+
+// Import-guarded: importing this module (as backfill.test.ts does) runs NO side
+// effects; main() executes only when the file is the process entry point.
+if (typeof import.meta !== 'undefined' && (import.meta as ImportMeta).main) {
+  void main(process.argv.slice(2)).then(code => {
+    process.exitCode = code
+  })
+}

--- a/scripts/ci/qa-fn-backfill-guard.test.sh
+++ b/scripts/ci/qa-fn-backfill-guard.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regression test for the qa-fn-backfill Makefile target's ROUND+TRACE mutual-
+# exclusion guard. The CLI's own strict-arity tests drive main() directly and never
+# exercise the Makefile recipe, so without this a dropped guard line would silently
+# re-select TRACE (enqueue) while ROUND is also set, with every TS test still green.
+#
+# Invokes the REAL make target with BOTH set and proves the guard SHORT-CIRCUITS
+# before the bun command: a `bun` stub is placed first on PATH that records a sentinel
+# and exits non-zero. A guard that kept its message but lost `exit 2` would fall
+# through to bun (sentinel present) yet still show a non-zero exit + the message — so
+# asserting the sentinel is ABSENT is what actually proves the short-circuit.
+#
+# Portable: no network, no BSD-only flags — this suite runs on Ubuntu CI.
+
+set -uo pipefail
+
+# Sanitize hook-inherited git env (a no-op outside the pre-push hook); this test runs
+# `make`, not git, but keep the suite's convention so nothing leaks into the real repo.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok() { PASS=$((PASS + 1)); }
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+SENTINEL="$STUB_DIR/bun-was-invoked"
+# A bun stub that would fire IF the guard fell through to the recipe's bun line.
+cat > "$STUB_DIR/bun" <<STUB
+#!/usr/bin/env bash
+touch "$SENTINEL"
+exit 1
+STUB
+chmod +x "$STUB_DIR/bun"
+
+# ROUND + TRACE together must error (non-zero) with the mutual-exclusion message,
+# BEFORE the bun command runs (bun stub never invoked → sentinel absent).
+out="$(PATH="$STUB_DIR:$PATH" make -C "$REPO_ROOT" qa-fn-backfill \
+  BEHAVIOR=CON-042 ROUND=abc1234 TRACE=t1 2>&1)"
+code=$?
+
+if [ "$code" -eq 0 ]; then
+  fail "ROUND+TRACE together should error, but make exited 0"
+elif ! printf '%s' "$out" | grep -q "mutually exclusive"; then
+  fail "expected a 'mutually exclusive' error message; got: $out"
+elif [ -e "$SENTINEL" ]; then
+  fail "the guard did NOT short-circuit — bun was reached despite ROUND+TRACE"
+else
+  ok
+fi
+
+echo "qa-fn-backfill-guard: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Arc PR3 (final) of the judge-as-tenant automation (`.ai/log/plan/judge-as-tenant-automation-arc.md`). Depends on PR1 (#684, api() seam) + PR2 (#685, export enrichment) — both merged. Test-infra/CLI only — no product runtime, no backend.

## What lands

`qa-fn-backfill` — a false-negative recall CLI (`frontend/tests/tours/judge/export/backfill.ts` + Makefile target). Given a downstream bug discovery, it enqueues the covering PASS trace into the `qa-triage` annotation queue so the maintainer can score it `should_fail` — turning false-negatives into ground truth without a giant audit queue.

- **Two-step, non-interactive**: `qa-fn-backfill <behavior_id> [--round <runId|gitSha>]` lists the covering-PASS candidate set; `qa-fn-backfill <behavior_id> <traceId>` enqueues a proven member.
- **Closed, fail-safe classification** over the merged PR2 verdict-scores: fetches ALL verdict scores (`fields=subject`, no `value` filter) and classifies per trace — exactly-one `pass` → candidate; exactly-one `fail`/`unsure` → excluded even if trace output is PASS; zero scores → output-PASS fallback (keyed on zero-score *presence*); multiple → ambiguous, report + non-zero. Trace subjects join on `subject.id` (per the Langfuse OpenAPI, `subject.traceId` is observation-only).
- **Behavior registry** = `SPEC_CATALOG` ∪ `INTENT_CATALOG` keys, so "unknown behavior" (typo) and "valid behavior, zero traces" (coverage gap) are distinct outcomes.
- **Existing-item = REPORT, never mutate**: zero → POST; one PENDING → no-op; one COMPLETED → report "reopen in UI" + non-zero; multiple → report all + non-zero. No PATCH/reopen.

## Fail-CLOSED write contract (inverse of PR2's best-effort export)

This CLI writes into the FN ground-truth pool, so it is conservative: every failure exits non-zero and does not report completion. Spec-invalid 2xx rows **fail closed** rather than being silently dropped to "absent" — a `subject.kind`/`objectType`/`status` value missing or outside its closed Langfuse enum set raises `BackfillDataError`, so a vanished score can't slip an output-PASS candidate through and a wrong-case `objectType` can't cause a duplicate POST. Strict arity is validated before any API call; the Makefile rejects `ROUND`+`TRACE` together.

## Reuse & review

Reuses PR1's `api()`/`ApiError`/`apiGetAllPages` + `triage-config.ts` names; no new deps, no backend changes. gpt-5.6-sol (`--effort xhigh`) review loop → **PASS** (P0=0 P1=0). 41 backfill unit tests (mocked fetch) + a Makefile-guard shell test (proves the guard short-circuits before `bun` via a PATH stub + sentinel); every fail-closed branch mutation-verified. Full frontend suite + `test-deploy-scripts` green; tsc + eslint clean.
