### PR TITLE
test(e2e): store Playwright browsers on the workspace volume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,11 +604,13 @@ jobs:
         uses: actions/cache@v4
         id: playwright-cache
         with:
-          path: ~/.cache/ms-playwright
+          path: ${{ github.workspace }}/.playwright-browsers
           key: playwright-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
 
       - name: Install Playwright browsers
         working-directory: frontend
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
         run: bunx playwright install chromium --with-deps
 
       - name: Wait for PostgreSQL
@@ -663,6 +665,7 @@ jobs:
         env:
           CI: true
           PLAYWRIGHT_WORKERS: 4
+          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
           DATABASE_URL: postgres://crm_user:crm_password@localhost:5432/personal_crm?sslmode=disable
           SESSION_SECRET: test-session-secret-for-ci
           API_KEY: test-api-key-for-ci

--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,9 @@ tests/junit.xml
 test-results/
 playwright-report/
 playwright/.cache/
+# Browsers are stored on the workspace volume (see PLAYWRIGHT_BROWSERS_PATH in
+# Makefile / playwright.config.ts) so they survive container rebuilds.
+.playwright-browsers/
 
 # Tours harness live-run output (captures + manifest + traces) — never committed
 frontend/tests/tours/.runs/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,18 @@
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 
+# Playwright browsers on the workspace volume, NOT the default
+# ~/.cache/ms-playwright home-layer cache — a container rebuild wipes that even
+# when the workspace persists, breaking every E2E test at browserType.launch.
+# Anchored on the git COMMON dir (the main repo's .git, identical for every
+# linked worktree) so all worktrees + the main checkout SHARE one browser cache
+# (Playwright namespaces by version, so this is safe across version bumps).
+# Falls back to the worktree toplevel if git resolution fails. Exported so every
+# e2e recipe and `playwright install` resolve the same path.
+MAIN_REPO_ROOT := $(shell cd "$$(dirname "$$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")" 2>/dev/null && pwd || git rev-parse --show-toplevel 2>/dev/null)
+PLAYWRIGHT_BROWSERS_PATH := $(MAIN_REPO_ROOT)/.playwright-browsers
+export PLAYWRIGHT_BROWSERS_PATH
+
 # Go build cache (workspace-local by default; override via env).
 GOCACHE ?= $(REPO_ROOT)/.gocache
 export GOCACHE

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,30 @@
 import { defineConfig, devices } from '@playwright/test'
 import os from 'os'
 import { readFileSync } from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+
+// Store browsers on the workspace volume, not the default ~/.cache/ms-playwright
+// home-layer cache — a container rebuild wipes that even when the workspace
+// persists, causing every test to fail at browserType.launch until reinstalled.
+// Anchored on the git common dir (main repo root) so all worktrees SHARE one
+// cache, matching the Makefile/CI. The Makefile, CI, and setup-dev.sh export the
+// SAME value for `playwright install`; this fallback covers a bare `playwright
+// test` invocation. Falls back to the frontend parent if git is unavailable.
+if (!process.env.PLAYWRIGHT_BROWSERS_PATH) {
+  let root = path.resolve(__dirname, '..')
+  try {
+    const commonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+      cwd: __dirname,
+    })
+      .toString()
+      .trim()
+    if (commonDir) root = path.dirname(commonDir)
+  } catch {
+    // not a git checkout — use the frontend parent
+  }
+  process.env.PLAYWRIGHT_BROWSERS_PATH = path.join(root, '.playwright-browsers')
+}
 
 // Effective CPU budget = the cgroup CFS quota when present, else the visible
 // core count. A container can be capped far below os.cpus(): our dev sandbox

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -290,6 +290,12 @@ echo_step "Installing Playwright browsers..."
 
 if [ -d "frontend" ] && command -v bun &> /dev/null; then
     cd frontend
+    # Install browsers onto the workspace volume, matching the Makefile / CI /
+    # playwright.config.ts location, so they survive container rebuilds that wipe
+    # the default ~/.cache/ms-playwright home-layer cache. Anchored on the git
+    # common dir (main repo root) so all worktrees share one cache; falls back to
+    # PROJECT_ROOT if git resolution fails.
+    export PLAYWRIGHT_BROWSERS_PATH="$(cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")" 2>/dev/null && pwd || echo "$PROJECT_ROOT")/.playwright-browsers"
     if bunx playwright --version &> /dev/null; then
         # Check if browsers are installed by trying to run a simple check
         if bunx playwright install --dry-run 2>&1 | grep -q "already installed"; then


### PR DESCRIPTION
## What
Set `PLAYWRIGHT_BROWSERS_PATH` to a workspace-volume path instead of the default `~/.cache/ms-playwright`, threaded consistently through every install/run site:
- **Makefile** — `PLAYWRIGHT_BROWSERS_PATH := <main-repo-root>/.playwright-browsers`, `export`ed so all e2e recipes inherit it.
- **playwright.config.ts** — fallback that sets the same path if the env is unset (covers a bare `playwright test`).
- **scripts/setup-dev.sh** — exports the same path before `playwright install`.
- **.github/workflows/ci.yml** — install + run step env, and the browser cache `path`, all point at `${{ github.workspace }}/.playwright-browsers`.
- **.gitignore** — `.playwright-browsers/`.

The path is anchored on the **git common dir** (the main repo's `.git`, identical for every linked worktree), so all worktrees + the main checkout **share one browser cache**. Playwright namespaces browsers by version, so a shared cache holds multiple versions side by side — safe across version bumps and concurrent worktree runs (read-only launches).

## Why
The dev sandbox's default `~/.cache/ms-playwright` lives on the **home layer**, which a container image rebuild wipes even when the workspace volume persists. That left the required chromium build missing → **every E2E test failed at `browserType.launch`**. `node_modules` and git hooks survived because they're on the workspace volume; the browser cache is the one artifact that wasn't. Moving it onto the workspace volume makes it survive rebuilds like the rest, and the shared anchor avoids N× copies across worktrees.

## Verification
Locally, with `~/.cache/ms-playwright` **deleted** so browsers exist *only* at the shared workspace path, `make test-e2e-local` ran green from a linked worktree (resolved the shared path via the Makefile export). CI validates the CI-side path independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)