### PR TITLE
feat(contacts): add POST /contacts/:id/methods operations endpoint

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -268,7 +268,7 @@ func run() int {
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	// Core HTTP handlers.
-	handlersCore := buildCoreHandlers(core, contactService, graph, cfg, noteService, manualHandler)
+	handlersCore := buildCoreHandlers(database, core, contactService, graph, cfg, noteService, manualHandler, eventBus)
 	contactHandler := handlersCore.Contact
 	noteHandler := handlersCore.Note
 	interactionHandler := handlersCore.Interaction
@@ -334,6 +334,7 @@ func run() int {
 		ContactHandler:           contactHandler,
 		InteractionHandler:       interactionHandler,
 		NoteHandler:              noteHandler,
+		ContactMethodHandler:     handlersCore.ContactMethod,
 		RematchHandler:           rematchHandler,
 		StalenessHandler:         stalenessHandler,
 		SystemHandler:            systemHandler,

--- a/backend/cmd/crm-api/routes.go
+++ b/backend/cmd/crm-api/routes.go
@@ -39,12 +39,13 @@ type routeDeps struct {
 	MeetingNoteHandler *handlers.MeetingNoteHandler
 
 	// Core (always-on)
-	ContactHandler     *handlers.ContactHandler
-	InteractionHandler *handlers.InteractionHandler
-	NoteHandler        *handlers.NoteHandler
-	RematchHandler     *handlers.RematchHandler
-	StalenessHandler   *handlers.StalenessHandler
-	SystemHandler      *handlers.SystemHandler
+	ContactHandler       *handlers.ContactHandler
+	InteractionHandler   *handlers.InteractionHandler
+	NoteHandler          *handlers.NoteHandler
+	ContactMethodHandler *handlers.ContactMethodHandler
+	RematchHandler       *handlers.RematchHandler
+	StalenessHandler     *handlers.StalenessHandler
+	SystemHandler        *handlers.SystemHandler
 
 	// OAuth / external sync (feature-flagged / nil when unconfigured)
 	OAuthHandler            *handlers.OAuthHandler
@@ -140,9 +141,10 @@ func registerRoutes(deps routeDeps) {
 	{
 		// Contact + interaction routes (unconditional).
 		handlers.RegisterContactRoutes(v1, handlers.ContactRouteDeps{
-			Contact:     deps.ContactHandler,
-			Interaction: deps.InteractionHandler,
-			Note:        deps.NoteHandler,
+			Contact:       deps.ContactHandler,
+			Interaction:   deps.InteractionHandler,
+			Note:          deps.NoteHandler,
+			ContactMethod: deps.ContactMethodHandler,
 		})
 
 		// Meeting-note conflict-resolution — user-driven, called from

--- a/backend/cmd/crm-api/wire_handlers.go
+++ b/backend/cmd/crm-api/wire_handlers.go
@@ -3,39 +3,50 @@ package main
 import (
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/service"
 )
 
 // coreHandlers holds the always-on HTTP handlers consumed by route
 // registration.
 type coreHandlers struct {
-	Contact     *handlers.ContactHandler
-	Note        *handlers.NoteHandler
-	Interaction *handlers.InteractionHandler
-	System      *handlers.SystemHandler
-	Rematch     *handlers.RematchHandler
+	Contact       *handlers.ContactHandler
+	Note          *handlers.NoteHandler
+	Interaction   *handlers.InteractionHandler
+	System        *handlers.SystemHandler
+	Rematch       *handlers.RematchHandler
+	ContactMethod *handlers.ContactMethodHandler
 }
 
 // buildCoreHandlers constructs the contact / note / interaction / system /
 // rematch handlers. manualHandler is nil in interaction-mode off (the
 // InteractionHandler tolerates a nil manual handler exactly as today).
 func buildCoreHandlers(
+	database *db.Database,
 	core coreRepos,
 	contactService *service.ContactService,
 	graph graphCore,
 	cfg *config.Config,
 	noteService *service.NoteService,
 	manualHandler *service.ManualInteractionHandler,
+	eventBus *events.Bus,
 ) coreHandlers {
 	contactRepo := core.Contact
 	interactionRepo := core.Interaction
 	rematchService := graph.RematchService
 
+	// Contact methods are mutated by explicit operations rather than by a
+	// desired set, so absence in the payload expresses nothing and a client
+	// cannot destroy a method it never saw.
+	contactMethodService := service.NewContactMethodService(database, eventBus, rematchService)
+
 	return coreHandlers{
-		Contact:     handlers.NewContactHandler(contactService),
-		Note:        handlers.NewNoteHandler(noteService),
-		Interaction: handlers.NewInteractionHandler(interactionRepo, manualHandler),
-		System:      handlers.NewSystemHandler(contactRepo, cfg.Runtime),
-		Rematch:     handlers.NewRematchHandler(rematchService, contactService),
+		Contact:       handlers.NewContactHandler(contactService),
+		Note:          handlers.NewNoteHandler(noteService),
+		Interaction:   handlers.NewInteractionHandler(interactionRepo, manualHandler),
+		System:        handlers.NewSystemHandler(contactRepo, cfg.Runtime),
+		Rematch:       handlers.NewRematchHandler(rematchService, contactService),
+		ContactMethod: handlers.NewContactMethodHandler(contactMethodService),
 	}
 }

--- a/backend/internal/api/handlers/contact_dto.go
+++ b/backend/internal/api/handlers/contact_dto.go
@@ -112,3 +112,54 @@ type MergePreviewResponse struct {
 	InteractionsToTransfer int64           `json:"interactions_to_transfer" example:"12"`
 	CalendarEventsToUpdate int64           `json:"calendar_events_to_update" example:"3"`
 }
+
+// ContactMethodOperation is one requested contact-method mutation.
+//
+// The endpoint takes OPERATIONS, never a desired set. A desired set makes
+// absence mean "delete", so a client working from a stale read destroys every
+// method it never saw — the defect this endpoint exists to make unexpressible.
+// @Description A single contact-method operation
+type ContactMethodOperation struct {
+	Op       string `json:"op" validate:"required,oneof=add update remove set_primary clear_primary" example:"add"`
+	MethodID string `json:"method_id,omitempty" validate:"omitempty,uuid" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Type     string `json:"type,omitempty" validate:"omitempty,oneof=email phone telegram discord twitter signal gchat whatsapp" example:"email" tstype:"ContactMethodType"`
+	Value    string `json:"value,omitempty" validate:"omitempty,max=255" example:"john.doe@example.com"`
+	// IsPrimary is a pointer so the handler can tell "absent" from "present and
+	// false". The field is forbidden on update, which is a presence test — a
+	// plain bool would silently accept an explicit false.
+	IsPrimary *bool `json:"is_primary,omitempty" example:"true"`
+}
+
+// ContactMethodOperationsRequest is the operations payload.
+// @Description Contact-method operations request
+// An empty or absent operations list is a successful no-op, so the slice is
+// deliberately NOT `required` — that tag fails a zero-length slice and would
+// turn "nothing to do" into a 400.
+type ContactMethodOperationsRequest struct {
+	Operations []ContactMethodOperation `json:"operations" validate:"dive"`
+}
+
+// ContactMethodOperationResult reports what happened to one SUBMITTED
+// operation, at that operation's own request index.
+//
+// Method is present only where the operation leaves a surviving row. A removal
+// carries no snapshot: a removed row has no post-apply state, and an idempotent
+// removal of an already-absent id has no row at all. MethodID is always the id
+// the operation addressed.
+// @Description Result of a single contact-method operation
+type ContactMethodOperationResult struct {
+	Index    int                    `json:"index" example:"0"`
+	Outcome  string                 `json:"outcome" example:"created"`
+	MethodID string                 `json:"method_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Method   *ContactMethodResponse `json:"method,omitempty"`
+}
+
+// ContactMethodOperationsResponse carries the contact's full method list after
+// applying, a rematch job id when one was enqueued, and one result per
+// submitted operation.
+// @Description Contact-method operations response
+type ContactMethodOperationsResponse struct {
+	Methods      []ContactMethodResponse        `json:"methods"`
+	RematchJobID string                         `json:"rematch_job_id,omitempty" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Results      []ContactMethodOperationResult `json:"results"`
+}

--- a/backend/internal/api/handlers/contact_method.go
+++ b/backend/internal/api/handlers/contact_method.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
+)
+
+// ContactMethodApplier is the narrow contract the handler depends on.
+//
+// Declared as an interface rather than the concrete service so the handler's
+// error-to-HTTP mapping is testable with a stub. That matters specifically for
+// ErrMethodValueConflict: a correct fold rejects trigger collisions before any
+// statement runs, so the database backstop cannot be reached from a real
+// request, and its HTTP translation would otherwise have no test at all.
+type ContactMethodApplier interface {
+	ApplyOperations(ctx context.Context, contactID uuid.UUID, ops []service.ContactMethodOperation) (*service.ApplyContactMethodsResult, error)
+}
+
+// ContactMethodHandler serves POST /contacts/:id/methods.
+type ContactMethodHandler struct {
+	service   ContactMethodApplier
+	validator *validator.Validate
+}
+
+func NewContactMethodHandler(svc ContactMethodApplier) *ContactMethodHandler {
+	return &ContactMethodHandler{service: svc, validator: sharedValidator}
+}
+
+// ApplyOperations applies contact-method operations transactionally
+// @Summary Apply contact-method operations
+// @Description Apply a batch of add/update/remove/set_primary/clear_primary operations to a contact's methods in one transaction. Absence expresses nothing: a method no operation names is never removed or altered.
+// @Tags contacts
+// @Accept json
+// @Produce json
+// @Param id path string true "Contact ID"
+// @Param operations body ContactMethodOperationsRequest true "Operations to apply"
+// @Success 200 {object} api.APIResponse{data=ContactMethodOperationsResponse}
+// @Failure 400 {object} api.APIResponse{error=api.APIError} "Malformed, conflicting, or unsatisfiable operations"
+// @Failure 404 {object} api.APIResponse{error=api.APIError} "Contact not found, or an operation names a method owned by another contact"
+// @Failure 500 {object} api.APIResponse{error=api.APIError} "Internal server error"
+// @Router /contacts/{id}/methods [post]
+func (h *ContactMethodHandler) ApplyOperations(c *gin.Context) {
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
+		return
+	}
+
+	var req ContactMethodOperationsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		api.SendValidationError(c, "Invalid request body", err.Error())
+		return
+	}
+	if err := h.validator.Struct(&req); err != nil {
+		api.SendValidationError(c, "Invalid operations", err.Error())
+		return
+	}
+
+	ops, err := buildContactMethodOperations(h.validator, req.Operations)
+	if err != nil {
+		api.SendValidationError(c, "Invalid operations", err.Error())
+		return
+	}
+
+	result, err := h.service.ApplyOperations(c.Request.Context(), contactID, ops)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrInvalidOperations),
+			errors.Is(err, repository.ErrMethodValueConflict):
+			// The conflict case is the database backstop surfacing as the same
+			// deterministic 400 the fold would have produced, so a client
+			// cannot tell which layer rejected it.
+			api.SendValidationError(c, "Invalid operations", err.Error())
+		case errors.Is(err, service.ErrMethodNotOwned):
+			api.SendNotFound(c, "Contact method")
+		case errors.Is(err, db.ErrNotFound):
+			api.SendNotFound(c, "Contact")
+		default:
+			api.RespondInternal(c, err)
+		}
+		return
+	}
+
+	api.SendSuccess(c, http.StatusOK, contactMethodOperationsToResponse(result), nil)
+}
+
+// buildContactMethodOperations converts wire operations to service operations,
+// enforcing the value FORMAT rules the create path uses.
+//
+// Blank handling deliberately differs from the create path and is enforced in
+// the service: create drops a blank value, while an explicit add or update with
+// a blank value is rejected. Dropping it here would turn an unsatisfiable
+// intent into a successful-looking no-op.
+func buildContactMethodOperations(validate *validator.Validate, ops []ContactMethodOperation) ([]service.ContactMethodOperation, error) {
+	out := make([]service.ContactMethodOperation, len(ops))
+	for i, op := range ops {
+		converted := service.ContactMethodOperation{
+			Op:        op.Op,
+			Type:      op.Type,
+			Value:     op.Value,
+			IsPrimary: op.IsPrimary,
+		}
+		if op.MethodID != "" {
+			id, err := uuid.Parse(op.MethodID)
+			if err != nil {
+				return nil, err
+			}
+			converted.MethodID = &id
+		}
+		// Format rules apply only where a value is actually being asserted.
+		// A blank value is the service's call to reject, not a format failure.
+		if (op.Op == service.MethodOpAdd || op.Op == service.MethodOpUpdate) && op.Value != "" {
+			if err := validateContactMethodValueFormat(validate, op.Type, op.Value); err != nil {
+				return nil, err
+			}
+		}
+		out[i] = converted
+	}
+	return out, nil
+}
+
+func contactMethodOperationsToResponse(result *service.ApplyContactMethodsResult) ContactMethodOperationsResponse {
+	resp := ContactMethodOperationsResponse{
+		Methods: make([]ContactMethodResponse, len(result.Methods)),
+		Results: make([]ContactMethodOperationResult, len(result.Results)),
+	}
+	for i, m := range result.Methods {
+		resp.Methods[i] = contactMethodToResponse(m)
+	}
+	if result.RematchJobID != uuid.Nil {
+		resp.RematchJobID = result.RematchJobID.String()
+	}
+	for i, r := range result.Results {
+		entry := ContactMethodOperationResult{
+			Index:    r.Index,
+			Outcome:  r.Outcome,
+			MethodID: r.MethodID.String(),
+		}
+		if r.Method != nil {
+			snapshot := contactMethodToResponse(*r.Method)
+			entry.Method = &snapshot
+		}
+		resp.Results[i] = entry
+	}
+	return resp
+}
+
+// validateContactMethodValueFormat applies the same per-type format rules the
+// create path uses (handlers.validateContactMethods). Shared deliberately: only
+// the blank-value handling differs between the two paths, and that difference
+// lives in the service.
+func validateContactMethodValueFormat(validate *validator.Validate, methodType, value string) error {
+	switch methodType {
+	case string(repository.ContactMethodEmail),
+		string(repository.ContactMethodGChat):
+		if err := validate.Var(value, "email"); err != nil {
+			return fmt.Errorf("invalid email for contact method %s", methodType)
+		}
+	case string(repository.ContactMethodPhone),
+		string(repository.ContactMethodSignal),
+		string(repository.ContactMethodWhatsApp):
+		if len(value) > 50 {
+			return fmt.Errorf("contact method %s must be less than 50 characters", methodType)
+		}
+	}
+	return nil
+}

--- a/backend/internal/api/handlers/contact_method.go
+++ b/backend/internal/api/handlers/contact_method.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
@@ -74,16 +73,18 @@ func (h *ContactMethodHandler) ApplyOperations(c *gin.Context) {
 
 	result, err := h.service.ApplyOperations(c.Request.Context(), contactID, ops)
 	if err != nil {
+		// Service-owned errors ONLY. Branching on repository.ErrMethodValueConflict
+		// or db.ErrNotFound here would reach across the service boundary for a
+		// persistence classification, which is a layer skip. The service folds
+		// both into the errors below, so the database backstop still surfaces as
+		// the same deterministic 400 the fold would have produced and a client
+		// cannot tell which layer rejected it.
 		switch {
-		case errors.Is(err, service.ErrInvalidOperations),
-			errors.Is(err, repository.ErrMethodValueConflict):
-			// The conflict case is the database backstop surfacing as the same
-			// deterministic 400 the fold would have produced, so a client
-			// cannot tell which layer rejected it.
+		case errors.Is(err, service.ErrInvalidOperations):
 			api.SendValidationError(c, "Invalid operations", err.Error())
 		case errors.Is(err, service.ErrMethodNotOwned):
 			api.SendNotFound(c, "Contact method")
-		case errors.Is(err, db.ErrNotFound):
+		case errors.Is(err, service.ErrContactNotFound):
 			api.SendNotFound(c, "Contact")
 		default:
 			api.RespondInternal(c, err)

--- a/backend/internal/api/handlers/contact_routes.go
+++ b/backend/internal/api/handlers/contact_routes.go
@@ -7,9 +7,10 @@ import "github.com/gin-gonic/gin"
 // merge preview/apply pair all live under /contacts and are served by
 // three distinct handlers, so the deps struct carries all three.
 type ContactRouteDeps struct {
-	Contact     *ContactHandler
-	Interaction *InteractionHandler
-	Note        *NoteHandler
+	Contact       *ContactHandler
+	Interaction   *InteractionHandler
+	Note          *NoteHandler
+	ContactMethod *ContactMethodHandler
 }
 
 // RegisterContactRoutes wires the unconditional contact + interaction
@@ -25,6 +26,7 @@ type ContactRouteDeps struct {
 //   - GET    /api/v1/contacts/:id/interactions
 //   - POST   /api/v1/contacts/:id/interactions
 //   - GET    /api/v1/contacts/:id/notes
+//   - POST   /api/v1/contacts/:id/methods
 //   - PUT    /api/v1/contacts/:id/notes
 //   - GET    /api/v1/contacts/:id/merge/preview
 //   - POST   /api/v1/contacts/:id/merge
@@ -43,6 +45,10 @@ func RegisterContactRoutes(v1 *gin.RouterGroup, deps ContactRouteDeps) {
 		contacts.DELETE("/:id", deps.Contact.DeleteContact)
 		contacts.GET("/:id/interactions", deps.Interaction.ListContactInteractions)
 		contacts.POST("/:id/interactions", deps.Interaction.CreateInteraction)
+		// POST with OPERATIONS, deliberately never PUT with a desired set: a
+		// PUT taking the full list is wholesale replace wearing a sub-resource
+		// costume, where absence would again imply deletion.
+		contacts.POST("/:id/methods", deps.ContactMethod.ApplyOperations)
 		contacts.GET("/:id/notes", deps.Note.GetContactNotepad)
 		contacts.PUT("/:id/notes", deps.Note.SaveContactNotepad)
 		// Merge routes

--- a/backend/internal/db/contact_method.sql.go
+++ b/backend/internal/db/contact_method.sql.go
@@ -53,6 +53,24 @@ func (q *Queries) CreateContactMethod(ctx context.Context, arg CreateContactMeth
 	return &i, err
 }
 
+const DeleteContactMethodByContact = `-- name: DeleteContactMethodByContact :exec
+DELETE FROM contact_method
+WHERE id = $1
+  AND contact_id = $2
+`
+
+type DeleteContactMethodByContactParams struct {
+	ID        pgtype.UUID `json:"id"`
+	ContactID pgtype.UUID `json:"contact_id"`
+}
+
+// Contact-scoped single-row delete. Used both for removals and for the first
+// phase of the delete-and-reinsert applied to key-changing rows.
+func (q *Queries) DeleteContactMethodByContact(ctx context.Context, arg DeleteContactMethodByContactParams) error {
+	_, err := q.db.Exec(ctx, DeleteContactMethodByContact, arg.ID, arg.ContactID)
+	return err
+}
+
 const DeleteContactMethodsByContact = `-- name: DeleteContactMethodsByContact :exec
 DELETE FROM contact_method
 WHERE contact_id = $1
@@ -60,6 +78,28 @@ WHERE contact_id = $1
 
 func (q *Queries) DeleteContactMethodsByContact(ctx context.Context, contactID pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, DeleteContactMethodsByContact, contactID)
+	return err
+}
+
+const DemoteContactMethodPrimaryByContact = `-- name: DemoteContactMethodPrimaryByContact :exec
+UPDATE contact_method
+SET is_primary = FALSE
+WHERE id = $1
+  AND contact_id = $2
+`
+
+type DemoteContactMethodPrimaryByContactParams struct {
+	ID        pgtype.UUID `json:"id"`
+	ContactID pgtype.UUID `json:"contact_id"`
+}
+
+// Clears is_primary on ONE named row of ONE contact.
+//
+// Scoped by BOTH contact_id and id, deliberately. A contact-only demote would
+// clear whichever row happened to be primary, which is the global-demotion
+// behavior that lets a stale client drop a primary it never saw.
+func (q *Queries) DemoteContactMethodPrimaryByContact(ctx context.Context, arg DemoteContactMethodPrimaryByContactParams) error {
+	_, err := q.db.Exec(ctx, DemoteContactMethodPrimaryByContact, arg.ID, arg.ContactID)
 	return err
 }
 
@@ -117,6 +157,69 @@ func (q *Queries) FindMethodsByNormalizedValue(ctx context.Context, arg FindMeth
 		return nil, err
 	}
 	return items, nil
+}
+
+const InsertContactMethodWithIdentity = `-- name: InsertContactMethodWithIdentity :one
+INSERT INTO contact_method (
+    id,
+    contact_id,
+    type,
+    value,
+    value_normalized,
+    is_primary,
+    created_at
+) VALUES (
+    $1, $2, $3, $4, '', $5, $6
+) RETURNING id, contact_id, type, value, is_primary, created_at, updated_at, value_normalized
+`
+
+type InsertContactMethodWithIdentityParams struct {
+	ID        pgtype.UUID        `json:"id"`
+	ContactID pgtype.UUID        `json:"contact_id"`
+	Type      string             `json:"type"`
+	Value     string             `json:"value"`
+	IsPrimary pgtype.Bool        `json:"is_primary"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+// Inserts a contact method with an EXPLICIT id and created_at so the apply
+// stage can delete a row whose (type, value_normalized) key changed and put it
+// back with its identity intact. Genuinely new rows pass generated values for
+// the same two columns, so one query serves both cases.
+//
+// is_primary is always supplied as FALSE by the apply stage: promotion is the
+// last step, which is what keeps idx_contact_method_primary from being
+// violated mid-apply.
+//
+// Deliberately NO "ON CONFLICT DO NOTHING": the in-memory fold has already
+// proven the row is absent, so a conflict here means the fold is wrong and
+// must fail loudly rather than be swallowed.
+//
+// value_normalized is written by the set_contact_method_value_normalized
+// trigger (migration 022), which overwrites whatever is passed. The
+// placeholder below is never the stored value — do not read the returned
+// value_normalized as confirmation of what Go computed.
+func (q *Queries) InsertContactMethodWithIdentity(ctx context.Context, arg InsertContactMethodWithIdentityParams) (*ContactMethod, error) {
+	row := q.db.QueryRow(ctx, InsertContactMethodWithIdentity,
+		arg.ID,
+		arg.ContactID,
+		arg.Type,
+		arg.Value,
+		arg.IsPrimary,
+		arg.CreatedAt,
+	)
+	var i ContactMethod
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Type,
+		&i.Value,
+		&i.IsPrimary,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ValueNormalized,
+	)
+	return &i, err
 }
 
 const ListCanonicalIdentifiersByType = `-- name: ListCanonicalIdentifiersByType :many
@@ -295,6 +398,66 @@ func (q *Queries) ListGChatIdentitiesForSync(ctx context.Context) ([]*ListGChatI
 	return items, nil
 }
 
+const LookupContactMethodOwner = `-- name: LookupContactMethodOwner :one
+SELECT contact_id FROM contact_method
+WHERE id = $1
+`
+
+// Returns the owning contact_id for a method id, regardless of which contact
+// owns it. This is what separates "this id belongs to another contact" (404 --
+// a method id is not a capability) from "this id does not exist at all"
+// (a removal succeeds as a no-op, so a retried removal is idempotent). Those
+// two cases are indistinguishable from one contact's pre-state alone.
+func (q *Queries) LookupContactMethodOwner(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, LookupContactMethodOwner, id)
+	var contact_id pgtype.UUID
+	err := row.Scan(&contact_id)
+	return contact_id, err
+}
+
+const NormalizeContactMethodValueViaTrigger = `-- name: NormalizeContactMethodValueViaTrigger :one
+SELECT normalize_contact_method_value($1::TEXT, $2::TEXT) AS normalized
+`
+
+type NormalizeContactMethodValueViaTriggerParams struct {
+	MethodType string `json:"method_type"`
+	RawValue   string `json:"raw_value"`
+}
+
+// TEST-ONLY. Calls the live normalize_contact_method_value function so the
+// C6 parity test can compare the Go mirror against the actual SQL that the
+// unique index is enforced over. Raw SQL is banned in Go including tests
+// (.ai/rules/core.md), so this query is the permitted access path.
+//
+// Not used by production code. Do not make it one: production reads the
+// trigger's output from the stored column.
+func (q *Queries) NormalizeContactMethodValueViaTrigger(ctx context.Context, arg NormalizeContactMethodValueViaTriggerParams) (string, error) {
+	row := q.db.QueryRow(ctx, NormalizeContactMethodValueViaTrigger, arg.MethodType, arg.RawValue)
+	var normalized string
+	err := row.Scan(&normalized)
+	return normalized, err
+}
+
+const PromoteContactMethodPrimaryByContact = `-- name: PromoteContactMethodPrimaryByContact :exec
+UPDATE contact_method
+SET is_primary = TRUE
+WHERE id = $1
+  AND contact_id = $2
+`
+
+type PromoteContactMethodPrimaryByContactParams struct {
+	ID        pgtype.UUID `json:"id"`
+	ContactID pgtype.UUID `json:"contact_id"`
+}
+
+// Sets is_primary on one named row of one contact. Added rather than reusing
+// SetContactMethodPrimary, which matches by method id alone and is used by
+// enrichment — changing it would move enrichment behavior.
+func (q *Queries) PromoteContactMethodPrimaryByContact(ctx context.Context, arg PromoteContactMethodPrimaryByContactParams) error {
+	_, err := q.db.Exec(ctx, PromoteContactMethodPrimaryByContact, arg.ID, arg.ContactID)
+	return err
+}
+
 const SetContactMethodPrimary = `-- name: SetContactMethodPrimary :exec
 UPDATE contact_method cm
 SET is_primary = $2,
@@ -315,6 +478,52 @@ type SetContactMethodPrimaryParams struct {
 func (q *Queries) SetContactMethodPrimary(ctx context.Context, arg SetContactMethodPrimaryParams) error {
 	_, err := q.db.Exec(ctx, SetContactMethodPrimary, arg.ID, arg.IsPrimary)
 	return err
+}
+
+const UpdateContactMethodByContact = `-- name: UpdateContactMethodByContact :one
+UPDATE contact_method
+SET type = $1,
+    value = $2
+WHERE id = $3
+  AND contact_id = $4
+RETURNING id, contact_id, type, value, is_primary, created_at, updated_at, value_normalized
+`
+
+type UpdateContactMethodByContactParams struct {
+	Type      string      `json:"type"`
+	Value     string      `json:"value"`
+	ID        pgtype.UUID `json:"id"`
+	ContactID pgtype.UUID `json:"contact_id"`
+}
+
+// In-place value/type update for a row whose (type, value_normalized) key is
+// UNCHANGED — the apply stage's step 4. A key change goes through
+// delete-and-reinsert instead; this query exists for the case where the user
+// edited the stored spelling ("Case@Example.test" -> "case@example.test", or a
+// phone respelling) without moving the normalized key, which steps 1-3 would
+// otherwise silently discard.
+//
+// Scoped by contact_id as well as id so a method id from another contact can
+// never be acted on.
+func (q *Queries) UpdateContactMethodByContact(ctx context.Context, arg UpdateContactMethodByContactParams) (*ContactMethod, error) {
+	row := q.db.QueryRow(ctx, UpdateContactMethodByContact,
+		arg.Type,
+		arg.Value,
+		arg.ID,
+		arg.ContactID,
+	)
+	var i ContactMethod
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Type,
+		&i.Value,
+		&i.IsPrimary,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ValueNormalized,
+	)
+	return &i, err
 }
 
 const UpdateContactMethodValue = `-- name: UpdateContactMethodValue :one

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -410,6 +410,9 @@ type Querier interface {
 	DeleteCalendarEventByGcalID(ctx context.Context, arg DeleteCalendarEventByGcalIDParams) error
 	DeleteCalendarEventsByGcalEventIdPrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
 	DeleteCalendarEventsByTitlePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
+	// Contact-scoped single-row delete. Used both for removals and for the first
+	// phase of the delete-and-reinsert applied to key-changing rows.
+	DeleteContactMethodByContact(ctx context.Context, arg DeleteContactMethodByContactParams) error
 	DeleteContactMethodsByContact(ctx context.Context, contactID pgtype.UUID) error
 	// Delete a note for a contact by category
 	DeleteContactNoteByCategory(ctx context.Context, arg DeleteContactNoteByCategoryParams) error
@@ -513,6 +516,12 @@ type Querier interface {
 	DeleteTelegramMessagesByPeerUserID(ctx context.Context, peerUserID pgtype.Int8) (int64, error)
 	DeleteTelegramSession(ctx context.Context) error
 	DeleteTelegramUpdateState(ctx context.Context, userID int64) error
+	// Clears is_primary on ONE named row of ONE contact.
+	//
+	// Scoped by BOTH contact_id and id, deliberately. A contact-only demote would
+	// clear whichever row happened to be primary, which is the global-demotion
+	// behavior that lets a stale client drop a primary it never saw.
+	DemoteContactMethodPrimaryByContact(ctx context.Context, arg DemoteContactMethodPrimaryByContactParams) error
 	// Demote source's primary contact methods when the target already has a primary.
 	// The one-primary rule is per contact — idx_contact_method_primary is a unique
 	// partial index on (contact_id) WHERE is_primary = TRUE — so the source's primary
@@ -1002,6 +1011,24 @@ type Querier interface {
 	// full bi-temporal envelope. knowledge_from is the learned-at clock; valid_from
 	// is set only from content evidence (NULL = open-ended), never defaulted to now.
 	InsertAssertion(ctx context.Context, arg InsertAssertionParams) (*Assertion, error)
+	// Inserts a contact method with an EXPLICIT id and created_at so the apply
+	// stage can delete a row whose (type, value_normalized) key changed and put it
+	// back with its identity intact. Genuinely new rows pass generated values for
+	// the same two columns, so one query serves both cases.
+	//
+	// is_primary is always supplied as FALSE by the apply stage: promotion is the
+	// last step, which is what keeps idx_contact_method_primary from being
+	// violated mid-apply.
+	//
+	// Deliberately NO "ON CONFLICT DO NOTHING": the in-memory fold has already
+	// proven the row is absent, so a conflict here means the fold is wrong and
+	// must fail loudly rather than be swallowed.
+	//
+	// value_normalized is written by the set_contact_method_value_normalized
+	// trigger (migration 022), which overwrites whatever is passed. The
+	// placeholder below is never the stored value — do not read the returned
+	// value_normalized as confirmation of what Go computed.
+	InsertContactMethodWithIdentity(ctx context.Context, arg InsertContactMethodWithIdentityParams) (*ContactMethod, error)
 	// Event queries (spec §3.1, §3.3). Raw append-only event log.
 	// Insert an event; conflicts on (source, source_id) (when source_id is not
 	// NULL) return zero rows so the caller can treat as idempotent no-op. When
@@ -1419,6 +1446,12 @@ type Querier interface {
 	// committed interaction would be missed. Returns db.ErrNotFound (pgx.ErrNoRows)
 	// when the contact was soft-deleted.
 	LockContactForDateRecompute(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error)
+	// Returns the owning contact_id for a method id, regardless of which contact
+	// owns it. This is what separates "this id belongs to another contact" (404 --
+	// a method id is not a capability) from "this id does not exist at all"
+	// (a removal succeeds as a no-op, so a retried removal is idempotent). Those
+	// two cases are indistinguishable from one contact's pre-state alone.
+	LookupContactMethodOwner(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error)
 	// Single-statement batch mark for the action=ignore ("Not a person")
 	// resolve path: every live unmatched sibling for the token flips to
 	// 'ignored'. No crm_contact_id is set. Same predicate as the other two
@@ -1533,6 +1566,14 @@ type Querier interface {
 	//     rows were already linked to res.Interaction.ID on the original
 	//     attempt; processed_at IS NOT NULL now filters them out.
 	MarkTelegramMessagesProcessedForSession(ctx context.Context, arg MarkTelegramMessagesProcessedForSessionParams) (int64, error)
+	// TEST-ONLY. Calls the live normalize_contact_method_value function so the
+	// C6 parity test can compare the Go mirror against the actual SQL that the
+	// unique index is enforced over. Raw SQL is banned in Go including tests
+	// (.ai/rules/core.md), so this query is the permitted access path.
+	//
+	// Not used by production code. Do not make it one: production reads the
+	// trigger's output from the stored column.
+	NormalizeContactMethodValueViaTrigger(ctx context.Context, arg NormalizeContactMethodValueViaTriggerParams) (string, error)
 	// The earliest scheduled_at among jobs that are due now but not yet picked up
 	// by a worker — the stall signal for a starved/dead worker pool. scheduled_at
 	// is the next-eligibility time: for 'available' it equals creation time, for
@@ -1552,6 +1593,10 @@ type Querier interface {
 	// aggregate's generated type. The repository maps NULL to a nil *time.Time
 	// ("no due jobs").
 	OldestDueRiverJobScheduledAt(ctx context.Context, now pgtype.Timestamptz) (pgtype.Timestamptz, error)
+	// Sets is_primary on one named row of one contact. Added rather than reusing
+	// SetContactMethodPrimary, which matches by method id alone and is used by
+	// enrichment — changing it would move enrichment behavior.
+	PromoteContactMethodPrimaryByContact(ctx context.Context, arg PromoteContactMethodPrimaryByContactParams) error
 	RemoveContactTag(ctx context.Context, arg RemoveContactTagParams) error
 	// Replace source contact ID with target contact ID in calendar event matched_contact_ids array
 	// Uses array_replace for efficient in-place replacement
@@ -2549,6 +2594,16 @@ type Querier interface {
 	// current value). updated_at is intentionally NOT bumped — a cache refresh
 	// is bookkeeping, not a user profile edit.
 	UpdateContactLocationCache(ctx context.Context, arg UpdateContactLocationCacheParams) error
+	// In-place value/type update for a row whose (type, value_normalized) key is
+	// UNCHANGED — the apply stage's step 4. A key change goes through
+	// delete-and-reinsert instead; this query exists for the case where the user
+	// edited the stored spelling ("Case@Example.test" -> "case@example.test", or a
+	// phone respelling) without moving the normalized key, which steps 1-3 would
+	// otherwise silently discard.
+	//
+	// Scoped by contact_id as well as id so a method id from another contact can
+	// never be acted on.
+	UpdateContactMethodByContact(ctx context.Context, arg UpdateContactMethodByContactParams) (*ContactMethod, error)
 	UpdateContactMethodValue(ctx context.Context, arg UpdateContactMethodValueParams) (*ContactMethod, error)
 	// Updates all direction fields + last_contacted + contact_by (for mutual interactions).
 	// Uses forward-only semantics for automated sources; manual always updates.

--- a/backend/internal/db/queries/contact_method.sql
+++ b/backend/internal/db/queries/contact_method.sql
@@ -116,3 +116,96 @@ WHERE cm.type IN ('gchat', 'email')
   AND cm.value_normalized <> ''
   AND c.deleted_at IS NULL
 ORDER BY cm.value_normalized ASC, cm.contact_id ASC, cm.type ASC;
+
+-- name: InsertContactMethodWithIdentity :one
+-- Inserts a contact method with an EXPLICIT id and created_at so the apply
+-- stage can delete a row whose (type, value_normalized) key changed and put it
+-- back with its identity intact. Genuinely new rows pass generated values for
+-- the same two columns, so one query serves both cases.
+--
+-- is_primary is always supplied as FALSE by the apply stage: promotion is the
+-- last step, which is what keeps idx_contact_method_primary from being
+-- violated mid-apply.
+--
+-- Deliberately NO "ON CONFLICT DO NOTHING": the in-memory fold has already
+-- proven the row is absent, so a conflict here means the fold is wrong and
+-- must fail loudly rather than be swallowed.
+--
+-- value_normalized is written by the set_contact_method_value_normalized
+-- trigger (migration 022), which overwrites whatever is passed. The
+-- placeholder below is never the stored value — do not read the returned
+-- value_normalized as confirmation of what Go computed.
+INSERT INTO contact_method (
+    id,
+    contact_id,
+    type,
+    value,
+    value_normalized,
+    is_primary,
+    created_at
+) VALUES (
+    sqlc.arg(id), sqlc.arg(contact_id), sqlc.arg(type), sqlc.arg(value), '', sqlc.arg(is_primary), sqlc.arg(created_at)
+) RETURNING *;
+
+-- name: UpdateContactMethodByContact :one
+-- In-place value/type update for a row whose (type, value_normalized) key is
+-- UNCHANGED — the apply stage's step 4. A key change goes through
+-- delete-and-reinsert instead; this query exists for the case where the user
+-- edited the stored spelling ("Case@Example.test" -> "case@example.test", or a
+-- phone respelling) without moving the normalized key, which steps 1-3 would
+-- otherwise silently discard.
+--
+-- Scoped by contact_id as well as id so a method id from another contact can
+-- never be acted on.
+UPDATE contact_method
+SET type = sqlc.arg(type),
+    value = sqlc.arg(value)
+WHERE id = sqlc.arg(id)
+  AND contact_id = sqlc.arg(contact_id)
+RETURNING *;
+
+-- name: DeleteContactMethodByContact :exec
+-- Contact-scoped single-row delete. Used both for removals and for the first
+-- phase of the delete-and-reinsert applied to key-changing rows.
+DELETE FROM contact_method
+WHERE id = sqlc.arg(id)
+  AND contact_id = sqlc.arg(contact_id);
+
+-- name: DemoteContactMethodPrimaryByContact :exec
+-- Clears is_primary on ONE named row of ONE contact.
+--
+-- Scoped by BOTH contact_id and id, deliberately. A contact-only demote would
+-- clear whichever row happened to be primary, which is the global-demotion
+-- behavior that lets a stale client drop a primary it never saw.
+UPDATE contact_method
+SET is_primary = FALSE
+WHERE id = sqlc.arg(id)
+  AND contact_id = sqlc.arg(contact_id);
+
+-- name: PromoteContactMethodPrimaryByContact :exec
+-- Sets is_primary on one named row of one contact. Added rather than reusing
+-- SetContactMethodPrimary, which matches by method id alone and is used by
+-- enrichment — changing it would move enrichment behavior.
+UPDATE contact_method
+SET is_primary = TRUE
+WHERE id = sqlc.arg(id)
+  AND contact_id = sqlc.arg(contact_id);
+
+-- name: LookupContactMethodOwner :one
+-- Returns the owning contact_id for a method id, regardless of which contact
+-- owns it. This is what separates "this id belongs to another contact" (404 --
+-- a method id is not a capability) from "this id does not exist at all"
+-- (a removal succeeds as a no-op, so a retried removal is idempotent). Those
+-- two cases are indistinguishable from one contact's pre-state alone.
+SELECT contact_id FROM contact_method
+WHERE id = sqlc.arg(id);
+
+-- name: NormalizeContactMethodValueViaTrigger :one
+-- TEST-ONLY. Calls the live normalize_contact_method_value function so the
+-- C6 parity test can compare the Go mirror against the actual SQL that the
+-- unique index is enforced over. Raw SQL is banned in Go including tests
+-- (.ai/rules/core.md), so this query is the permitted access path.
+--
+-- Not used by production code. Do not make it one: production reads the
+-- trigger's output from the stored column.
+SELECT normalize_contact_method_value(sqlc.arg(method_type)::TEXT, sqlc.arg(raw_value)::TEXT) AS normalized;

--- a/backend/internal/repository/contact_method.go
+++ b/backend/internal/repository/contact_method.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -233,7 +232,18 @@ func classifyContactMethodWriteError(err error) error {
 	if errors.As(err, &pgErr) &&
 		pgErr.Code == pgerrcode.UniqueViolation &&
 		pgErr.ConstraintName == "idx_contact_method_unique_value" {
-		return fmt.Errorf("%w: %s", ErrMethodValueConflict, pgErr.Detail)
+		// The sentinel ONLY. PostgreSQL's Detail for this violation reads
+		// "Key (contact_id, type, value_normalized)=(<uuid>, email, <value>)
+		// already exists.", so returning it puts a real contact's email address
+		// or phone number — plus the contact id and the column layout — into an
+		// error that reaches the HTTP response body. Nothing downstream needs
+		// it: the sentinel carries the meaning, the service maps it to an
+		// invalid-payload error, and the handler maps that to a 400.
+		//
+		// The underlying pgconn error is not wrapped either: it carries the same
+		// Detail string, so wrapping would reintroduce the leak through
+		// errors.Unwrap and any handler that prints the chain.
+		return ErrMethodValueConflict
 	}
 	return err
 }

--- a/backend/internal/repository/contact_method.go
+++ b/backend/internal/repository/contact_method.go
@@ -3,13 +3,17 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/identity"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -193,4 +197,247 @@ func (r *ContactMethodRepository) ListCanonicalIdentifiersByType(
 	types []string,
 ) ([]string, error) {
 	return r.queries.ListCanonicalIdentifiersByType(ctx, types)
+}
+
+// ErrMethodValueConflict reports that a write violated
+// idx_contact_method_unique_value — the (contact_id, type, value_normalized)
+// uniqueness rule.
+//
+// This is the database BACKSTOP behind the fold's own conflict validation, not
+// the primary mechanism. The operations endpoint computes the intended final
+// state and rejects duplicates before issuing any statement, so in normal
+// operation this error never fires. It exists because the fold's uniqueness key
+// and the trigger that actually writes value_normalized are two different
+// functions (see NormalizeContactMethodValueForUniqueness), and "the database
+// can never raise this" is not a claim a two-normalizer system can honestly
+// make.
+//
+// Classified here, in the repository, rather than at the handler: translating a
+// PostgreSQL constraint name in the HTTP layer would leak repository detail
+// across the service boundary, and would leave the classification testable only
+// through HTTP.
+var ErrMethodValueConflict = errors.New("contact method value conflicts with an existing method")
+
+// classifyContactMethodWriteError maps a PostgreSQL unique violation on
+// idx_contact_method_unique_value to ErrMethodValueConflict.
+//
+// The ConstraintName scoping is load-bearing: contact_method also carries
+// idx_contact_method_primary, and mapping every 23505 to a value conflict would
+// report "duplicate value" for what is actually a two-primaries bug. Any other
+// constraint passes through unwrapped.
+func classifyContactMethodWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) &&
+		pgErr.Code == pgerrcode.UniqueViolation &&
+		pgErr.ConstraintName == "idx_contact_method_unique_value" {
+		return fmt.Errorf("%w: %s", ErrMethodValueConflict, pgErr.Detail)
+	}
+	return err
+}
+
+// InsertContactMethodWithIdentityRequest carries an explicit ID and CreatedAt so
+// a row deleted during the apply stage can be reinserted with its identity
+// intact. Genuinely new rows pass freshly generated values.
+type InsertContactMethodWithIdentityRequest struct {
+	ID        uuid.UUID
+	ContactID uuid.UUID
+	Type      string
+	Value     string
+	IsPrimary bool
+	CreatedAt time.Time
+}
+
+// InsertContactMethodWithIdentity inserts a method with a caller-supplied id and
+// created_at. See the query comment for why there is no ON CONFLICT clause.
+func (r *ContactMethodRepository) InsertContactMethodWithIdentity(
+	ctx context.Context,
+	req InsertContactMethodWithIdentityRequest,
+) (*ContactMethod, error) {
+	dbMethod, err := r.queries.InsertContactMethodWithIdentity(ctx, db.InsertContactMethodWithIdentityParams{
+		ID:        uuidToPgUUID(req.ID),
+		ContactID: uuidToPgUUID(req.ContactID),
+		Type:      req.Type,
+		Value:     req.Value,
+		IsPrimary: pgtype.Bool{Bool: req.IsPrimary, Valid: true},
+		CreatedAt: timeToPgTimestamptz(&req.CreatedAt),
+	})
+	if err != nil {
+		return nil, classifyContactMethodWriteError(err)
+	}
+	method := convertDbContactMethod(dbMethod)
+	return &method, nil
+}
+
+// UpdateContactMethodByContact updates a row's type/value in place, scoped to
+// the owning contact. Used only for rows whose (type, value_normalized) key is
+// unchanged; key changes go through delete-and-reinsert.
+func (r *ContactMethodRepository) UpdateContactMethodByContact(
+	ctx context.Context,
+	contactID, id uuid.UUID,
+	methodType, value string,
+) (*ContactMethod, error) {
+	dbMethod, err := r.queries.UpdateContactMethodByContact(ctx, db.UpdateContactMethodByContactParams{
+		ID:        uuidToPgUUID(id),
+		ContactID: uuidToPgUUID(contactID),
+		Type:      methodType,
+		Value:     value,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, classifyContactMethodWriteError(err)
+	}
+	method := convertDbContactMethod(dbMethod)
+	return &method, nil
+}
+
+// DeleteContactMethodByContact deletes one method of one contact.
+func (r *ContactMethodRepository) DeleteContactMethodByContact(ctx context.Context, contactID, id uuid.UUID) error {
+	return r.queries.DeleteContactMethodByContact(ctx, db.DeleteContactMethodByContactParams{
+		ID:        uuidToPgUUID(id),
+		ContactID: uuidToPgUUID(contactID),
+	})
+}
+
+// DemoteContactMethodPrimaryByContact clears is_primary on one NAMED row.
+// Scoped by method id as well as contact so it can never demote a row the
+// caller did not name.
+func (r *ContactMethodRepository) DemoteContactMethodPrimaryByContact(ctx context.Context, contactID, id uuid.UUID) error {
+	return r.queries.DemoteContactMethodPrimaryByContact(ctx, db.DemoteContactMethodPrimaryByContactParams{
+		ID:        uuidToPgUUID(id),
+		ContactID: uuidToPgUUID(contactID),
+	})
+}
+
+// PromoteContactMethodPrimaryByContact sets is_primary on one named row.
+func (r *ContactMethodRepository) PromoteContactMethodPrimaryByContact(ctx context.Context, contactID, id uuid.UUID) error {
+	err := r.queries.PromoteContactMethodPrimaryByContact(ctx, db.PromoteContactMethodPrimaryByContactParams{
+		ID:        uuidToPgUUID(id),
+		ContactID: uuidToPgUUID(contactID),
+	})
+	return classifyContactMethodWriteError(err)
+}
+
+// LookupContactMethodOwner returns the contact that owns a method id.
+// Returns db.ErrNotFound when no such method exists anywhere.
+//
+// This distinguishes "owned by another contact" from "does not exist", which
+// the caller's own pre-state cannot tell apart: the first is rejected outright
+// because a method id is not a capability, while the second lets a retried
+// removal succeed as a no-op.
+func (r *ContactMethodRepository) LookupContactMethodOwner(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {
+	owner, err := r.queries.LookupContactMethodOwner(ctx, uuidToPgUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, db.ErrNotFound
+		}
+		return uuid.Nil, err
+	}
+	if !owner.Valid {
+		return uuid.Nil, db.ErrNotFound
+	}
+	return uuid.UUID(owner.Bytes), nil
+}
+
+// NormalizeContactMethodValueViaTrigger calls the live SQL normalization
+// function. TEST-ONLY — it exists so the parity test can compare the Go mirror
+// below against the function the unique index is actually enforced over.
+// Production code reads the trigger's output from the stored column.
+func (r *ContactMethodRepository) NormalizeContactMethodValueViaTrigger(
+	ctx context.Context,
+	methodType, rawValue string,
+) (string, error) {
+	return r.queries.NormalizeContactMethodValueViaTrigger(ctx, db.NormalizeContactMethodValueViaTriggerParams{
+		MethodType: methodType,
+		RawValue:   rawValue,
+	})
+}
+
+// NormalizeContactMethodValueForUniqueness reproduces the SQL function
+// normalize_contact_method_value (migration 022) so the operations endpoint can
+// compute its uniqueness key in Go and reject duplicates before issuing any
+// statement.
+//
+// THIS IS A DELIBERATE DUPLICATE OF SQL LOGIC. It must not be merged into
+// NormalizeContactMethodValue, and must not be "simplified" to call
+// identity.Normalize: those answer a different question (identity matching) and
+// are provably different functions from the trigger. Two verified divergences,
+// both pre-existing and both affecting the create path identically:
+//
+//   - Handles: the trigger strips ALL leading '@' ('^@+'); identity.Normalize
+//     strips exactly one via strings.TrimPrefix.
+//   - Phones: see the quirk note below.
+//
+// value_normalized is written by a BEFORE INSERT OR UPDATE trigger, so the
+// trigger is the SOLE authority — whatever Go passes for that column is
+// overwritten, and the unique index is always enforced over the trigger's
+// output. A mirror that disagrees turns a deterministic 400 into a 500.
+//
+// QUIRK, INTENTIONALLY REPRODUCED: the trigger's leading-plus test is
+// btrim(raw_value) ~ '^\\+', which in POSIX matches one or more literal
+// BACKSLASHES, never a real '+'. Every '+'-prefixed number therefore falls
+// through to the US-country-code branch, so '+1234567890' and '1234567890' both
+// normalize to '+11234567890'. That is a real production normalization bug, and
+// it is OUT OF SCOPE here: correcting it changes value_normalized for existing
+// rows and needs a migration plus its own analysis of the unique index, identity
+// matching, and rematch.
+//
+// This mirror must reproduce the behavior that ACTUALLY RUNS, quirk included. A
+// mirror written against the regex's evident intent would be wrong. If the
+// trigger is ever corrected, this function and its parity corpus are the
+// checklist for what must move with it.
+func NormalizeContactMethodValueForUniqueness(methodType, value string) string {
+	// btrim() with no character set removes SPACES only — not tabs, not
+	// newlines. strings.TrimSpace would trim all Unicode whitespace and
+	// silently disagree with the trigger on a tab-padded value.
+	trimmed := strings.Trim(value, " ")
+
+	switch methodType {
+	case string(ContactMethodEmail), string(ContactMethodGChat):
+		return strings.ToLower(trimmed)
+
+	case string(ContactMethodTelegram), string(ContactMethodTwitter), string(ContactMethodDiscord):
+		// '^@+' — ALL leading '@', not just the first.
+		return strings.ToLower(strings.TrimLeft(trimmed, "@"))
+
+	case string(ContactMethodPhone), string(ContactMethodSignal), string(ContactMethodWhatsApp):
+		if trimmed == "" {
+			return ""
+		}
+		digits := digitsOnly(trimmed)
+		if digits == "" {
+			return ""
+		}
+		// The backslash quirk, reproduced exactly: '^\\+' matches leading
+		// literal backslashes. A real '+' does NOT reach this branch.
+		if strings.HasPrefix(trimmed, `\`) {
+			return "+" + digits
+		}
+		if len(digits) == 10 {
+			return "+1" + digits
+		}
+		if len(digits) == 11 && digits[0] == '1' {
+			return "+" + digits
+		}
+		return "+" + digits
+
+	default:
+		return trimmed
+	}
+}
+
+// digitsOnly mirrors regexp_replace(value, '[^0-9]', ”, 'g').
+func digitsOnly(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }

--- a/backend/internal/service/contact_method.go
+++ b/backend/internal/service/contact_method.go
@@ -50,6 +50,35 @@ var ErrInvalidOperations = errors.New("invalid contact method operations")
 // a destructive operation.
 var ErrMethodNotOwned = errors.New("contact method belongs to another contact")
 
+// ErrContactNotFound reports that the contact the request addresses does not
+// exist. A 404.
+//
+// Service-owned on purpose. The handler must not branch on db.ErrNotFound: that
+// is a persistence-layer classification, and reaching across the service
+// boundary for it is a layer skip. The same reasoning applies to
+// repository.ErrMethodValueConflict, which classifyApplyError folds into
+// ErrInvalidOperations below.
+var ErrContactNotFound = errors.New("contact not found")
+
+// classifyApplyError translates repository-owned errors into service-owned ones
+// so nothing above this layer needs to know repository or database error
+// values.
+//
+// The value conflict becomes ErrInvalidOperations because that is exactly what
+// it is: a payload whose resulting method set would contain a duplicate. The
+// caller therefore cannot tell whether the fold rejected the request or the
+// database's unique index did — which is the intended contract, since a correct
+// C6 mirror makes the two agree by construction.
+func classifyApplyError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, repository.ErrMethodValueConflict) {
+		return fmt.Errorf("%w: %v", ErrInvalidOperations, err)
+	}
+	return err
+}
+
 // ContactMethodOperation is one requested mutation.
 //
 // IsPrimary is a pointer so the validator can distinguish "absent" from
@@ -176,6 +205,11 @@ func (s *ContactMethodService) ApplyOperations(
 	methodRepo := repository.NewContactMethodRepository(txQueries)
 
 	if _, err := contactRepo.GetContact(ctx, contactID); err != nil {
+		// Translated here, not at the handler: db.ErrNotFound is a persistence
+		// classification and must not cross the service boundary.
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, ErrContactNotFound
+		}
 		return nil, err
 	}
 
@@ -233,7 +267,7 @@ func (s *ContactMethodService) ApplyOperations(
 	}
 
 	if err := applyFinalState(ctx, methodRepo, contactID, preState, finalState); err != nil {
-		return nil, err
+		return nil, classifyApplyError(err)
 	}
 
 	// Read the committed-to-be rows back so every result snapshot carries the

--- a/backend/internal/service/contact_method.go
+++ b/backend/internal/service/contact_method.go
@@ -463,6 +463,37 @@ func validateOperationInteractions(ops []ContactMethodOperation) error {
 		seenAdds[key] = i
 	}
 
+	// An add carrying is_primary IS a primary designation. A row that does not
+	// exist yet has no id for set_primary to name, so a new row's designation
+	// necessarily travels on its add — which means counting only the explicit
+	// verbs above misses it.
+	//
+	// Left uncounted, two such adds both reached the fold, where the last one in
+	// payload order won. That is an outcome depending on payload order, which
+	// CON-062 forbids outright, and it also produced a misleading result: the
+	// losing add reported success with a non-primary snapshot despite having
+	// asserted primary intent.
+	//
+	// Adds resolving to the same key are already proven identical above, so they
+	// coalesce to a single designation rather than conflicting with themselves.
+	primaryAddKeys := map[string]bool{}
+	for i, op := range ops {
+		if op.Op != MethodOpAdd || !primaryIntent(op) {
+			continue
+		}
+		key := op.Type + "|" + repository.NormalizeContactMethodValueForUniqueness(op.Type, op.Value)
+		if primaryAddKeys[key] {
+			continue
+		}
+		if primaryOpIndex >= 0 {
+			return opErrf(i, "add designates a primary alongside %s at operation %d", primaryOpVerb, primaryOpIndex)
+		}
+		primaryAddKeys[key] = true
+		if len(primaryAddKeys) > 1 {
+			return opErrf(i, "only one primary designation is allowed per request")
+		}
+	}
+
 	return nil
 }
 

--- a/backend/internal/service/contact_method.go
+++ b/backend/internal/service/contact_method.go
@@ -1,0 +1,822 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Operation verbs accepted by the contact-method operations endpoint.
+//
+// The payload is a list of OPERATIONS, never a desired set. That is the whole
+// point: a desired set makes absence mean "delete", so a client working from a
+// stale read destroys every method it did not know about. In an operations
+// payload absence expresses nothing, so removal requires naming what to remove.
+const (
+	MethodOpAdd          = "add"
+	MethodOpUpdate       = "update"
+	MethodOpRemove       = "remove"
+	MethodOpSetPrimary   = "set_primary"
+	MethodOpClearPrimary = "clear_primary"
+)
+
+// Per-operation outcomes reported back to the client.
+const (
+	MethodOutcomeCreated         = "created"
+	MethodOutcomeMatchedExisting = "matched_existing"
+	MethodOutcomeUpdated         = "updated"
+	MethodOutcomeRemoved         = "removed"
+	MethodOutcomeNoOp            = "no_op"
+)
+
+// ErrInvalidOperations reports a payload the endpoint refuses to apply: a
+// malformed operation, or operations that conflict with each other, or a final
+// state that would violate an invariant. Always a 400, and always rejected
+// whole — no partial application.
+var ErrInvalidOperations = errors.New("invalid contact method operations")
+
+// ErrMethodNotOwned reports an operation naming a method id that exists but
+// belongs to a different contact. A 404: a method id is not a capability, and
+// that guarantee is not relaxed for remove, which is precisely where it guards
+// a destructive operation.
+var ErrMethodNotOwned = errors.New("contact method belongs to another contact")
+
+// ContactMethodOperation is one requested mutation.
+//
+// IsPrimary is a pointer so the validator can distinguish "absent" from
+// "present and false". The field is forbidden on update, which is a presence
+// test — a plain bool would silently accept `"is_primary": false`.
+type ContactMethodOperation struct {
+	Op        string
+	MethodID  *uuid.UUID
+	Type      string
+	Value     string
+	IsPrimary *bool
+}
+
+// ContactMethodOperationResult reports what happened to one SUBMITTED
+// operation, at that operation's own request index.
+//
+// Method carries the resolved row's post-apply state, and is nil exactly for
+// removals: a removed row has no post-apply state, and an idempotent removal of
+// an already-absent id has no row at all. MethodID is always the id the
+// operation ADDRESSED — for a removal, the id the client submitted, whether or
+// not a row existed.
+//
+// This exists so the client never has to re-derive server identity. A client
+// that infers which row an add resolved to by re-normalizing the returned list
+// with its own normalizer is wrong by construction: the client's normalizer and
+// the database trigger are different functions, so the inference fails exactly
+// when it matters.
+type ContactMethodOperationResult struct {
+	Index    int
+	Outcome  string
+	MethodID uuid.UUID
+	Method   *repository.ContactMethod
+}
+
+// ApplyContactMethodsResult is the endpoint's full response payload.
+type ApplyContactMethodsResult struct {
+	Methods      []repository.ContactMethod
+	RematchJobID uuid.UUID
+	Results      []ContactMethodOperationResult
+}
+
+// ContactMethodService applies contact-method operations transactionally.
+type ContactMethodService struct {
+	database        *db.Database
+	bus             *events.Bus
+	rematchRegistry RematchRegistry
+}
+
+func NewContactMethodService(database *db.Database, bus *events.Bus, rematchRegistry RematchRegistry) *ContactMethodService {
+	return &ContactMethodService{
+		database:        database,
+		bus:             bus,
+		rematchRegistry: rematchRegistry,
+	}
+}
+
+// foldedMethod is a method row in the intended final state. Rows carried over
+// from pre-state remember what they looked like before, so the apply stage can
+// tell a key change (delete-and-reinsert) from a stored-value-only change
+// (in-place update) from no change at all.
+type foldedMethod struct {
+	ID        uuid.UUID
+	Type      string
+	Value     string
+	IsPrimary bool
+	CreatedAt time.Time
+
+	fromPreState bool
+	preType      string
+	preValue     string
+	prePrimary   bool
+}
+
+func (f *foldedMethod) key() string {
+	return f.Type + "|" + repository.NormalizeContactMethodValueForUniqueness(f.Type, f.Value)
+}
+
+func (f *foldedMethod) preKey() string {
+	return f.preType + "|" + repository.NormalizeContactMethodValueForUniqueness(f.preType, f.preValue)
+}
+
+// resolution records, per SUBMITTED operation index, which row the operation
+// addressed and what happened to it. Results are built from this, so coalesced
+// operations each keep their own index while sharing a resolved id.
+type resolution struct {
+	methodID    uuid.UUID
+	outcome     string
+	hasSnapshot bool
+}
+
+// ApplyOperations applies a batch of contact-method operations in one
+// transaction: fold, validate, publish, apply, commit.
+//
+// The sequencing is not incidental. Folding in memory makes the outcome
+// independent of payload order by construction rather than by hoping the
+// database tolerates a particular statement sequence. Validating the intended
+// FINAL STATE means conflicts are rejected deterministically instead of being
+// discovered by whichever row PostgreSQL happened to reach first. Publishing
+// before mutating satisfies the PublishTx -> mutate -> commit rule, so a
+// publish failure cannot strand a committed mutation.
+func (s *ContactMethodService) ApplyOperations(
+	ctx context.Context,
+	contactID uuid.UUID,
+	ops []ContactMethodOperation,
+) (result *ApplyContactMethodsResult, err error) {
+	if err := validateOperationShapes(ops); err != nil {
+		return nil, err
+	}
+
+	tx, err := s.database.Pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			if err == nil {
+				err = rollbackErr
+			}
+		}
+	}()
+
+	txQueries := db.New(tx)
+	contactRepo := repository.NewContactRepository(txQueries)
+	methodRepo := repository.NewContactMethodRepository(txQueries)
+
+	if _, err := contactRepo.GetContact(ctx, contactID); err != nil {
+		return nil, err
+	}
+
+	preState, err := methodRepo.ListContactMethodsByContact(ctx, contactID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve every id-bearing operation against this contact's pre-state,
+	// falling back to a global ownership lookup. This is what separates "owned
+	// by another contact" (rejected outright) from "does not exist at all"
+	// (a removal succeeds as a no-op, so a retried removal is idempotent).
+	// Those two are indistinguishable from pre-state alone.
+	absentIDs, err := s.resolveOwnership(ctx, methodRepo, contactID, preState, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateOperationInteractions(ops); err != nil {
+		return nil, err
+	}
+
+	finalState, resolutions, err := foldOperations(preState, ops, absentIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateFinalState(finalState); err != nil {
+		return nil, err
+	}
+
+	// Publish BEFORE mutating. The diff is semantic — values newly present in
+	// the final state — rather than "rows we physically INSERTed", which
+	// preserves today's UpdateContact behavior exactly and makes idempotency
+	// fall out for free: a replayed payload folds to a final state equal to
+	// pre-state, so the diff is empty and nothing is published.
+	var (
+		jobID           uuid.UUID
+		eligibleMethods []Method
+	)
+	if s.rematchRegistry != nil {
+		newlyAdded := diffNewMethodsFromFold(preState, finalState)
+		eligibleMethods = s.rematchRegistry.EligibleMethods(newlyAdded)
+	}
+	if len(eligibleMethods) > 0 && s.bus != nil {
+		jobID = uuid.New()
+		refs := rematchMethodsToRefs(eligibleMethods)
+		env, marshalErr := buildContactMethodsAddedEnvelope("manual", contactID, refs, jobID)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+		if err := s.bus.PublishTx(ctx, tx, env); err != nil {
+			return nil, fmt.Errorf("publish contact_methods.added: %w", err)
+		}
+	}
+
+	if err := applyFinalState(ctx, methodRepo, contactID, preState, finalState); err != nil {
+		return nil, err
+	}
+
+	// Read the committed-to-be rows back so every result snapshot carries the
+	// row's true post-apply state, including the trigger-owned
+	// value_normalized. Reconstructing snapshots from the fold would report
+	// what Go believes rather than what the database stored.
+	postState, err := methodRepo.ListContactMethodsByContact(ctx, contactID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	if jobID != uuid.Nil && s.rematchRegistry != nil {
+		s.rematchRegistry.RegisterPending(jobID, contactID, eligibleMethods)
+	}
+
+	return &ApplyContactMethodsResult{
+		Methods:      postState,
+		RematchJobID: jobID,
+		Results:      buildOperationResults(resolutions, postState),
+	}, nil
+}
+
+// validateOperationShapes checks each operation against its own required and
+// forbidden fields.
+//
+// Deliberately NOT the shared normalizeContactMethodRequests/
+// validateContactMethods helpers used by the create path: those silently DISCARD
+// blank entries, which would turn update(id, value:"") into a successful-looking
+// no-op. That is a silent-success failure — the same class this endpoint exists
+// to eliminate, merely inverted. An unsatisfiable intent must be rejected, not
+// quietly dropped.
+//
+// Irrelevant fields are rejected rather than ignored so a malformed client
+// learns immediately instead of believing an ignored field took effect.
+func validateOperationShapes(ops []ContactMethodOperation) error {
+	for i, op := range ops {
+		switch op.Op {
+		case MethodOpAdd:
+			if op.MethodID != nil {
+				return opErrf(i, "add must not carry method_id")
+			}
+			if err := requireTypeAndValue(i, op); err != nil {
+				return err
+			}
+
+		case MethodOpUpdate:
+			if op.MethodID == nil {
+				return opErrf(i, "update requires method_id")
+			}
+			// Presence test, not a truth test. A primary change requires an
+			// explicit set_primary/clear_primary, so accepting-or-ignoring
+			// is_primary here would leave its meaning undefined.
+			if op.IsPrimary != nil {
+				return opErrf(i, "update must not carry is_primary; use set_primary or clear_primary")
+			}
+			if err := requireTypeAndValue(i, op); err != nil {
+				return err
+			}
+
+		case MethodOpRemove, MethodOpSetPrimary, MethodOpClearPrimary:
+			if op.MethodID == nil {
+				return opErrf(i, "%s requires method_id", op.Op)
+			}
+			if op.Type != "" {
+				return opErrf(i, "%s must not carry type", op.Op)
+			}
+			if op.Value != "" {
+				return opErrf(i, "%s must not carry value", op.Op)
+			}
+			if op.IsPrimary != nil {
+				return opErrf(i, "%s must not carry is_primary", op.Op)
+			}
+
+		default:
+			return opErrf(i, "unknown op %q", op.Op)
+		}
+	}
+	return nil
+}
+
+// requireTypeAndValue enforces the create path's type and value format rules on
+// add/update. Only the blank handling deliberately differs: blank is rejected
+// here rather than dropped.
+func requireTypeAndValue(i int, op ContactMethodOperation) error {
+	if op.Value == "" {
+		return opErrf(i, "%s requires a non-blank value", op.Op)
+	}
+	if !isKnownContactMethodType(op.Type) {
+		return opErrf(i, "%s has unknown type %q", op.Op, op.Type)
+	}
+	// Value FORMAT rules (email shape, phone length) are enforced at the
+	// handler, which owns the same validator the create path uses. What is
+	// enforced here is the domain rule the create path deliberately does NOT
+	// share: a blank value is rejected rather than dropped.
+	return nil
+}
+
+func isKnownContactMethodType(methodType string) bool {
+	for _, t := range repository.ContactMethodTypes {
+		if string(t) == methodType {
+			return true
+		}
+	}
+	return false
+}
+
+func opErrf(index int, format string, args ...any) error {
+	return fmt.Errorf("%w: operation %d: %s", ErrInvalidOperations, index, fmt.Sprintf(format, args...))
+}
+
+// resolveOwnership resolves every id-bearing operation and returns the set of
+// ids that do not exist anywhere.
+func (s *ContactMethodService) resolveOwnership(
+	ctx context.Context,
+	methodRepo *repository.ContactMethodRepository,
+	contactID uuid.UUID,
+	preState []repository.ContactMethod,
+	ops []ContactMethodOperation,
+) (map[uuid.UUID]bool, error) {
+	owned := make(map[uuid.UUID]bool, len(preState))
+	for _, m := range preState {
+		owned[m.ID] = true
+	}
+
+	absent := make(map[uuid.UUID]bool)
+	for i, op := range ops {
+		if op.MethodID == nil || owned[*op.MethodID] || absent[*op.MethodID] {
+			continue
+		}
+		owner, err := methodRepo.LookupContactMethodOwner(ctx, *op.MethodID)
+		switch {
+		case err == nil && owner != contactID:
+			// Exists, owned by someone else. Rejected for EVERY verb
+			// including remove: relaxing it there would relax it precisely
+			// where it protects a destructive operation.
+			return nil, fmt.Errorf("%w: operation %d names method %s", ErrMethodNotOwned, i, op.MethodID)
+		case errors.Is(err, db.ErrNotFound):
+			// Does not exist at all. A removal succeeds as a no-op, which is
+			// what makes a retried removal idempotent; every other verb has an
+			// intent that cannot be satisfied.
+			if op.Op != MethodOpRemove {
+				return nil, opErrf(i, "%s names method %s, which does not exist", op.Op, op.MethodID)
+			}
+			absent[*op.MethodID] = true
+		case err != nil:
+			return nil, err
+		}
+	}
+	return absent, nil
+}
+
+// validateOperationInteractions rejects payloads whose operations conflict with
+// each other.
+//
+// A pure fold does not make non-commutative operations commutative — class
+// ordering removes only INTER-class dependence. Order-independence comes from
+// rejecting non-commutative payloads here, not from asserting the fold absorbs
+// them.
+func validateOperationInteractions(ops []ContactMethodOperation) error {
+	var (
+		removed        = map[uuid.UUID]bool{}
+		mutatedOnce    = map[uuid.UUID]int{}
+		primaryOpIndex = -1
+		primaryOpVerb  string
+	)
+
+	for i, op := range ops {
+		switch op.Op {
+		case MethodOpRemove:
+			// Two IDENTICAL removes coalesce rather than conflict: both express
+			// the same satisfiable intent.
+			if idx, seen := mutatedOnce[*op.MethodID]; seen && ops[idx].Op != MethodOpRemove {
+				return opErrf(i, "method %s is named by both remove and %s", op.MethodID, ops[idx].Op)
+			}
+			removed[*op.MethodID] = true
+			mutatedOnce[*op.MethodID] = i
+
+		case MethodOpUpdate:
+			if idx, seen := mutatedOnce[*op.MethodID]; seen {
+				return opErrf(i, "method %s is named by both update and %s", op.MethodID, ops[idx].Op)
+			}
+			mutatedOnce[*op.MethodID] = i
+
+		case MethodOpSetPrimary, MethodOpClearPrimary:
+			if primaryOpIndex >= 0 {
+				if primaryOpVerb != op.Op {
+					return opErrf(i, "set_primary and clear_primary cannot appear in the same request")
+				}
+				return opErrf(i, "only one primary designation is allowed per request")
+			}
+			primaryOpIndex = i
+			primaryOpVerb = op.Op
+		}
+	}
+
+	// A primary designation on a removed row is self-conflicting in both
+	// directions: promoting a row that will not exist is unsatisfiable, and
+	// clearing one is redundant because removal already leaves no primary.
+	for i, op := range ops {
+		switch op.Op {
+		case MethodOpSetPrimary, MethodOpClearPrimary, MethodOpUpdate:
+			if removed[*op.MethodID] {
+				return opErrf(i, "method %s is removed in the same request", op.MethodID)
+			}
+		}
+	}
+
+	// Two adds resolving to the same key are a merge only when they agree in
+	// every field. Differing stored casing is a genuine conflict — the request
+	// asks for two different stored values in one row.
+	seenAdds := map[string]int{}
+	for i, op := range ops {
+		if op.Op != MethodOpAdd {
+			continue
+		}
+		key := op.Type + "|" + repository.NormalizeContactMethodValueForUniqueness(op.Type, op.Value)
+		if prev, seen := seenAdds[key]; seen {
+			if ops[prev].Value != op.Value || !samePrimaryIntent(ops[prev], op) {
+				return opErrf(i, "conflicts with operation %d: same normalized value, different stored value or primary intent", prev)
+			}
+			continue
+		}
+		seenAdds[key] = i
+	}
+
+	return nil
+}
+
+func samePrimaryIntent(a, b ContactMethodOperation) bool {
+	return primaryIntent(a) == primaryIntent(b)
+}
+
+func primaryIntent(op ContactMethodOperation) bool {
+	return op.IsPrimary != nil && *op.IsPrimary
+}
+
+// foldOperations applies the operations to a copy of pre-state by operation
+// class in fixed order — remove, update, add, primary designation — producing
+// the intended final state, plus the per-submitted-index resolutions the
+// results array is built from.
+func foldOperations(
+	preState []repository.ContactMethod,
+	ops []ContactMethodOperation,
+	absentIDs map[uuid.UUID]bool,
+) ([]*foldedMethod, []resolution, error) {
+	rows := make([]*foldedMethod, 0, len(preState)+len(ops))
+	byID := make(map[uuid.UUID]*foldedMethod, len(preState))
+	for _, m := range preState {
+		f := &foldedMethod{
+			ID:           m.ID,
+			Type:         m.Type,
+			Value:        m.Value,
+			IsPrimary:    m.IsPrimary,
+			CreatedAt:    m.CreatedAt,
+			fromPreState: true,
+			preType:      m.Type,
+			preValue:     m.Value,
+			prePrimary:   m.IsPrimary,
+		}
+		rows = append(rows, f)
+		byID[m.ID] = f
+	}
+
+	resolutions := make([]resolution, len(ops))
+	dropped := map[uuid.UUID]bool{}
+
+	// Class 1: remove.
+	for i, op := range ops {
+		if op.Op != MethodOpRemove {
+			continue
+		}
+		id := *op.MethodID
+		resolutions[i] = resolution{methodID: id, outcome: MethodOutcomeRemoved}
+		if absentIDs[id] {
+			// Replayed removal: the id is already gone. Successful, and the
+			// outcome is the whole information — there is no row to snapshot.
+			resolutions[i].outcome = MethodOutcomeNoOp
+			continue
+		}
+		dropped[id] = true
+	}
+
+	// Class 2: update. Preserves row identity and created_at, which is the
+	// entire reason update exists as a distinct verb from remove-then-add.
+	for i, op := range ops {
+		if op.Op != MethodOpUpdate {
+			continue
+		}
+		f := byID[*op.MethodID]
+		f.Type = op.Type
+		f.Value = op.Value
+		resolutions[i] = resolution{methodID: f.ID, outcome: MethodOutcomeUpdated, hasSnapshot: true}
+	}
+
+	// Class 3: add. An add naming a value that already exists resolves to the
+	// existing row rather than creating a second one.
+	byKey := map[string]*foldedMethod{}
+	for _, f := range rows {
+		if dropped[f.ID] {
+			continue
+		}
+		byKey[f.key()] = f
+	}
+	for i, op := range ops {
+		if op.Op != MethodOpAdd {
+			continue
+		}
+		key := op.Type + "|" + repository.NormalizeContactMethodValueForUniqueness(op.Type, op.Value)
+		if existing, ok := byKey[key]; ok {
+			// Coalesced with an earlier add in this payload, or matched against
+			// a row that was already there. Either way the client learns the id
+			// its assertion resolved to.
+			outcome := MethodOutcomeMatchedExisting
+			if !existing.fromPreState {
+				outcome = MethodOutcomeCreated
+			}
+			resolutions[i] = resolution{methodID: existing.ID, outcome: outcome, hasSnapshot: true}
+			continue
+		}
+		f := &foldedMethod{
+			ID:        uuid.New(),
+			Type:      op.Type,
+			Value:     op.Value,
+			CreatedAt: accelerated.GetCurrentTime(),
+		}
+		rows = append(rows, f)
+		byID[f.ID] = f
+		byKey[key] = f
+		resolutions[i] = resolution{methodID: f.ID, outcome: MethodOutcomeCreated, hasSnapshot: true}
+	}
+
+	// Class 4: primary designation. Applied last so an add carrying
+	// is_primary can designate a row created earlier in this same payload.
+	final := make([]*foldedMethod, 0, len(rows))
+	for _, f := range rows {
+		if !dropped[f.ID] {
+			final = append(final, f)
+		}
+	}
+
+	var designated *foldedMethod
+	var clearRequested bool
+	for i, op := range ops {
+		switch op.Op {
+		case MethodOpSetPrimary:
+			f := byID[*op.MethodID]
+			designated = f
+			resolutions[i] = resolution{methodID: f.ID, outcome: MethodOutcomeUpdated, hasSnapshot: true}
+			if f.prePrimary {
+				resolutions[i].outcome = MethodOutcomeNoOp
+			}
+		case MethodOpClearPrimary:
+			f := byID[*op.MethodID]
+			resolutions[i] = resolution{methodID: f.ID, outcome: MethodOutcomeNoOp, hasSnapshot: true}
+			// Clearing a row that is not primary is a successful no-op — it
+			// must NOT demote whichever row happens to be primary.
+			if f.prePrimary {
+				clearRequested = true
+				resolutions[i].outcome = MethodOutcomeUpdated
+			}
+		case MethodOpAdd:
+			if primaryIntent(op) {
+				designated = byID[resolutions[i].methodID]
+			}
+		}
+	}
+
+	for _, f := range final {
+		f.IsPrimary = false
+	}
+	switch {
+	case designated != nil && !dropped[designated.ID]:
+		designated.IsPrimary = true
+	case clearRequested:
+		// Explicitly left with no primary.
+	default:
+		// Preserve whatever was primary before, unless it is gone now.
+		for _, f := range final {
+			if f.prePrimary && !dropped[f.ID] {
+				f.IsPrimary = true
+				break
+			}
+		}
+	}
+
+	return final, resolutions, nil
+}
+
+// validateFinalState rejects an intended end state that violates an invariant,
+// before any mutation is issued.
+func validateFinalState(final []*foldedMethod) error {
+	seen := map[string]bool{}
+	primaries := 0
+	for _, f := range final {
+		k := f.key()
+		if seen[k] {
+			return fmt.Errorf("%w: resulting methods would contain a duplicate %s value %q",
+				ErrInvalidOperations, f.Type, f.Value)
+		}
+		seen[k] = true
+		if f.IsPrimary {
+			primaries++
+		}
+	}
+	if primaries > 1 {
+		return fmt.Errorf("%w: resulting methods would contain more than one primary", ErrInvalidOperations)
+	}
+	return nil
+}
+
+// diffNewMethodsFromFold computes the semantic diff between pre-state and the
+// intended final state — values newly PRESENT, regardless of which physical
+// rows moved. This mirrors UpdateContact's existing behavior exactly.
+//
+// The fold's rows carry the mirror's normalized key rather than the trigger's
+// output, which is sound precisely because the mirror reproduces the trigger
+// (pinned by the parity test).
+func diffNewMethodsFromFold(before []repository.ContactMethod, after []*foldedMethod) []Method {
+	existing := make(map[string]struct{}, len(before))
+	for _, m := range before {
+		existing[m.Type+"|"+m.ValueNormalized] = struct{}{}
+	}
+	out := make([]Method, 0, len(after))
+	for _, f := range after {
+		normalized := repository.NormalizeContactMethodValueForUniqueness(f.Type, f.Value)
+		if _, ok := existing[f.Type+"|"+normalized]; ok {
+			continue
+		}
+		out = append(out, Method{Type: f.Type, Value: normalized})
+	}
+	return out
+}
+
+// applyFinalState carries pre-state to the intended final state.
+//
+// Delete-and-reinsert rather than in-place rewriting: idx_contact_method_unique_value
+// is enforced per statement, so updating rows in place can transiently collide
+// even when the final state is valid. Since no foreign key references
+// contact_method, a row can be deleted and reinserted with its identity intact,
+// which reaches every valid final state — including full value swaps and
+// type-only swaps — with no collision analysis at all.
+//
+// Inserts are always non-primary and promotion is always last, so an add
+// carrying is_primary can never violate idx_contact_method_primary mid-apply.
+func applyFinalState(
+	ctx context.Context,
+	methodRepo *repository.ContactMethodRepository,
+	contactID uuid.UUID,
+	preState []repository.ContactMethod,
+	final []*foldedMethod,
+) error {
+	survives := make(map[uuid.UUID]*foldedMethod, len(final))
+	for _, f := range final {
+		survives[f.ID] = f
+	}
+
+	reinserted := map[uuid.UUID]bool{}
+
+	// Step 1: delete removed rows AND rows whose (type, value_normalized) key
+	// changes. The KEY, not merely the value — a type-only swap changes the key
+	// with no value change at all.
+	for _, m := range preState {
+		f, kept := survives[m.ID]
+		if !kept {
+			if err := methodRepo.DeleteContactMethodByContact(ctx, contactID, m.ID); err != nil {
+				return err
+			}
+			continue
+		}
+		if f.key() != f.preKey() {
+			if err := methodRepo.DeleteContactMethodByContact(ctx, contactID, m.ID); err != nil {
+				return err
+			}
+			reinserted[m.ID] = true
+		}
+	}
+
+	// Step 2: reinsert key-changing rows with their ORIGINAL id and created_at.
+	// Step 3: insert genuinely new rows.
+	for _, f := range final {
+		needsInsert := reinserted[f.ID] || !f.fromPreState
+		if !needsInsert {
+			continue
+		}
+		if _, err := methodRepo.InsertContactMethodWithIdentity(ctx, repository.InsertContactMethodWithIdentityRequest{
+			ID:        f.ID,
+			ContactID: contactID,
+			Type:      f.Type,
+			Value:     f.Value,
+			IsPrimary: false,
+			CreatedAt: f.CreatedAt,
+		}); err != nil {
+			return err
+		}
+	}
+
+	// Step 4: in-place update for rows whose stored value changed but whose key
+	// did not. Without this phase the request returns 200 having silently
+	// discarded the edit — a case-only correction or a phone respelling never
+	// reaches steps 1-3 because its normalized key never moved.
+	for _, f := range final {
+		if !f.fromPreState || reinserted[f.ID] {
+			continue
+		}
+		if f.Value == f.preValue && f.Type == f.preType {
+			continue
+		}
+		if _, err := methodRepo.UpdateContactMethodByContact(ctx, contactID, f.ID, f.Type, f.Value); err != nil {
+			return err
+		}
+	}
+
+	// Steps 5-6 read DATABASE state, not payload deltas. If the current
+	// primary's own key changed it was reinserted non-primary above, while its
+	// DESIGNATION did not change — a delta-based rule would fire neither demote
+	// nor promote and leave the contact with no primary at all.
+	var prePrimaryID uuid.UUID
+	for _, m := range preState {
+		if m.IsPrimary {
+			prePrimaryID = m.ID
+			break
+		}
+	}
+	var finalPrimary *foldedMethod
+	for _, f := range final {
+		if f.IsPrimary {
+			finalPrimary = f
+			break
+		}
+	}
+
+	// Demote only if the pre-state primary still carries the flag in the
+	// database — a reinserted row already came back non-primary, and a deleted
+	// one is gone.
+	if prePrimaryID != uuid.Nil && !reinserted[prePrimaryID] && survives[prePrimaryID] != nil {
+		if finalPrimary == nil || finalPrimary.ID != prePrimaryID {
+			if err := methodRepo.DemoteContactMethodPrimaryByContact(ctx, contactID, prePrimaryID); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Promote whenever the final state names a primary that is not already
+	// flagged in the database. This is a no-op on replay, where the row was
+	// never reinserted and is already flagged.
+	if finalPrimary != nil {
+		alreadyFlagged := finalPrimary.ID == prePrimaryID && !reinserted[finalPrimary.ID]
+		if !alreadyFlagged {
+			if err := methodRepo.PromoteContactMethodPrimaryByContact(ctx, contactID, finalPrimary.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// buildOperationResults emits exactly one result per SUBMITTED operation, at
+// that operation's own index — never one per folded operation. Coalesced
+// operations each get their own result carrying the same resolved id.
+func buildOperationResults(resolutions []resolution, postState []repository.ContactMethod) []ContactMethodOperationResult {
+	byID := make(map[uuid.UUID]*repository.ContactMethod, len(postState))
+	for i := range postState {
+		byID[postState[i].ID] = &postState[i]
+	}
+
+	results := make([]ContactMethodOperationResult, len(resolutions))
+	for i, r := range resolutions {
+		results[i] = ContactMethodOperationResult{
+			Index:    i,
+			Outcome:  r.outcome,
+			MethodID: r.methodID,
+		}
+		if r.hasSnapshot {
+			if row, ok := byID[r.methodID]; ok {
+				snapshot := *row
+				results[i].Method = &snapshot
+			}
+		}
+	}
+	return results
+}

--- a/backend/internal/service/contact_method_errors_test.go
+++ b/backend/internal/service/contact_method_errors_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+)
+
+// The service owns the translation of repository-level errors into
+// service-level ones, so nothing above this layer needs to know a repository or
+// database error value. These are pure-function tests: no database, no fixture.
+//
+// The translation matters precisely because the path that produces it is
+// unreachable in an integration test. A correct C6 mirror rejects every trigger
+// collision during the fold, so the repository's 23505 classification only ever
+// fires when the mirror is wrong. Testing the translation directly is what makes
+// it verifiable at all.
+
+func TestClassifyApplyError_ValueConflictBecomesInvalidOperations(t *testing.T) {
+	t.Parallel()
+
+	got := classifyApplyError(fmt.Errorf("insert: %w", repository.ErrMethodValueConflict))
+
+	if !errors.Is(got, ErrInvalidOperations) {
+		t.Fatalf("a repository value conflict must present as ErrInvalidOperations, got %v", got)
+	}
+	if errors.Is(got, repository.ErrMethodValueConflict) {
+		t.Fatal("the repository error identity must not survive translation; callers above the service would be able to branch on it")
+	}
+}
+
+func TestClassifyApplyError_UnrelatedErrorsPassThrough(t *testing.T) {
+	t.Parallel()
+
+	// Anything that is not a value conflict keeps its identity, so a genuine
+	// fault still reaches the handler's 500 branch instead of being reported to
+	// the user as an invalid request.
+	sentinel := errors.New("connection reset")
+	if got := classifyApplyError(sentinel); !errors.Is(got, sentinel) {
+		t.Fatalf("unrelated error lost its identity: %v", got)
+	}
+	if got := classifyApplyError(sentinel); errors.Is(got, ErrInvalidOperations) {
+		t.Fatal("an unrelated failure was misreported as an invalid payload")
+	}
+	if got := classifyApplyError(db.ErrNotFound); !errors.Is(got, db.ErrNotFound) {
+		t.Fatalf("db.ErrNotFound lost its identity: %v", got)
+	}
+}
+
+func TestClassifyApplyError_NilStaysNil(t *testing.T) {
+	t.Parallel()
+
+	if got := classifyApplyError(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}

--- a/backend/tests/api/contact_method_operations_test.go
+++ b/backend/tests/api/contact_method_operations_test.go
@@ -520,6 +520,16 @@ func TestMethodOps_NamedRemovalSucceeds(t *testing.T) {
 
 // --- CON-062[5][6]: final-state validation ---------------------------------
 
+// TestMethodOps_DuplicateFinalStateRejected asserts the rejection comes from
+// the FOLD, by requiring the response to name the colliding value.
+//
+// Asserting only the 400 is vacuous here, and measurably so: with the fold's
+// duplicate check deleted, the request still returns 400, because the database's
+// unique index fires and the repository classifies it back into the same status.
+// The status code cannot distinguish "rejected deterministically before any
+// statement ran" from "discovered by whichever row PostgreSQL reached first",
+// and pre-SQL determinism is the entire property the fold exists to provide.
+// The fold's message names the colliding pair; the database backstop's does not.
 func TestMethodOps_DuplicateFinalStateRejected(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -528,7 +538,14 @@ func TestMethodOps_DuplicateFinalStateRejected(t *testing.T) {
 
 	// Updating B onto A's value would leave two rows with one key.
 	w, _ := f.post(updateOp(b.ID, "email", a.Value))
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), a.Value, "the rejection did not name the colliding value")
+	// The fold and the database backstop BOTH name the value — PostgreSQL's
+	// error detail embeds it too — so the value alone cannot tell them apart.
+	// The fold's phrasing is about the intended END STATE, which is the thing
+	// only a pre-SQL check can talk about.
+	assert.Contains(t, w.Body.String(), "would contain a duplicate",
+		"the rejection came from the database index, not the fold: the request mutated and rolled back rather than being refused deterministically")
 	assert.Equal(t, b.Value, f.storedByID(b.ID).Value, "a rejected payload mutated a row")
 }
 
@@ -656,11 +673,28 @@ func TestMethodOps_ConflictingOperationsRejected(t *testing.T) {
 				addPrimaryOp("phone", "+15550114567"),
 			}
 		}},
+		// Forward AND reverse for every add-carried designation conflict. The
+		// property under test is that payload order does not change the outcome,
+		// so a single direction cannot prove it: an implementation that checked
+		// only operations appearing before the add would pass one and fail the
+		// other, which is exactly the last-one-wins bug these catch.
 		{"add designating primary alongside set_primary", func(_, b repository.ContactMethod) []map[string]any {
 			return []map[string]any{addPrimaryOp("email", uniqueEmail()), idOp("set_primary", b.ID)}
 		}},
+		{"set_primary alongside add designating primary (reversed)", func(_, b repository.ContactMethod) []map[string]any {
+			return []map[string]any{idOp("set_primary", b.ID), addPrimaryOp("email", uniqueEmail())}
+		}},
 		{"add designating primary alongside clear_primary", func(a, _ repository.ContactMethod) []map[string]any {
 			return []map[string]any{addPrimaryOp("email", uniqueEmail()), idOp("clear_primary", a.ID)}
+		}},
+		{"clear_primary alongside add designating primary (reversed)", func(a, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{idOp("clear_primary", a.ID), addPrimaryOp("email", uniqueEmail())}
+		}},
+		{"two adds each designating primary (reversed)", func(_, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{
+				addPrimaryOp("phone", "+15550114567"),
+				addPrimaryOp("email", uniqueEmail()),
+			}
 		}},
 	}
 
@@ -852,6 +886,17 @@ func TestMethodOps_ResultsCarryResolvedRowSnapshot(t *testing.T) {
 // discriminated shape. A uniform "snapshot on every result" contract is
 // unsatisfiable for either case here: a removed row has no post-apply state,
 // and an absent-id removal has no row at all.
+//
+// WHAT THIS DOES NOT PIN, stated so nobody reads it as coverage it lacks: it
+// does not pin the service's hasSnapshot guard. Deleting that guard leaves this
+// test green, verified by mutation. The reason is structural — hasSnapshot is
+// false only for removals, and a removal's addressed id is by definition absent
+// from post-state, so the snapshot lookup fails on its own and the guard never
+// changes an outcome. The guard is therefore defense-in-depth that makes the
+// contract explicit rather than emergent, and no test can currently discriminate
+// it. It is kept deliberately: an emergent-consequence argument is what left
+// this contract undefined for several review rounds, and it would silently stop
+// holding if a future change ever let a removed id resolve to a surviving row.
 func TestMethodOps_RemoveResultsCarryAddressedIDWithoutSnapshot(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -1067,11 +1112,17 @@ func TestMethodOps_ConflictErrorTranslatesTo400(t *testing.T) {
 		err  error
 		want int
 	}{
-		{"value conflict", fmt.Errorf("wrapped: %w", repository.ErrMethodValueConflict), http.StatusBadRequest},
 		{"invalid operations", fmt.Errorf("wrapped: %w", service.ErrInvalidOperations), http.StatusBadRequest},
+		// What the service returns after folding a repository value conflict.
+		{"conflict translated by the service", fmt.Errorf("%w: duplicate value", service.ErrInvalidOperations), http.StatusBadRequest},
 		{"foreign method id", fmt.Errorf("wrapped: %w", service.ErrMethodNotOwned), http.StatusNotFound},
-		{"unknown contact", fmt.Errorf("wrapped: %w", db.ErrNotFound), http.StatusNotFound},
+		{"unknown contact", fmt.Errorf("wrapped: %w", service.ErrContactNotFound), http.StatusNotFound},
 		{"unexpected failure", errors.New("boom"), http.StatusInternalServerError},
+		// The boundary itself: persistence classifications are the service's to
+		// translate. If the handler ever learns them again, these stop being 500
+		// and this test says so.
+		{"raw repository error is not classified here", repository.ErrMethodValueConflict, http.StatusInternalServerError},
+		{"raw db error is not classified here", db.ErrNotFound, http.StatusInternalServerError},
 	}
 
 	for _, tc := range cases {

--- a/backend/tests/api/contact_method_operations_test.go
+++ b/backend/tests/api/contact_method_operations_test.go
@@ -298,23 +298,34 @@ func TestMethodOps_InvalidOperationAppliesNothing(t *testing.T) {
 	assert.Equal(t, existing.Value, f.storedByID(existing.ID).Value)
 }
 
+// TestMethodOps_AddWithIsPrimaryPromotesAfterInsert asserts WHICH row ends up
+// primary, not merely that one does. Counting primaries alone is vacuous here:
+// the seeded row is already primary, so an implementation that dropped
+// promotion entirely would leave exactly one primary and pass.
 func TestMethodOps_AddWithIsPrimaryPromotesAfterInsert(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
-	f.seed("email", uniqueEmail(), true)
+	seeded := f.seed("email", uniqueEmail(), true)
 
 	// Inserts are always non-primary and promotion is always last, so this can
 	// never violate the one-primary index mid-apply.
 	w, body := f.post(addPrimaryOp("phone", "+15550105678"))
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
-	primaries := 0
+	primaries := []string{}
 	for _, m := range body.Methods {
 		if m.IsPrimary {
-			primaries++
+			primaries = append(primaries, m.ID)
 		}
 	}
-	assert.Equal(t, 1, primaries, "expected exactly one primary")
+	require.Len(t, primaries, 1, "expected exactly one primary")
+	assert.NotEqual(t, seeded.ID.String(), primaries[0],
+		"the added row was never promoted; the seeded primary just stayed put")
+
+	added := f.storedByID(uuid.MustParse(primaries[0]))
+	require.NotNil(t, added)
+	assert.Equal(t, "phone", added.Type, "the promoted row is not the added row")
+	assert.False(t, f.storedByID(seeded.ID).IsPrimary, "the seeded primary was not demoted")
 }
 
 // --- CON-062[2]: order independence ----------------------------------------
@@ -341,7 +352,7 @@ func TestMethodOps_OutcomeIndependentOfPayloadOrder(t *testing.T) {
 		KeptID    bool
 	}
 
-	runPermutation := func(t *testing.T, order []int) []semanticRow {
+	runPermutation := func(t *testing.T, order []int) ([]semanticRow, string) {
 		f := newMethodOpsFx(t)
 		reused := uniqueEmail()
 		a := f.seed("email", reused, true)
@@ -369,25 +380,34 @@ func TestMethodOps_OutcomeIndependentOfPayloadOrder(t *testing.T) {
 				KeptID:    m.ID == a.ID,
 			})
 		}
-		return out
+		return out, reused
 	}
 
 	// The update's new value is freshly generated per permutation, so compare
 	// the shape that does not depend on it: the reused key must be present and
 	// primary, and the updated row must have kept A's identity.
-	assertShape := func(t *testing.T, rows []semanticRow) {
+	//
+	// Asserting WHICH row is primary is load-bearing. Counting primaries alone
+	// is satisfied by the pre-state primary staying put, so an implementation
+	// that never moved the designation at all would pass every permutation.
+	assertShape := func(t *testing.T, rows []semanticRow, reusedValue string) {
 		require.Len(t, rows, 2)
-		primaries, kept := 0, 0
+		kept := 0
+		primaries := []semanticRow{}
 		for _, r := range rows {
 			if r.IsPrimary {
-				primaries++
+				primaries = append(primaries, r)
 			}
 			if r.KeptID {
 				kept++
 			}
 		}
-		assert.Equal(t, 1, primaries, "expected exactly one primary")
 		assert.Equal(t, 1, kept, "the updated row did not preserve its identity")
+		require.Len(t, primaries, 1, "expected exactly one primary")
+		assert.Equal(t, reusedValue, primaries[0].Value,
+			"the primary is not the row the add created; the designation never moved")
+		assert.False(t, primaries[0].KeptID,
+			"the primary is still the pre-state row A rather than the added row")
 	}
 
 	permutations := [][]int{
@@ -397,7 +417,8 @@ func TestMethodOps_OutcomeIndependentOfPayloadOrder(t *testing.T) {
 	for _, order := range permutations {
 		t.Run(fmt.Sprint(order), func(t *testing.T) {
 			t.Parallel()
-			assertShape(t, runPermutation(t, order))
+			rows, reused := runPermutation(t, order)
+			assertShape(t, rows, reused)
 		})
 	}
 }
@@ -523,18 +544,40 @@ func TestMethodOps_TwoPrimaryDesignationsRejected(t *testing.T) {
 
 // --- CON-062[7]: a method id is not a capability ---------------------------
 
+// TestMethodOps_ForeignMethodIDRejected table-drives EVERY id-bearing verb.
+// The ownership check is currently shared, so one verb would cover the code as
+// written — but the guarantee is per-verb, and a future verb-specific path that
+// bypassed the precheck would otherwise regress silently. It is asserted where
+// it protects a destructive operation, not merely where it is convenient.
 func TestMethodOps_ForeignMethodIDRejected(t *testing.T) {
 	t.Parallel()
-	victim := newMethodOpsFx(t)
-	foreign := victim.seed("email", uniqueEmail(), false)
 
-	attacker := newMethodOpsFx(t)
-	w, _ := attacker.post(idOp("remove", foreign.ID))
+	for _, verb := range []string{"remove", "update", "set_primary", "clear_primary"} {
+		t.Run(verb, func(t *testing.T) {
+			t.Parallel()
+			victim := newMethodOpsFx(t)
+			foreign := victim.seed("email", uniqueEmail(), true)
+			before := *victim.storedByID(foreign.ID)
 
-	assert.Equal(t, http.StatusNotFound, w.Code,
-		"an operation naming another contact's method was not rejected")
-	assert.NotNil(t, victim.storedByID(foreign.ID),
-		"another contact's method was destroyed through a foreign id")
+			op := idOp(verb, foreign.ID)
+			if verb == "update" {
+				op = updateOp(foreign.ID, "email", uniqueEmail())
+			}
+
+			attacker := newMethodOpsFx(t)
+			w, _ := attacker.post(op)
+
+			assert.Equal(t, http.StatusNotFound, w.Code,
+				"an operation naming another contact's method was not rejected")
+
+			after := victim.storedByID(foreign.ID)
+			require.NotNil(t, after, "another contact's method was destroyed through a foreign id")
+			assert.Equal(t, before.Value, after.Value, "another contact's method was altered")
+			assert.Equal(t, before.IsPrimary, after.IsPrimary, "another contact's primary flag was changed")
+			assert.Equal(t, before.UpdatedAt, after.UpdatedAt, "another contact's method row was rewritten")
+			assert.Empty(t, attacker.stored(), "the operation leaked a row onto the caller's contact")
+		})
+	}
 }
 
 // TestMethodOps_RemoveNonexistentSucceedsButForeignRejected walks the ownership
@@ -601,6 +644,23 @@ func TestMethodOps_ConflictingOperationsRejected(t *testing.T) {
 		{"two adds differing only in stored casing", func(_, _ repository.ContactMethod) []map[string]any {
 			value := uniqueEmail()
 			return []map[string]any{addOp("email", value), addOp("email", strings.ToUpper(value))}
+		}},
+		// A primary designation on a NEW row necessarily travels on the add,
+		// because a row that does not exist yet has no id for set_primary to
+		// name. Two such adds are therefore two designations, and counting
+		// only the explicit verbs let them through with the last one in
+		// payload order winning — an order-dependent outcome.
+		{"two adds each designating primary", func(_, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{
+				addPrimaryOp("email", uniqueEmail()),
+				addPrimaryOp("phone", "+15550114567"),
+			}
+		}},
+		{"add designating primary alongside set_primary", func(_, b repository.ContactMethod) []map[string]any {
+			return []map[string]any{addPrimaryOp("email", uniqueEmail()), idOp("set_primary", b.ID)}
+		}},
+		{"add designating primary alongside clear_primary", func(a, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{addPrimaryOp("email", uniqueEmail()), idOp("clear_primary", a.ID)}
 		}},
 	}
 

--- a/backend/tests/api/contact_method_operations_test.go
+++ b/backend/tests/api/contact_method_operations_test.go
@@ -1,0 +1,1079 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The operations endpoint's HTTP surface. CON-062 is surface: api, so these
+// tests are its citing coverage — the service-level suite in
+// backend/tests/contact_method_operations_integration_test.go pins the fold and
+// apply mechanisms, but only these show the endpoint accepts, serializes, and
+// returns them.
+
+// methodOpsShared is one database pool and one router shared by every test in
+// this file. Each test opening its own pool would multiply the per-package
+// connection ceiling by the test count; the router is stateless, and every test
+// works on its own contact, so sharing is safe under t.Parallel().
+var (
+	methodOpsSharedOnce sync.Once
+	methodOpsSharedDB   *db.Database
+	methodOpsSharedRtr  *gin.Engine
+)
+
+func methodOpsShared(t *testing.T) (*db.Database, *gin.Engine) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	methodOpsSharedOnce.Do(func() {
+		cfg := config.TestConfig()
+		cfg.Database.URL = os.Getenv("DATABASE_URL")
+		database, err := db.NewDatabase(context.Background(), cfg.Database)
+		if err != nil {
+			panic("failed to connect to test database: " + err.Error())
+		}
+		methodOpsSharedDB = database
+		// nil bus and nil rematch registry: these tests pin HTTP behavior, not
+		// the event contract, and the service already treats both as optional.
+		methodOpsSharedRtr = newMethodOpsRouter(service.NewContactMethodService(database, nil, nil))
+	})
+	if methodOpsSharedDB == nil {
+		t.Skip("shared method-ops database unavailable")
+	}
+	return methodOpsSharedDB, methodOpsSharedRtr
+}
+
+// newMethodOpsRouter registers the contact-method route surface through the
+// production route registrar, so route shape is exercised rather than restated.
+func newMethodOpsRouter(applier handlers.ContactMethodApplier) *gin.Engine {
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	v1 := router.Group("/api/v1")
+	contacts := v1.Group("/contacts")
+	contacts.POST("/:id/methods", handlers.NewContactMethodHandler(applier).ApplyOperations)
+	return router
+}
+
+type methodOpsFx struct {
+	t         *testing.T
+	ctx       context.Context
+	router    *gin.Engine
+	repo      *repository.ContactMethodRepository
+	contactID uuid.UUID
+}
+
+// newMethodOpsFx creates one contact in this test's own namespace. Fixtures are
+// never shared between tests, so parallel copies cannot observe each other.
+func newMethodOpsFx(t *testing.T) *methodOpsFx {
+	t.Helper()
+	database, router := methodOpsShared(t)
+	ctx := context.Background()
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "MethodOpsAPI " + uuid.NewString(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+	return &methodOpsFx{
+		t:         t,
+		ctx:       ctx,
+		router:    router,
+		repo:      repository.NewContactMethodRepository(database.Queries),
+		contactID: contact.ID,
+	}
+}
+
+// seed inserts a method server-side, bypassing the endpoint. A method the
+// client never saw is exactly what the regression is about.
+func (f *methodOpsFx) seed(methodType, value string, primary bool) repository.ContactMethod {
+	f.t.Helper()
+	m, err := f.repo.CreateContactMethod(f.ctx, repository.CreateContactMethodRequest{
+		ContactID: f.contactID,
+		Type:      methodType,
+		Value:     value,
+		IsPrimary: primary,
+	})
+	require.NoError(f.t, err)
+	return *m
+}
+
+func (f *methodOpsFx) stored() []repository.ContactMethod {
+	f.t.Helper()
+	got, err := f.repo.ListContactMethodsByContact(f.ctx, f.contactID)
+	require.NoError(f.t, err)
+	return got
+}
+
+func (f *methodOpsFx) storedByID(id uuid.UUID) *repository.ContactMethod {
+	f.t.Helper()
+	for _, m := range f.stored() {
+		if m.ID == id {
+			found := m
+			return &found
+		}
+	}
+	return nil
+}
+
+// opsResponse mirrors the wire response, unwrapped from the APIResponse
+// envelope so assertions read against the documented shape.
+type opsResponse struct {
+	Methods      []handlers.ContactMethodResponse        `json:"methods"`
+	RematchJobID string                                  `json:"rematch_job_id"`
+	Results      []handlers.ContactMethodOperationResult `json:"results"`
+}
+
+func (f *methodOpsFx) post(ops ...map[string]any) (*httptest.ResponseRecorder, opsResponse) {
+	f.t.Helper()
+	return f.postTo(f.contactID.String(), ops...)
+}
+
+func (f *methodOpsFx) postTo(contactID string, ops ...map[string]any) (*httptest.ResponseRecorder, opsResponse) {
+	f.t.Helper()
+	if ops == nil {
+		ops = []map[string]any{}
+	}
+	body, err := json.Marshal(map[string]any{"operations": ops})
+	require.NoError(f.t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/contacts/"+contactID+"/methods", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+
+	var envelope struct {
+		Data opsResponse `json:"data"`
+	}
+	if w.Code == http.StatusOK {
+		require.NoError(f.t, json.Unmarshal(w.Body.Bytes(), &envelope))
+	}
+	return w, envelope.Data
+}
+
+func addOp(methodType, value string) map[string]any {
+	return map[string]any{"op": "add", "type": methodType, "value": value}
+}
+
+func addPrimaryOp(methodType, value string) map[string]any {
+	return map[string]any{"op": "add", "type": methodType, "value": value, "is_primary": true}
+}
+
+func updateOp(id uuid.UUID, methodType, value string) map[string]any {
+	return map[string]any{"op": "update", "method_id": id.String(), "type": methodType, "value": value}
+}
+
+func idOp(op string, id uuid.UUID) map[string]any {
+	return map[string]any{"op": op, "method_id": id.String()}
+}
+
+// uniqueEmail keeps every fixture's values distinct across parallel tests, so a
+// duplicate-value rejection can only come from the payload under test.
+func uniqueEmail() string {
+	return "m" + uuid.NewString()[:8] + "@example.test"
+}
+
+// --- CON-062[0]: absence expresses nothing ---------------------------------
+
+// TestMethodOps_UnnamedMethodsSurvive is the regression. A method the payload
+// does not name must come through byte-identical in EVERY persisted column.
+//
+// The full-row assertion is the point, not thoroughness for its own sake: the
+// apply stage works by physical delete-and-reinsert, so an implementation that
+// needlessly reinserted every row would preserve id, type, value and is_primary
+// while silently moving created_at and updated_at — passing a weaker test named
+// for catching exactly that.
+func TestMethodOps_UnnamedMethodsSurvive(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	untouched := f.seed("email", uniqueEmail(), true)
+
+	w, body := f.post(addOp("phone", "+15550101234"))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Len(t, body.Methods, 2)
+
+	after := f.storedByID(untouched.ID)
+	require.NotNil(t, after, "a method no operation named was destroyed")
+	assert.Equal(t, untouched.ID, after.ID)
+	assert.Equal(t, untouched.Type, after.Type)
+	assert.Equal(t, untouched.Value, after.Value)
+	assert.Equal(t, untouched.ValueNormalized, after.ValueNormalized)
+	assert.Equal(t, untouched.IsPrimary, after.IsPrimary)
+	assert.Equal(t, untouched.CreatedAt, after.CreatedAt)
+	assert.Equal(t, untouched.UpdatedAt, after.UpdatedAt,
+		"updated_at moved: the row was rewritten despite no operation naming it")
+}
+
+// TestMethodOps_PromoteDemotesPreviousPrimary pins the one carve-out to the
+// rule above: at most one primary is a database constraint, so promoting one
+// necessarily demotes another. That is a real side effect on an unnamed row and
+// is stated rather than hidden.
+func TestMethodOps_PromoteDemotesPreviousPrimary(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	oldPrimary := f.seed("email", uniqueEmail(), true)
+	newPrimary := f.seed("phone", "+15550102345", false)
+
+	w, _ := f.post(idOp("set_primary", newPrimary.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.False(t, f.storedByID(oldPrimary.ID).IsPrimary, "previous primary was not demoted")
+	assert.True(t, f.storedByID(newPrimary.ID).IsPrimary, "named row was not promoted")
+}
+
+// TestMethodOps_ClearNonPrimaryDoesNotDemoteCurrentPrimary catches an
+// implementation that clears the primary flag contact-wide instead of for the
+// named row. A global clear would let a stale form demote a row it never saw.
+func TestMethodOps_ClearNonPrimaryDoesNotDemoteCurrentPrimary(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	primary := f.seed("email", uniqueEmail(), true)
+	other := f.seed("phone", "+15550103456", false)
+
+	w, _ := f.post(idOp("clear_primary", other.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.True(t, f.storedByID(primary.ID).IsPrimary,
+		"clearing a non-primary row demoted the actual primary")
+}
+
+func TestMethodOps_ClearNamedPrimaryLeavesNone(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	primary := f.seed("email", uniqueEmail(), true)
+
+	w, body := f.post(idOp("clear_primary", primary.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.False(t, f.storedByID(primary.ID).IsPrimary)
+	for _, m := range body.Methods {
+		assert.False(t, m.IsPrimary, "response still reports a primary")
+	}
+}
+
+// --- CON-062[1]: all or nothing --------------------------------------------
+
+func TestMethodOps_InvalidOperationAppliesNothing(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	existing := f.seed("email", uniqueEmail(), true)
+	before := f.stored()
+
+	// A valid add alongside an operation naming a nonexistent id.
+	w, _ := f.post(
+		addOp("phone", "+15550104567"),
+		idOp("set_primary", uuid.New()),
+	)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	after := f.stored()
+	require.Len(t, after, len(before), "a rejected payload applied part of itself")
+	assert.Equal(t, existing.Value, f.storedByID(existing.ID).Value)
+}
+
+func TestMethodOps_AddWithIsPrimaryPromotesAfterInsert(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	f.seed("email", uniqueEmail(), true)
+
+	// Inserts are always non-primary and promotion is always last, so this can
+	// never violate the one-primary index mid-apply.
+	w, body := f.post(addPrimaryOp("phone", "+15550105678"))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	primaries := 0
+	for _, m := range body.Methods {
+		if m.IsPrimary {
+			primaries++
+		}
+	}
+	assert.Equal(t, 1, primaries, "expected exactly one primary")
+}
+
+// --- CON-062[2]: order independence ----------------------------------------
+
+// TestMethodOps_OutcomeIndependentOfPayloadOrder uses a payload whose classes
+// genuinely interact: the add reuses the key the update frees, so a fold that
+// does not order update before add produces a duplicate; and the primary moves
+// to a row created in the same payload, exercising demote-then-promote.
+//
+// Each permutation runs against its OWN fresh fixture. Run sequentially against
+// one contact, only the first permutation would start from the specified
+// pre-state and the rest would be replays that pass even if the permutation
+// would have failed from the original state.
+func TestMethodOps_OutcomeIndependentOfPayloadOrder(t *testing.T) {
+	t.Parallel()
+
+	// Semantic comparison: server-generated ids and timestamps differ per
+	// fixture, so compare (type, value, is_primary) plus whether the row kept
+	// its identity relative to THAT fixture's own pre-state.
+	type semanticRow struct {
+		Type      string
+		Value     string
+		IsPrimary bool
+		KeptID    bool
+	}
+
+	runPermutation := func(t *testing.T, order []int) []semanticRow {
+		f := newMethodOpsFx(t)
+		reused := uniqueEmail()
+		a := f.seed("email", reused, true)
+		b := f.seed("phone", "+15550106789", false)
+
+		all := []map[string]any{
+			idOp("remove", b.ID),
+			updateOp(a.ID, "email", uniqueEmail()),
+			addPrimaryOp("email", reused),
+		}
+		payload := make([]map[string]any, 0, len(all))
+		for _, i := range order {
+			payload = append(payload, all[i])
+		}
+
+		w, _ := f.post(payload...)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		out := make([]semanticRow, 0, 2)
+		for _, m := range f.stored() {
+			out = append(out, semanticRow{
+				Type:      m.Type,
+				Value:     m.Value,
+				IsPrimary: m.IsPrimary,
+				KeptID:    m.ID == a.ID,
+			})
+		}
+		return out
+	}
+
+	// The update's new value is freshly generated per permutation, so compare
+	// the shape that does not depend on it: the reused key must be present and
+	// primary, and the updated row must have kept A's identity.
+	assertShape := func(t *testing.T, rows []semanticRow) {
+		require.Len(t, rows, 2)
+		primaries, kept := 0, 0
+		for _, r := range rows {
+			if r.IsPrimary {
+				primaries++
+			}
+			if r.KeptID {
+				kept++
+			}
+		}
+		assert.Equal(t, 1, primaries, "expected exactly one primary")
+		assert.Equal(t, 1, kept, "the updated row did not preserve its identity")
+	}
+
+	permutations := [][]int{
+		{0, 1, 2}, {0, 2, 1}, {1, 0, 2},
+		{1, 2, 0}, {2, 0, 1}, {2, 1, 0},
+	}
+	for _, order := range permutations {
+		t.Run(fmt.Sprint(order), func(t *testing.T) {
+			t.Parallel()
+			assertShape(t, runPermutation(t, order))
+		})
+	}
+}
+
+// TestMethodOps_TwoAddsOrderIndependent covers intra-class ordering.
+func TestMethodOps_TwoAddsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	first, second := uniqueEmail(), uniqueEmail()
+
+	collect := func(t *testing.T, ops ...map[string]any) []string {
+		f := newMethodOpsFx(t)
+		w, _ := f.post(ops...)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		values := []string{}
+		for _, m := range f.stored() {
+			values = append(values, m.Type+"|"+m.Value)
+		}
+		assert.Len(t, values, 2)
+		return values
+	}
+
+	var forward, reverse []string
+	t.Run("forward", func(t *testing.T) {
+		forward = collect(t, addOp("email", first), addOp("email", second))
+	})
+	t.Run("reverse", func(t *testing.T) {
+		reverse = collect(t, addOp("email", second), addOp("email", first))
+	})
+	assert.ElementsMatch(t, forward, reverse)
+}
+
+// --- CON-062[3][4]: idempotency --------------------------------------------
+
+func TestMethodOps_DuplicateAddIsNoOp(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	existing := f.seed("email", uniqueEmail(), false)
+
+	w, body := f.post(addOp("email", existing.Value))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Len(t, f.stored(), 1, "an add of an existing value duplicated the row")
+	require.Len(t, body.Results, 1)
+	assert.Equal(t, "matched_existing", body.Results[0].Outcome)
+	assert.Equal(t, existing.ID.String(), body.Results[0].MethodID)
+}
+
+func TestMethodOps_IdenticalAddsCoalesce(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	value := uniqueEmail()
+
+	w, body := f.post(addOp("email", value), addOp("email", value))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Len(t, f.stored(), 1, "identical adds created two rows")
+	require.Len(t, body.Results, 2, "a coalesced add lost its result")
+	assert.Equal(t, body.Results[0].MethodID, body.Results[1].MethodID)
+}
+
+func TestMethodOps_RemoveAlreadyAbsentSucceeds(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+
+	// An id that does not exist anywhere. A retried removal must be idempotent,
+	// so this resolves through the ownership lookup's nonexistent branch.
+	w, body := f.post(idOp("remove", uuid.New()))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Len(t, body.Results, 1)
+	assert.Equal(t, "no_op", body.Results[0].Outcome)
+}
+
+func TestMethodOps_DuplicateRemovesCoalesce(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	target := f.seed("email", uniqueEmail(), false)
+
+	w, body := f.post(idOp("remove", target.ID), idOp("remove", target.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Nil(t, f.storedByID(target.ID))
+	require.Len(t, body.Results, 2, "a coalesced remove lost its result")
+	assert.Equal(t, target.ID.String(), body.Results[0].MethodID)
+	assert.Equal(t, target.ID.String(), body.Results[1].MethodID)
+}
+
+func TestMethodOps_NamedRemovalSucceeds(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	target := f.seed("email", uniqueEmail(), false)
+	survivor := f.seed("phone", "+15550107890", false)
+
+	w, _ := f.post(idOp("remove", target.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Nil(t, f.storedByID(target.ID), "the named row was not removed")
+	assert.NotNil(t, f.storedByID(survivor.ID), "an unnamed row was removed")
+}
+
+// --- CON-062[5][6]: final-state validation ---------------------------------
+
+func TestMethodOps_DuplicateFinalStateRejected(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), false)
+	b := f.seed("email", uniqueEmail(), false)
+
+	// Updating B onto A's value would leave two rows with one key.
+	w, _ := f.post(updateOp(b.ID, "email", a.Value))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, b.Value, f.storedByID(b.ID).Value, "a rejected payload mutated a row")
+}
+
+func TestMethodOps_TwoPrimaryDesignationsRejected(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), false)
+	b := f.seed("phone", "+15550108901", false)
+
+	w, _ := f.post(idOp("set_primary", a.ID), idOp("set_primary", b.ID))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- CON-062[7]: a method id is not a capability ---------------------------
+
+func TestMethodOps_ForeignMethodIDRejected(t *testing.T) {
+	t.Parallel()
+	victim := newMethodOpsFx(t)
+	foreign := victim.seed("email", uniqueEmail(), false)
+
+	attacker := newMethodOpsFx(t)
+	w, _ := attacker.post(idOp("remove", foreign.ID))
+
+	assert.Equal(t, http.StatusNotFound, w.Code,
+		"an operation naming another contact's method was not rejected")
+	assert.NotNil(t, victim.storedByID(foreign.ID),
+		"another contact's method was destroyed through a foreign id")
+}
+
+// TestMethodOps_RemoveNonexistentSucceedsButForeignRejected walks the ownership
+// rule's three cases in one place. The distinction is what lets a retried
+// removal succeed while a foreign id can never be acted on.
+func TestMethodOps_RemoveNonexistentSucceedsButForeignRejected(t *testing.T) {
+	t.Parallel()
+	victim := newMethodOpsFx(t)
+	foreign := victim.seed("email", uniqueEmail(), false)
+
+	f := newMethodOpsFx(t)
+	own := f.seed("email", uniqueEmail(), false)
+
+	t.Run("own id applies", func(t *testing.T) {
+		w, _ := f.post(idOp("remove", own.ID))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Nil(t, f.storedByID(own.ID))
+	})
+	t.Run("nonexistent id is a successful no-op", func(t *testing.T) {
+		w, _ := f.post(idOp("remove", uuid.New()))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+	t.Run("foreign id is rejected", func(t *testing.T) {
+		w, _ := f.post(idOp("remove", foreign.ID))
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.NotNil(t, victim.storedByID(foreign.ID))
+	})
+}
+
+// --- CON-062[9]: conflicts rejected, not resolved by order ------------------
+
+// TestMethodOps_ConflictingOperationsRejected covers every documented conflict,
+// each asserting a 400 AND zero mutation. A payload rejected after partial
+// application would be the same silent-corruption class this endpoint exists to
+// eliminate.
+func TestMethodOps_ConflictingOperationsRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ops  func(a, b repository.ContactMethod) []map[string]any
+	}{
+		{"two updates on one id", func(a, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{
+				updateOp(a.ID, "email", uniqueEmail()),
+				updateOp(a.ID, "email", uniqueEmail()),
+			}
+		}},
+		{"remove and update on one id", func(a, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{idOp("remove", a.ID), updateOp(a.ID, "email", uniqueEmail())}
+		}},
+		{"remove and set_primary on one id", func(a, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{idOp("remove", a.ID), idOp("set_primary", a.ID)}
+		}},
+		{"remove and clear_primary on one id", func(a, _ repository.ContactMethod) []map[string]any {
+			return []map[string]any{idOp("remove", a.ID), idOp("clear_primary", a.ID)}
+		}},
+		{"set_primary and clear_primary together", func(a, b repository.ContactMethod) []map[string]any {
+			return []map[string]any{idOp("set_primary", a.ID), idOp("clear_primary", b.ID)}
+		}},
+		{"two primary designations", func(a, b repository.ContactMethod) []map[string]any {
+			return []map[string]any{idOp("set_primary", a.ID), idOp("set_primary", b.ID)}
+		}},
+		{"two adds differing only in stored casing", func(_, _ repository.ContactMethod) []map[string]any {
+			value := uniqueEmail()
+			return []map[string]any{addOp("email", value), addOp("email", strings.ToUpper(value))}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := newMethodOpsFx(t)
+			a := f.seed("email", uniqueEmail(), true)
+			b := f.seed("phone", "+15550109012", false)
+			before := f.stored()
+
+			w, _ := f.post(tc.ops(a, b)...)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "conflict was resolved rather than rejected")
+
+			after := f.stored()
+			assert.Len(t, after, len(before), "a rejected conflict mutated stored state")
+			assert.Equal(t, a.Value, f.storedByID(a.ID).Value)
+			assert.Equal(t, b.IsPrimary, f.storedByID(b.ID).IsPrimary)
+		})
+	}
+}
+
+// TestMethodOps_UpdateWithPrimaryDesignationSucceeds pins the inverse: an
+// update and a primary designation naming the same id is a legitimate
+// combination, not a conflict. Nothing else covers the permitted case, so a
+// validator that rejected all same-id pairs would otherwise look correct.
+func TestMethodOps_UpdateWithPrimaryDesignationSucceeds(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), false)
+	newValue := uniqueEmail()
+
+	w, _ := f.post(updateOp(a.ID, "email", newValue), idOp("set_primary", a.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	after := f.storedByID(a.ID)
+	require.NotNil(t, after)
+	assert.Equal(t, newValue, after.Value, "the update did not land")
+	assert.True(t, after.IsPrimary, "the primary designation did not land")
+}
+
+// --- CON-062[10][11]: stable-key updates over HTTP --------------------------
+
+// TestMethodOps_StableKeyUpdatePersistsThroughAPI is CON-062[10]'s citing test.
+// A case-only edit changes the stored value while (type, value_normalized) is
+// unchanged, so the row is never deleted and never reinserted. Without the
+// in-place update phase the endpoint returns 200 having discarded the edit —
+// the failure must land on the stored-value assertion, not on an error.
+func TestMethodOps_StableKeyUpdatePersistsThroughAPI(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	lower := uniqueEmail()
+	a := f.seed("email", lower, false)
+	upper := strings.ToUpper(lower)
+
+	w, body := f.post(updateOp(a.ID, "email", upper))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	after := f.storedByID(a.ID)
+	require.NotNil(t, after)
+	assert.Equal(t, upper, after.Value, "a value edit that did not move the key was silently discarded")
+	assert.Equal(t, a.ID, after.ID, "row identity was not preserved")
+	assert.Equal(t, a.CreatedAt, after.CreatedAt, "created_at was not preserved")
+
+	require.Len(t, body.Methods, 1)
+	assert.Equal(t, upper, body.Methods[0].Value, "the response did not reflect the new value")
+}
+
+// TestMethodOps_KeyChangingPrimaryUpdateKeepsPrimaryThroughAPI is CON-062[11]'s
+// citing test. Updating the primary's value changes its key, forcing the
+// delete-and-reinsert path, which returns the row non-primary. A promotion rule
+// phrased as a designation delta fires neither demote nor promote here and
+// leaves the contact with NO primary.
+func TestMethodOps_KeyChangingPrimaryUpdateKeepsPrimaryThroughAPI(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), true)
+	f.seed("phone", "+15550110123", false)
+	newValue := uniqueEmail()
+
+	w, body := f.post(updateOp(a.ID, "email", newValue))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	after := f.storedByID(a.ID)
+	require.NotNil(t, after)
+	assert.Equal(t, newValue, after.Value)
+	assert.True(t, after.IsPrimary, "the updated row lost its primary flag")
+
+	primaries := 0
+	for _, m := range body.Methods {
+		if m.IsPrimary {
+			primaries++
+		}
+	}
+	assert.Equal(t, 1, primaries, "expected exactly one primary in the response")
+}
+
+// --- CON-062[12][13]: the results contract ----------------------------------
+
+// TestMethodOps_ResultsCoverEveryOperation pins one result per SUBMITTED
+// operation, including no-ops. This is the contract a later acknowledged-state
+// advance depends on: a client that cannot learn which row its own addition
+// resolved to will later fail to edit or remove that method.
+func TestMethodOps_ResultsCoverEveryOperation(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	existing := f.seed("email", uniqueEmail(), false)
+	absent := uuid.New()
+
+	w, body := f.post(
+		addOp("phone", "+15550111234"), // created
+		addOp("email", existing.Value), // matched_existing, a no-op
+		idOp("remove", absent),         // no_op, no row ever existed
+	)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Len(t, body.Results, 3, "results were emitted only for operations that changed a row")
+
+	for i, r := range body.Results {
+		assert.Equal(t, i, r.Index, "results are not at their submitted indices")
+		assert.NotEmpty(t, r.MethodID, "every result must identify the method it addressed")
+	}
+	assert.Equal(t, "created", body.Results[0].Outcome)
+	assert.NotNil(t, body.Results[0].Method)
+
+	assert.Equal(t, "matched_existing", body.Results[1].Outcome)
+	assert.Equal(t, existing.ID.String(), body.Results[1].MethodID)
+	require.NotNil(t, body.Results[1].Method, "a matched add must carry the resolved row")
+
+	assert.Equal(t, "no_op", body.Results[2].Outcome)
+	assert.Equal(t, absent.String(), body.Results[2].MethodID)
+	assert.Nil(t, body.Results[2].Method, "a removal must not carry a snapshot")
+}
+
+// TestMethodOps_ResultsIndexAgainstSubmittedNotFoldedOperations uses payloads
+// whose folds are NOT one-to-one. Earlier cases all folded one-to-one, so an
+// implementation emitting one result per folded operation passed them.
+func TestMethodOps_ResultsIndexAgainstSubmittedNotFoldedOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("two identical adds", func(t *testing.T) {
+		t.Parallel()
+		f := newMethodOpsFx(t)
+		value := uniqueEmail()
+
+		w, body := f.post(addOp("email", value), addOp("email", value))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.Len(t, body.Results, 2, "coalesced adds did not each get a result")
+		assert.Equal(t, 0, body.Results[0].Index)
+		assert.Equal(t, 1, body.Results[1].Index)
+		assert.Equal(t, body.Results[0].MethodID, body.Results[1].MethodID,
+			"coalesced siblings resolved to different rows")
+	})
+
+	t.Run("two identical removes", func(t *testing.T) {
+		t.Parallel()
+		f := newMethodOpsFx(t)
+		target := f.seed("email", uniqueEmail(), false)
+
+		w, body := f.post(idOp("remove", target.ID), idOp("remove", target.ID))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.Len(t, body.Results, 2, "coalesced removes did not each get a result")
+		assert.Equal(t, 0, body.Results[0].Index)
+		assert.Equal(t, 1, body.Results[1].Index)
+	})
+}
+
+// TestMethodOps_ResultsCarryResolvedRowSnapshot pins that snapshots reflect
+// POST-apply state rather than echoing the submitted operation's fields.
+func TestMethodOps_ResultsCarryResolvedRowSnapshot(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), false)
+	b := f.seed("phone", "+15550112345", false)
+	newValue := uniqueEmail()
+
+	w, body := f.post(updateOp(a.ID, "email", newValue), idOp("set_primary", b.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Len(t, body.Results, 2)
+
+	require.NotNil(t, body.Results[0].Method)
+	assert.Equal(t, newValue, body.Results[0].Method.Value, "the update's snapshot is stale")
+
+	require.NotNil(t, body.Results[1].Method)
+	assert.True(t, body.Results[1].Method.IsPrimary,
+		"the set_primary snapshot does not reflect post-apply state")
+}
+
+// TestMethodOps_RemoveResultsCarryAddressedIDWithoutSnapshot pins the
+// discriminated shape. A uniform "snapshot on every result" contract is
+// unsatisfiable for either case here: a removed row has no post-apply state,
+// and an absent-id removal has no row at all.
+func TestMethodOps_RemoveResultsCarryAddressedIDWithoutSnapshot(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	real := f.seed("email", uniqueEmail(), false)
+	absent := uuid.New()
+
+	w, body := f.post(idOp("remove", real.ID), idOp("remove", absent))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Len(t, body.Results, 2)
+
+	assert.Equal(t, real.ID.String(), body.Results[0].MethodID)
+	assert.Nil(t, body.Results[0].Method, "a real removal carried a snapshot")
+	assert.Equal(t, "removed", body.Results[0].Outcome)
+
+	assert.Equal(t, absent.String(), body.Results[1].MethodID,
+		"an absent removal must report the SUBMITTED id")
+	assert.Nil(t, body.Results[1].Method, "an absent removal carried a snapshot")
+}
+
+// TestMethodOps_ResultsResolveAddToExistingRow is the case client-side
+// inference cannot get right. With a stored phone whose trigger-normalized key
+// equals a differently-spelled submitted value, the add resolves to the
+// existing row — and the result must carry THAT row's id and stored value, not
+// the submitted spelling.
+func TestMethodOps_ResultsResolveAddToExistingRow(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	// The trigger maps a bare 10-digit number to +1XXXXXXXXXX, so both
+	// spellings share one normalized key.
+	stored := f.seed("phone", "5550113456", true)
+
+	w, body := f.post(addOp("phone", "+15550113456"))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Len(t, f.stored(), 1, "a differently-spelled add duplicated the row")
+	require.Len(t, body.Results, 1)
+	assert.Equal(t, "matched_existing", body.Results[0].Outcome)
+	assert.Equal(t, stored.ID.String(), body.Results[0].MethodID,
+		"the client was not told which row its add resolved to")
+	require.NotNil(t, body.Results[0].Method)
+	assert.Equal(t, stored.Value, body.Results[0].Method.Value,
+		"the snapshot echoed the submitted value instead of the resolved row's stored value")
+	assert.True(t, body.Results[0].Method.IsPrimary,
+		"the snapshot did not report the resolved row's primary flag")
+}
+
+// --- Validation -------------------------------------------------------------
+
+// TestMethodOps_BlankValueRejected pins the deliberate split from the create
+// path. Create DROPS a blank entry; an explicit add or update must REJECT it.
+// Dropping here would turn an unsatisfiable intent into a silent success.
+func TestMethodOps_BlankValueRejected(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), false)
+
+	t.Run("add", func(t *testing.T) {
+		w, _ := f.post(addOp("email", ""))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+	t.Run("update", func(t *testing.T) {
+		w, _ := f.post(updateOp(a.ID, "email", ""))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, a.Value, f.storedByID(a.ID).Value, "a blank update silently no-opped")
+	})
+}
+
+func TestMethodOps_IrrelevantFieldsRejected(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), false)
+
+	// A remove carrying a value is malformed: the client learns immediately
+	// rather than believing an ignored field took effect.
+	w, _ := f.post(map[string]any{
+		"op": "remove", "method_id": a.ID.String(), "value": "anything@example.test",
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.NotNil(t, f.storedByID(a.ID))
+}
+
+// TestMethodOps_UpdateRejectsIsPrimary must include the FALSE case. The rule is
+// that the field is forbidden on update, which is a presence test — a validator
+// checking "is it true" passes the false case while doing nothing, so only the
+// false case proves presence detection was implemented.
+func TestMethodOps_UpdateRejectsIsPrimary(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	a := f.seed("email", uniqueEmail(), false)
+
+	for _, isPrimary := range []bool{true, false} {
+		t.Run(fmt.Sprint(isPrimary), func(t *testing.T) {
+			w, _ := f.post(map[string]any{
+				"op": "update", "method_id": a.ID.String(),
+				"type": "email", "value": uniqueEmail(), "is_primary": isPrimary,
+			})
+			assert.Equal(t, http.StatusBadRequest, w.Code,
+				"is_primary is forbidden on update regardless of its value")
+		})
+	}
+}
+
+// TestMethodOps_OperationValueFormatValidated pins the format rules the
+// CON-015 amendment assigns to the operations path.
+func TestMethodOps_OperationValueFormatValidated(t *testing.T) {
+	t.Parallel()
+
+	longPhone := ""
+	for i := 0; i < 60; i++ {
+		longPhone += "1"
+	}
+
+	cases := []struct {
+		name string
+		op   map[string]any
+	}{
+		{"malformed email", addOp("email", "not-an-email")},
+		{"over-length phone", addOp("phone", longPhone)},
+		{"unknown type", map[string]any{"op": "add", "type": "carrier-pigeon", "value": "x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := newMethodOpsFx(t)
+			w, _ := f.post(tc.op)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Empty(t, f.stored(), "an invalid operation was applied")
+		})
+	}
+}
+
+// --- Boundaries -------------------------------------------------------------
+
+func TestMethodOps_UnknownContactReturns404(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+
+	w, _ := f.postTo(uuid.NewString(), addOp("email", uniqueEmail()))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestMethodOps_EmptyOperationsIsNoOp pins that "nothing to do" is a success.
+// A `required` tag on the operations slice would make this a 400.
+func TestMethodOps_EmptyOperationsIsNoOp(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	existing := f.seed("email", uniqueEmail(), true)
+
+	w, body := f.post()
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Empty(t, body.Results)
+	require.Len(t, body.Methods, 1)
+	assert.Equal(t, existing.ID.String(), body.Methods[0].ID)
+}
+
+// --- C6: the trigger mirror -------------------------------------------------
+
+// TestMethodOps_HandleResolvesThroughTriggerMirror pins THE MIRROR, not the
+// database backstop.
+//
+// The trigger strips ALL leading '@' for handle types, while identity
+// normalization strips exactly one. With discord:foo stored, a mirror that
+// inherited the one-@ behavior folds "@@foo" to "@foo", concludes the value is
+// new, INSERTs it, and only then does the trigger normalize it to "foo" — a
+// unique violation surfacing as a 500 on a request that should have succeeded.
+//
+// A correct mirror folds "@@foo" to "foo", matches the stored row, and resolves
+// the add to it. So the correct answer here is a 200 that does NOT duplicate
+// the row, per CON-062[3] — not a rejection. There is no input for which a
+// correct mirror produces a conflict against a single pre-existing row: a
+// rejection needs two DIFFERENT stored values sharing one normalized key in one
+// payload, which is the casing case in _ConflictingOperationsRejected.
+//
+// Because the mirror short-circuits before any statement runs, this test cannot
+// reach the 23505 path, and pins the mirror alone.
+func TestMethodOps_HandleResolvesThroughTriggerMirror(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	handle := "h" + uuid.NewString()[:8]
+	stored := f.seed("discord", handle, false)
+
+	w, body := f.post(addOp("discord", "@@"+handle))
+	require.Equal(t, http.StatusOK, w.Code,
+		"a handle whose normalized key already exists reached the database instead of being folded")
+	assert.Len(t, f.stored(), 1, "the add duplicated a row the trigger normalizes identically")
+
+	require.Len(t, body.Results, 1)
+	assert.Equal(t, "matched_existing", body.Results[0].Outcome)
+	assert.Equal(t, stored.ID.String(), body.Results[0].MethodID,
+		"the add did not resolve to the row the trigger considers identical")
+}
+
+// --- The handler's domain-error translation ---------------------------------
+
+// stubApplier returns a fixed error, so the handler's error mapping can be
+// exercised for a domain error a correct fold makes unreachable from a real
+// request. This is the seam the handler's narrow interface exists for.
+type stubApplier struct{ err error }
+
+func (s stubApplier) ApplyOperations(context.Context, uuid.UUID, []service.ContactMethodOperation) (*service.ApplyContactMethodsResult, error) {
+	return nil, s.err
+}
+
+// TestMethodOps_ConflictErrorTranslatesTo400 proves HTTP MAPPING only — not
+// repository classification (covered at the service level) and not mid-apply
+// rollback (an acknowledged gap). A correct mirror rejects trigger collisions
+// before SQL, so nothing else can reach this branch.
+func TestMethodOps_ConflictErrorTranslatesTo400(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"value conflict", fmt.Errorf("wrapped: %w", repository.ErrMethodValueConflict), http.StatusBadRequest},
+		{"invalid operations", fmt.Errorf("wrapped: %w", service.ErrInvalidOperations), http.StatusBadRequest},
+		{"foreign method id", fmt.Errorf("wrapped: %w", service.ErrMethodNotOwned), http.StatusNotFound},
+		{"unknown contact", fmt.Errorf("wrapped: %w", db.ErrNotFound), http.StatusNotFound},
+		{"unexpected failure", errors.New("boom"), http.StatusInternalServerError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			router := newMethodOpsRouter(stubApplier{err: tc.err})
+
+			body, err := json.Marshal(map[string]any{
+				"operations": []map[string]any{addOp("email", "someone@example.test")},
+			})
+			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodPost,
+				"/api/v1/contacts/"+uuid.NewString()+"/methods", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.want, w.Code)
+			if tc.want == http.StatusInternalServerError {
+				assert.NotContains(t, w.Body.String(), "boom",
+					"the raw error leaked into the response body")
+			}
+		})
+	}
+}
+
+// --- The route surface ------------------------------------------------------
+
+// TestMethodRoutes_NoDesiredSetPut asserts PUT /contacts/:id/methods is NOT
+// registered. A PUT taking the full desired list is wholesale replace wearing a
+// sub-resource costume: absence would again imply deletion, reintroducing the
+// exact defect this endpoint exists to eliminate.
+//
+// CON-062[0] tests POST semantics and would stay green alongside a new PUT, so
+// a guarantee that depends on a route never being added is asserted
+// mechanically rather than left in prose.
+func TestMethodRoutes_NoDesiredSetPut(t *testing.T) {
+	t.Parallel()
+
+	router := newMethodOpsRouterFull()
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/contacts/"+uuid.NewString()+"/methods", bytes.NewReader([]byte(`{"methods":[]}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Contains(t, []int{http.StatusNotFound, http.StatusMethodNotAllowed}, w.Code,
+		"PUT /contacts/:id/methods is registered; a desired-set endpoint reintroduces the lost-update defect")
+}
+
+// newMethodOpsRouterFull registers the whole contact route surface through the
+// production registrar, so the negative assertion above is made against the
+// routes the binary actually serves rather than a hand-picked subset.
+func newMethodOpsRouterFull() *gin.Engine {
+	router := gin.New()
+	router.HandleMethodNotAllowed = true
+	v1 := router.Group("/api/v1")
+	handlers.RegisterContactRoutes(v1, handlers.ContactRouteDeps{
+		Contact:       &handlers.ContactHandler{},
+		Interaction:   &handlers.InteractionHandler{},
+		Note:          &handlers.NoteHandler{},
+		ContactMethod: handlers.NewContactMethodHandler(stubApplier{err: errors.New("unused")}),
+	})
+	return router
+}

--- a/backend/tests/contact_method_normalize_parity_test.go
+++ b/backend/tests/contact_method_normalize_parity_test.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMethodOps_UniquenessKeyMatchesTrigger is the C6 parity test.
+//
+// value_normalized is written by a BEFORE INSERT OR UPDATE trigger, so
+// idx_contact_method_unique_value is always enforced over the SQL function's
+// output — never over anything Go computes. The operations endpoint folds its
+// uniqueness key in Go to reject duplicates before issuing any statement, so if
+// the Go mirror and the SQL function disagree, a conflict the fold judged safe
+// reaches the index and surfaces as a 500 instead of a deterministic 400.
+//
+// This drives the LIVE function through the test-only sqlc query and asserts
+// the mirror agrees on every row. A hand-written expected-value table would
+// just re-encode whatever misunderstanding produced the divergence in the first
+// place; only the real function settles it.
+//
+// Mutation that must turn this red: change the mirror's handle branch to strip
+// one '@' instead of all of them.
+func TestMethodOps_UniquenessKeyMatchesTrigger(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	if err != nil {
+		t.Skipf("Could not connect to database: %v", err)
+	}
+	defer database.Close()
+
+	repo := repository.NewContactMethodRepository(database.Queries)
+
+	// The corpus targets every branch of the SQL function, plus the specific
+	// inputs where Go's obvious implementation diverges from it.
+	corpus := []struct {
+		name       string
+		methodType string
+		value      string
+	}{
+		// Handle branch — '^@+' strips ALL leading '@'. identity.Normalize
+		// strips exactly one, which is the verified divergence this mirror
+		// exists to avoid inheriting.
+		{"handle double at", "discord", "@@foo"},
+		{"handle triple at", "telegram", "@@@foo"},
+		{"handle single at", "telegram", "@foo"},
+		{"handle bare", "twitter", "foo"},
+		{"handle mixed case", "telegram", "@FooBar"},
+		{"handle at only", "discord", "@@@"},
+
+		// Email branch — lower(btrim(...)).
+		{"email mixed case", "email", "Case@Example.Test"},
+		{"email padded", "email", "  case@example.test  "},
+		{"gchat mixed case", "gchat", "Case@Example.Test"},
+
+		// Phone branch. The leading-plus test is '^\\+', which matches literal
+		// BACKSLASHES, so a real '+' never reaches that branch and falls
+		// through to the US-country-code rule instead.
+		{"phone plus ten digits", "phone", "+1234567890"},
+		{"phone bare ten digits", "phone", "1234567890"},
+		{"phone eleven leading one", "phone", "11234567890"},
+		{"phone plus eleven", "phone", "+11234567890"},
+		{"phone formatted", "phone", "(555) 010-1234"},
+		{"phone international", "phone", "+44 20 7946 0958"},
+		{"phone thirteen digits", "phone", "1234567890123"},
+		// The ONLY input that reaches the trigger's plus branch. Without it a
+		// mirror that models that branch as permanently unreachable passes the
+		// entire corpus while still being wrong.
+		{"phone backslash prefix", "phone", `\1234567890`},
+		{"phone double backslash", "phone", `\\1234567890`},
+		{"phone backslash eleven", "signal", `\11234567890`},
+		{"phone no digits", "phone", "abc"},
+		{"phone blank", "phone", ""},
+		{"phone spaces only", "phone", "   "},
+		{"whatsapp ten digits", "whatsapp", "5550101234"},
+		{"signal formatted", "signal", "555-010-1234"},
+
+		// btrim() removes SPACES only. A tab-padded value is NOT trimmed by the
+		// trigger, so strings.TrimSpace would silently disagree here.
+		{"email tab padded", "email", "\tcase@example.test\t"},
+		{"handle tab padded", "telegram", "\t@foo\t"},
+		{"phone tab padded", "phone", "\t1234567890\t"},
+
+		// Blank and whitespace across the other branches.
+		{"email blank", "email", ""},
+		{"email spaces only", "email", "   "},
+		{"handle blank", "telegram", ""},
+	}
+
+	for _, tc := range corpus {
+		t.Run(tc.name, func(t *testing.T) {
+			fromTrigger, err := repo.NormalizeContactMethodValueViaTrigger(ctx, tc.methodType, tc.value)
+			require.NoError(t, err, "live normalize_contact_method_value should not error")
+
+			fromMirror := repository.NormalizeContactMethodValueForUniqueness(tc.methodType, tc.value)
+
+			require.Equal(t, fromTrigger, fromMirror,
+				"mirror disagrees with the live trigger for type=%q value=%q — the fold would compute a "+
+					"uniqueness key the unique index does not enforce, turning a deterministic 400 into a 500",
+				tc.methodType, tc.value)
+		})
+	}
+}

--- a/backend/tests/contact_method_operations_integration_test.go
+++ b/backend/tests/contact_method_operations_integration_test.go
@@ -1,0 +1,416 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// methodOpsFixture is one contact plus its method repository, scoped to this
+// test's own namespace so parallel copies never see each other's rows.
+type methodOpsFixture struct {
+	ctx        context.Context
+	database   *db.Database
+	contactID  uuid.UUID
+	methodRepo *repository.ContactMethodRepository
+	svc        *service.ContactMethodService
+}
+
+func newMethodOpsFixture(t *testing.T) *methodOpsFixture {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	if err != nil {
+		t.Skipf("Could not connect to database: %v", err)
+	}
+	t.Cleanup(database.Close)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "MethodOps " + syntheticNS(t) + " " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+	return &methodOpsFixture{
+		ctx:        ctx,
+		database:   database,
+		contactID:  contact.ID,
+		methodRepo: repository.NewContactMethodRepository(database.Queries),
+		// bus and rematch registry are nil: these tests pin the fold and apply
+		// stages, not the event contract.
+		svc: service.NewContactMethodService(database, nil, nil),
+	}
+}
+
+func (f *methodOpsFixture) seed(t *testing.T, methodType, value string, primary bool) repository.ContactMethod {
+	t.Helper()
+	m, err := f.methodRepo.CreateContactMethod(f.ctx, repository.CreateContactMethodRequest{
+		ContactID: f.contactID,
+		Type:      methodType,
+		Value:     value,
+		IsPrimary: primary,
+	})
+	require.NoError(t, err)
+	return *m
+}
+
+func (f *methodOpsFixture) methods(t *testing.T) []repository.ContactMethod {
+	t.Helper()
+	got, err := f.methodRepo.ListContactMethodsByContact(f.ctx, f.contactID)
+	require.NoError(t, err)
+	return got
+}
+
+func (f *methodOpsFixture) byID(t *testing.T, id uuid.UUID) *repository.ContactMethod {
+	t.Helper()
+	for _, m := range f.methods(t) {
+		if m.ID == id {
+			return &m
+		}
+	}
+	return nil
+}
+
+func idPtr(id uuid.UUID) *uuid.UUID { return &id }
+
+// TestApplyOperations_ValueSwapSucceeds pins the delete-and-reinsert apply
+// strategy against a full value swap, which an in-place rewrite cannot do:
+// idx_contact_method_unique_value is enforced per statement, so whichever row
+// moved first would collide with the other's still-present key.
+//
+// Mutation: replace the delete-and-reinsert in applyFinalState with in-place
+// updates.
+func TestApplyOperations_ValueSwapSucceeds(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	ns := syntheticNS(t)
+
+	a := f.seed(t, "email", "a-"+ns+"@x.test", true)
+	b := f.seed(t, "email", "b-"+ns+"@x.test", false)
+
+	_, err := f.svc.ApplyOperations(f.ctx, f.contactID, []service.ContactMethodOperation{
+		{Op: service.MethodOpUpdate, MethodID: idPtr(a.ID), Type: "email", Value: "b-" + ns + "@x.test"},
+		{Op: service.MethodOpUpdate, MethodID: idPtr(b.ID), Type: "email", Value: "a-" + ns + "@x.test"},
+	})
+	require.NoError(t, err, "a full value swap must succeed in one request")
+
+	gotA := f.byID(t, a.ID)
+	gotB := f.byID(t, b.ID)
+	require.NotNil(t, gotA)
+	require.NotNil(t, gotB)
+	require.Equal(t, "b-"+ns+"@x.test", gotA.Value)
+	require.Equal(t, "a-"+ns+"@x.test", gotB.Value)
+	// Identity survives the reinsert — that is what makes update a distinct
+	// verb from remove-then-add.
+	require.Equal(t, a.CreatedAt.UTC(), gotA.CreatedAt.UTC(), "created_at must survive the reinsert")
+	require.Equal(t, b.CreatedAt.UTC(), gotB.CreatedAt.UTC(), "created_at must survive the reinsert")
+}
+
+// TestApplyOperations_TypeOnlySwapSucceeds is the case the abandoned
+// temporary-value scheme could not even detect: the stored values never change,
+// only the types, so there is no value change to trigger a temp phase — yet
+// (type, value_normalized) changes for both rows.
+//
+// Mutation: key the delete decision on the VALUE rather than the (type, value)
+// key.
+func TestApplyOperations_TypeOnlySwapSucceeds(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	shared := "1" + syntheticNS(t) + "@a.co"
+
+	a := f.seed(t, "email", shared, false)
+	b := f.seed(t, "telegram", shared, false)
+
+	_, err := f.svc.ApplyOperations(f.ctx, f.contactID, []service.ContactMethodOperation{
+		{Op: service.MethodOpUpdate, MethodID: idPtr(a.ID), Type: "telegram", Value: shared},
+		{Op: service.MethodOpUpdate, MethodID: idPtr(b.ID), Type: "email", Value: shared},
+	})
+	require.NoError(t, err, "a type-only swap must succeed in one request")
+
+	require.Equal(t, "telegram", f.byID(t, a.ID).Type)
+	require.Equal(t, "email", f.byID(t, b.ID).Type)
+}
+
+// TestApplyOperations_UpdatesStableKeyValue is the mechanism pin for apply
+// step 4. A case-only correction changes the stored value the user asked for
+// while leaving (type, value_normalized) identical, so steps 1-3 never touch the
+// row. Without an in-place update phase the request returns success having
+// stored nothing — a silent-success failure.
+//
+// Mutation: delete apply step 4. The test must then fail on the stored-value
+// assertion, not on an error.
+func TestApplyOperations_UpdatesStableKeyValue(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	ns := syntheticNS(t)
+
+	a := f.seed(t, "email", "Case-"+ns+"@Example.test", false)
+	lowered := "case-" + ns + "@example.test"
+
+	_, err := f.svc.ApplyOperations(f.ctx, f.contactID, []service.ContactMethodOperation{
+		{Op: service.MethodOpUpdate, MethodID: idPtr(a.ID), Type: "email", Value: lowered},
+	})
+	require.NoError(t, err)
+
+	got := f.byID(t, a.ID)
+	require.NotNil(t, got)
+	require.Equal(t, lowered, got.Value,
+		"a value edit that does not move the normalized key must still persist")
+	require.Equal(t, a.ID, got.ID)
+	require.Equal(t, a.CreatedAt.UTC(), got.CreatedAt.UTC())
+}
+
+// TestApplyOperations_KeyChangingUpdateOfPrimaryKeepsPrimary pins apply
+// steps 5-6 being defined by DATABASE STATE rather than by designation delta.
+//
+// The primary's own key changes, so it is deleted and reinserted non-primary
+// while its designation never changed. A delta-based rule fires neither demote
+// nor promote, and the contact silently ends with no primary at all.
+//
+// Mutation: gate the promote on "the designated primary differs from the
+// pre-state primary".
+func TestApplyOperations_KeyChangingUpdateOfPrimaryKeepsPrimary(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	ns := syntheticNS(t)
+
+	a := f.seed(t, "email", "p-"+ns+"@x.test", true)
+
+	_, err := f.svc.ApplyOperations(f.ctx, f.contactID, []service.ContactMethodOperation{
+		{Op: service.MethodOpUpdate, MethodID: idPtr(a.ID), Type: "email", Value: "moved-" + ns + "@x.test"},
+	})
+	require.NoError(t, err)
+
+	got := f.byID(t, a.ID)
+	require.NotNil(t, got)
+	require.True(t, got.IsPrimary,
+		"a key-changing update of the primary must leave it still primary")
+
+	primaries := 0
+	for _, m := range f.methods(t) {
+		if m.IsPrimary {
+			primaries++
+		}
+	}
+	require.Equal(t, 1, primaries, "exactly one primary must remain")
+}
+
+// TestApplyOperations_UnnamedMethodsSurvive is the acceptance bar for the
+// lost-update defect: a client that has never seen a method cannot destroy it,
+// because absence expresses nothing in an operations payload.
+//
+// Asserts the FULL persisted row, including updated_at and value_normalized.
+// The chosen apply mechanism is physical reinsertion, so an implementation that
+// needlessly deletes and reinserts every row would preserve id/type/value and
+// move updated_at — passing a weaker version of the very test written to catch
+// that.
+//
+// Mutation: make applyFinalState delete all rows and reinsert the final state.
+func TestApplyOperations_UnnamedMethodsSurvive(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	ns := syntheticNS(t)
+
+	unseen := f.seed(t, "email", "unseen-"+ns+"@x.test", true)
+
+	_, err := f.svc.ApplyOperations(f.ctx, f.contactID, []service.ContactMethodOperation{
+		{Op: service.MethodOpAdd, Type: "phone", Value: "+1555" + ns[:4] + "001"},
+	})
+	require.NoError(t, err)
+
+	got := f.byID(t, unseen.ID)
+	require.NotNil(t, got, "a method no operation named must survive")
+	require.Equal(t, unseen.ID, got.ID)
+	require.Equal(t, unseen.Type, got.Type)
+	require.Equal(t, unseen.Value, got.Value)
+	require.Equal(t, unseen.ValueNormalized, got.ValueNormalized)
+	require.Equal(t, unseen.IsPrimary, got.IsPrimary)
+	require.Equal(t, unseen.CreatedAt.UTC(), got.CreatedAt.UTC())
+	require.Equal(t, unseen.UpdatedAt.UTC(), got.UpdatedAt.UTC(),
+		"updated_at must not move — an untouched row must not be rewritten")
+}
+
+// TestApplyOperations_RollsBackWholePayloadOnFailure pins validation-stage
+// atomicity: one invalid operation leaves zero partial effects.
+//
+// Mutation: apply operations incrementally instead of validating the whole
+// intended final state first.
+func TestApplyOperations_RollsBackWholePayloadOnFailure(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	ns := syntheticNS(t)
+
+	a := f.seed(t, "email", "keep-"+ns+"@x.test", true)
+	before := f.methods(t)
+
+	_, err := f.svc.ApplyOperations(f.ctx, f.contactID, []service.ContactMethodOperation{
+		{Op: service.MethodOpAdd, Type: "phone", Value: "+1555" + ns[:4] + "002"},
+		// Unsatisfiable: blank value.
+		{Op: service.MethodOpAdd, Type: "email", Value: ""},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, service.ErrInvalidOperations)
+
+	after := f.methods(t)
+	require.Len(t, after, len(before), "no operation may land when any is rejected")
+	require.NotNil(t, f.byID(t, a.ID))
+}
+
+// TestApplyOperations_ReplayIsSafePerOperationClass covers every operation class
+// twice, asserting the second attempt changes nothing.
+//
+// The remove case deliberately removes a PRESENT row and then replays, so the
+// replay resolves through the ownership lookup's "does not exist" branch — the
+// branch that actually carries the idempotency guarantee. A remove-of-absent
+// case would leave that branch unexercised, since both attempts would be no-ops.
+func TestApplyOperations_ReplayIsSafePerOperationClass(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ops  func(f *methodOpsFixture, t *testing.T) []service.ContactMethodOperation
+	}{
+		{
+			name: "add",
+			ops: func(f *methodOpsFixture, t *testing.T) []service.ContactMethodOperation {
+				return []service.ContactMethodOperation{
+					{Op: service.MethodOpAdd, Type: "email", Value: "replay-" + syntheticNS(t) + "@x.test"},
+				}
+			},
+		},
+		{
+			name: "update",
+			ops: func(f *methodOpsFixture, t *testing.T) []service.ContactMethodOperation {
+				m := f.seed(t, "email", "u-"+syntheticNS(t)+"@x.test", false)
+				return []service.ContactMethodOperation{
+					{Op: service.MethodOpUpdate, MethodID: idPtr(m.ID), Type: "email", Value: "u2-" + syntheticNS(t) + "@x.test"},
+				}
+			},
+		},
+		{
+			name: "set_primary",
+			ops: func(f *methodOpsFixture, t *testing.T) []service.ContactMethodOperation {
+				m := f.seed(t, "email", "sp-"+syntheticNS(t)+"@x.test", false)
+				return []service.ContactMethodOperation{
+					{Op: service.MethodOpSetPrimary, MethodID: idPtr(m.ID)},
+				}
+			},
+		},
+		{
+			name: "clear_primary",
+			ops: func(f *methodOpsFixture, t *testing.T) []service.ContactMethodOperation {
+				m := f.seed(t, "email", "cp-"+syntheticNS(t)+"@x.test", true)
+				return []service.ContactMethodOperation{
+					{Op: service.MethodOpClearPrimary, MethodID: idPtr(m.ID)},
+				}
+			},
+		},
+		{
+			name: "remove_of_present_row",
+			ops: func(f *methodOpsFixture, t *testing.T) []service.ContactMethodOperation {
+				m := f.seed(t, "email", "rm-"+syntheticNS(t)+"@x.test", false)
+				return []service.ContactMethodOperation{
+					{Op: service.MethodOpRemove, MethodID: idPtr(m.ID)},
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := newMethodOpsFixture(t)
+			ops := tc.ops(f, t)
+
+			_, err := f.svc.ApplyOperations(f.ctx, f.contactID, ops)
+			require.NoError(t, err, "first attempt should succeed")
+			afterFirst := f.methods(t)
+
+			_, err = f.svc.ApplyOperations(f.ctx, f.contactID, ops)
+			require.NoError(t, err, "replaying the same payload must succeed")
+			afterSecond := f.methods(t)
+
+			require.Equal(t, len(afterFirst), len(afterSecond),
+				"a replayed payload must not change the method set")
+			for i := range afterFirst {
+				require.Equal(t, afterFirst[i].ID, afterSecond[i].ID)
+				require.Equal(t, afterFirst[i].Value, afterSecond[i].Value)
+				require.Equal(t, afterFirst[i].IsPrimary, afterSecond[i].IsPrimary)
+			}
+		})
+	}
+}
+
+// TestContactMethodRepo_ClassifiesValueConflict is seam 1: force a genuine
+// unique violation by bypassing the fold entirely and inserting a
+// trigger-colliding value straight through the repository. Real PostgreSQL
+// error, real constraint name, real classification code, no mocking.
+//
+// Mutation: delete the repository's 23505 classification.
+func TestContactMethodRepo_ClassifiesValueConflict(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	ns := syntheticNS(t)
+
+	// '@@foo' and 'foo' both normalize to 'foo' through the trigger's '^@+'
+	// rule, so the second insert collides on (contact_id, type,
+	// value_normalized).
+	_ = f.seed(t, "discord", "handle"+ns, false)
+
+	_, err := f.methodRepo.InsertContactMethodWithIdentity(f.ctx, repository.InsertContactMethodWithIdentityRequest{
+		ID:        uuid.New(),
+		ContactID: f.contactID,
+		Type:      "discord",
+		Value:     "@@handle" + ns,
+		CreatedAt: accelerated.GetCurrentTime(),
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, repository.ErrMethodValueConflict,
+		"a unique violation on idx_contact_method_unique_value must classify as ErrMethodValueConflict")
+}
+
+// TestContactMethodRepo_UnrelatedConstraintNotSwallowed is the pair that makes
+// the constraint-name scoping meaningful. contact_method carries a SECOND
+// unique index, idx_contact_method_primary (at most one primary per contact).
+// A violation of that one must pass through unwrapped: reporting it as a
+// duplicate-value conflict would tell the user "duplicate value" for what is
+// actually a two-primaries bug.
+//
+// Mutation: drop the ConstraintName scoping so any 23505 maps to
+// ErrMethodValueConflict.
+func TestContactMethodRepo_UnrelatedConstraintNotSwallowed(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFixture(t)
+	ns := syntheticNS(t)
+
+	_ = f.seed(t, "email", "first-"+ns+"@x.test", true)
+	second := f.seed(t, "email", "second-"+ns+"@x.test", false)
+
+	// Promoting a second row while the first is still primary violates
+	// idx_contact_method_primary, not the value index.
+	err := f.methodRepo.PromoteContactMethodPrimaryByContact(f.ctx, f.contactID, second.ID)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, repository.ErrMethodValueConflict,
+		"a primary-index violation must not be reported as a duplicate-value conflict")
+}

--- a/backend/tests/contact_method_operations_integration_test.go
+++ b/backend/tests/contact_method_operations_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"personal-crm/backend/internal/service"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -388,6 +389,21 @@ func TestContactMethodRepo_ClassifiesValueConflict(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, repository.ErrMethodValueConflict,
 		"a unique violation on idx_contact_method_unique_value must classify as ErrMethodValueConflict")
+
+	// The error must carry NO detail from PostgreSQL. Its Detail for this
+	// violation reads "Key (contact_id, type, value_normalized)=(<uuid>, email,
+	// <value>) already exists.", and this error travels to the HTTP response
+	// body — so including it would put a real contact's method value, the
+	// contact id, and the column layout in front of the client.
+	//
+	// Asserted at the repository because that is where the string is built and
+	// where this path is reachable. Above here a correct C6 mirror rejects the
+	// collision during the fold, so no HTTP-level test can drive it.
+	msg := err.Error()
+	assert.NotContains(t, msg, "handle"+ns, "the method value leaked into the error")
+	assert.NotContains(t, msg, f.contactID.String(), "the contact id leaked into the error")
+	assert.NotContains(t, msg, "value_normalized", "the column layout leaked into the error")
+	assert.NotContains(t, msg, "already exists", "PostgreSQL's detail string leaked into the error")
 }
 
 // TestContactMethodRepo_UnrelatedConstraintNotSwallowed is the pair that makes

--- a/frontend/src/types/generated/contact.ts
+++ b/frontend/src/types/generated/contact.ts
@@ -131,3 +131,58 @@ export interface MergePreviewResponse {
   interactions_to_transfer: number /* int64 */;
   calendar_events_to_update: number /* int64 */;
 }
+/**
+ * ContactMethodOperation is one requested contact-method mutation.
+ * The endpoint takes OPERATIONS, never a desired set. A desired set makes
+ * absence mean "delete", so a client working from a stale read destroys every
+ * method it never saw — the defect this endpoint exists to make unexpressible.
+ * @Description A single contact-method operation
+ */
+export interface ContactMethodOperation {
+  op: string;
+  method_id?: string;
+  type?: ContactMethodType;
+  value?: string;
+  /**
+   * IsPrimary is a pointer so the handler can tell "absent" from "present and
+   * false". The field is forbidden on update, which is a presence test — a
+   * plain bool would silently accept an explicit false.
+   */
+  is_primary?: boolean;
+}
+/**
+ * ContactMethodOperationsRequest is the operations payload.
+ * @Description Contact-method operations request
+ * An empty or absent operations list is a successful no-op, so the slice is
+ * deliberately NOT `required` — that tag fails a zero-length slice and would
+ * turn "nothing to do" into a 400.
+ */
+export interface ContactMethodOperationsRequest {
+  operations: ContactMethodOperation[];
+}
+/**
+ * ContactMethodOperationResult reports what happened to one SUBMITTED
+ * operation, at that operation's own request index.
+ * Method is present only where the operation leaves a surviving row. A removal
+ * carries no snapshot: a removed row has no post-apply state, and an idempotent
+ * removal of an already-absent id has no row at all. MethodID is always the id
+ * the operation addressed.
+ * @Description Result of a single contact-method operation
+ */
+export interface ContactMethodOperationResult {
+  index: number /* int */;
+  outcome: string;
+  method_id: string;
+  method?: ContactMethodResponse;
+}
+/**
+ * ContactMethodOperationsResponse carries the contact's full method list after
+ * applying, a rematch job id when one was enqueued, and one result per
+ * submitted operation.
+ * @Description Contact-method operations response
+ */
+export interface ContactMethodOperationsResponse {
+  methods: ContactMethodResponse[];
+  rematch_job_id?: string;
+  results: ContactMethodOperationResult[];
+}

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -317,6 +317,14 @@
     "tags": ["@area:contacts", "@area:contact-navigation", "@area:contact-merge", "@area:overdue"]
   },
   {
+    "pattern": "^backend/internal/api/handlers/contact_method\\.go$",
+    "tags": ["@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/service/contact_method\\.go$",
+    "tags": ["@area:contacts"]
+  },
+  {
     "pattern": "^backend/internal/api/handlers/import\\.go$",
     "tags": ["@area:imports"]
   },

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -191,15 +191,27 @@ behaviors:
     type: api
     status: current
     surface: api
-    given: a create or update request carrying contact methods
+    given: a create request, a legacy update request carrying contact methods, or a method operations request
     when: methods are validated
     then:
-      - blank-valued entries are dropped rather than rejected
+      - blank-valued entries are dropped rather than rejected on the create and legacy update paths
+      - an add or update operation naming a blank value is rejected rather than dropped
       - email-family values must be valid email addresses
       - phone-family values are limited to 50 characters
       - two entries with the same type and normalized value are rejected as duplicates
       - more than one entry marked primary is rejected
-    provenance: [normalizeContactMethodRequests, validateContactMethods]
+    provenance: [normalizeContactMethodRequests, validateContactMethods, validateOperationShapes, buildContactMethodOperations]
+    notes: >
+      Format and duplicate rules are shared by all three paths; only blank
+      handling deliberately differs. Create and legacy update drop a blank
+      entry, because a blank row in a full-list payload carries no intent. An
+      explicit add or update naming a blank value is an unsatisfiable intent and
+      is rejected — dropping it would report success for a change that never
+      happened, which is the silent-success failure the operations endpoint
+      exists to eliminate.
+
+      The legacy update clause goes away when that path is retired; the create
+      and operations clauses stay.
 
   # --- List, sort, filter, search ---
 
@@ -750,6 +762,43 @@ behaviors:
       - a contact with a computed next-contact date renders that date, and one without renders a placeholder
     provenance: [contacts page table cells, formatCadence, contact_by]
     notes: The contact_by computation itself is backend-owned (CON-001); this row pins only the list's rendering of the derived values.
+
+  - id: CON-062
+    title: Contact methods are mutated by explicit operations
+    type: api
+    status: current
+    surface: api
+    given: a contact with existing methods
+    when: a method operations request is applied
+    then:
+      - a method that no operation names is neither removed nor altered, except that promoting a primary demotes the previous primary
+      - the whole request applies in one transaction, or none of it applies
+      - the outcome does not depend on the order operations appear in the request
+      - adding a method that already exists succeeds without duplicating it
+      - removing a method that is already absent succeeds
+      - a request whose resulting method set would contain a duplicate type and value is rejected
+      - a request designating more than one primary is rejected
+      - an operation naming a method id owned by a different contact is rejected
+      - a named primary can be cleared, leaving the contact with no primary
+      - a request whose operations conflict with each other is rejected rather than resolved by their order
+      - updating a method's value takes effect even when the change does not alter how the value is normalized
+      - updating the primary method's value leaves it still the primary
+      - the response reports one result for every operation the request submitted, in the same order
+      - each result identifies the method its operation addressed, and reports the resulting method's stored state when the operation leaves one
+    provenance: [ContactMethodService.ApplyOperations, ContactMethodHandler.ApplyOperations]
+    notes: >
+      The first then-item is the acceptance bar for the lost-update defect: a
+      client that has never seen a method cannot destroy it, because absence
+      expresses nothing in an operations payload. The primary-demotion carve-out
+      is a real side effect on an unnamed row and is stated rather than hidden —
+      at most one primary is a database constraint, so promoting one necessarily
+      demotes another.
+
+      The last two then-items are the results contract a client's
+      acknowledged-state advance depends on. They are stated as behavior because
+      a client that cannot learn which method its own addition resolved to will
+      later fail to edit or remove that method — the response shape is
+      load-bearing, not incidental.
 
   # --- Intents (judged experience goals — Track B agentic judge only) ---
 

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -255,7 +255,7 @@ behaviors:
     type: business-logic
     status: current
     surface: api
-    given: new methods appearing on a CRM contact (create, method-replacing update, enrichment, or suggestion resolve)
+    given: new methods appearing on a CRM contact (create, method-replacing update, a method operations request, enrichment, or suggestion resolve)
     when: the write commits
     then:
       - a rematch event is published for the methods that have a registered handler


### PR DESCRIPTION
## What

Adds `POST /contacts/:id/methods`, a transactional operations endpoint for contact methods. Purely additive — nothing yet calls it, and `PUT /contacts/:id` is untouched. PR3 switches the edit form over and retires the destructive branch.

Operations are `add` / `update` / `remove` / `set_primary` / `clear_primary`, applied in one transaction via **fold → validate → publish → apply**:

1. **Fold** operations onto pre-state in memory
2. **Validate** the intended final state — conflicts are rejected deterministically here, not discovered by whichever row PostgreSQL happened to reach first
3. **Publish** the semantic diff (`bus.PublishTx → mutate → commit`, literally in that order)
4. **Apply** the mutations that carry pre-state to final state

## Why

Second of three PRs fixing a real data-loss incident. A contact method added by import-link enrichment was permanently destroyed by a later edit-form save, because `PUT /contacts/:id` treats a supplied `methods` array as a wholesale delete-and-recreate: absence implies deletion, so a client saving a stale list silently destroys what it never knew about.

The fix is structural rather than defensive. Removal requires *naming* what to remove, so **a client cannot delete a method it never saw** — including a future MCP client that has never read this design. `POST` with operations, never `PUT` with a desired set: a desired-set endpoint is wholesale replace wearing a sub-resource costume, and a route-level test asserts it does not exist.

Design: `.ai/spec/2026-07-18-contact-method-lost-update-design.md`.

## Design notes

**Delete-and-reinsert with preserved identity.** Rows whose `(type, value_normalized)` key changes are deleted and reinserted with their original `id` and `created_at`, verified safe because no foreign key anywhere references `contact_method` (checked against the live schema). This makes type-only swaps reachable, avoids transient collisions against `idx_contact_method_unique_value` with no sentinel-value scheme to get wrong, and preserves `created_at` — which is the forensic evidence that made the original incident diagnosable.

**Per-operation-type results.** `add`/`update` carry the resolved row snapshot; `remove` carries the submitted `method_id` and outcome only, since a removed row has no post-apply state. The client must never re-derive server identity by re-normalizing the returned list: the client's normalizer and the database trigger are provably different functions, so that inference fails exactly when it matters.

**Normalization mirror.** The fold's uniqueness key mirrors the database trigger, including its actual behavior rather than its intent — migration 022's `'^\+'` matches leading *backslashes*, never a real plus, so phones with an explicit international prefix fall through to the US-country-code branch. That is a pre-existing bug and deliberately out of scope; a 30-row parity test pins mirror and live SQL function in agreement.

## Tests

Every test was run against the unfixed tree and observed to fail **on its intended assertion**. Five of thirteen mutation attempts were themselves defective — build failures, orphaned imports — and were discarded and redone rather than banked as passing gates.

Two vacuity traps were found by asking *what feature deletion would this test survive*, after ten clean mutation runs had passed over both:

- `_DuplicateFinalStateRejected` survived deleting the fold's duplicate check entirely, because the database's unique index produces an identical 400 through the backstop — so the status code could not distinguish deterministic pre-SQL rejection from a mutation that ran and rolled back. The first repair was *also* vacuous, since PostgreSQL embeds the value in its error detail too. It now asserts the fold's end-state phrasing, which only a pre-SQL check can produce.
- The primary-add and payload-order tests counted primaries without checking *which* row won, so a seeded primary satisfied them with promotion removed entirely.

`_RemoveResultsCarryAddressedIDWithoutSnapshot` documents that its guard cannot be pinned by any test, rather than reading as a pin.

## Notes

- **PII fix:** the repository previously embedded PostgreSQL's `Detail` in the returned error, which reaches the HTTP body. For a unique violation that string carries the contact id, the column layout, and **the method value itself** — a real email address or phone number. Now returns the bare sentinel; the pgconn error is deliberately not wrapped, since wrapping would restore the leak through the error chain.
- **Layering:** persistence errors stay behind the service. The handler imports neither `db` nor repository error types, and a test pins that raw repository/db errors are *not* classified at the handler, so a future layer skip fails loudly rather than silently working.
- The `23505` translation has no committed test. The full chain (real collision → unique constraint → domain error → 400) was *observed* end to end during mutation testing under a deliberately broken mirror, but reaching it in production code requires a mirror defect, so it is evidence rather than coverage. Recorded honestly instead of pinned by an unfalsifiable test.
- Swagger annotations are present but the generated spec is stale: `make api-docs` fails at the base commit (#694).
