### PR TITLE
fix(imports): invalidate contact detail after linking a candidate

### DIFF
--- a/.ai/spec/2026-07-18-contact-method-lost-update-design.md
+++ b/.ai/spec/2026-07-18-contact-method-lost-update-design.md
@@ -1,0 +1,116 @@
+# Contact-method lost update: stale-cache clobber on PUT /contacts/:id
+
+Status: design, ready to plan
+Date: 2026-07-18
+
+## Summary
+
+A contact method added server-side by import-link enrichment can be silently and permanently destroyed by a subsequent contact edit from the UI. Two independent defects compound: the contact detail cache is not invalidated after a link, so the UI shows a stale method list; and `PUT /contacts/:id` treats a supplied `methods` array as a wholesale replace with no concurrency control, so saving that stale list deletes anything the client did not know about.
+
+This document specifies the fix for both, plus a related gap in reconcile coverage found during the investigation.
+
+## Observed incident
+
+Reconstructed from prod DB state (request logs for the window were lost to a container restart). One contact, one email method:
+
+| Time (UTC) | Event | Evidence |
+|---|---|---|
+| 20:12:52.201 | Contact created from a telegram import; telegram method inserted | `contact_methods.added` event, telegram |
+| 20:12:59.074 | Calendar candidate linked; email method inserted and committed | `contact_methods.added` event, email + `contact_enrichment` audit row |
+| 20:13:31.661 | Contact edited to add a handle; all methods deleted and recreated from the submitted list | contact `updated_at` and both surviving methods' `created_at` identical to the microsecond |
+
+The email was absent from the recreated set and was permanently lost. The telegram method's `created_at` (20:13:31) not matching its own `contact_methods.added` event (20:12:52) is the tell: the row was destroyed and reinserted.
+
+The user reported the email as missing *before* the edit at 20:13:31, at which point it was present in the database. That report was the stale cache (defect 1). The remediation action it prompted then triggered the destructive write (defect 2).
+
+## Defect 1: contact detail not invalidated after link
+
+`frontend/src/lib/query-invalidation.ts` maps `'import:linked'` to `[importKeys.lists(), importKeys.suggestionsLists(), contactKeys.lists()]`. The contact *detail* key is absent, so a contact page already in cache does not refetch after a link enriches it.
+
+Every sibling rule that enriches an existing contact already includes the detail key via the factory pattern: `method-suggestion:resolved`, `meeting-note:resolved`, `name-candidate:resolved`. `import:linked` is the outlier, and its own comment ("Linking enriches an existing contact") describes behavior it does not implement.
+
+### Fix
+
+Add the per-contact detail key to the `import:linked` rule and pass the contact id at the call site. The link mutation already holds `crm_contact_id`, so no new plumbing is needed — this is the same shape as `method-suggestion:resolved`.
+
+## Defect 2: PUT /contacts/:id is a destructive replace with no concurrency control
+
+`UpdateContact` (`backend/internal/service/contact.go`) branches on a `replaceMethods` flag:
+
+```go
+if replaceMethods {
+    contactMethodRepo.DeleteContactMethodsByContact(ctx, id)  // deletes ALL methods
+    createContactMethods(ctx, contactMethodRepo, id, methods) // recreates from payload
+}
+```
+
+The handler sets `replaceMethods` to `req.Methods != nil`. Any client that submits a `methods` array built from a stale read destroys every method absent from that array, with no error and no signal to the user. The only surviving trace is the `contact_enrichment` audit row, which lives in a different table and is not consulted anywhere.
+
+The stale cache is one trigger. Others remain: background sync, enrichment from any source, a second browser tab. Fixing defect 1 alone leaves the destructive primitive loaded.
+
+### Why `contact.updated_at` is not a sufficient precondition
+
+Adding a contact method does not change `contact.updated_at`. Two independent reasons, both verified:
+
+1. `EnrichContactFromExternalWithSelections` gates the contact-row UPDATE behind a `needsUpdate` flag covering only photo, birthday, location, cadence, and name. A methods-only enrichment leaves the contact row untouched.
+2. The only triggers on `contact_method` are `set_contact_method_value_normalized` and `update_contact_method_updated_at`, both of which write to `contact_method` itself. Nothing propagates to `contact`.
+
+An `If-Match` on `contact.updated_at` would therefore have passed cleanly in the observed incident. The precondition must cover the method set.
+
+### Fix: optimistic concurrency scoped to PUT-writable fields
+
+**ETag.** `GET /contacts/:id` returns an `ETag` header computed over exactly the state `PUT` writes: `full_name`, `cadence`, and the normalized method set (type, value, `is_primary`), order-independent. Deriving it from writable fields only means an incoming interaction moving `last_contacted` does not produce a spurious conflict.
+
+**Precondition.** `PUT /contacts/:id` accepts `If-Match`:
+
+| Request | Behavior |
+|---|---|
+| `If-Match` present, matches current ETag | Apply |
+| `If-Match` present, stale | `409` with the current representation in the body |
+| `If-Match` absent | Apply unconditionally (unchanged from today) |
+
+Returning the current representation on 409 lets the client replay without a second round-trip. Treating an absent `If-Match` as unconditional keeps non-browser clients (mac-daemon, scripts) working without modification: protection is opt-in per client, and the web UI opts in.
+
+**Client.** The edit form captures the ETag it loaded and sends it on save. On 409 it re-applies the user's dirty fields onto the returned fresh representation and resubmits once. A second 409 surfaces a message asking the user to review. One retry, never a loop.
+
+For a single-user CRM the overwhelmingly common conflict is benign — the server added a method the client had not seen, which does not overlap the field the user edited — so a silent successful save is the correct outcome and a conflict dialog would be noise.
+
+## Related finding: calendar-sourced links are outside reconcile coverage
+
+`addressBookReconcileSources` in `backend/internal/service/address_book_reconcile.go` is `{gcontacts, icloud_contacts}`. Calendar-attendee rows are explicitly out of scope.
+
+That means for a calendar-sourced link, neither reconcile branch ever runs: no `autoPropagate` for a `matched` link and no `recordSuggestions` for an `imported` one. There is no safety net — a method missed at link time is missed permanently, and never even surfaces as a pending suggestion.
+
+A prod audit of linked calendar rows carrying an email found 10 whose email is absent from the contact. Triaged via the `contact_enrichment` audit table, which records a row only after a successful method insert:
+
+- **1** had an audit row: the incident above. Data loss. Restored manually.
+- **6** point at soft-deleted contacts. Expected — the methods were removed with the contact.
+- **2** are `matched` links with no audit row. These are genuine unfilled gaps: the system's stated semantics for a `matched` link are that an unapplied method is "a genuine gap → auto-propagate," but the source exclusion means that never happens.
+- **1** is an `imported` (curated) link on a contact with several other methods. Consistent with a deliberate deselection at curation time; no action.
+
+### Scope decision
+
+Extending reconcile coverage to calendar-attendee rows is deliberately **out of scope** for this work. It is a behavior change to a matching subsystem with its own semantics, and it is not on the path of the reported bug. It should be filed separately, along with a decision on whether to backfill the 2 `matched` rows.
+
+## Testing
+
+**Regression (integration).** Link a candidate so enrichment adds a method, then `PUT` with an `If-Match` captured before the link and a method list omitting it. Assert `409` and that the enriched method survives. This reproduces the incident exactly and fails against current `main`.
+
+**Compatibility (integration).** A `PUT` with no `If-Match` still applies, so existing non-browser clients are unaffected.
+
+**ETag (unit).** Order-independent across the method set; changes on method add, remove, and `is_primary` flip; does not change when `last_contacted` moves.
+
+**E2E.** Link a candidate and assert the contact detail surface shows the new method with no manual refresh. Covers defect 1, and is required regardless: the behavior is `surface: ui` in an `e2e_settled` domain, so it cannot land uncited.
+
+## Spec updates
+
+Both domains are `e2e_settled: true`; per `spec/README.md` a new or changed `surface: ui` then-item must land with its citing E2E test in the same PR.
+
+- `spec/imports-matching.yaml` — linking a candidate refreshes the contact detail surface.
+- `spec/contacts.yaml` — conditional-update semantics for `PUT /contacts/:id`, including the absent-`If-Match` fallback.
+
+## Out of scope
+
+- Reconcile coverage for calendar-attendee rows, and backfill of the 2 `matched` gaps (file separately).
+- Replacing the wholesale-replace primitive with additive method endpoints. Considered and rejected for now: optimistic concurrency closes the lost-update class at a fraction of the cost, and additive endpoints would require rewriting the edit form's submit path.
+- Extending `If-Match` to other write endpoints. Same pattern will apply if wanted later; this work establishes it on the endpoint with demonstrated data loss.

--- a/.ai/spec/2026-07-18-contact-method-lost-update-design.md
+++ b/.ai/spec/2026-07-18-contact-method-lost-update-design.md
@@ -28,7 +28,7 @@ The user reported the email as missing *before* the edit at 20:13:31, at which p
 These are assumptions the design rests on. If one stops holding, the reasoning must be revisited.
 
 1. **There will be multiple writing clients.** Today the web form is the only one — verified: mac-daemon touches only `/ingest/events` and `/host/*`, scripts only issue unauthenticated GET health probes, and crm-admin operates at the service layer. But a future MCP server is expected to write contacts. The design must therefore be safe for a client that has never read this document.
-2. **There will not be concurrent writes from multiple sources.** Single-user CRM, one human, no simultaneous editors. This premise is what retires optimistic concurrency (see Rejected alternatives).
+2. **There will not be concurrent writes from multiple sources.** Single-user CRM, one human, no simultaneous editors. This premise is what retires optimistic concurrency (see Rejected alternatives). The consequence, stated plainly: a genuinely concurrent add-and-remove from two clients is not defended against. Under this design that failure mode is benign — concurrent operations compose rather than clobber — which is why the premise is affordable here and was not under the rejected ETag approach, where the same premise would have left a silent lost update.
 3. **`PUT /contacts/:id` will eventually be atomized** into per-property endpoints for MCP-client flexibility. That work is out of scope here, but among fixes that work, this design prefers the one that moves toward it.
 
 ## Defect 1: contact detail not invalidated after link
@@ -64,20 +64,25 @@ Premise 1 sharpens this. A future MCP server told "add a phone number for this c
 
 Methods move to a sub-resource with explicit operations, so that removal requires *naming* what to remove. A client cannot delete what it never saw.
 
-The codebase already uses this pattern for every other child collection on a contact — notes, interactions, tasks, identities. `contact_task_routes.go` is a near-exact template:
+The codebase already uses this pattern for every other child collection on a contact — notes, interactions, tasks, identities. Contact methods are the last child collection still managed by wholesale replacement through the parent PUT, and the only one that has lost data. This design brings them into line with the existing convention rather than introducing a new one.
 
-```
-GET    /contacts/:id/tasks
-POST   /contacts/:id/tasks
-DELETE /contacts/:id/tasks/:taskId
-```
+### Shape: one transactional operations endpoint
 
-Contact methods are the last child collection still managed by wholesale replacement through the parent PUT, and the only one that has lost data. This design brings them into line with the existing convention rather than introducing a new one.
+`POST /contacts/:id/methods`, taking a list of operations (add / remove / set-primary), applied in a single transaction.
+
+**It must be `POST` with operations, never `PUT` with a desired set.** A `PUT /contacts/:id/methods` accepting the full method list is wholesale replace wearing a sub-resource costume: absence would again imply deletion, reintroducing this exact bug at a new URL. The structural property being bought is that *absence expresses nothing*, so nothing can be inferred from it. A naive client's "add a phone number" is a one-element list that cannot affect any other method.
+
+Two database constraints drive this shape, both verified:
+
+- `idx_contact_method_primary ON contact_method(contact_id) WHERE is_primary = TRUE` — at most one primary per contact, DB-enforced. Promoting a new primary before demoting the old one is a **constraint violation, not a logical wrinkle**. With granular routes the client must demote-then-promote across two round trips, and a failure between them leaves the contact with no primary. Inside one transaction the server orders operations correctly by construction and the client never needs to know the constraint exists. That invariant should not live in the frontend.
+- `idx_contact_method_unique_value ON contact_method(contact_id, type, value_normalized)` — a duplicate add is a unique violation rather than a second row, which makes every operation naturally idempotent. Combined with the contact PUT being idempotent, this means **retrying a whole save is safe**, so partial-failure recovery can be "report what failed and offer retry" rather than bespoke rollback.
+
+Granular routes (`DELETE /contacts/:id/methods/:methodId`) remain available later if a client wants them; this design declines to build them now for a client that does not yet exist. The task-routes template's granular shape fits tasks because tasks are created one at a time, whereas methods are edited in bulk behind a Save button.
 
 Two consequences follow, and the plan must decide both explicitly:
 
-- **`methods` on `PUT /contacts/:id`.** Once methods have their own endpoints, the PUT's methods branch has no remaining caller. Retiring it removes the destructive primitive outright rather than guarding it, and retires `CON-008`. Whether that retirement lands in this work or immediately after is a planning decision; leaving a destructive branch reachable is not.
-- **The multi-request save.** The edit form currently saves contact and notepad together via `Promise.all` (`frontend/src/app/contacts/[id]/page.tsx:198`), and the "contact saved, note failed" direction is already unhandled. Per-method operations make partial failure more likely, not less. This needs deliberate state handling and a named test, not discovery in review.
+- **`methods` on `PUT /contacts/:id`.** Once methods have their own endpoint, the PUT's methods branch has no remaining caller. Retiring it removes the destructive primitive outright rather than guarding it, and retires `CON-008`. Whether that retirement lands in this work or immediately after is a planning decision; leaving a destructive branch reachable is not.
+- **The multi-request save.** The edit form saves contact and notepad together via `Promise.all` (`frontend/src/app/contacts/[id]/page.tsx:198`), and the "contact saved, note failed" direction is already unhandled. The operations endpoint keeps the save at two requests rather than one-per-method, so this stays a single pre-existing seam instead of multiplying. It should be fixed here on its own terms: sequence rather than `Promise.all`, and report precisely what landed. Cross-resource atomicity via a compound endpoint is explicitly rejected — notes are a genuinely separate resource, and re-centralizing runs against premise 3.
 
 ## Rejected alternatives
 

--- a/.ai/spec/2026-07-18-contact-method-lost-update-design.md
+++ b/.ai/spec/2026-07-18-contact-method-lost-update-design.md
@@ -1,13 +1,13 @@
 # Contact-method lost update: stale-cache clobber on PUT /contacts/:id
 
 Status: design, ready to plan
-Date: 2026-07-18
+Date: 2026-07-18 (revised — see Design history)
 
 ## Summary
 
-A contact method added server-side by import-link enrichment can be silently and permanently destroyed by a subsequent contact edit from the UI. Two independent defects compound: the contact detail cache is not invalidated after a link, so the UI shows a stale method list; and `PUT /contacts/:id` treats a supplied `methods` array as a wholesale replace with no concurrency control, so saving that stale list deletes anything the client did not know about.
+A contact method added server-side by import-link enrichment can be silently and permanently destroyed by a subsequent contact edit from the UI. Two independent defects compound: the contact detail cache is not invalidated after a link, so the UI shows a stale method list; and `PUT /contacts/:id` treats a supplied `methods` array as a wholesale delete-and-recreate, so saving that stale list deletes anything the client did not know about.
 
-This document specifies the fix for both, plus a related gap in reconcile coverage found during the investigation.
+The fix is to invalidate the cache, and to retire the wholesale-replace primitive by moving contact methods onto dedicated sub-resource endpoints with explicit operations — the pattern this codebase already uses for every other child collection on a contact.
 
 ## Observed incident
 
@@ -23,6 +23,14 @@ The email was absent from the recreated set and was permanently lost. The telegr
 
 The user reported the email as missing *before* the edit at 20:13:31, at which point it was present in the database. That report was the stale cache (defect 1). The remediation action it prompted then triggered the destructive write (defect 2).
 
+## Premises
+
+These are assumptions the design rests on. If one stops holding, the reasoning must be revisited.
+
+1. **There will be multiple writing clients.** Today the web form is the only one — verified: mac-daemon touches only `/ingest/events` and `/host/*`, scripts only issue unauthenticated GET health probes, and crm-admin operates at the service layer. But a future MCP server is expected to write contacts. The design must therefore be safe for a client that has never read this document.
+2. **There will not be concurrent writes from multiple sources.** Single-user CRM, one human, no simultaneous editors. This premise is what retires optimistic concurrency (see Rejected alternatives).
+3. **`PUT /contacts/:id` will eventually be atomized** into per-property endpoints for MCP-client flexibility. That work is out of scope here, but among fixes that work, this design prefers the one that moves toward it.
+
 ## Defect 1: contact detail not invalidated after link
 
 `frontend/src/lib/query-invalidation.ts` maps `'import:linked'` to `[importKeys.lists(), importKeys.suggestionsLists(), contactKeys.lists()]`. The contact *detail* key is absent, so a contact page already in cache does not refetch after a link enriches it.
@@ -33,7 +41,9 @@ Every sibling rule that enriches an existing contact already includes the detail
 
 Add the per-contact detail key to the `import:linked` rule and pass the contact id at the call site. The link mutation already holds `crm_contact_id`, so no new plumbing is needed — this is the same shape as `method-suggestion:resolved`.
 
-## Defect 2: PUT /contacts/:id is a destructive replace with no concurrency control
+This is independent of defect 2 and correct regardless of how the write path is fixed.
+
+## Defect 2: `PUT /contacts/:id` destroys methods it was not told to destroy
 
 `UpdateContact` (`backend/internal/service/contact.go`) branches on a `replaceMethods` flag:
 
@@ -48,32 +58,34 @@ The handler sets `replaceMethods` to `req.Methods != nil`. Any client that submi
 
 The stale cache is one trigger. Others remain: background sync, enrichment from any source, a second browser tab. Fixing defect 1 alone leaves the destructive primitive loaded.
 
-### Why `contact.updated_at` is not a sufficient precondition
+Premise 1 sharpens this. A future MCP server told "add a phone number for this contact" would naturally send `methods: [{phone}]` — and silently destroy every other method. Under the current contract, every new client re-earns this bug. **"Absent means delete" must stop being expressible, not merely stop being triggered.**
 
-Adding a contact method does not change `contact.updated_at`. Two independent reasons, both verified:
+### Fix: dedicated contact-method endpoints
 
-1. `EnrichContactFromExternalWithSelections` gates the contact-row UPDATE behind a `needsUpdate` flag covering only photo, birthday, location, cadence, and name. A methods-only enrichment leaves the contact row untouched.
-2. The only triggers on `contact_method` are `set_contact_method_value_normalized` and `update_contact_method_updated_at`, both of which write to `contact_method` itself. Nothing propagates to `contact`.
+Methods move to a sub-resource with explicit operations, so that removal requires *naming* what to remove. A client cannot delete what it never saw.
 
-An `If-Match` on `contact.updated_at` would therefore have passed cleanly in the observed incident. The precondition must cover the method set.
+The codebase already uses this pattern for every other child collection on a contact — notes, interactions, tasks, identities. `contact_task_routes.go` is a near-exact template:
 
-### Fix: optimistic concurrency scoped to PUT-writable fields
+```
+GET    /contacts/:id/tasks
+POST   /contacts/:id/tasks
+DELETE /contacts/:id/tasks/:taskId
+```
 
-**ETag.** `GET /contacts/:id` returns an `ETag` header computed over exactly the state `PUT` writes: `full_name`, `cadence`, and the normalized method set (type, value, `is_primary`), order-independent. Deriving it from writable fields only means an incoming interaction moving `last_contacted` does not produce a spurious conflict.
+Contact methods are the last child collection still managed by wholesale replacement through the parent PUT, and the only one that has lost data. This design brings them into line with the existing convention rather than introducing a new one.
 
-**Precondition.** `PUT /contacts/:id` accepts `If-Match`:
+Two consequences follow, and the plan must decide both explicitly:
 
-| Request | Behavior |
-|---|---|
-| `If-Match` present, matches current ETag | Apply |
-| `If-Match` present, stale | `409` with the current representation in the body |
-| `If-Match` absent | Apply unconditionally (unchanged from today) |
+- **`methods` on `PUT /contacts/:id`.** Once methods have their own endpoints, the PUT's methods branch has no remaining caller. Retiring it removes the destructive primitive outright rather than guarding it, and retires `CON-008`. Whether that retirement lands in this work or immediately after is a planning decision; leaving a destructive branch reachable is not.
+- **The multi-request save.** The edit form currently saves contact and notepad together via `Promise.all` (`frontend/src/app/contacts/[id]/page.tsx:198`), and the "contact saved, note failed" direction is already unhandled. Per-method operations make partial failure more likely, not less. This needs deliberate state handling and a named test, not discovery in review.
 
-Returning the current representation on 409 lets the client replay without a second round-trip. Treating an absent `If-Match` as unconditional keeps non-browser clients (mac-daemon, scripts) working without modification: protection is opt-in per client, and the web UI opts in.
+## Rejected alternatives
 
-**Client.** The edit form captures the ETag it loaded and sends it on save. On 409 it re-applies the user's dirty fields onto the returned fresh representation and resubmits once. A second 409 surfaces a message asking the user to review. One retry, never a loop.
+**Optimistic concurrency (`ETag` / `If-Match` on `PUT /contacts/:id`).** This was the original design and was abandoned after two review rounds. Versioning a full representation requires enumerating every field the endpoint writes, which pulled in the knowledge writer (`location`, `birthday`, `how_met`), the cadence updater (`contact_by`), and `profile_photo`; and making the precondition atomic required a lock protocol honored by every `contact_method` writer, which pulled in enrichment, merge, and calendar-decline lock ordering. The plan reached ~1059 lines across five subsystems with five open P0 findings, to defend a primitive that should be removed instead. Premise 2 retires its core benefit: with no concurrent writers, there is no lost update for a precondition to catch that explicit operations do not already prevent. A further argument against: its compatibility carve-out ("absent `If-Match` keeps non-browser clients working") was written to protect a client population that does not exist.
 
-For a single-user CRM the overwhelmingly common conflict is benign — the server added a method the client had not seen, which does not overlap the field the user edited — so a silent successful save is the correct outcome and a conflict dialog would be noise.
+**Dirty-field partial submit.** Having the form send only fields the user touched. This does not fix the incident: the user edited a *method*, so `methods` is dirty and the full stale array ships regardless. It would also require inverting `CON-006` ("Contact update is full-replace for managed profile fields", `status: current`) across four fields, relocating complexity into the knowledge writer rather than removing it.
+
+**Additive `methods` plus an explicit removals field.** Structurally sound and cheaper than the above — a removal set derived from the client's own baseline cannot name a method the client never saw. Rejected only because it adds a *third* convention for mutating methods alongside the PUT and the existing suggestions endpoints, where dedicated endpoints collapse toward one and move with premise 3.
 
 ## Related finding: calendar-sourced links are outside reconcile coverage
 
@@ -88,29 +100,34 @@ A prod audit of linked calendar rows carrying an email found 10 whose email is a
 - **2** are `matched` links with no audit row. These are genuine unfilled gaps: the system's stated semantics for a `matched` link are that an unapplied method is "a genuine gap → auto-propagate," but the source exclusion means that never happens.
 - **1** is an `imported` (curated) link on a contact with several other methods. Consistent with a deliberate deselection at curation time; no action.
 
-### Scope decision
-
-Extending reconcile coverage to calendar-attendee rows is deliberately **out of scope** for this work. It is a behavior change to a matching subsystem with its own semantics, and it is not on the path of the reported bug. It should be filed separately, along with a decision on whether to backfill the 2 `matched` rows.
-
 ## Testing
 
-**Regression (integration).** Link a candidate so enrichment adds a method, then `PUT` with an `If-Match` captured before the link and a method list omitting it. Assert `409` and that the enriched method survives. This reproduces the incident exactly and fails against current `main`.
+**Regression (integration).** The acceptance bar from defect 2: a client that has never seen a method must not be able to destroy it. Add a method server-side, then exercise the write path a naive client would use, and assert the unseen method survives. This reproduces the incident and fails against current `main`.
 
-**Compatibility (integration).** A `PUT` with no `If-Match` still applies, so existing non-browser clients are unaffected.
+**Endpoint behavior (integration).** Add, remove, and primary-flag changes through the new endpoints, including removal of a method the client did name (which must succeed — the guarantee is about *unnamed* methods, not immutability).
 
-**ETag (unit).** Order-independent across the method set; changes on method add, remove, and `is_primary` flip; does not change when `last_contacted` moves.
+**Partial failure (frontend).** Both directions of the multi-request save, including "contact saved, method operation failed". State handling must be defined, not incidental.
 
 **E2E.** Link a candidate and assert the contact detail surface shows the new method with no manual refresh. Covers defect 1, and is required regardless: the behavior is `surface: ui` in an `e2e_settled` domain, so it cannot land uncited.
+
+Two known E2E vacuity traps, both verified, that a test here must avoid:
+- `frontend/src/lib/query-client.ts` sets `staleTime: 0` under the custom Playwright fixture, which makes a stale-cache assertion vacuous. Specs that import ordinary `@playwright/test` retain the production five-minute cache.
+- `RematchJobWatcher` independently invalidates `contactKeys.detail` on job completion, which can mask a missing invalidation. The test must avoid triggering a rematch, or assert none occurred.
 
 ## Spec updates
 
 Both domains are `e2e_settled: true`; per `spec/README.md` a new or changed `surface: ui` then-item must land with its citing E2E test in the same PR.
 
 - `spec/imports-matching.yaml` — linking a candidate refreshes the contact detail surface.
-- `spec/contacts.yaml` — conditional-update semantics for `PUT /contacts/:id`, including the absent-`If-Match` fallback.
+- `spec/contacts.yaml` — contact-method mutation semantics move to the new endpoints; `CON-008` (method replacement gated on the `methods` field being present) is retired or amended in step with the PUT branch.
 
 ## Out of scope
 
-- Reconcile coverage for calendar-attendee rows, and backfill of the 2 `matched` gaps (file separately).
-- Replacing the wholesale-replace primitive with additive method endpoints. Considered and rejected for now: optimistic concurrency closes the lost-update class at a fraction of the cost, and additive endpoints would require rewriting the edit form's submit path.
-- Extending `If-Match` to other write endpoints. Same pattern will apply if wanted later; this work establishes it on the endpoint with demonstrated data loss.
+- **Atomizing `PUT /contacts/:id`** into per-property endpoints. Directionally intended (premise 3) but not this work; this design only ensures methods move the right way.
+- **Reconcile coverage for calendar-attendee rows**, and backfill of the 2 `matched` gaps. A behavior change to a matching subsystem with its own semantics, not on the path of the reported bug. File separately.
+- **`profile_photo` being nulled on every edit-form save** — same defect class, same endpoint, tracked as issue #691 and deliberately descoped by the user. `how_met` is unaffected: `applyUpdate` deliberately no-ops it when absent, pinned by `CON-006`.
+- **Optimistic concurrency on any endpoint.** Retired by premise 2. If concurrent writers ever appear, this is where to start.
+
+## Design history
+
+The original version of this document specified optimistic concurrency (`ETag` + `If-Match`) on `PUT /contacts/:id`. Two rounds of plan review showed the approach expanding across five subsystems to defend a primitive that should be removed, and surfaced two errors in the design itself: an ETag enumerated over an incomplete set of PUT-written fields, and a compatibility carve-out protecting a client population that does not exist. The approach was re-evaluated at the design level and replaced with the present one. The rejected alternatives above record what was considered and why it lost, so the reasoning is not re-litigated from scratch.

--- a/frontend/src/hooks/__tests__/use-imports.test.tsx
+++ b/frontend/src/hooks/__tests__/use-imports.test.tsx
@@ -385,7 +385,11 @@ describe('use-imports hooks', () => {
       expect(mockedImportsApi.linkCandidate).toHaveBeenCalledWith('ext-123', {
         crm_contact_id: 'crm-456',
       })
-      expect(mockedInvalidateFor).toHaveBeenCalledWith('import:linked')
+      // The linked contact id must reach invalidateFor: the import:linked rule
+      // carries contactKeys.detail via a factory entry, and invalidateFor skips
+      // factory entries when the id is undefined. Turns red if the call site
+      // drops the second argument.
+      expect(mockedInvalidateFor).toHaveBeenCalledWith('import:linked', 'crm-456')
     })
 
     it('links candidate with method selection and conflict resolutions', async () => {
@@ -406,7 +410,7 @@ describe('use-imports hooks', () => {
       await result.current.mutateAsync({ id: 'ext-123', request })
 
       expect(mockedImportsApi.linkCandidate).toHaveBeenCalledWith('ext-123', request)
-      expect(mockedInvalidateFor).toHaveBeenCalledWith('import:linked')
+      expect(mockedInvalidateFor).toHaveBeenCalledWith('import:linked', 'crm-456')
     })
   })
 

--- a/frontend/src/hooks/use-imports.ts
+++ b/frontend/src/hooks/use-imports.ts
@@ -62,7 +62,7 @@ export function useLinkCandidate() {
     mutationFn: ({ id, request }: { id: string; request: LinkContactRequest }) =>
       importsApi.linkCandidate(id, request),
     onSuccess: (response, vars) => {
-      invalidateFor('import:linked')
+      invalidateFor('import:linked', vars.request.crm_contact_id)
       if (response.rematch_job_id) {
         registerJob({
           jobId: response.rematch_job_id,

--- a/frontend/src/lib/__tests__/query-invalidation.test.ts
+++ b/frontend/src/lib/__tests__/query-invalidation.test.ts
@@ -100,7 +100,32 @@ describe('query-invalidation', () => {
         })
       })
 
-      it('invalidates import, suggestions, and contact lists on import:linked', () => {
+      // Turns red if the (contactId) => contactKeys.detail(contactId) entry is
+      // dropped from the import:linked rule: a linked contact's cached detail
+      // view would keep serving its pre-link method list.
+      it('invalidates the linked contact detail key on import:linked', () => {
+        invalidateFor('import:linked', 'crm-456')
+
+        expect(mockInvalidateQueries).toHaveBeenCalledTimes(4)
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({
+          queryKey: importKeys.lists(),
+        })
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({
+          queryKey: importKeys.suggestionsLists(),
+        })
+        // Cross-domain: linking enriches an existing contact
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({
+          queryKey: contactKeys.lists(),
+        })
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({
+          queryKey: contactKeys.detail('crm-456'),
+        })
+      })
+
+      // The factory-skip contract: invalidateFor drops factory entries when no
+      // contactId is supplied, so the static keys must still fire for callers
+      // that have no contact in hand.
+      it('invalidates only the static keys on import:linked without a contact id', () => {
         invalidateFor('import:linked')
 
         expect(mockInvalidateQueries).toHaveBeenCalledTimes(3)
@@ -110,7 +135,6 @@ describe('query-invalidation', () => {
         expect(mockInvalidateQueries).toHaveBeenCalledWith({
           queryKey: importKeys.suggestionsLists(),
         })
-        // Cross-domain: linking enriches an existing contact
         expect(mockInvalidateQueries).toHaveBeenCalledWith({
           queryKey: contactKeys.lists(),
         })

--- a/frontend/src/lib/query-invalidation.ts
+++ b/frontend/src/lib/query-invalidation.ts
@@ -87,8 +87,16 @@ const invalidationRules: Record<DomainEvent, InvalidationKey[]> = {
   // The suggestions surface composes the same candidate list, so it must
   // refresh too.
   'import:imported': [importKeys.lists(), importKeys.suggestionsLists(), contactKeys.lists()],
-  // Linking enriches an existing contact
-  'import:linked': [importKeys.lists(), importKeys.suggestionsLists(), contactKeys.lists()],
+  // Linking enriches an existing contact — a link can add methods to it — so
+  // the contact's detail key is invalidated via the factory pattern alongside
+  // the lists. Without it, a detail view already in cache keeps serving the
+  // pre-link method list for the whole staleTime window.
+  'import:linked': [
+    importKeys.lists(),
+    importKeys.suggestionsLists(),
+    contactKeys.lists(),
+    (contactId: string) => contactKeys.detail(contactId),
+  ],
   // Ignoring only affects the imports + suggestions lists
   'import:ignored': [importKeys.lists(), importKeys.suggestionsLists()],
   // Sync trigger updates sync states; completion may add new candidates

--- a/frontend/tests/e2e/helpers/imports-helpers.ts
+++ b/frontend/tests/e2e/helpers/imports-helpers.ts
@@ -128,3 +128,69 @@ export async function findCandidateByName(
     // (reload + re-walk) costs a few seconds on the dev server.
   }).toPass({ timeout: 45000 })
 }
+
+/**
+ * Same walk as findCandidateByName, minus the `page.reload()` recovery.
+ *
+ * A reload is a full navigation, which tears down the react-query cache. Any
+ * spec whose subject IS the cache (does a mutation invalidate an already-cached
+ * query?) goes vacuous the moment a reload happens — the remounted page
+ * refetches from scratch and passes with or without the invalidation under
+ * test. findCandidateByName's reload fires only on a retry attempt, so such a
+ * spec passes locally and silently loses its meaning under parallel-worker
+ * load.
+ *
+ * This variant rewinds by clicking the page-1 control when one exists, and
+ * otherwise re-probes in place. If the candidate is genuinely unreachable the
+ * toPass budget expires and the test fails loudly, which is the correct
+ * outcome: a noisy failure beats a quiet vacuity.
+ *
+ * Deliberately a separate export. findCandidateByName keeps its reload — its
+ * other callers rely on it for parallel-safety and do not care about the cache.
+ */
+export async function findCandidateByNameNoReload(
+  page: Page,
+  displayName: string,
+  maxPages = 5
+): Promise<void> {
+  const contactHeading = page.getByRole('heading', { name: displayName, exact: true })
+  const seen = (locator: Locator, timeout: number) =>
+    locator
+      .waitFor({ state: 'visible', timeout })
+      .then(() => true)
+      .catch(() => false)
+
+  let attempt = 0
+  await expect(async () => {
+    attempt++
+    if (attempt > 1) {
+      // Rewind to page 1 if the control is present. When it is not, the pool
+      // fits one page (nothing to rewind) or a mid-walk shrink stranded the
+      // client with no rewind affordance — re-probe in place rather than
+      // reload, and let the budget expire if the candidate never appears.
+      const firstPageButton = page.getByRole('button', { name: '1', exact: true }).first()
+      if (await seen(firstPageButton, 500)) {
+        await firstPageButton.click()
+      }
+    }
+
+    for (let i = 0; i < maxPages; i++) {
+      if (await seen(contactHeading, 1500)) {
+        return
+      }
+
+      // Exact match so "Next candidate" inside the resolver modal never matches.
+      const nextButton = page.getByRole('button', { name: 'Next', exact: true })
+      if (await seen(nextButton, 500)) {
+        if (!(await nextButton.isDisabled())) {
+          await nextButton.click()
+          continue
+        }
+      }
+
+      break
+    }
+
+    await expect(contactHeading).toBeVisible({ timeout: 1000 })
+  }).toPass({ timeout: 45000 })
+}

--- a/frontend/tests/e2e/imports-link-invalidation.spec.ts
+++ b/frontend/tests/e2e/imports-link-invalidation.spec.ts
@@ -1,0 +1,239 @@
+// This spec MUST import from '@playwright/test', never from './fixtures'.
+//
+// The custom fixture sets window.__PLAYWRIGHT__, which makes query-client.ts
+// use staleTime: 0 (frontend/src/lib/query-client.ts). The behavior under test
+// here IS the production five-minute cache — whether linking an import
+// invalidates an already-cached contact detail entry. Under staleTime: 0 every
+// remount refetches anyway, so the assertion would pass with or without the
+// invalidation and this file would become decorative. A later "standardize the
+// imports specs onto ./fixtures" edit silently deletes the coverage.
+import { test, expect, Page } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+import {
+  candidateCardByName,
+  expectModalCandidate,
+  findCandidateByNameNoReload,
+  resolverDialog,
+} from './helpers/imports-helpers'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
+const API_HEADERS = {
+  'X-API-Key': API_KEY,
+  'Content-Type': 'application/json',
+}
+
+/** Marker used to prove no full page load happened after it was planted. */
+const SENTINEL = '__crmNoReloadSentinel'
+
+type SentinelWindow = Window & { [SENTINEL]?: boolean }
+
+async function plantNoReloadSentinel(page: Page): Promise<void> {
+  await page.evaluate(name => {
+    ;(window as SentinelWindow)[name as typeof SENTINEL] = true
+  }, SENTINEL)
+}
+
+async function noReloadSentinelSurvived(page: Page): Promise<boolean> {
+  return page.evaluate(
+    name => (window as SentinelWindow)[name as typeof SENTINEL] === true,
+    SENTINEL
+  )
+}
+
+test.describe('Import link invalidates contact detail @area:imports', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  // spec: IMP-040[0]
+  test("linked candidate's new method appears on the contact detail without a refresh", async ({
+    page,
+    request,
+  }) => {
+    // This test walks four surfaces client-side (detail -> imports -> link ->
+    // contacts -> detail) and cannot shortcut any of them with a goto, since a
+    // hard navigation would discard the cache under test. The default 30s
+    // budget is not enough for that route on the dev server.
+    test.setTimeout(120_000)
+
+    const prefix = testApi.prefix
+    // Distinct values so the candidate does not auto-match the contact: the
+    // link must be the explicit user action this spec drives.
+    const seededEmail = `${prefix}-seeded@example.test`
+    const candidateEmail = `${prefix}-linked@example.test`
+    const contactName = `${prefix}-Invalidation Target`
+    const candidateName = `${prefix}-Invalidation Candidate`
+
+    const { ids: contactIds } = await testApi.seedContacts([
+      {
+        full_name: 'Invalidation Target',
+        methods: [{ type: 'email', value: seededEmail, is_primary: true }],
+      },
+    ])
+    const contactId = contactIds[0]
+
+    // A second candidate keeps the review queue non-empty after the link. On a
+    // clean E2E database the seeded candidate would otherwise be the last one,
+    // and the resolver modal crashes its host page while unwinding an emptied
+    // queue — a pre-existing defect unrelated to cache invalidation, which
+    // would take the nav with it and strand the rest of this test.
+    const { ids: externalIds } = await testApi.seedExternalContacts([
+      { display_name: 'Invalidation Candidate', emails: [candidateEmail] },
+      { display_name: 'Invalidation Bystander', emails: [`${prefix}-bystander@example.test`] },
+    ])
+    const externalId = externalIds[0]
+
+    // --- Step 1: populate the contact detail cache -------------------------
+    // The only hard navigation in this test. Everything after the sentinel is
+    // planted must stay client-side.
+    await page.goto(`/contacts/${contactId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    // The seeded method proves the detail query actually resolved and is now
+    // cached — without this, "candidate email absent" would be trivially true
+    // on a page that never loaded, and the cache under test would not exist.
+    await expect(page.getByText(seededEmail)).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(candidateEmail)).toHaveCount(0)
+
+    await plantNoReloadSentinel(page)
+
+    // --- Step 2: suppress rematch-watcher registration ---------------------
+    // useLinkCandidate registers a RematchJobWatcher whenever the link response
+    // carries a rematch_job_id, and that watcher independently invalidates
+    // contactKeys.detail on job completion
+    // (frontend/src/components/providers/rematch-job-watcher.tsx). Email is
+    // rematch-eligible, so without this the detail cache would be invalidated
+    // by that path regardless of the import:linked rule under test.
+    //
+    // Stripping the id from the response is what makes the import:linked rule
+    // the ONLY thing that can invalidate the detail entry.
+    const deliveredLinkBodies: Array<{ data?: { rematch_job_id?: string } }> = []
+
+    await page.route(`**/api/v1/imports/${externalId}/link`, async route => {
+      if (route.request().method() !== 'POST') {
+        return route.fallback()
+      }
+      const response = await route.fetch()
+      const json = (await response.json()) as { data?: { rematch_job_id?: string } }
+      if (json?.data) {
+        delete json.data.rematch_job_id
+      }
+      deliveredLinkBodies.push(json)
+      // Upstream headers are forwarded so the cross-origin CORS headers survive,
+      // but content-length/encoding are dropped: they describe the ORIGINAL
+      // body, and re-serializing without rematch_job_id changes its length. A
+      // stale content-length truncates the body and the app blows up parsing it.
+      const headers = { ...response.headers() }
+      delete headers['content-length']
+      delete headers['content-encoding']
+      await route.fulfill({
+        status: response.status(),
+        headers,
+        contentType: 'application/json',
+        body: JSON.stringify(json),
+      })
+    })
+
+    // --- Step 3: link the candidate, client-side throughout ----------------
+    // Scoped to the app nav: these are next/link anchors, so the transition is
+    // client-side and the query cache survives it.
+    const nav = page.getByRole('navigation').first()
+    await nav.getByRole('link', { name: 'Imports' }).click()
+    await expect(page).toHaveURL(/\/imports/)
+
+    // findCandidateByName is deliberately NOT used: it calls page.reload() on
+    // retry attempts, which would destroy the very cache under test.
+    await findCandidateByNameNoReload(page, candidateName)
+
+    const card = candidateCardByName(page, candidateName)
+    await card.getByRole('button', { name: /Link/i }).click()
+    await expectModalCandidate(page, candidateName)
+
+    const dialog = resolverDialog(page)
+    await dialog.getByText('Search for a contact...').click()
+    await dialog.getByPlaceholder('Search for a contact...').fill(prefix)
+    const contactOption = dialog.getByText(contactName, { exact: false }).last()
+    await expect(contactOption).toBeVisible({ timeout: 5000 })
+    await contactOption.click()
+
+    // The method comparison only renders once a target contact is chosen. The
+    // candidate's email is offered there, pre-selected by default, so linking
+    // applies it to the contact.
+    await expect(dialog.getByText(candidateEmail)).toBeVisible({ timeout: 10000 })
+
+    const linkResponsePromise = page.waitForResponse(
+      res =>
+        res.url().includes(`/api/v1/imports/${externalId}/link`) &&
+        res.request().method() === 'POST'
+    )
+    await page.getByRole('button', { name: /Link Contact/i }).click()
+    const linkResponse = await linkResponsePromise
+    expect(linkResponse.ok()).toBe(true)
+
+    // --- Step 4: prove the watcher suppression actually happened -----------
+    // A page.route that silently fails to match leaves the watcher registered
+    // and this whole test vacuous, so the interception is asserted rather than
+    // assumed.
+    expect(deliveredLinkBodies.length, 'link response interception must have fired').toBe(1)
+    expect(
+      deliveredLinkBodies[0]?.data,
+      'intercepted response body should have been delivered'
+    ).toBeTruthy()
+    expect(
+      deliveredLinkBodies[0]?.data?.rematch_job_id,
+      'the response the app received must carry no rematch_job_id'
+    ).toBeUndefined()
+
+    // Server-side proof that the method landed. This separates "the link did
+    // not apply the email" from "the UI did not refresh", so a failure below is
+    // unambiguously about the cache.
+    const contactRes = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
+      headers: API_HEADERS,
+    })
+    expect(contactRes.ok()).toBe(true)
+    const contactBody = await contactRes.json()
+    const methods: Array<{ type: string; value: string }> = contactBody?.data?.methods ?? []
+    expect(
+      methods.some(m => m.type === 'email' && m.value === candidateEmail),
+      'linking should have added the candidate email server-side'
+    ).toBe(true)
+
+    // A render crash replaces the whole app with the error boundary, which
+    // takes the nav with it and turns every later step into an unexplained
+    // locator timeout. Assert it directly so a crash names itself.
+    await expect(page.getByRole('heading', { name: 'Something went wrong' })).toHaveCount(0)
+
+    // --- Step 5: navigate back to the contact, still client-side -----------
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden({ timeout: 10000 })
+
+    await nav.getByRole('link', { name: 'Contacts' }).click()
+    await expect(page).toHaveURL(/\/contacts/)
+    await page.getByPlaceholder('Search contacts...').fill(prefix)
+    const contactLink = page.getByRole('link', { name: contactName, exact: true })
+    await expect(contactLink).toBeVisible({ timeout: 15000 })
+    await contactLink.click()
+
+    // --- Step 6: the assertion this spec exists for ------------------------
+    // Without the import:linked detail invalidation, the detail entry cached in
+    // step 1 is still fresh (staleTime is five minutes in production) and the
+    // remount serves it, so the newly linked email never appears.
+    await expect(page.getByText(candidateEmail)).toBeVisible({ timeout: 15000 })
+
+    // --- Step 7: prove the whole run was reload-free ------------------------
+    // A full page load from ANY source — a stray goto, a helper's reload, an
+    // app-level window.location — wipes the query cache and makes step 6 pass
+    // regardless of the fix. The sentinel turns that into a loud failure.
+    expect(
+      await noReloadSentinelSurvived(page),
+      'a full page load occurred, which discards the query cache and makes this test vacuous'
+    ).toBe(true)
+  })
+})

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -487,6 +487,26 @@ behaviors:
       - dismissal resolves nothing — the candidate stays unmatched in its queue, and an uncommitted name edit is discarded
     provenance: [suggestion-modal.tsx onClose paths, Escape keydown handler, handleCancelNameEdit]
 
+  - id: IMP-040
+    title: A linked candidate's new methods appear on the contact without a manual refresh
+    type: ux
+    status: current
+    surface: ui
+    given: a contact whose detail view has already been viewed in this session
+    when: an import candidate is linked to that contact, adding a method
+    then:
+      - returning to the contact's detail view shows the newly added method, with no manual refresh or hard reload
+    provenance: ['invalidationRules import:linked', 'useLinkCandidate onSuccess']
+    notes: >
+      The detail view is cached for five minutes in production, so the linked
+      enrichment is only visible if the link invalidates the contact's detail
+      entry. The citing E2E must run under the production cache — it imports
+      @playwright/test rather than the custom fixture, which sets staleTime to
+      0 — must suppress rematch-watcher registration so the assertion cannot
+      be satisfied by RematchJobWatcher's own invalidation, and must
+      navigate client-side rather than via a hard reload, which would discard
+      the cache the behavior is about.
+
   # --- Proposed ---
 
   - id: IMP-032


### PR DESCRIPTION
## What

`import:linked` now invalidates the per-contact detail key, so a contact page already in cache refetches after a link enriches it.

`frontend/src/lib/query-invalidation.ts` mapped `'import:linked'` to `[importKeys.lists(), importKeys.suggestionsLists(), contactKeys.lists()]` — omitting the `(contactId) => contactKeys.detail(contactId)` factory entry that every sibling enrich-an-existing-contact rule already has (`method-suggestion:resolved`, `meeting-note:resolved`, `name-candidate:resolved`). `useLinkCandidate` now supplies the linked contact id at the call site; it already held `crm_contact_id`, so no new plumbing was needed.

The rule's own comment — "Linking enriches an existing contact" — described behavior it did not implement.

## Why

First of three PRs fixing a real data-loss incident. A contact method added server-side by import-link enrichment was permanently destroyed by a subsequent edit-form save.

Two defects compounded. This PR fixes the first: the contact detail page showed a stale method list after a link, so the enriched method appeared missing when it was present in the database. The remediation that observation prompted then triggered the second defect — a wholesale delete-and-recreate on `PUT /contacts/:id` — which is fixed in PR2 and PR3.

Design: `.ai/spec/2026-07-18-contact-method-lost-update-design.md` (included in this PR).

## Tests

Every test was run against the unfixed tree and observed to fail **on its intended assertion**, per arc invariant I5. This workstream has found five tests that would have passed whether or not the code worked, three of which would have shipped as green coverage — so discrimination is verified, not assumed.

| Test | Mutation | Observed failure |
|---|---|---|
| detail-key invalidation | source reverted | `expected 4 times, but got 3 times` |
| static-keys-without-contact-id | factories called with undefined id instead of skipped | `expected 3 times, but got 4 times` |
| `useLinkCandidate` × 2 | call site reverted | `expected to be called with ['import:linked', ...]` |
| E2E step 6 | both source edits reverted | fails at the cached-view assertion, all earlier steps green including server-side proof the method was added |
| no-reload sentinel | `page.reload()` injected after the detail page settles | fails on the sentinel |
| interception assertion | route glob broken | `link response interception must have fired` |

The E2E avoids three known vacuity traps: it imports ordinary `@playwright/test` (the custom fixture sets `staleTime: 0`, which would make any stale-cache assertion vacuous), suppresses `RematchJobWatcher`'s independent invalidation of the same key, and never uses a hard `page.goto` after the sentinel.

`IMP-040[0]` coverage attribution was verified by removing the citation and confirming orphans rose to 1.

## Notes

- A pre-existing crash was found and worked around, not fixed: resolving the **last** import candidate drops the app into the error boundary (#692). Worked around by seeding a bystander candidate so the queue never empties. The spec now asserts the error boundary is absent, so a future regression names itself instead of presenting as a locator timeout.
- Two small plan deviations: the email-method assertion moved after contact selection (the modal renders a placeholder until then), and `test.setTimeout(120_000)` for an all-client-side route across four surfaces on a cold dev server. Neither changes what the test proves.
- `test-map.json` needed no edit — the existing `^frontend/tests/e2e/imports(-[a-z]+)*\.spec\.ts$` pattern matches the new filename.
