### PR TITLE
feat(qa): nightly-round orchestrator for the QA judge loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -540,6 +540,7 @@ test-deploy-scripts:
 	@bash scripts/staging-reset.test.sh
 	@bash scripts/ci/staging-reseed-decision.test.sh
 	@bash scripts/ci/qa-round-cadence-gate.test.sh
+	@bash scripts/ci/qa-nightly-round.test.sh
 	@bash scripts/ci/qa-fn-backfill-guard.test.sh
 	@bash scripts/staging-deployed-sha.test.sh
 	@bash scripts/staging-reseed.test.sh

--- a/scripts/ci/qa-nightly-round.sh
+++ b/scripts/ci/qa-nightly-round.sh
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+# qa-nightly-round.sh — PURE, STATELESS, PARAMETERIZED orchestrator for ONE nightly
+# QA judge round. It sequences the in-repo QA pipeline (which versions in lockstep
+# with this script) and emits a machine-readable decision for the host wrapper to act
+# on. It NEVER checks out, NEVER reseeds/deploys by itself, NEVER persists a watermark
+# or any other state, and NEVER reads host facts directly — every host-specific is
+# INJECTED as env/args. The wrapper (personal-ops, host-entangled) owns the checkout,
+# supplying the reseed/deployed-sha commands + creds, and persisting the watermark
+# from the `advance=`/`target=` decision this script emits.
+#
+# INJECTED INPUTS (env):
+#   QA_BASE_SHA          last-round deployed sha        -> cadence gate <BASE>
+#   QA_HEAD_SHA          currently-deployed staging sha -> cadence gate <HEAD>, the
+#                        pre-tours pin, and (when the round is clean) the advance target
+#   QA_DAYS_SINCE        whole days since the last round -> cadence gate <DAYS_SINCE>
+#   QA_JUDGE_TRACE       FRESH per-round JSONL path the wrapper supplies (the judge
+#                        appends spans here; the whole file is exported). REQUIRED on a
+#                        run; a reused path only self-warns (export's sidecar guard).
+#   QA_RESEED_CMD        shell command that reseeds staging (optional; abort-on-fail).
+#                        When set, tours run with TOURS_SKIP_RESET=1 so tours does not
+#                        double-reseed. When unset (local/dev), tours reset themselves.
+#   QA_DEPLOYED_SHA_CMD  shell command that PRINTS the current deployed staging sha,
+#                        RE-READ after tours so a mid-round redeploy is caught.
+#   LANGFUSE_*           export creds (passed through the environment to qa-export).
+#   TOURS_*              tours env (TOURS_BASE_URL/…); passed through to `make tours`.
+#   QA_SALT_PASSES       optional; passed through to qa-export.
+#   QA_MAKE              test seam: the `make` to invoke (default `make`).
+#
+# THE PIPELINE IS THREE DISTINCT TARGETS (not one) — reflected in this sequence:
+#   `make tours`             run-tours.sh: (skippable) reseed + Playwright tours ->
+#                            captures + manifest.json in frontend/tests/tours/.runs/<id>/
+#   `make qa-report JUDGE=1` judge + TRAP self-test; its EXIT CODE is the hard trap
+#                            signal (non-zero = a missed/non-executable trap, e.g. a
+#                            tour failure left a behavior uncaptured). Writes QA_JUDGE_TRACE.
+#                            It does NOT export.
+#   `make qa-export`         ships the spans and PRINTS the RESULT counts (traces /
+#                            screenshots / FAILED / enqueue attempted-ok-skipped-failed);
+#                            exits 1 iff a trace failed to ship. Run as an INDEPENDENT
+#                            step (`;`, never `&&`) so a trap-miss trace STILL ships its
+#                            diagnostic — the round's clean/incomplete grade is computed
+#                            afterward, it never gates the ship.
+#
+# SEQUENCE:
+#   1. cadence gate -> run_round. Emit the gate's decision.
+#   2. run_round=false -> emit round=skipped, advance=false, exit 0. (Nothing else runs.)
+#   3. run_round=true:
+#      a. pre-tours pin: assert the checkout HEAD == QA_HEAD_SHA (the wrapper is
+#         assumed to have checked it out; this PROVES it). Fail -> round=aborted, exit≠0.
+#      b. reseed via QA_RESEED_CMD (if set); non-zero -> round=aborted, exit≠0.
+#      c. tours (fresh TOURS_RUN_ID we mint = the run dir + the QA_RUN_ID provenance) ->
+#         qa-report JUDGE=1 (capture the trap exit) ->  ; qa-export (capture RESULT counts).
+#      d. re-read the deployed sha; post-tours provenance assert vs <RUNDIR>/manifest.json
+#         (a mid-round redeploy makes CURRENT != HEAD -> assert fails -> do not advance).
+#      e. CLEAN-ROUND PREDICATE (conservative; ANY ambiguity -> advance=false, the round
+#         re-runs next cadence). advance=true ONLY if the round is provably complete.
+#      f. clean -> advance=true target=QA_HEAD_SHA; else advance=false + why.
+#   4. EMIT advance=true|false + target=<sha>. This script NEVER writes a watermark.
+#
+# CLEAN-ROUND PREDICATE — computed over the signals that EXIST TODAY:
+#   tours exit == 0 (a tour failure / incomplete coverage must NOT advance)
+#   AND qa-report exit == 0 (no missed/non-executable trap)
+#   AND qa-export exit == 0 AND shipped-FAILED == 0 (every trace shipped)
+#   AND traces > 0 (something shipped; a missing-creds no-op ships nothing -> no advance)
+#   AND enqueue-failed == 0 (no dropped triage POST)
+#   AND enqueued + already-queued >= 1 (the mandatory fail/trap enqueue actually landed;
+#       a silently-skipped enqueue pass, e.g. an unresolved queue, is a partial-enrichment
+#       loss and must NOT advance)
+#   AND the post-tours provenance assert passed.
+#
+# A direct EXPECTED-vs-EXECUTED capture signal does not exist yet: render.ts renders
+# behavior coverage from collected grades + a static skip-list (it does not prove every
+# scheduled capture executed), and manifest.json holds provenance, not an
+# expected/executed set. So this predicate cannot verify "all scheduled captures present"
+# directly; it approximates completeness via the trap self-test exit (a trap on an
+# uncaptured behavior goes non-executable -> non-zero) + the tours exit, and stays
+# CONSERVATIVE — any ambiguity degrades to advance=false and the round simply re-runs.
+# A missing signal is never fabricated; it degrades to not advancing.
+#
+# KNOWN RESIDUALS (need signals/isolation outside this orchestrator; tracked for the follow-up
+# wrapper/exporter work — the gate still FAILS SAFE around them):
+#   - Per-trace media completeness: the export summary reports only the TOTAL screenshot count,
+#     so an all-media-failed round is caught but a per-trace partial loss is not (needs the
+#     expected-vs-executed capture signal).
+#   - Judge-span error status: an LLM judge call that ERRORS into `unsure` without failing a
+#     trap is not visible from the export counts (needs the exporter to surface a judge-error
+#     count); the trap self-test exit is the current best judge-health proxy.
+#   - Judge env isolation: `env -u` strips the injected command vars + the pipeline's API creds
+#     from the qa-report child, but the CRM tooling (bun/next) reloads frontend/.env.local, which
+#     can re-introduce app env (e.g. NEXT_PUBLIC_* — public by convention). Fully isolating the
+#     judge's Codex subprocess from .env.local is a broader concern than this orchestrator.
+#
+# EXIT CONTRACT: a round that RAN and produced a decision — clean OR incomplete — exits 0
+# with advance= reflecting cleanliness, so the wrapper reads the decision from the emitted
+# key=values. Non-zero means the decision is NOT a normal round outcome:
+#   - round=aborted (via abort(), exit 1 — except a cadence-gate failure propagates the
+#     gate's own exit code): could not resolve the script/repo root, the cadence-gate
+#     script is missing, the cadence gate itself failed, QA_JUDGE_TRACE is unset, the
+#     pre-tours pin failed, the reseed failed, or the run dir could not be reserved (a
+#     run-id collision OR a filesystem/permission error creating it).
+#   - exit 3 from emit(): a $GITHUB_ENV write failed, so a decision (of any kind) did not
+#     propagate — surfaced loudly rather than a silent exit 0.
+# In every case the wrapper must NOT advance the watermark on a non-zero exit.
+
+set -uo pipefail   # NO -e: a failed sub-step must be graded (degrade), not abort silently.
+
+# Sanitize the repo's standard git-location isolation set so nothing this script (or a
+# child it spawns — make/tours/qa-report, which run git) inherits from a poisoned caller
+# env (e.g. a git hook) resolves the wrong repo. The sibling gate/assert scripts also
+# unset these internally; clearing here keeps a leaked var from ever reaching `git`.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
+# Also clear an INHERITED TOURS_SKIP_RESET: this orchestrator decides reset/reseed itself
+# (skip only when it reseeded via QA_RESEED_CMD). If the caller's env already carried
+# TOURS_SKIP_RESET=1, an un-reseeded round would run tours against stale staging yet still
+# be graded clean — so start from a known-clear state and set it explicitly only when reseeding.
+unset TOURS_SKIP_RESET
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)"
+CADENCE_GATE="$SCRIPT_DIR/qa-round-cadence-gate.sh"
+SHA_ASSERT="$SCRIPT_DIR/qa-round-deployed-sha-assert.sh"
+MAKE="${QA_MAKE:-make}"
+RUNS_ROOT="$REPO_ROOT/frontend/tests/tours/.runs"
+
+emit() {
+  # emit <key> <value>: stdout for humans/tests + $GITHUB_ENV for the wrapper/CI. A lost
+  # $GITHUB_ENV append means the decision did not propagate -> fail VISIBLY (non-zero +
+  # stderr) rather than exit 0 having written only to stdout (the sibling gate's contract).
+  # The value is normalized to a single line first: the wrapper parses key=value lines, so
+  # a newline/CR embedded in a value (e.g. reached from raw external command output) must
+  # never inject a spurious extra key=value line into stdout or $GITHUB_ENV.
+  local v="$2"
+  v="${v//$'\n'/ }"
+  v="${v//$'\r'/ }"
+  printf '%s=%s\n' "$1" "$v"
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    if ! printf '%s=%s\n' "$1" "$v" >> "$GITHUB_ENV"; then
+      printf 'qa-nightly-round: failed to write %s to GITHUB_ENV (%s)\n' "$1" "$GITHUB_ENV" >&2
+      exit 3
+    fi
+  fi
+}
+
+# abort <reason> [code]: the round could not validly start. Emit the aborted decision
+# and exit non-zero (the wrapper must NOT advance and should surface the failure).
+abort() {
+  printf 'qa-nightly-round: ABORT — %s\n' "$1" >&2
+  emit round aborted
+  emit advance false
+  emit target ""
+  emit reason "$1"
+  exit "${2:-1}"
+}
+
+QA_BASE_SHA="${QA_BASE_SHA:-}"
+QA_HEAD_SHA="${QA_HEAD_SHA:-}"
+QA_DAYS_SINCE="${QA_DAYS_SINCE:-}"
+
+[ -n "$SCRIPT_DIR" ] && [ -n "$REPO_ROOT" ] || abort "could not resolve script/repo root"
+
+# ---------------------------------------------------------------------------
+# 1. Cadence gate — decides whether to run at all. It emits its own four-flag tuple
+#    (run_round/judge_relevant_change/base_known/changed_groups) to stdout AND, since it
+#    inherits $GITHUB_ENV, appends them there itself. We re-print its stdout (visibility)
+#    and read run_round to branch. A non-zero gate rc is its lost-decision signal (a
+#    failed $GITHUB_ENV write) — propagate it rather than proceed on an untrusted tuple.
+# ---------------------------------------------------------------------------
+[ -x "$CADENCE_GATE" ] || [ -f "$CADENCE_GATE" ] || abort "cadence gate not found at $CADENCE_GATE"
+gate_out="$(bash "$CADENCE_GATE" "$QA_BASE_SHA" "$QA_HEAD_SHA" "$QA_DAYS_SINCE")"
+gate_rc=$?
+printf '%s\n' "$gate_out"
+if [ "$gate_rc" -ne 0 ]; then
+  abort "cadence gate exited $gate_rc (decision not trustworthy)" "$gate_rc"
+fi
+run_round="$(printf '%s\n' "$gate_out" | grep -E '^run_round=' | head -1 | cut -d= -f2-)"
+
+# ---------------------------------------------------------------------------
+# 2. Skip — nothing else runs.
+# ---------------------------------------------------------------------------
+if [ "$run_round" != "true" ]; then
+  emit round skipped
+  emit advance false
+  emit target ""
+  emit reason "cadence gate: run_round=${run_round:-<unset>}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Run the round.
+# ---------------------------------------------------------------------------
+# The judge trace path is mandatory on a run — the judge writes it and qa-export ships
+# it. A run without it cannot produce a gradeable round, so this is a start-time abort.
+[ -n "${QA_JUDGE_TRACE:-}" ] || abort "QA_JUDGE_TRACE unset — the wrapper must supply a fresh per-round trace path"
+# The judge APPENDS spans to QA_JUDGE_TRACE and the exporter ships the WHOLE file, so a path
+# reused across rounds would mix stale spans into this round's export (and the exporter's
+# stale-round WARNING only fires when a provenance sidecar exists to disagree). Guarantee
+# freshness here by TRUNCATING the trace to empty at the start of the round — the wrapper
+# should also hand a fresh path, but this makes the round self-contained regardless.
+: > "$QA_JUDGE_TRACE" 2>/dev/null || abort "cannot initialize (truncate) trace file $QA_JUDGE_TRACE"
+
+# 3a. Pre-tours pin: prove the checkout the tours will run FROM is the deployed sha.
+if ! bash "$SHA_ASSERT" "$QA_HEAD_SHA"; then
+  abort "pre-tours deployed-sha assert failed — checkout not pinned to $QA_HEAD_SHA"
+fi
+
+# 3b. Reserve the run dir + validate the run id BEFORE the destructive reseed, so an
+#     invalid id / collision / filesystem error aborts WITHOUT having reseeded staging.
+# The run id doubles as the run-dir name (globalSetup honors a pre-set TOURS_RUN_ID) AND
+# the QA_RUN_ID export provenance (its %Y%m%dT%H%M%SZ form is a valid run id). QA_GIT_SHA
+# = the deployed HEAD. run-tours.sh derives manifest.gitSha from the pinned checkout HEAD.
+# QA_RUN_ID_OVERRIDE is a test seam (fix the id so a fixture can construct a collision);
+# unset in production, so a fresh second-granular UTC id is minted each round.
+RUN_ID="${QA_RUN_ID_OVERRIDE:-$(date -u +%Y%m%dT%H%M%SZ)}"
+# Validate the run id HERE, before it flows into RUNDIR_ABS + the mkdir reservation below:
+# a traversal value (e.g. an `../..`-bearing QA_RUN_ID_OVERRIDE) would otherwise create a
+# directory OUTSIDE .runs at the reservation step, before run-tours.sh's own check runs. The
+# date-minted default always matches; only a bad override is rejected.
+[[ "$RUN_ID" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || abort "invalid run id ($RUN_ID) — must be a UTC run-id timestamp (YYYYMMDDTHHMMSSZ)"
+RUNDIR_ABS="$RUNS_ROOT/$RUN_ID"
+RUNDIR_REL="tests/tours/.runs/$RUN_ID"   # relative to frontend/, as qa-report expects
+
+# The run id is only second-granular, so two rounds in the same second (a rapid retry or
+# a concurrent invocation) could collide on the run dir; globalSetup mkdir -p's it without
+# rejecting a pre-existing dir, which would silently POOL two rounds' captures and break
+# fresh-per-round. RESERVE the dir ATOMICALLY: a non-recursive `mkdir` (no -p) succeeds
+# only if it did not already exist, so it is a race-free claim — a check-then-act test
+# would let two concurrent rounds both see it absent and then share it. mkdir -p on the
+# parent first (that is not the raced resource); the leaf mkdir is the reservation. tours'
+# own `mkdir -p` is then a harmless no-op on the dir we pre-created.
+mkdir -p "$RUNS_ROOT" 2>/dev/null
+if ! mkdir "$RUNDIR_ABS" 2>/dev/null; then
+  # mkdir can fail because the dir already existed (a real run-id collision) OR for an
+  # I/O / permission / missing-parent error — distinguish so the reason is accurate.
+  if [ -e "$RUNDIR_ABS" ]; then
+    abort "run dir already exists ($RUNDIR_ABS) — run-id collision; refusing to reuse it (fresh-per-round)"
+  else
+    abort "could not create run dir ($RUNDIR_ABS) — filesystem/permission error"
+  fi
+fi
+
+# has_nul <file>: true (0) if the file contains a NUL byte. bash $()/$(<) SILENTLY STRIP
+# NUL bytes, so an injected reader returning e.g. "A\0B" would compare EQUAL to "AB" and
+# could wrongly permit advance; we compare raw byte counts to reject/flag such reads.
+has_nul() { [ "$(wc -c < "$1" 2>/dev/null)" != "$(tr -d '\000' < "$1" 2>/dev/null | wc -c)" ]; }
+
+# Optional monotonic deploy-GENERATION seam. The post-tours sha-equality pin catches a
+# deploy that STAYS on a different sha, but NOT an A->B->A redeploy+rollback WITHIN the
+# round: staging moves to B during tours then rolls back to the target before the post
+# read, so every sha (reader / checkout / manifest) reads the target while the captures
+# are mixed-version — sha alone cannot see it. If the wrapper injects QA_DEPLOYED_GEN_CMD
+# (a command printing a monotonic deploy generation — a counter or deploy timestamp), we
+# capture it BEFORE the reseed+tours window and compare AFTER: any redeploy bumps the generation even on a
+# rollback to the same sha -> detected -> no advance. When UNSET, that case is UNDETECTABLE
+# by sha alone and is a known best-effort limitation until the wrapper supplies a
+# generation source (a deploy-system concern, same shape as the expected-vs-executed gap).
+# The emitted deploy_gen_checked records which mode ran. gen values are opaque host text —
+# they are compared, never emitted, so they cannot leak into the decision output.
+gen_pre=""
+gen_pre_ok=true
+if [ -n "${QA_DEPLOYED_GEN_CMD:-}" ]; then
+  gen_pre_file="$RUNDIR_ABS/.gen-pre-read"
+  bash -c "$QA_DEPLOYED_GEN_CMD" >"$gen_pre_file" 2>/dev/null
+  gen_pre_rc=$?
+  gen_pre="$(cat "$gen_pre_file" 2>/dev/null)"
+  # A NUL in the raw pre-read makes the (NUL-stripped) string compare unreliable -> untrusted.
+  ! has_nul "$gen_pre_file" || gen_pre_ok=false
+  rm -f "$gen_pre_file"
+  # Only the pre-read EXIT STATUS is checked here (an errored read is untrustworthy even if
+  # it printed a value). An empty-but-rc0 pre-read is deliberately NOT rejected here: the
+  # post-read guard below already refuses to advance on an empty gen_post (and a persistently
+  # empty reader yields gen_post="" too), so a separate pre-empty check would be redundant
+  # and untestable in isolation.
+  [ "$gen_pre_rc" -eq 0 ] || gen_pre_ok=false
+fi
+
+# 3c. Reseed (abort-on-fail). When we reseed here, tours skip their own reset.
+# QA_RESEED_CMD is arbitrary host-supplied text that can embed credentials / private
+# hostnames / paths, so on failure the emitted reason carries ONLY a fixed message + the
+# exit code — never the command contents (the repo's never-echo-secrets rule).
+skip_reset=()
+if [ -n "${QA_RESEED_CMD:-}" ]; then
+  # DISCARD (do not inherit) the reseed command's stdout+stderr: QA_RESEED_CMD is arbitrary
+  # host text that can PRINT secret-bearing content (credentials, private hostnames) or emit
+  # a shell diagnostic naming them, so its output must never reach the round's output. On
+  # failure the abort below carries ONLY a fixed message + the exit code.
+  ( cd "$REPO_ROOT" && bash -c "$QA_RESEED_CMD" ) >/dev/null 2>&1
+  reseed_rc=$?
+  if [ "$reseed_rc" -ne 0 ]; then
+    abort "reseed command failed (exit $reseed_rc)"
+  fi
+  skip_reset=(TOURS_SKIP_RESET=1)
+fi
+
+
+
+# Tours are NON-FATAL here: a tour failure still yields a diagnostic-bearing round (the
+# trap self-test + export surface it). We capture the exit for the clean-round predicate
+# — a failed/incomplete tours run must not advance — but do not abort on it.
+# The ${arr[@]+"${arr[@]}"} form expands to nothing (no unbound error) when skip_reset
+# is empty — required under `set -u` on bash 3.2 (the macOS judge host's default bash).
+# The injected QA_*_CMD vars can embed secrets; strip them from every make child
+# (qa-report spawns the Codex judge, which would otherwise inherit them) — the
+# orchestrator consumes those commands itself, the children never need them.
+( cd "$REPO_ROOT" && env -u QA_RESEED_CMD -u QA_DEPLOYED_SHA_CMD -u QA_DEPLOYED_GEN_CMD TOURS_RUN_ID="$RUN_ID" ${skip_reset[@]+"${skip_reset[@]}"} "$MAKE" tours )
+tours_rc=$?
+
+# Judge + trap self-test. Its EXIT CODE is the hard trap signal (0 = all traps caught).
+# qa-report runs the LLM JUDGE (a Codex subprocess that reads untrusted tour captures). It
+# needs none of the pipeline's API secrets — tours owns TOURS_*; export owns LANGFUSE_* — so
+# strip them from the judge's environment too, alongside the injected command vars, so a
+# prompt-injected or misbehaving judge cannot read/exfiltrate a credential it never needs.
+( cd "$REPO_ROOT" && env -u QA_RESEED_CMD -u QA_DEPLOYED_SHA_CMD -u QA_DEPLOYED_GEN_CMD \
+    -u TOURS_API_KEY -u LANGFUSE_SECRET_KEY -u LANGFUSE_PUBLIC_KEY -u LANGFUSE_HOST \
+    QA_JUDGE_TRACE="$QA_JUDGE_TRACE" "$MAKE" qa-report JUDGE=1 RUNDIR="$RUNDIR_REL" )
+report_rc=$?
+
+# Export — INDEPENDENT `;` step (INV-B: a trap-miss trace still ships). Capture the RESULT
+# summary line + exit. Provenance (QA_RUN_ID/QA_GIT_SHA) rides the environment.
+export_out="$( cd "$REPO_ROOT" && env -u QA_RESEED_CMD -u QA_DEPLOYED_SHA_CMD -u QA_DEPLOYED_GEN_CMD QA_RUN_ID="$RUN_ID" QA_GIT_SHA="$QA_HEAD_SHA" "$MAKE" qa-export TRACE="$QA_JUDGE_TRACE" 2>&1 )"
+export_rc=$?
+printf '%s\n' "$export_out"
+
+# Parse the RESULT counts from qa-export's ONE canonical summary line. run.ts prints
+# EXACTLY (langfuse.ts ExportResult):
+#   "qa-export: N trace(s), M screenshot(s)[, F FAILED]; enqueued E/A[, S already queued][, X enqueue-failed]"
+# We do NOT scan the merged stdout+stderr for field fragments: the exporter also logs a
+# pre-summary "enqueued E/A" line and can embed up to ~200 chars of an external HTTP error
+# body (which could itself contain a string like "enqueued 1/1") — a fragment scan could
+# pick either over the real final counts and manufacture a false-clean. Instead, match the
+# WHOLE line against an anchored regex and require EXACTLY ONE such line; a
+# missing/duplicate/malformed summary is treated as no-data (parsed as zeros -> no advance,
+# plus an explicit duplicate reason). Fields are then read from that single clean line only.
+SUMMARY_RE='^qa-export: [0-9]{1,9} trace\(s\), [0-9]{1,9} screenshot\(s\)(, [0-9]{1,9} FAILED)?; enqueued [0-9]{1,9}/[0-9]{1,9}(, [0-9]{1,9} already queued)?(, [0-9]{1,9} enqueue-failed)?$'
+summary_count="$(printf '%s\n' "$export_out" | grep -cE "$SUMMARY_RE")"
+summary_line="$(printf '%s\n' "$export_out" | grep -E "$SUMMARY_RE" | tail -1)"
+
+field_num() {
+  # field_num <ERE-labeled-count> <default> — extract ONE count from the single summary line.
+  local m
+  m="$(printf '%s' "$summary_line" | grep -oE "$1" | grep -oE '[0-9]+' | head -1)"
+  printf '%s' "${m:-$2}"
+}
+if [ "$summary_count" -eq 1 ]; then
+  traces="$(field_num '[0-9]+ trace\(s\)' 0)"
+  screenshots="$(field_num '[0-9]+ screenshot\(s\)' 0)"
+  ship_failed="$(field_num '[0-9]+ FAILED' 0)"
+  enq_skipped="$(field_num '[0-9]+ already queued' 0)"
+  enq_failed="$(field_num '[0-9]+ enqueue-failed' 0)"
+  enq_pair="$(printf '%s' "$summary_line" | grep -oE 'enqueued [0-9]+/[0-9]+')"
+  enq_ok="$(printf '%s' "$enq_pair" | grep -oE '[0-9]+' | head -1)"; enq_ok="${enq_ok:-0}"
+  enq_attempted="$(printf '%s' "$enq_pair" | grep -oE '[0-9]+' | tail -1)"; enq_attempted="${enq_attempted:-0}"
+else
+  # No summary (missing creds / no spans) OR more than one (malformed/duplicate) -> no
+  # trustworthy counts. Zero everything so the predicate degrades to advance=false.
+  traces=0; screenshots=0; ship_failed=0; enq_skipped=0; enq_failed=0; enq_ok=0; enq_attempted=0
+fi
+
+# 3d. Post-tours provenance assert: re-read the deployed sha and prove the round both
+# STARTED and ENDED on the sha we are about to advance the watermark to (QA_HEAD_SHA).
+# This is a fail-closed integrity gate, so "cannot confirm" == "do not advance":
+#   - QA_DEPLOYED_SHA_CMD unset -> cannot verify.
+#   - the reader command EXITS NON-ZERO -> cannot trust its stdout (a command that prints
+#     the expected sha then fails must NOT pass; its stdout is discarded).
+#   - the reader's output is not EXACTLY one 40-hex sha (empty / multiline / malformed) ->
+#     cannot verify (and must never reach the emit protocol as raw text).
+#   - the re-read sha != QA_HEAD_SHA -> a mid-round redeploy moved staging off the round's
+#     target. Without this, a deployment + checkout + manifest that ALL move to sha B
+#     mid-round would agree with each other (assert passes) while we advance to A — pinning
+#     the watermark to a sha the round did not run against. The invariant: end on the target.
+#   - then the assert ties the checkout HEAD + the run manifest to that same sha.
+# Only a clean, single 40-hex read equal to QA_HEAD_SHA is handed to the assert. post_reason
+# is a FIXED string, never interpolated with the raw command output.
+is_hex40() { case "$1" in ""|*[!0-9a-f]*) return 1;; esac; [ "${#1}" -eq 40 ]; }
+post_ok=true
+post_reason=""
+if [ -z "${QA_DEPLOYED_SHA_CMD:-}" ]; then
+  post_ok=false
+  post_reason="QA_DEPLOYED_SHA_CMD unset — cannot verify post-tours provenance"
+else
+  # Capture the reader's RAW bytes to a file: bash $()/$(…) SILENTLY STRIP NUL bytes, so a
+  # malformed "<40hex>\0" response would otherwise be accepted as a clean 40-hex sha on this
+  # fail-closed integrity path. We detect a NUL in the raw bytes (a tr-stripped copy differs
+  # in size) and reject. The file lives in the run dir we reserved; stderr is discarded so a
+  # secret-bearing reader diagnostic cannot leak.
+  sha_raw="$RUNDIR_ABS/.deployed-sha-read"
+  bash -c "$QA_DEPLOYED_SHA_CMD" >"$sha_raw" 2>/dev/null
+  deployed_cmd_rc=$?
+  CURRENT="$(cat "$sha_raw" 2>/dev/null)"
+  deployed_has_nul=false
+  has_nul "$sha_raw" && deployed_has_nul=true
+  rm -f "$sha_raw"
+  if [ "$deployed_cmd_rc" -ne 0 ]; then
+    post_ok=false
+    post_reason="deployed-sha reader exited $deployed_cmd_rc — cannot confirm post-tours provenance"
+  elif [ "$deployed_has_nul" = true ]; then
+    post_ok=false
+    post_reason="deployed-sha reader emitted NUL byte(s) (malformed) — cannot confirm post-tours provenance"
+  elif ! is_hex40 "$CURRENT"; then
+    post_ok=false
+    post_reason="deployed-sha reader did not return a single 40-hex sha — cannot confirm post-tours provenance"
+  elif [ "$CURRENT" != "$QA_HEAD_SHA" ]; then
+    post_ok=false
+    post_reason="deployed sha moved mid-round (re-read != the round's target) — cannot advance"
+  elif ! bash "$SHA_ASSERT" "$CURRENT" "$RUNDIR_ABS/manifest.json"; then
+    post_ok=false
+    post_reason="post-tours provenance assert failed (checkout or manifest mismatch)"
+  fi
+fi
+
+# Deploy-generation check (paired with the pre-tours capture): a changed generation means
+# a redeploy happened mid-round even if the sha rolled back to the target. Only evaluated
+# when the sha checks passed (one advance=false reason suffices) and the seam is provided.
+if [ "$post_ok" = true ] && [ -n "${QA_DEPLOYED_GEN_CMD:-}" ]; then
+  if [ "$gen_pre_ok" != true ]; then
+    post_ok=false
+    post_reason="deploy-generation reader failed pre-tours — cannot confirm no mid-round redeploy"
+  else
+    gen_post_file="$RUNDIR_ABS/.gen-post-read"
+    bash -c "$QA_DEPLOYED_GEN_CMD" >"$gen_post_file" 2>/dev/null
+    gen_post_rc=$?
+    gen_post="$(cat "$gen_post_file" 2>/dev/null)"
+    gen_post_nul=false; has_nul "$gen_post_file" && gen_post_nul=true
+    rm -f "$gen_post_file"
+    if [ "$gen_post_rc" -ne 0 ] || [ -z "$gen_post" ] || [ "$gen_post_nul" = true ]; then
+      post_ok=false
+      post_reason="deploy-generation reader failed post-tours — cannot confirm no mid-round redeploy"
+    elif [ "$gen_post" != "$gen_pre" ]; then
+      post_ok=false
+      post_reason="deploy generation changed mid-round (redeploy/rollback detected) — cannot advance"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3e. Clean-round predicate — conservative; degrade to NOT advancing on any ambiguity.
+# ---------------------------------------------------------------------------
+reasons=()
+[ "$tours_rc" -eq 0 ]  || reasons+=("tours failed/incomplete (make tours exit $tours_rc)")
+[ "$report_rc" -eq 0 ] || reasons+=("trap self-test / judge failed (qa-report exit $report_rc)")
+{ [ "$export_rc" -eq 0 ] && [ "$ship_failed" -eq 0 ]; } || reasons+=("trace export failed (exit $export_rc, $ship_failed failed)")
+[ "$summary_count" -le 1 ] || reasons+=("ambiguous qa-export summary ($summary_count matching lines)")
+[ "$traces" -gt 0 ]    || reasons+=("no traces shipped (nothing to grade / missing creds)")
+# Media completeness (coarse): every judged tour trace carries screenshot evidence (the triage
+# UI renders it), so traces shipped WITH ZERO total screenshots means the media uploads failed
+# (best-effort in the exporter, so export still exits 0) — a degraded round that must not advance.
+# RESIDUAL: the summary reports only the TOTAL screenshot count, so this catches an all-media-
+# failed round but NOT a per-trace partial loss (trace A uploads, trace B's media fails while
+# total stays > 0). Per-trace media accounting needs the expected-vs-executed capture signal that
+# does not exist yet (documented above); until it does, this coarse guard is the best available
+# and the gate stays conservative elsewhere.
+{ [ "$traces" -eq 0 ] || [ "$screenshots" -gt 0 ]; } || reasons+=("traces shipped but 0 screenshots — media upload failed (degraded round)")
+[ "$enq_failed" -eq 0 ] || reasons+=("$enq_failed triage enqueue POST(s) failed")
+# enqueued + failed must account for EVERY attempted POST. The exporter partitions attempted
+# into enqueued + failed, so a summary like "enqueued 2/3" WITHOUT a matching "1 enqueue-failed"
+# suffix is truncated/inconsistent — do not treat it as clean even though enq_failed defaults 0.
+[ "$((enq_ok + enq_failed))" -eq "$enq_attempted" ] || reasons+=("inconsistent enqueue summary (enqueued $enq_ok + failed $enq_failed != attempted $enq_attempted)")
+[ "$((enq_ok + enq_skipped))" -ge 1 ] || reasons+=("mandatory triage enqueue landed 0 items")
+# The exporter WARNS (still shipping) on degraded/uncertain provenance — a reused trace path
+# relabeling stale spans, an unreadable/inaccessible stale-round sidecar, or unlabelable traces.
+# A clean summary can follow such a warning, so the counts alone look fine; treat ANY exporter
+# warning as mixed/untrustworthy evidence and do not advance.
+if grep -qE '^qa-export: WARNING' <<<"$export_out"; then
+  reasons+=("exporter emitted a degradation/uncertainty warning (stale or degraded provenance)")
+fi
+$post_ok || reasons+=("$post_reason")
+
+if [ "${#reasons[@]}" -eq 0 ]; then
+  emit round clean
+  emit advance true
+  emit target "$QA_HEAD_SHA"
+  emit reason "clean round"
+else
+  # Join reasons into a single newline-free line.
+  joined="$(printf '%s; ' "${reasons[@]}")"
+  emit round incomplete
+  emit advance false
+  emit target ""
+  emit reason "${joined%; }"
+fi
+
+# Observability: the raw signals the decision was computed from.
+emit tours_exit "$tours_rc"
+emit report_exit "$report_rc"
+emit export_exit "$export_rc"
+emit export_summary_lines "$summary_count"
+emit traces "$traces"
+emit ship_failed "$ship_failed"
+emit enqueue_attempted "$enq_attempted"
+emit enqueue_ok "$enq_ok"
+emit enqueue_skipped_existing "$enq_skipped"
+emit enqueue_failed "$enq_failed"
+# Records whether the A->B->A redeploy-rollback guard actually ran this round (the deploy-
+# generation seam was provided) or degraded to the sha-only guard (its residual blind spot).
+if [ -n "${QA_DEPLOYED_GEN_CMD:-}" ]; then emit deploy_gen_checked true; else emit deploy_gen_checked false; fi
+exit 0

--- a/scripts/ci/qa-nightly-round.test.sh
+++ b/scripts/ci/qa-nightly-round.test.sh
@@ -1,0 +1,854 @@
+#!/usr/bin/env bash
+# Tests for qa-nightly-round.sh — the pure, stateless nightly QA-round orchestrator.
+#
+# The orchestrator sequences four collaborators: the cadence gate, the deployed-sha
+# assert, the reseed command, and the `make` pipeline (tours -> qa-report -> qa-export).
+# Each is STUBBED here so every branch of the orchestrator's own logic — skip, clean
+# advance, the incomplete-round grades, and the start-time aborts — is exercised
+# deterministically with no network, browser, git repo, or Langfuse:
+#   - the two sibling scripts are COPIED as controllable stubs into the fixture's
+#     scripts/ci/ (the orchestrator resolves them relative to its own location, so the
+#     fixture copy shadows the real ones);
+#   - `make` is a stub bin pointed at by QA_MAKE that dispatches on the target, writes
+#     the manifest / trace, prints a controllable qa-export RESULT line, and records
+#     each call (+ its inherited git-location env) to a call log;
+#   - QA_RESEED_CMD / QA_DEPLOYED_SHA_CMD are injected shell commands.
+# Every assertion pins the EXACT advance/round decision (not just the exit), so a logic
+# revert in the predicate or the branch flips the grade and reddens the test.
+#
+# Portable: no network, no BSD-only flags — runs on Ubuntu CI and the macOS judge host.
+
+set -uo pipefail
+
+# Sanitize hook-inherited git env BEFORE anything (this suite may run under the pre-push
+# hook, which exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE). Also lets the git-env
+# isolation test set them explicitly per-run without a leaked baseline.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REAL_ORCH="$REPO_ROOT/scripts/ci/qa-nightly-round.sh"
+HEAD_SHA="abc1230000000000000000000000000000000def"  # a plausible 40-hex deployed sha
+BASE_SHA="def4560000000000000000000000000000000abc"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+# require_tmpdir <varname>: mktemp -d into the named var, aborting the WHOLE run if it
+# fails or yields no directory (an empty dir would make the fixture write into the real
+# tree). The repo's git-fixture hazard, guarded hard — same contract as the sibling.
+require_tmpdir() {
+    local __d
+    __d="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 2; }
+    { [ -n "$__d" ] && [ -d "$__d" ]; } || { echo "FATAL: mktemp -d produced no directory" >&2; exit 2; }
+    printf -v "$1" '%s' "$__d"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: the orchestrator copy + controllable stubs.
+# ---------------------------------------------------------------------------
+make_fixture() {
+    require_tmpdir FIXTURE
+    GHENV="$FIXTURE/ghenv"
+    CALL_LOG="$FIXTURE/calls.log"
+    mkdir -p "$FIXTURE/scripts/ci" "$FIXTURE/bin"
+    cp "$REAL_ORCH" "$FIXTURE/scripts/ci/qa-nightly-round.sh"
+
+    # Stub cadence gate: emits the four-flag tuple (stdout + GITHUB_ENV, like the real
+    # one) with a controllable run_round; STUB_GATE_RC drives the lost-decision path.
+    cat > "$FIXTURE/scripts/ci/qa-round-cadence-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+e() { printf '%s=%s\n' "$1" "$2"; [ -n "${GITHUB_ENV:-}" ] && printf '%s=%s\n' "$1" "$2" >> "$GITHUB_ENV"; }
+e run_round "${STUB_RUN_ROUND:-true}"
+e judge_relevant_change true
+e base_known true
+e changed_groups backend
+exit "${STUB_GATE_RC:-0}"
+EOF
+
+    # Stub deployed-sha assert: 1 arg = pre-tours pin (STUB_ASSERT_PRE_RC), 2 args =
+    # post-tours provenance (STUB_ASSERT_POST_RC). Keyed on arg count, like the real call sites.
+    cat > "$FIXTURE/scripts/ci/qa-round-deployed-sha-assert.sh" <<'EOF'
+#!/usr/bin/env bash
+if [ "$#" -eq 1 ]; then exit "${STUB_ASSERT_PRE_RC:-0}"; else exit "${STUB_ASSERT_POST_RC:-0}"; fi
+EOF
+
+    # Stub `make`: dispatch on target. Records each call + its inherited git-location env
+    # to the call log (for the isolation contract test). `tours` writes the manifest under
+    # the run id the orchestrator passed; `qa-report` writes the trace; `qa-export` prints
+    # a controllable RESULT line.
+    cat > "$FIXTURE/bin/make" <<'EOF'
+#!/usr/bin/env bash
+log="${STUB_CALL_LOG:?}"
+# Record the FULL arg vector + the provenance/isolation env each call inherited, so a test
+# can assert that dropping JUDGE=1 / RUNDIR / TRACE / QA_RUN_ID / QA_GIT_SHA reddens.
+printf 'make %s | args:%s | gitenv:GIT_DIR=%s,GIT_WORK_TREE=%s,GIT_INDEX_FILE=%s,GIT_COMMON_DIR=%s,GIT_OBJECT_DIRECTORY=%s | skip_reset=%s | judge_trace=%s | run_id=%s | git_sha=%s | reseed_cmd=%s | sha_cmd=%s | gen_cmd=%s | lang_secret=%s | tours_key=%s\n' \
+    "$1" "$*" "${GIT_DIR:-}" "${GIT_WORK_TREE:-}" "${GIT_INDEX_FILE:-}" "${GIT_COMMON_DIR:-}" "${GIT_OBJECT_DIRECTORY:-}" "${TOURS_SKIP_RESET:-}" "${QA_JUDGE_TRACE:-}" "${QA_RUN_ID:-}" "${QA_GIT_SHA:-}" "${QA_RESEED_CMD:-}" "${QA_DEPLOYED_SHA_CMD:-}" "${QA_DEPLOYED_GEN_CMD:-}" "${LANGFUSE_SECRET_KEY:-}" "${TOURS_API_KEY:-}" >> "$log"
+case "$1" in
+  tours)
+    mkdir -p "frontend/tests/tours/.runs/${TOURS_RUN_ID:?}"
+    printf '{"gitSha":"%s"}\n' "${STUB_MANIFEST_SHA:-unknown}" > "frontend/tests/tours/.runs/${TOURS_RUN_ID}/manifest.json"
+    exit "${STUB_TOURS_RC:-0}" ;;
+  qa-report)
+    [ -n "${QA_JUDGE_TRACE:-}" ] && printf 'span\n' >> "$QA_JUDGE_TRACE"
+    exit "${STUB_REPORT_RC:-0}" ;;
+  qa-export)
+    printf '%s\n' "${STUB_EXPORT_OUT:-qa-export: 5 trace(s), 12 screenshot(s); enqueued 3/3}"
+    exit "${STUB_EXPORT_RC:-0}" ;;
+  *) echo "stub make: unexpected target $1" >&2; exit 99 ;;
+esac
+EOF
+    chmod +x "$FIXTURE/bin/make"
+}
+
+cleanup_fixture() { [ -n "${FIXTURE:-}" ] && rm -rf "$FIXTURE"; }
+
+# run_orch <ENV=val...>: run the orchestrator copy with all seams injected; sets RC.
+# Extra args override/add env (e.g. STUB_RUN_ROUND=false, QA_RESEED_CMD=false).
+OUT=""; ERR=""; RC=0
+run_orch() {
+    : > "$GHENV"; : > "$CALL_LOG"
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    ( cd "$FIXTURE" && env \
+        QA_MAKE="$FIXTURE/bin/make" \
+        GITHUB_ENV="$GHENV" \
+        STUB_CALL_LOG="$CALL_LOG" \
+        QA_BASE_SHA="$BASE_SHA" QA_HEAD_SHA="$HEAD_SHA" QA_DAYS_SINCE=0 \
+        QA_JUDGE_TRACE="$FIXTURE/trace.jsonl" \
+        QA_DEPLOYED_SHA_CMD="printf %s $HEAD_SHA" \
+        STUB_MANIFEST_SHA="$HEAD_SHA" \
+        "$@" \
+        bash "$FIXTURE/scripts/ci/qa-nightly-round.sh" ) >"$OUT" 2>"$ERR"
+    RC=$?
+}
+
+# ghv <key>: the LAST value emitted for <key> in $GITHUB_ENV (the orchestrator's own
+# decision keys win over the gate's; last-write is the emitted decision).
+ghv() { grep -E "^$1=" "$GHENV" | tail -1 | cut -d= -f2-; }
+
+assert_rc0()     { if [ "$RC" -eq 0 ]; then ok; else fail "$1: want exit 0, got $RC (err: $(head -2 "$ERR"))"; fi; }
+assert_rc_nz()   { if [ "$RC" -ne 0 ]; then ok; else fail "$1: want non-zero exit, got 0"; fi; }
+assert_kv()      { local got; got="$(ghv "$1")"; if [ "$got" = "$2" ]; then ok; else fail "$3: want $1=$2, got '$got'"; fi; }
+assert_ran()     { if grep -q "^make $1 " "$CALL_LOG"; then ok; else fail "$2: expected 'make $1' to run"; fi; }
+assert_not_ran() { if grep -q "^make $1 " "$CALL_LOG"; then fail "$2: 'make $1' must NOT run"; else ok; fi; }
+# assert_call <ERE> <label>: a recorded call line matches the pattern (argv/env forwarding).
+assert_call()    { if grep -qE "$1" "$CALL_LOG"; then ok; else fail "$2: no call matches /$1/ in log"; fi; }
+# assert_reason <substr> <label>: the emitted reason contains <substr>.
+assert_reason()  { case "$(ghv reason)" in *"$1"*) ok;; *) fail "$2: reason should contain '$1', got '$(ghv reason)'";; esac; }
+
+# ===========================================================================
+# Branch coverage — every assertion pins the exact decision (mutation-reddens).
+# ===========================================================================
+
+test_skip() {
+    echo "test: run_round=false -> round=skipped, advance=false, nothing else runs"
+    make_fixture
+    run_orch STUB_RUN_ROUND=false
+    assert_rc0 skip
+    assert_kv round skipped skip
+    assert_kv advance false skip
+    assert_not_ran tours skip
+    assert_not_ran qa-report skip
+    assert_not_ran qa-export skip
+    cleanup_fixture
+}
+
+test_clean() {
+    echo "test: run_round=true + all green -> round=clean, advance=true, target=HEAD"
+    make_fixture
+    run_orch
+    assert_rc0 clean
+    assert_kv round clean clean
+    assert_kv advance true clean
+    assert_kv target "$HEAD_SHA" clean
+    assert_ran tours clean
+    assert_ran qa-report clean
+    assert_ran qa-export clean
+    # Provenance/args are forwarded: qa-report gets JUDGE=1 + a RUNDIR + the trace path;
+    # qa-export gets QA_RUN_ID (timestamp form) + QA_GIT_SHA=HEAD. Dropping any reddens.
+    assert_call '^make qa-report \| args:qa-report JUDGE=1 RUNDIR=tests/tours/\.runs/[0-9]{8}T[0-9]{6}Z' clean-report-args
+    assert_call "^make qa-report .*judge_trace=$FIXTURE/trace\.jsonl" clean-report-trace
+    assert_call "^make qa-export \| args:qa-export TRACE=$FIXTURE/trace\.jsonl" clean-export-trace-arg
+    assert_call "^make qa-export .*run_id=[0-9]{8}T[0-9]{6}Z .*git_sha=$HEAD_SHA" clean-export-prov
+    # Observability counts are surfaced for the wrapper.
+    assert_kv traces 5 clean
+    assert_kv enqueue_ok 3 clean
+    cleanup_fixture
+}
+
+test_export_failed() {
+    echo "test: a trace ship failure -> round=incomplete, advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_RC=1 \
+        STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s), 2 FAILED; enqueued 1/3, 1 already queued, 1 enqueue-failed"
+    assert_rc0 export-failed
+    assert_kv round incomplete export-failed
+    assert_kv advance false export-failed
+    assert_kv ship_failed 2 export-failed
+    cleanup_fixture
+}
+
+test_pre_assert_fail() {
+    echo "test: pre-tours pin fail -> round=aborted, advance=false, exit!=0, tours never run"
+    make_fixture
+    run_orch STUB_ASSERT_PRE_RC=1
+    assert_rc_nz pre-assert
+    assert_kv round aborted pre-assert
+    assert_kv advance false pre-assert
+    assert_not_ran tours pre-assert
+    assert_not_ran qa-export pre-assert
+    cleanup_fixture
+}
+
+test_post_assert_fail() {
+    echo "test: mid-round redeploy (post-tours assert fail) -> advance=false, but the round RAN"
+    make_fixture
+    run_orch STUB_ASSERT_POST_RC=1
+    assert_rc0 post-assert
+    assert_kv round incomplete post-assert
+    assert_kv advance false post-assert
+    assert_ran qa-export post-assert   # the round still ran + shipped
+    cleanup_fixture
+}
+
+test_reseed_fail() {
+    echo "test: reseed command fails -> round=aborted, advance=false, exit!=0, tours never run"
+    make_fixture
+    run_orch QA_RESEED_CMD=false
+    assert_rc_nz reseed-fail
+    assert_kv round aborted reseed-fail
+    assert_kv advance false reseed-fail
+    assert_not_ran tours reseed-fail
+    cleanup_fixture
+}
+
+test_reseed_fail_no_secret_leak() {
+    echo "test: a failing QA_RESEED_CMD's OUTPUT (secret-bearing) never leaks into the round output"
+    make_fixture
+    # QA_RESEED_CMD can PRINT credentials / private hostnames (or a shell diagnostic naming
+    # them). The reseed cmd here emits a secret token to stdout AND stderr, then fails; the
+    # orchestrator must DISCARD its output, so the token appears nowhere and the abort reason
+    # is a fixed message. (A cmd that only takes the token as an ARG — `false TOKEN` — never
+    # prints it, so it would pass even without the suppression; that is NOT a real test.)
+    run_orch QA_RESEED_CMD='echo SECRETTOKEN_zzz; echo SECRETTOKEN_zzz >&2; exit 1'
+    assert_rc_nz reseed-noleak
+    assert_kv round aborted reseed-noleak
+    if grep -rq 'SECRETTOKEN_zzz' "$GHENV" "$OUT" "$ERR"; then fail "reseed-noleak: reseed command output leaked into round output"; else ok; fi
+    if [ "$(grep -c '^round=' "$GHENV")" -eq 1 ]; then ok; else fail "reseed-noleak: emit protocol corrupted (duplicate keys)"; fi
+    cleanup_fixture
+}
+
+test_reseed_ok_skips_tours_reset() {
+    echo "test: a supplied reseed runs first + tours get TOURS_SKIP_RESET=1 (no double reseed)"
+    make_fixture
+    run_orch QA_RESEED_CMD=true
+    assert_rc0 reseed-ok
+    assert_kv round clean reseed-ok
+    if grep -qE '^make tours .*skip_reset=1' "$CALL_LOG"; then ok; else fail "reseed-ok: tours must get TOURS_SKIP_RESET=1"; fi
+    cleanup_fixture
+}
+
+test_no_reseed_lets_tours_reset() {
+    echo "test: no reseed cmd -> tours run WITHOUT skip_reset (tours resets itself)"
+    make_fixture
+    run_orch   # QA_RESEED_CMD unset
+    if grep -qE '^make tours .*skip_reset=1' "$CALL_LOG"; then fail "no-reseed: tours must NOT get skip_reset"; else ok; fi
+    cleanup_fixture
+}
+
+test_trap_miss_still_exports() {
+    echo "test: trap miss (qa-report exit!=0) -> incomplete, advance=false, export STILL ships (INV-B)"
+    make_fixture
+    run_orch STUB_REPORT_RC=2
+    assert_rc0 trap-miss
+    assert_kv round incomplete trap-miss
+    assert_kv advance false trap-miss
+    assert_ran qa-export trap-miss   # the ; step ships the diagnostic trace regardless
+    cleanup_fixture
+}
+
+test_tours_fail() {
+    echo "test: tours fail/incomplete -> advance=false, but report+export still run"
+    make_fixture
+    run_orch STUB_TOURS_RC=1
+    assert_rc0 tours-fail
+    assert_kv round incomplete tours-fail
+    assert_kv advance false tours-fail
+    assert_ran qa-report tours-fail
+    assert_ran qa-export tours-fail
+    cleanup_fixture
+}
+
+test_no_enqueue_landed() {
+    echo "test: zero eligible enqueue landed (0/0, none already queued) -> advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s); enqueued 0/0"
+    assert_rc0 no-enqueue
+    assert_kv round incomplete no-enqueue
+    assert_kv advance false no-enqueue
+    cleanup_fixture
+}
+
+test_enqueue_via_already_queued() {
+    echo "test: mandatory item already-queued (0 new, 2 already) -> counts as landed -> clean"
+    make_fixture
+    run_orch STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s); enqueued 0/0, 2 already queued"
+    assert_rc0 already-queued
+    assert_kv round clean already-queued
+    assert_kv advance true already-queued
+    cleanup_fixture
+}
+
+test_no_traces_missing_creds() {
+    echo "test: export ships nothing (missing creds / no spans) -> traces=0 -> advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_OUT="qa-export: LANGFUSE_HOST / LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set — nothing shipped."
+    assert_rc0 no-traces
+    assert_kv round incomplete no-traces
+    assert_kv advance false no-traces
+    assert_kv traces 0 no-traces
+    cleanup_fixture
+}
+
+test_gate_rc_nonzero() {
+    echo "test: cadence gate exits non-zero (lost decision) -> round=aborted, exit!=0"
+    make_fixture
+    run_orch STUB_GATE_RC=3
+    assert_rc_nz gate-rc
+    assert_kv round aborted gate-rc
+    assert_not_ran tours gate-rc
+    cleanup_fixture
+}
+
+test_missing_judge_trace() {
+    echo "test: QA_JUDGE_TRACE unset on a run -> round=aborted, exit!=0"
+    make_fixture
+    run_orch QA_JUDGE_TRACE=""
+    assert_rc_nz missing-trace
+    assert_kv round aborted missing-trace
+    assert_not_ran tours missing-trace
+    cleanup_fixture
+}
+
+test_missing_deployed_sha_cmd() {
+    echo "test: QA_DEPLOYED_SHA_CMD unset -> cannot verify provenance -> advance=false"
+    make_fixture
+    run_orch QA_DEPLOYED_SHA_CMD=""
+    assert_rc0 no-deployed-cmd
+    assert_kv round incomplete no-deployed-cmd
+    assert_kv advance false no-deployed-cmd
+    cleanup_fixture
+}
+
+# ===========================================================================
+# ISOLATED predicate-term cases — each fails EXACTLY ONE term, so dropping that
+# term from the predicate stops reddening it (mutation-discriminating). The
+# multi-term cases above still exercise realistic combinations.
+# ===========================================================================
+test_isolated_export_exit() {
+    echo "test: ISOLATED export exit!=0 (clean summary otherwise) -> advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_RC=1 \
+        STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s); enqueued 3/3"
+    assert_rc0 iso-export-exit
+    assert_kv advance false iso-export-exit
+    assert_kv ship_failed 0 iso-export-exit   # only the exit term is bad
+    cleanup_fixture
+}
+
+test_isolated_failed_only() {
+    echo "test: ISOLATED shipped FAILED>0 (export exit 0) -> advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_RC=0 \
+        STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s), 2 FAILED; enqueued 3/3"
+    assert_rc0 iso-failed
+    assert_kv advance false iso-failed
+    assert_kv ship_failed 2 iso-failed
+    assert_kv export_exit 0 iso-failed
+    cleanup_fixture
+}
+
+test_isolated_enqueue_failed_only() {
+    echo "test: ISOLATED enqueue-failed>0 (export exits 0 — the easiest term to lose) -> advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_RC=0 \
+        STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s); enqueued 2/3, 1 enqueue-failed"
+    assert_rc0 iso-enq-failed
+    assert_kv advance false iso-enq-failed
+    assert_kv enqueue_failed 1 iso-enq-failed
+    assert_kv export_exit 0 iso-enq-failed   # proves this term isn't covered by the exit term
+    cleanup_fixture
+}
+
+test_isolated_traces_zero() {
+    echo "test: ISOLATED traces==0 but an enqueue landed -> advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_RC=0 \
+        STUB_EXPORT_OUT="qa-export: 0 trace(s), 0 screenshot(s); enqueued 3/3"
+    assert_rc0 iso-traces0
+    assert_kv advance false iso-traces0
+    assert_kv traces 0 iso-traces0
+    assert_kv enqueue_ok 3 iso-traces0   # the enqueue term is satisfied; only traces fails
+    cleanup_fixture
+}
+
+test_deployed_sha_moved() {
+    echo "test: mid-round redeploy — re-read sha is a DIFFERENT valid sha, assert PASSES -> no advance"
+    make_fixture
+    # The reader returns a valid 40-hex sha that is NOT the round's target, and the post
+    # assert stub SUCCEEDS. Only the CURRENT==QA_HEAD_SHA pin can catch this: a deployment
+    # that moved mid-round must not advance the watermark to a sha the round didn't run on.
+    local other="feedfeed0000000000000000000000000000feed"
+    run_orch QA_DEPLOYED_SHA_CMD="printf %s $other" STUB_ASSERT_POST_RC=0
+    assert_rc0 sha-moved
+    assert_kv round incomplete sha-moved
+    assert_kv advance false sha-moved
+    cleanup_fixture
+}
+
+test_deployed_cmd_fails() {
+    echo "test: deployed-sha reader prints the sha then EXITS NONZERO -> advance=false"
+    make_fixture
+    # Stdout is the expected sha, but exit is nonzero: a discarded exit status would
+    # wrongly pass the post-assert. The stub assert would pass (STUB_ASSERT_POST_RC=0),
+    # so ONLY the reader's exit status can catch this.
+    run_orch QA_DEPLOYED_SHA_CMD="printf %s $HEAD_SHA; exit 7"
+    assert_rc0 deployed-cmd-fail
+    assert_kv round incomplete deployed-cmd-fail
+    assert_kv advance false deployed-cmd-fail
+    cleanup_fixture
+}
+
+test_deployed_cmd_multiline() {
+    echo "test: deployed-sha reader returns multiline/garbage -> advance=false, emit stays single-line"
+    make_fixture
+    run_orch QA_DEPLOYED_SHA_CMD="printf '%s\n../evil\n' $HEAD_SHA"
+    assert_rc0 deployed-multiline
+    assert_kv advance false deployed-multiline
+    # The raw multiline output must NOT corrupt the emit protocol: every emitted line is a
+    # single key=value, so `advance=` appears exactly once and there is no stray line.
+    if [ "$(grep -c '^advance=' "$GHENV")" -eq 1 ]; then ok; else fail "deployed-multiline: advance= emitted more than once (protocol corrupted)"; fi
+    if grep -q '../evil' "$GHENV"; then fail "deployed-multiline: raw command output leaked into GITHUB_ENV"; else ok; fi
+    cleanup_fixture
+}
+
+test_export_summary_fragment_ignored() {
+    echo "test: a pre-summary/HTTP-body 'enqueued 1/1' fragment is IGNORED; the FINAL summary governs"
+    make_fixture
+    # A queue-resolve error embeds an external body containing 'enqueued 1/1', plus a
+    # pre-summary log line, BEFORE the real final summary (enqueued 0/0). A fragment scan
+    # would pick 1/1 and falsely pass the mandatory-enqueue term. The anchored single-line
+    # parse must use the final summary (0/0) -> mandatory enqueue landed 0 -> advance=false.
+    run_orch STUB_EXPORT_OUT="  enqueue: queue resolve failed: {\"error\":\"body says enqueued 1/1 haha\"}
+  enqueued 9/9 (pre-summary progress log)
+qa-export: 5 trace(s), 12 screenshot(s); enqueued 0/0"
+    assert_rc0 fragment
+    assert_kv advance false fragment
+    assert_kv enqueue_ok 0 fragment          # parsed from the FINAL summary, not the fragment
+    assert_kv enqueue_attempted 0 fragment
+    cleanup_fixture
+}
+
+test_export_duplicate_summary() {
+    echo "test: two lines matching the summary shape -> ambiguous -> advance=false"
+    make_fixture
+    run_orch STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s); enqueued 3/3
+qa-export: 6 trace(s), 12 screenshot(s); enqueued 3/3"
+    assert_rc0 dup-summary
+    assert_kv round incomplete dup-summary
+    assert_kv advance false dup-summary
+    assert_kv export_summary_lines 2 dup-summary
+    cleanup_fixture
+}
+
+test_runid_collision_aborts() {
+    echo "test: run-id collision (run dir already exists) -> round=aborted, exit!=0, tours never run"
+    make_fixture
+    # Pre-create the exact run dir the orchestrator will target (via the QA_RUN_ID_OVERRIDE
+    # test seam), so the fresh-per-round collision guard must fail-closed.
+    mkdir -p "$FIXTURE/frontend/tests/tours/.runs/20260101T000000Z"
+    run_orch QA_RUN_ID_OVERRIDE=20260101T000000Z
+    assert_rc_nz collision
+    assert_kv round aborted collision
+    assert_kv advance false collision
+    assert_reason collision collision   # a pre-existing dir is labeled a collision, not an fs error
+    assert_not_ran tours collision
+    cleanup_fixture
+}
+
+test_rundir_create_error() {
+    echo "test: run dir cannot be created (fs/permission, not a collision) -> aborted with a distinct reason"
+    if [ "$(id -u)" -eq 0 ]; then echo "  SKIP: running as root, chmod bypassed"; return; fi
+    make_fixture
+    # Make the .runs parent read-only so the atomic leaf mkdir fails WITHOUT the dir existing
+    # -> the "could not create" branch, distinct from a collision.
+    mkdir -p "$FIXTURE/frontend/tests/tours/.runs"
+    chmod 555 "$FIXTURE/frontend/tests/tours/.runs"
+    run_orch QA_RUN_ID_OVERRIDE=20260101T000000Z
+    chmod 755 "$FIXTURE/frontend/tests/tours/.runs"
+    assert_rc_nz rundir-fs
+    assert_kv round aborted rundir-fs
+    assert_reason "could not create" rundir-fs
+    assert_not_ran tours rundir-fs
+    cleanup_fixture
+}
+
+test_deploy_gen_unset_records_false() {
+    echo "test: no deploy-generation seam -> clean via sha-only guard; deploy_gen_checked=false (residual documented)"
+    make_fixture
+    run_orch   # QA_DEPLOYED_GEN_CMD unset
+    assert_rc0 gen-unset
+    assert_kv round clean gen-unset
+    assert_kv advance true gen-unset
+    assert_kv deploy_gen_checked false gen-unset
+    cleanup_fixture
+}
+
+test_deploy_gen_matches_clean() {
+    echo "test: deploy generation provided + unchanged pre/post -> clean, deploy_gen_checked=true"
+    make_fixture
+    run_orch QA_DEPLOYED_GEN_CMD="echo 42"
+    assert_rc0 gen-match
+    assert_kv round clean gen-match
+    assert_kv advance true gen-match
+    assert_kv deploy_gen_checked true gen-match
+    cleanup_fixture
+}
+
+test_deploy_gen_bump_no_advance() {
+    echo "test: deploy generation BUMPS mid-round (A->B->A rollback) -> advance=false though the sha matches"
+    make_fixture
+    # A monotonic counter file: pre-tours read=1, post-tours read=2 -> generation changed, so
+    # a redeploy happened even though the deployed sha (default stub) still equals the target
+    # -> the case the sha-equality pin alone cannot catch.
+    run_orch QA_DEPLOYED_GEN_CMD="n=\$(cat $FIXTURE/gen 2>/dev/null || echo 0); n=\$((n+1)); echo \$n > $FIXTURE/gen; echo \$n"
+    assert_rc0 gen-bump
+    assert_kv round incomplete gen-bump
+    assert_kv advance false gen-bump
+    cleanup_fixture
+}
+
+test_deploy_gen_reader_fails() {
+    echo "test: deploy-generation reader fails -> cannot confirm -> advance=false"
+    make_fixture
+    run_orch QA_DEPLOYED_GEN_CMD="exit 5"
+    assert_rc0 gen-fail
+    assert_kv advance false gen-fail
+    cleanup_fixture
+}
+
+test_lost_github_env_write() {
+    echo "test: an unwritable GITHUB_ENV makes emit fail VISIBLY (non-zero), not a silent exit-0"
+    make_fixture
+    OUT="$FIXTURE/out.txt"; ERR="$FIXTURE/err.txt"
+    # Point GITHUB_ENV at a path whose parent doesn't exist; run_round=false reaches the
+    # first orchestrator emit quickly. A lost decision write must exit non-zero.
+    ( cd "$FIXTURE" && env \
+        QA_MAKE="$FIXTURE/bin/make" STUB_CALL_LOG="$CALL_LOG" \
+        GITHUB_ENV="$FIXTURE/no-such-dir/ghenv" \
+        QA_BASE_SHA="$BASE_SHA" QA_HEAD_SHA="$HEAD_SHA" QA_DAYS_SINCE=0 \
+        QA_JUDGE_TRACE="$FIXTURE/trace.jsonl" \
+        STUB_RUN_ROUND=false \
+        bash "$FIXTURE/scripts/ci/qa-nightly-round.sh" ) >"$OUT" 2>"$ERR"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then ok; else fail "lost-ghenv: want non-zero exit on GITHUB_ENV write failure"; fi
+    cleanup_fixture
+}
+
+# ===========================================================================
+# Contract tests: fixture fail-closed guard + git-env isolation.
+# ===========================================================================
+test_require_tmpdir_fails_closed() {
+    echo "test: require_tmpdir aborts (non-zero) when mktemp fails (fixture guard is fail-closed)"
+    if ( mktemp() { return 1; }; require_tmpdir X ) >/dev/null 2>&1; then
+        fail "require_tmpdir must abort on mktemp failure"
+    else
+        ok
+    fi
+}
+
+test_git_env_isolation() {
+    echo "test: the orchestrator unsets ALL git-location vars before invoking children"
+    make_fixture
+    # Poison all five in the outer env; the stub make records what it inherited. The
+    # orchestrator must have cleared them all, so make sees every one EMPTY. Dropping any
+    # var from the orchestrator's unset line reddens this (that var reaches the child).
+    run_orch GIT_DIR=/x GIT_WORK_TREE=/x GIT_INDEX_FILE=/x GIT_COMMON_DIR=/x GIT_OBJECT_DIRECTORY=/x
+    assert_rc0 git-iso
+    if grep -qE 'gitenv:GIT_DIR=,GIT_WORK_TREE=,GIT_INDEX_FILE=,GIT_COMMON_DIR=,GIT_OBJECT_DIRECTORY= ' "$CALL_LOG"; then
+        ok
+    else
+        fail "git-iso: a git-location var leaked to a child ($(grep -m1 gitenv "$CALL_LOG"))"
+    fi
+    cleanup_fixture
+}
+
+# ===========================================================================
+# Predicate discrimination: enqueue accounting, exporter warnings, run-id safety.
+# ===========================================================================
+test_enqueue_inconsistent() {
+    echo "test: 'enqueued 2/3' with NO enqueue-failed suffix -> inconsistent summary -> no advance"
+    make_fixture
+    # enqueued(2) + failed(0, absent suffix) != attempted(3): a truncated/mixed summary. The
+    # counts otherwise look clean (failed=0, landed>=1), so only the partition check catches it.
+    run_orch STUB_EXPORT_OUT="qa-export: 5 trace(s), 12 screenshot(s); enqueued 2/3"
+    assert_rc0 enq-inconsistent
+    assert_kv advance false enq-inconsistent
+    assert_reason "inconsistent enqueue summary" enq-inconsistent
+    cleanup_fixture
+}
+
+test_export_warning_no_advance() {
+    echo "test: an exporter 'qa-export: WARNING' (degraded provenance) before a clean summary -> no advance"
+    make_fixture
+    # A reused-trace-path / degraded-sidecar warning means the round's evidence is stale/mixed;
+    # a clean summary can still follow, so the counts look fine — only the warning scan catches it.
+    run_orch STUB_EXPORT_OUT="$(printf 'qa-export: WARNING — trace path reused across rounds; stale spans are being relabeled.\nqa-export: 5 trace(s), 12 screenshot(s); enqueued 3/3')"
+    assert_rc0 export-warn
+    assert_kv advance false export-warn
+    assert_reason "degradation/uncertainty warning" export-warn
+    cleanup_fixture
+}
+
+test_runid_traversal_rejected() {
+    echo "test: a traversal QA_RUN_ID_OVERRIDE -> aborted BEFORE the mkdir reservation; no dir escapes .runs"
+    make_fixture
+    run_orch QA_RUN_ID_OVERRIDE="../evilrun"
+    assert_rc_nz runid-traversal
+    assert_kv round aborted runid-traversal
+    assert_reason "invalid run id" runid-traversal
+    # The reservation must not have created a directory outside .runs.
+    if [ -e "$FIXTURE/frontend/tests/tours/evilrun" ] || [ -e "$FIXTURE/frontend/tests/evilrun" ]; then
+        fail "runid-traversal: a directory was created outside .runs"
+    else
+        ok
+    fi
+    cleanup_fixture
+}
+
+test_deploy_gen_stdout_nonzero() {
+    echo "test: deploy-gen PRE-read prints a value but EXITS NON-ZERO -> untrusted -> no advance (ISOLATES the pre-read rc guard)"
+    make_fixture
+    # Counter cmd: the PRE read (n=1) prints "7" but exits 3; the POST read (n=2) prints the
+    # SAME "7" and exits 0. So the post comparison (7 == 7) would PASS — only the pre-read rc
+    # guard catches the untrusted pre value. Removing that guard reddens this (post masks the
+    # earlier same-command tests; this one does not).
+    run_orch QA_DEPLOYED_GEN_CMD="n=\$(cat $FIXTURE/gsn 2>/dev/null || echo 0); n=\$((n+1)); echo \$n > $FIXTURE/gsn; echo 7; [ \$n -eq 1 ] && exit 3; exit 0"
+    assert_rc0 gen-stdout-nz
+    assert_kv advance false gen-stdout-nz
+    cleanup_fixture
+}
+
+test_deploy_gen_empty_no_advance() {
+    echo "test: deploy-gen reader EXITS ZERO but empty (both reads) -> no generation to trust -> no advance (post-read empty guard)"
+    make_fixture
+    run_orch QA_DEPLOYED_GEN_CMD="true"   # exit 0, prints nothing, both reads
+    assert_rc0 gen-empty
+    assert_kv advance false gen-empty
+    cleanup_fixture
+}
+
+test_deploy_gen_post_read_fails() {
+    echo "test: deploy-gen reader OK pre-tours but FAILS post-tours -> cannot confirm no redeploy -> no advance"
+    make_fixture
+    # Succeeds on the first (pre) read, fails on the second (post) read via a counter file.
+    run_orch QA_DEPLOYED_GEN_CMD="n=\$(cat $FIXTURE/gp 2>/dev/null || echo 0); n=\$((n+1)); echo \$n > $FIXTURE/gp; [ \$n -ge 2 ] && exit 9; echo ok"
+    assert_rc0 gen-post-fail
+    assert_kv advance false gen-post-fail
+    cleanup_fixture
+}
+
+test_trace_freshness_truncated() {
+    echo "test: a REUSED (stale) QA_JUDGE_TRACE is truncated at round start -> the round's export is fresh"
+    make_fixture
+    # Pre-populate the trace path with a stale span; the stub qa-report APPENDS (like the real
+    # judge). If the orchestrator did not truncate, the stale span would survive into the export.
+    printf 'STALE_SPAN_zzz\n' > "$FIXTURE/trace.jsonl"
+    run_orch
+    assert_rc0 trace-fresh
+    if grep -q 'STALE_SPAN_zzz' "$FIXTURE/trace.jsonl"; then fail "trace-fresh: stale span survived — trace not truncated"; else ok; fi
+    cleanup_fixture
+}
+
+test_tours_skip_reset_cleared() {
+    echo "test: an INHERITED TOURS_SKIP_RESET=1 with NO reseed is cleared -> tours still reset (not advance an unreseeded round)"
+    make_fixture
+    # Poison the outer env with TOURS_SKIP_RESET=1 and provide NO QA_RESEED_CMD. The orchestrator
+    # must clear it so `make tours` sees it EMPTY (reset happens). The stub records skip_reset=<val>.
+    run_orch TOURS_SKIP_RESET=1
+    assert_rc0 skip-reset-clear
+    if grep -qE '^make tours .* skip_reset= ' "$CALL_LOG"; then ok; else fail "skip-reset-clear: TOURS_SKIP_RESET leaked to tours ($(grep -m1 '^make tours' "$CALL_LOG"))"; fi
+    cleanup_fixture
+}
+
+test_media_incomplete_no_advance() {
+    echo "test: traces shipped but 0 screenshots (media upload failed, export still exit 0) -> no advance"
+    make_fixture
+    run_orch STUB_EXPORT_OUT="qa-export: 3 trace(s), 0 screenshot(s); enqueued 3/3"
+    assert_rc0 media-incomplete
+    assert_kv advance false media-incomplete
+    assert_reason "0 screenshots" media-incomplete
+    cleanup_fixture
+}
+
+test_reader_stderr_no_leak() {
+    echo "test: an injected reader's STDERR (secret-bearing) is discarded, not leaked into the round output"
+    make_fixture
+    # The deployed-sha reader prints the (valid) sha to stdout but a secret token to stderr.
+    # The orchestrator captures stdout with 2>/dev/null, so the token must appear nowhere.
+    run_orch QA_DEPLOYED_SHA_CMD="printf %s $HEAD_SHA; echo SHASECRET_zzz >&2"
+    if grep -rq 'SHASECRET_zzz' "$GHENV" "$OUT" "$ERR"; then fail "reader-noleak: reader stderr leaked into round output"; else ok; fi
+    cleanup_fixture
+}
+
+test_cmd_vars_stripped_from_children() {
+    echo "test: the injected QA_*_CMD vars (secret-bearing) are stripped from make children (judge Codex can't inherit them)"
+    make_fixture
+    run_orch QA_RESEED_CMD="true" QA_DEPLOYED_GEN_CMD="echo 1"
+    assert_rc0 cmd-strip
+    # Every recorded make call must show the command vars EMPTY (env -u removed them).
+    if grep -qE 'reseed_cmd=true|sha_cmd=[^ ]| gen_cmd=echo' "$CALL_LOG"; then
+        fail "cmd-strip: a QA_*_CMD leaked into a make child ($(grep -m1 'reseed_cmd=[^ ]' "$CALL_LOG"))"
+    else
+        ok
+    fi
+    cleanup_fixture
+}
+
+test_deployed_sha_nul_rejected() {
+    echo "test: a deployed-sha reader emitting <sha>+NUL (bash \$() strips NUL) is rejected as malformed -> no advance"
+    make_fixture
+    run_orch QA_DEPLOYED_SHA_CMD="printf '%s\\000' $HEAD_SHA"
+    assert_rc0 sha-nul
+    assert_kv advance false sha-nul
+    assert_reason "NUL byte" sha-nul
+    cleanup_fixture
+}
+
+test_reader_gen_stderr_no_leak() {
+    echo "test: the deploy-GEN reader's STDERR (secret-bearing) is discarded, not leaked"
+    make_fixture
+    run_orch QA_DEPLOYED_GEN_CMD="echo 5; echo GENSECRET_zzz >&2"
+    if grep -rq 'GENSECRET_zzz' "$GHENV" "$OUT" "$ERR"; then fail "gen-noleak: gen reader stderr leaked"; else ok; fi
+    cleanup_fixture
+}
+
+test_gen_baseline_before_reseed() {
+    echo "test: the deploy-generation baseline is captured BEFORE the reseed -> a redeploy DURING reseed is caught"
+    make_fixture
+    # gen reader = a counter file that does not exist yet at round start; the reseed writes "1"
+    # to it. Baselined BEFORE reseed, gen_pre="0" (file absent) and gen_post="1" -> changed -> no
+    # advance. If the baseline were taken AFTER reseed, gen_pre would already be "1" == gen_post
+    # and the round would wrongly advance.
+    run_orch QA_DEPLOYED_GEN_CMD="cat $FIXTURE/gc 2>/dev/null || echo 0" QA_RESEED_CMD="echo 1 > $FIXTURE/gc"
+    assert_rc0 gen-baseline
+    assert_kv advance false gen-baseline
+    cleanup_fixture
+}
+
+test_judge_creds_stripped() {
+    echo "test: tours/langfuse API secrets are stripped from the qa-report JUDGE env (Codex can't read them)"
+    make_fixture
+    run_orch LANGFUSE_SECRET_KEY=sk-SECRET TOURS_API_KEY=tk-SECRET
+    assert_rc0 judge-creds
+    # The qa-report (judge) call must show BOTH secrets empty (env -u removed them).
+    local jline; jline="$(grep '^make qa-report ' "$CALL_LOG")"
+    if printf '%s' "$jline" | grep -qE 'lang_secret=sk-SECRET|tours_key=tk-SECRET'; then
+        fail "judge-creds: a secret leaked into the judge env ($jline)"
+    else
+        ok
+    fi
+    cleanup_fixture
+}
+
+test_deploy_gen_nul_no_advance() {
+    echo "test: PRE gen read has a NUL that strips to == the (clean) POST read -> false-equal -> no advance (ISOLATES pre-NUL guard)"
+    make_fixture
+    # Counter: PRE (n=1) prints "A\0B" (raw, with NUL); POST (n=2) prints clean "AB". bash \$()
+    # strips the NUL so both become "AB" and would compare EQUAL -> advance. Only the pre-read
+    # NUL guard catches it (the post read has no NUL, so the post NUL guard cannot).
+    run_orch QA_DEPLOYED_GEN_CMD="n=\$(cat $FIXTURE/gnul 2>/dev/null || echo 0); n=\$((n+1)); echo \$n > $FIXTURE/gnul; if [ \$n -eq 1 ]; then printf 'A\\000B'; else printf 'AB'; fi"
+    assert_rc0 gen-nul
+    assert_kv advance false gen-nul
+    cleanup_fixture
+}
+
+test_reseed_after_runid_validation() {
+    echo "test: an invalid run id aborts BEFORE the destructive reseed runs (reseed ordering)"
+    make_fixture
+    # The reseed cmd drops a sentinel if it runs. An invalid run-id must abort first, so the
+    # sentinel must NOT appear — proving the reserve/validate step precedes the reseed.
+    run_orch QA_RUN_ID_OVERRIDE="../evil2" QA_RESEED_CMD="touch $FIXTURE/reseed-ran"
+    assert_rc_nz reseed-order
+    assert_reason "invalid run id" reseed-order
+    if [ -e "$FIXTURE/reseed-ran" ]; then fail "reseed-order: reseed ran before run-id validation (destructive)"; else ok; fi
+    cleanup_fixture
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_skip
+    test_clean
+    test_export_failed
+    test_pre_assert_fail
+    test_post_assert_fail
+    test_reseed_fail
+    test_reseed_fail_no_secret_leak
+    test_reseed_ok_skips_tours_reset
+    test_no_reseed_lets_tours_reset
+    test_trap_miss_still_exports
+    test_tours_fail
+    test_no_enqueue_landed
+    test_enqueue_via_already_queued
+    test_no_traces_missing_creds
+    test_gate_rc_nonzero
+    test_missing_judge_trace
+    test_missing_deployed_sha_cmd
+
+    test_isolated_export_exit
+    test_isolated_failed_only
+    test_isolated_enqueue_failed_only
+    test_isolated_traces_zero
+    test_deployed_sha_moved
+    test_deployed_cmd_fails
+    test_deployed_cmd_multiline
+    test_export_summary_fragment_ignored
+    test_export_duplicate_summary
+    test_runid_collision_aborts
+    test_rundir_create_error
+    test_deploy_gen_unset_records_false
+    test_deploy_gen_matches_clean
+    test_deploy_gen_bump_no_advance
+    test_deploy_gen_reader_fails
+    test_lost_github_env_write
+
+    test_enqueue_inconsistent
+    test_export_warning_no_advance
+    test_runid_traversal_rejected
+    test_deploy_gen_stdout_nonzero
+    test_deploy_gen_empty_no_advance
+    test_deploy_gen_post_read_fails
+    test_trace_freshness_truncated
+    test_tours_skip_reset_cleared
+    test_media_incomplete_no_advance
+    test_reader_stderr_no_leak
+    test_cmd_vars_stripped_from_children
+    test_deployed_sha_nul_rejected
+    test_reader_gen_stderr_no_leak
+    test_judge_creds_stripped
+    test_deploy_gen_nul_no_advance
+    test_reseed_after_runid_validation
+    test_gen_baseline_before_reseed
+
+    test_require_tmpdir_fails_closed
+    test_git_env_isolation
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/run-tours.sh
+++ b/scripts/run-tours.sh
@@ -36,6 +36,23 @@ if [ "${#missing[@]}" -gt 0 ]; then
     exit 1
 fi
 
+# --- Resolve + validate the run id BEFORE any destructive reset ---
+# A caller (e.g. the nightly-round orchestrator) may pre-set TOURS_RUN_ID so it knows the
+# run dir (frontend/tests/tours/.runs/<id>) deterministically; globalSetup honors a pre-set
+# value. Absent an override, mint a fresh filesystem-safe UTC timestamp (also a valid
+# QA_RUN_ID). The run id becomes a path segment (RUNS_ROOT/<id>), so a caller-supplied value
+# must be exactly the run-id timestamp form — otherwise `../` (or any separator) escapes the
+# .runs tree. Validate HERE, before the reseed/reset below, so a bad id never triggers a
+# destructive reseed first. `[[ =~ ]]` matches the WHOLE string (not line-by-line like grep),
+# so an embedded-newline injection cannot slip a valid line past. (This is a shape check; the
+# real-UTC round-trip lives in run.ts validRunId for the export provenance — a well-formed but
+# unreal timestamp like 20269999T999999Z is filesystem-safe, so it is not a traversal risk.)
+export TOURS_RUN_ID="${TOURS_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+if [[ ! "$TOURS_RUN_ID" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
+    echo "run-tours: TOURS_RUN_ID must be a UTC run-id timestamp (^[0-9]{8}T[0-9]{6}Z\$) — got '$TOURS_RUN_ID'" >&2
+    exit 1
+fi
+
 # --- Reset staging to the prod-shaped world (unless skipped) ---
 if [ "${TOURS_SKIP_RESET:-0}" = "1" ]; then
     echo "run-tours: TOURS_SKIP_RESET=1 — skipping staging-reset (using existing seeded staging)" >&2
@@ -79,7 +96,7 @@ if [ -z "$IMAGE_DIGEST" ]; then
 fi
 
 # --- Export run env consumed by globalSetup + the capture helper ---
-export TOURS_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+# (TOURS_RUN_ID was resolved + validated above, before the reset.)
 export TOURS_GIT_SHA="$(git rev-parse HEAD)"
 export TOURS_IMAGE_DIGEST="$IMAGE_DIGEST"
 

--- a/scripts/run-tours.test.sh
+++ b/scripts/run-tours.test.sh
@@ -72,6 +72,17 @@ run() {
     RC=$?
 }
 
+# run_err <ENV=val...> : like run() but captures the script's STDERR into ERR_OUT
+# (the launch banner reports the resolved runId there).
+run_err() {
+    : > "$CALL_LOG"
+    ERR_OUT="$(env PATH="$SANDBOX/bin:$PATH" \
+        TOURS_BASE_URL="http://staging.test" TOURS_API_KEY="k" \
+        "$@" \
+        bash "$SANDBOX/run-tours.sh" 2>&1 >/dev/null)"
+    RC=$?
+}
+
 echo "run-tours.sh reset-path selection tests"
 make_sandbox
 trap cleanup_sandbox EXIT
@@ -109,6 +120,35 @@ run TOURS_SKIP_RESET=1 TOURS_RESEED_SSH="qa-staging@10.100.0.1" TOURS_RESEED_KEY
 grep -qE 'ssh .*reseed' "$CALL_LOG" && fail "precedence: skip must win over reseed ssh" || ok
 grep -q 'staging-reset.sh' "$CALL_LOG" && fail "precedence: staging-reset must NOT run" || ok
 grep -q 'bunx .*playwright' "$CALL_LOG" && ok || fail "precedence: playwright should launch"
+
+# 5. A pre-set TOURS_RUN_ID is HONORED (not clobbered) — the nightly-round
+#    orchestrator relies on this to know the run dir deterministically.
+run_err TOURS_SKIP_RESET=1 TOURS_RUN_ID="20260101T000000Z"
+grep -q 'runId=20260101T000000Z' <<<"$ERR_OUT" && ok \
+    || fail "override: pre-set TOURS_RUN_ID must pass through (got: $ERR_OUT)"
+
+# 5b. With TOURS_RUN_ID explicitly empty, the default timestamp-shaped runId is minted
+#     (explicit empty, so an ambient value can't mask the defaulting path).
+run_err TOURS_SKIP_RESET=1 TOURS_RUN_ID=
+grep -qE 'runId=[0-9]{8}T[0-9]{6}Z' <<<"$ERR_OUT" && ok \
+    || fail "default: a timestamp runId must be minted (got: $ERR_OUT)"
+
+# 5c. A TOURS_RUN_ID that is NOT the run-id timestamp form is REJECTED before launch —
+#     it becomes a path segment (RUNS_ROOT/<id>), so `../` must never escape .runs.
+for bad in "../evil" "20260101T000000Z/../x" "not-a-runid" "20260101T000000Z
+../evil"; do
+    run_err TOURS_SKIP_RESET=1 TOURS_RUN_ID="$bad"
+    [ "$RC" -ne 0 ] && ok || fail "traversal: TOURS_RUN_ID='$bad' must be rejected (exit!=0)"
+    grep -q 'bunx .*playwright' "$CALL_LOG" && fail "traversal: playwright must NOT launch for '$bad'" || ok
+done
+
+# 5d. An invalid TOURS_RUN_ID is rejected BEFORE any destructive reset — WITHOUT
+#     TOURS_SKIP_RESET, so the default staging-reset path is active. A bad id must exit
+#     before that reset runs (never reseed against a bad id, then error).
+run TOURS_RUN_ID="../evil"
+[ "$RC" -ne 0 ] && ok || fail "pre-reset-validate: invalid id must exit non-zero"
+grep -q 'staging-reset.sh' "$CALL_LOG" && fail "pre-reset-validate: reset must NOT run before rejecting a bad id" || ok
+grep -q 'bunx .*playwright' "$CALL_LOG" && fail "pre-reset-validate: playwright must NOT launch" || ok
 
 echo "  PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
The CRM orchestration core of the QA nightly runner (out-of-arc follow-on to the judge-as-tenant automation). Test-infra / CI shell only — no product runtime.

## What lands

`scripts/ci/qa-nightly-round.sh` — a **pure, stateless, parameterized** orchestrator for one nightly judge round, plus a `scripts/run-tours.sh` `TOURS_RUN_ID` override (so the caller controls the run-dir deterministically) and shell tests wired into `make test-deploy-scripts`.

Every host-specific is **injected** (deployed sha, days-since, reseed command, deployed-sha/generation readers, creds, trace path). The orchestrator sequences `make tours` → `make qa-report JUDGE=1` → `; make qa-export`, computes a clean-round predicate, and **emits** `advance=true|false target=<sha>` — it never checks out, reseeds, deploys, or persists a watermark. The personal-ops host glue owns all of that.

## Design contract

- **Fail-closed / degrade-to-not-advance**: any uncertainty → `advance=false`; the round re-runs next cadence. Advisory nightly gate with a manual-trigger backstop.
- **Provenance integrity**: pre-tours pin (checkout == deployed sha) + post-tours re-read requiring `CURRENT == QA_HEAD_SHA` (start *and* end on the target) + a manifest assert; an optional monotonic deploy-generation seam catches an A→B→A redeploy the sha-equality alone can't.
- **Secret hygiene**: injected command vars and the tours/langfuse API creds are stripped from the make children (the `qa-report` judge spawns a Codex subprocess that must not read them); injected-command stdout/stderr is discarded; NUL-bearing reader output is rejected.
- **Fresh-per-round**: run-dir reserved atomically (before the destructive reseed), trace file truncated, run-id validated (traversal-safe).
- **Documented residuals**: per-trace media completeness and the no-generation A→B→A rollback need the expected-vs-executed capture signal that doesn't exist yet.

## Review

Driven through a gpt-5.6-sol (`--effort xhigh`) review loop over 7+ rounds (many genuine fail-open / secret / correctness findings fixed); the last rounds were fixed directly by the coordinator and each guard mutation-verified. 168 shell tests pass, `shellcheck -x` clean, full pre-push suite (incl. E2E) green.
