### PR TITLE
fix(db): grant crm_user SUPERUSER in native-pg provisioning

### DIFF
--- a/scripts/start-postgres-native.sh
+++ b/scripts/start-postgres-native.sh
@@ -79,6 +79,13 @@ else
     sudo -u postgres psql -c "ALTER USER $POSTGRES_USER WITH PASSWORD '$ESCAPED_PASSWORD';"
 fi
 
+# SUPERUSER is required for the test harness to CREATE EXTENSION vector (an
+# untrusted extension) in personal_crm_test and its per-worktree templates.
+# Applied unconditionally so it also restores a role that regressed to
+# non-super after a container rebuild (the DB is provisioned at runtime, not
+# baked into the image). Dev/native only — prod uses infra/setup-pi.sh.
+sudo -u postgres psql -c "ALTER USER $POSTGRES_USER WITH SUPERUSER;"
+
 # Check if database exists
 DB_EXISTS=$(sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='$POSTGRES_DB';")
 


### PR DESCRIPTION
## What
`scripts/start-postgres-native.sh` creates `crm_user` with `CREATEDB` but not `SUPERUSER`. Add an unconditional `ALTER USER crm_user WITH SUPERUSER` after the create/exists branches.

## Why
`CREATE EXTENSION vector` (pgvector is an *untrusted* extension) requires superuser, so without this `make e2e-db` / the native-PG test path fails with:
```
ERROR: extension "vector" is not available
```
This surfaced after a sandbox container rebuild: the role is provisioned at runtime (not baked into the image) and came back as `CREATEDB`-only. The grant is applied unconditionally so it also **self-heals a role that regressed** — it runs in the `ensure-postgres-for-tests.sh → start-postgres-native.sh` chain, so the first `make e2e-db` after a rebuild restores it, no manual `ALTER ROLE` needed.

## Scope
Native-PG (no-Docker) dev/test only — the sandbox and dev machines running tests without Docker. It does **not** affect:
- **Docker-based dev / prod (Pi):** `ensure-postgres-for-tests.sh` takes the Docker branch and never calls this script; the `postgres` image already creates `POSTGRES_USER=crm_user` as a superuser. This change simply brings the native path **in line** with the Docker default.
- **CI:** does not invoke this script (provisions its own Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)