### PR TITLE
feat(contacts)!: migrate the edit form to method operations; retire the PUT methods branch

### DIFF
--- a/backend/internal/api/handlers/anarlog_discovery_test.go
+++ b/backend/internal/api/handlers/anarlog_discovery_test.go
@@ -130,8 +130,8 @@ func (f *fakeDiscoveryContacts) GetContact(ctx context.Context, id uuid.UUID) (*
 func (f *fakeDiscoveryContacts) CreateContact(ctx context.Context, req repository.CreateContactRequest, methods []service.ContactMethodInput) (*repository.Contact, uuid.UUID, error) {
 	return &repository.Contact{ID: uuid.New(), FullName: req.FullName}, uuid.Nil, nil
 }
-func (f *fakeDiscoveryContacts) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest, methods []service.ContactMethodInput, replaceMethods bool) (*repository.Contact, uuid.UUID, error) {
-	return &repository.Contact{ID: id, FullName: req.FullName}, uuid.Nil, nil
+func (f *fakeDiscoveryContacts) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest) (*repository.Contact, error) {
+	return &repository.Contact{ID: id, FullName: req.FullName}, nil
 }
 func (f *fakeDiscoveryContacts) DeleteContact(ctx context.Context, id uuid.UUID) error {
 	return nil

--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -381,45 +381,56 @@ func (h *ContactHandler) UpdateContact(c *gin.Context) {
 		return
 	}
 
+	// Both binds must be ShouldBindBodyWithJSON: a plain ShouldBindJSON consumes
+	// the body, and Gin caches it only when the ShouldBindBodyWith* call performs
+	// the read itself — so a later probe would see nothing.
 	var req UpdateContactRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
+	if err := c.ShouldBindBodyWithJSON(&req); err != nil {
 		api.SendValidationError(c, "Invalid request body", err.Error())
 		return
 	}
 
-	methodsProvided := req.Methods != nil
-	normalizedMethods, err := normalizeContactMethodRequests(req.Methods)
-	if err != nil {
-		api.SendValidationError(c, "Validation failed", err.Error())
+	// Contact methods are no longer part of this request. Dropping the field
+	// silently would let a stale browser or a naive client send a method
+	// addition, receive 200, and believe it landed — a silent-success failure,
+	// the same class this work eliminates, merely inverted from silent
+	// destruction. So the key is detected and rejected.
+	var legacy legacyContactMethodsProbe
+	if err := c.ShouldBindBodyWithJSON(&legacy); err == nil && legacy.Methods != nil {
+		api.SendValidationError(c,
+			"Validation failed",
+			"contact methods are no longer accepted on this endpoint; use POST /contacts/{id}/methods",
+		)
 		return
 	}
-	req.Methods = normalizedMethods
 
 	if err := h.validator.Struct(req); err != nil {
 		api.SendValidationError(c, "Validation failed", err.Error())
 		return
 	}
 
-	if err := validateContactMethods(h.validator, req.Methods); err != nil {
-		api.SendValidationError(c, "Validation failed", err.Error())
-		return
-	}
-
-	contact, rematchJobID, err := h.contactService.UpdateContact(
+	contact, err := h.contactService.UpdateContact(
 		c.Request.Context(),
 		id,
 		updateRequestToRepo(req),
-		buildContactMethodInputs(req.Methods),
-		methodsProvided,
 	)
 	if err != nil {
 		api.RespondError(c, err, "Contact")
 		return
 	}
 
-	response := contactToResponse(contact)
-	response.RematchJobID = nilStringPtrFromUUID(rematchJobID)
-	api.SendSuccess(c, http.StatusOK, response, nil)
+	// RematchJobID is populated by the create path only. A rematch is triggered
+	// by newly-present method values, and this request can no longer carry any.
+	api.SendSuccess(c, http.StatusOK, contactToResponse(contact), nil)
+}
+
+// legacyContactMethodsProbe detects a `methods` key on the update payload.
+//
+// json.RawMessage is deliberately NOT a pointer: a *json.RawMessage cannot tell
+// `"methods": null` from an absent key, and a client sending an explicit null
+// has still addressed the retired field.
+type legacyContactMethodsProbe struct {
+	Methods json.RawMessage `json:"methods"`
 }
 
 // DeleteContact deletes a contact

--- a/backend/internal/api/handlers/contact_dto.go
+++ b/backend/internal/api/handlers/contact_dto.go
@@ -28,7 +28,12 @@ type ContactResponse struct {
 	ProfilePhoto       *string                 `json:"profile_photo,omitempty" example:"https://example.com/photo.jpg"`
 	CreatedAt          time.Time               `json:"created_at" example:"2024-01-01T00:00:00Z"`
 	UpdatedAt          time.Time               `json:"updated_at" example:"2024-01-15T10:30:00Z"`
-	RematchJobID       *string                 `json:"rematch_job_id,omitempty"`
+	// RematchJobID is populated by the CREATE path only. A rematch is triggered
+	// by newly-present method values, and update no longer carries methods, so
+	// it has no job to report. This type is shared by create, get, update, list,
+	// merge, and overdue; the field is omitempty, so a path that leaves it unset
+	// simply omits the key rather than publishing an always-null contract.
+	RematchJobID *string `json:"rematch_job_id,omitempty"`
 }
 
 // ContactMethodResponse represents a contact method in responses
@@ -61,15 +66,20 @@ type CreateContactRequest struct {
 }
 
 // UpdateContactRequest represents the request to update a contact
+//
+// Contact methods are NOT part of this request. A full methods array made
+// absence mean "delete", so a client saving from a stale read destroyed every
+// method it had never seen. Methods are mutated through
+// POST /contacts/{id}/methods, which takes operations. A `methods` key on this
+// payload is rejected rather than ignored — see UpdateContact.
 // @Description Update contact request
 type UpdateContactRequest struct {
-	FullName     string                 `json:"full_name" validate:"required,min=1,max=255" example:"John Doe"`
-	Methods      []ContactMethodRequest `json:"methods,omitempty" validate:"omitempty,dive"`
-	Location     *string                `json:"location,omitempty" validate:"omitempty,max=255" example:"San Francisco, CA"`
-	Birthday     *DateOnly              `json:"birthday,omitempty" example:"1990-01-15" tstype:"string"`
-	HowMet       *string                `json:"how_met,omitempty" validate:"omitempty,max=500" example:"Met at tech conference"`
-	Cadence      *string                `json:"cadence,omitempty" validate:"omitempty,oneof=weekly biweekly monthly quarterly biannual annual" example:"monthly"`
-	ProfilePhoto *string                `json:"profile_photo,omitempty" validate:"omitempty,url,max=500" example:"https://example.com/photo.jpg"`
+	FullName     string    `json:"full_name" validate:"required,min=1,max=255" example:"John Doe"`
+	Location     *string   `json:"location,omitempty" validate:"omitempty,max=255" example:"San Francisco, CA"`
+	Birthday     *DateOnly `json:"birthday,omitempty" example:"1990-01-15" tstype:"string"`
+	HowMet       *string   `json:"how_met,omitempty" validate:"omitempty,max=500" example:"Met at tech conference"`
+	Cadence      *string   `json:"cadence,omitempty" validate:"omitempty,oneof=weekly biweekly monthly quarterly biannual annual" example:"monthly"`
+	ProfilePhoto *string   `json:"profile_photo,omitempty" validate:"omitempty,url,max=500" example:"https://example.com/photo.jpg"`
 }
 
 // ContactIDsResponse represents the response for ID-only queries

--- a/backend/internal/service/anarlog_discovery.go
+++ b/backend/internal/service/anarlog_discovery.go
@@ -48,7 +48,7 @@ type discoveryGroupRepo interface {
 type discoveryContactWriter interface {
 	GetContact(ctx context.Context, id uuid.UUID) (*repository.Contact, error)
 	CreateContact(ctx context.Context, req repository.CreateContactRequest, methods []ContactMethodInput) (*repository.Contact, uuid.UUID, error)
-	UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest, methods []ContactMethodInput, replaceMethods bool) (*repository.Contact, uuid.UUID, error)
+	UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest) (*repository.Contact, error)
 	// DeleteContact backs orphan cleanup: when the import mark touches zero
 	// siblings (a concurrent resolve already claimed the group), the contact
 	// just created is soft-deleted so the race never strands a duplicate.
@@ -263,7 +263,7 @@ func (s *AnarlogDiscoveryService) resolveLink(ctx context.Context, req ResolveTo
 		if req.Cadence != nil {
 			updateReq.Cadence = req.Cadence
 		}
-		if _, _, uErr := s.contacts.UpdateContact(ctx, contactID, updateReq, nil, false); uErr != nil {
+		if _, uErr := s.contacts.UpdateContact(ctx, contactID, updateReq); uErr != nil {
 			return nil, fmt.Errorf("update link target contact: %w", uErr)
 		}
 	}

--- a/backend/internal/service/anarlog_discovery_test.go
+++ b/backend/internal/service/anarlog_discovery_test.go
@@ -119,14 +119,14 @@ func (s *stubDiscoveryContacts) CreateContact(ctx context.Context, req repositor
 	s.createdContact = c
 	return c, uuid.Nil, nil
 }
-func (s *stubDiscoveryContacts) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest, methods []ContactMethodInput, replaceMethods bool) (*repository.Contact, uuid.UUID, error) {
+func (s *stubDiscoveryContacts) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest) (*repository.Contact, error) {
 	s.updateCalled = true
 	r := req
 	s.updateReq = &r
 	if s.updateErr != nil {
-		return nil, uuid.Nil, s.updateErr
+		return nil, s.updateErr
 	}
-	return &repository.Contact{ID: id, FullName: req.FullName, Cadence: req.Cadence}, uuid.Nil, nil
+	return &repository.Contact{ID: id, FullName: req.FullName, Cadence: req.Cadence}, nil
 }
 func (s *stubDiscoveryContacts) DeleteContact(ctx context.Context, id uuid.UUID) error {
 	s.deleteCalled = true

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -380,22 +380,29 @@ func (s *ContactService) CreateContact(ctx context.Context, req repository.Creat
 	return contact, jobID, nil
 }
 
-func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest, methods []ContactMethodInput, replaceMethods bool) (contact *repository.Contact, jobID uuid.UUID, err error) {
+// UpdateContact updates a contact's scalar profile fields.
+//
+// It does NOT touch contact methods. The method-replacing branch this function
+// used to carry made absence mean "delete", so a client saving from a stale
+// read destroyed every method it had never seen. Methods are mutated through
+// ContactMethodService.ApplyOperations, which takes operations and therefore
+// cannot express a removal the caller did not name.
+func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest) (contact *repository.Contact, err error) {
 	if s.cadence == nil {
 		// Sole-writer invariant: contact_by recomputation on cadence
 		// edits must route through CadenceUpdater. Refusing to operate
 		// without it prevents a silent rollback to the direct-path
 		// behavior.
-		return nil, uuid.Nil, errors.New("update contact: cadence updater not wired (pass cadence to NewContactService)")
+		return nil, errors.New("update contact: cadence updater not wired (pass cadence to NewContactService)")
 	}
 	if s.knowledge == nil {
 		// Authority-flip invariant: location/birthday/how_met flow from the
 		// assertion store, not the contact SQL.
-		return nil, uuid.Nil, errors.New("update contact: knowledge writer not wired (pass assertSvc+knowledgeCache to NewContactService)")
+		return nil, errors.New("update contact: knowledge writer not wired (pass assertSvc+knowledgeCache to NewContactService)")
 	}
 	tx, err := s.database.Pool.Begin(ctx)
 	if err != nil {
-		return nil, uuid.Nil, err
+		return nil, err
 	}
 	defer func() {
 		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
@@ -412,7 +419,7 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 
 	existingContact, err := contactRepo.GetContact(ctx, id)
 	if err != nil {
-		return nil, uuid.Nil, err
+		return nil, err
 	}
 
 	// Contact_by recomputation is a user-cadence-preference edit and
@@ -443,7 +450,7 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 	req.ContactBy = nil
 
 	if _, err = contactRepo.UpdateContact(ctx, id, req); err != nil {
-		return nil, uuid.Nil, err
+		return nil, err
 	}
 
 	// Keep the person node's display label synced with the contact's name.
@@ -452,7 +459,7 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 	// would let a stale-read non-rename update leave node and contact divergent
 	// under concurrency. A redundant no-op UPDATE on a non-rename edit is cheap.
 	if err = nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, id, req.FullName); err != nil {
-		return nil, uuid.Nil, fmt.Errorf("sync person node label: %w", err)
+		return nil, fmt.Errorf("sync person node label: %w", err)
 	}
 
 	// Authority flip: reconcile location/birthday/how_met against the contact's
@@ -468,11 +475,11 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 			ProducerKind:   repository.ProducerKindUser,
 			SourceIDPrefix: "edit",
 		}); err != nil {
-		return nil, uuid.Nil, fmt.Errorf("apply contact knowledge: %w", err)
+		return nil, fmt.Errorf("apply contact knowledge: %w", err)
 	}
 
 	if err := s.cadence.ApplyContactByOverride(ctx, tx, id, newContactBy); err != nil {
-		return nil, uuid.Nil, fmt.Errorf("apply cadence contact_by override: %w", err)
+		return nil, fmt.Errorf("apply cadence contact_by override: %w", err)
 	}
 	// ApplyContactByOverride is a second UPDATE on the contact row, so
 	// the profile-only UpdateContact's RETURNING values (notably
@@ -482,67 +489,25 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 	// caller receives matches the committed row bit-for-bit.
 	contact, err = contactRepo.GetContact(ctx, id)
 	if err != nil {
-		return nil, uuid.Nil, fmt.Errorf("refetch contact after cadence override: %w", err)
+		return nil, fmt.Errorf("refetch contact after cadence override: %w", err)
 	}
 
-	var (
-		updatedMethods []repository.ContactMethod
-		existingBefore []repository.ContactMethod
-	)
-	if replaceMethods {
-		existingBefore, err = contactMethodRepo.ListContactMethodsByContact(ctx, id)
-		if err != nil {
-			return nil, uuid.Nil, err
-		}
-		if err := contactMethodRepo.DeleteContactMethodsByContact(ctx, id); err != nil {
-			return nil, uuid.Nil, err
-		}
-
-		updatedMethods, err = createContactMethods(ctx, contactMethodRepo, id, methods)
-		if err != nil {
-			return nil, uuid.Nil, err
-		}
-	} else {
-		updatedMethods, err = contactMethodRepo.ListContactMethodsByContact(ctx, id)
-		if err != nil {
-			return nil, uuid.Nil, err
-		}
-		sortContactMethods(updatedMethods)
+	// Methods are read back only so the returned contact carries them. Nothing
+	// here writes a method, so there is no diff to publish and no rematch job to
+	// mint: a rematch is triggered by newly-present method values, which now
+	// arrive exclusively through ContactMethodService.ApplyOperations.
+	updatedMethods, err := contactMethodRepo.ListContactMethodsByContact(ctx, id)
+	if err != nil {
+		return nil, err
 	}
-
-	// Compute method diff + publish inside the tx so event row + river
-	// job + method rows commit/roll back together (spec §4). Only the
-	// replaceMethods branch can add new methods — !replaceMethods leaves
-	// methods as-is.
-	//
-	// Filter to eligible methods first (see CreateContact for rationale):
-	// unhandled types skip publishing and return uuid.Nil.
-	var eligibleAddedMethods []Method
-	if replaceMethods && s.rematchRegistry != nil {
-		newlyAdded := diffNewMethods(existingBefore, updatedMethods)
-		eligibleAddedMethods = s.rematchRegistry.EligibleMethods(newlyAdded)
-	}
-	if replaceMethods && len(eligibleAddedMethods) > 0 && s.bus != nil {
-		jobID = uuid.New()
-		refs := rematchMethodsToRefs(eligibleAddedMethods)
-		env, marshalErr := buildContactMethodsAddedEnvelope("manual", id, refs, jobID)
-		if marshalErr != nil {
-			return nil, uuid.Nil, marshalErr
-		}
-		if err := s.bus.PublishTx(ctx, tx, env); err != nil {
-			return nil, uuid.Nil, fmt.Errorf("publish contact_methods.added: %w", err)
-		}
-	}
+	sortContactMethods(updatedMethods)
 
 	if err = tx.Commit(ctx); err != nil {
-		return nil, uuid.Nil, err
+		return nil, err
 	}
 
 	assignMethods(contact, updatedMethods)
-	if jobID != uuid.Nil && s.rematchRegistry != nil {
-		s.rematchRegistry.RegisterPending(jobID, id, eligibleAddedMethods)
-	}
-	return contact, jobID, nil
+	return contact, nil
 }
 
 // DeleteContact soft-deletes a contact and propagates the tombstone to its

--- a/backend/internal/service/contact_method.go
+++ b/backend/internal/service/contact_method.go
@@ -362,6 +362,16 @@ func requireTypeAndValue(i int, op ContactMethodOperation) error {
 	if !isKnownContactMethodType(op.Type) {
 		return opErrf(i, "%s has unknown type %q", op.Op, op.Type)
 	}
+	// A value that is non-empty but normalizes to empty — "@@@" for a handle,
+	// whitespace, a phone with no digits — is just as unsatisfiable as a blank
+	// one. Accepting it stores a row with an empty value_normalized, which the
+	// unique index caps at one per contact+type and which identity and sync
+	// queries then filter out: a row that exists, cannot be matched on, and
+	// blocks the slot. Checked through the C6 mirror so the emptiness test is
+	// the trigger's, not a second opinion.
+	if repository.NormalizeContactMethodValueForUniqueness(op.Type, op.Value) == "" {
+		return opErrf(i, "%s value %q is empty once normalized", op.Op, op.Value)
+	}
 	// Value FORMAT rules (email shape, phone length) are enforced at the
 	// handler, which owns the same validator the create path uses. What is
 	// enforced here is the domain rule the create path deliberately does NOT

--- a/backend/internal/service/contact_method_blank_test.go
+++ b/backend/internal/service/contact_method_blank_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A value that is non-empty but normalizes to empty is as unsatisfiable as a
+// blank one, and until this check existed it was accepted: the row persisted
+// with an empty value_normalized, which the unique index caps at one per
+// (contact, type) and which identity and sync queries filter out with
+// a non-empty-value_normalized predicate. The result is a row that exists, cannot be matched
+// on, and occupies the slot — inert rather than corrupting, which is why it was
+// non-blocking, but reachable the moment the form starts sending operations.
+//
+// Reachability is type-dependent and the table says so: email and gchat are
+// already protected by the handler's email validator, phone/signal/whatsapp are
+// length-checked only, and telegram/discord/twitter have no format rule at all.
+// The handle and phone rows are the ones that reach this check in production.
+func TestRequireTypeAndValue_RejectsValuesEmptyAfterNormalization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		methodType string
+		value      string
+	}{
+		{"handle of only at-signs", "discord", "@@@"},
+		{"single at-sign handle", "telegram", "@"},
+		{"twitter handle of spaces", "twitter", "   "},
+		{"phone with no digits", "phone", "()- "},
+		{"signal with no digits", "signal", "+"},
+		{"whatsapp of spaces", "whatsapp", "  "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Precondition: the value is genuinely non-blank, so the literal
+			// empty-string check cannot be what rejects it. Without this the
+			// test would pass against a build that has no normalization check
+			// at all.
+			require.NotEmpty(t, tc.value)
+			require.Empty(t, repository.NormalizeContactMethodValueForUniqueness(tc.methodType, tc.value),
+				"fixture does not normalize to empty, so it does not exercise this rule")
+
+			for _, op := range []ContactMethodOperation{
+				{Op: MethodOpAdd, Type: tc.methodType, Value: tc.value},
+				{Op: MethodOpUpdate, MethodID: uuidPtr(uuid.New()), Type: tc.methodType, Value: tc.value},
+			} {
+				err := validateOperationShapes([]ContactMethodOperation{op})
+				require.Error(t, err, "%s with a value empty after normalization was accepted", op.Op)
+				assert.ErrorIs(t, err, ErrInvalidOperations)
+				assert.Contains(t, err.Error(), "empty once normalized")
+			}
+		})
+	}
+}
+
+// The companion direction: a value that survives normalization is not rejected
+// by the new check. Without this, deleting the whole rule and rejecting every
+// add would leave the table above green.
+func TestRequireTypeAndValue_AcceptsValuesThatSurviveNormalization(t *testing.T) {
+	t.Parallel()
+
+	for _, op := range []ContactMethodOperation{
+		{Op: MethodOpAdd, Type: "discord", Value: "@@handle"},
+		{Op: MethodOpAdd, Type: "phone", Value: "(555) 555-0100"},
+		{Op: MethodOpAdd, Type: "email", Value: "person@example.test"},
+	} {
+		assert.NoError(t, validateOperationShapes([]ContactMethodOperation{op}), "op %+v", op)
+	}
+}
+
+func uuidPtr(id uuid.UUID) *uuid.UUID { return &id }

--- a/backend/internal/service/contact_method_diff_test.go
+++ b/backend/internal/service/contact_method_diff_test.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// preStateRow builds a pre-state row the way the database would: value_normalized
+// is the trigger's output, which the C6 mirror reproduces.
+func preStateRow(methodType, value string) repository.ContactMethod {
+	return repository.ContactMethod{
+		ID:              uuid.New(),
+		Type:            methodType,
+		Value:           value,
+		ValueNormalized: repository.NormalizeContactMethodValueForUniqueness(methodType, value),
+	}
+}
+
+func foldRow(methodType, value string) *foldedMethod {
+	return &foldedMethod{ID: uuid.New(), Type: methodType, Value: value}
+}
+
+// diffNewMethodsFromFold is what decides whether a rematch job is minted, and it
+// had no direct coverage. Its doc comment claims the semantic diff makes
+// idempotency fall out for free — a replayed payload folds to a final state
+// equal to pre-state, so the diff is empty and nothing is published. That claim
+// is the property pinned here.
+func TestDiffNewMethodsFromFold(t *testing.T) {
+	t.Parallel()
+
+	existingEmail := preStateRow("email", "existing@example.test")
+
+	cases := []struct {
+		name   string
+		before []repository.ContactMethod
+		after  []*foldedMethod
+		want   []Method
+	}{
+		{
+			name:   "a value newly present is reported",
+			before: nil,
+			after:  []*foldedMethod{foldRow("email", "added@example.test")},
+			want:   []Method{{Type: "email", Value: "added@example.test"}},
+		},
+		{
+			// The replay property. A payload applied twice folds to a final
+			// state equal to pre-state; if this diff were computed over
+			// physical inserts instead of values newly PRESENT, a replay would
+			// re-publish and mint a second rematch job.
+			name:   "replaying a payload produces an empty diff",
+			before: []repository.ContactMethod{existingEmail},
+			after:  []*foldedMethod{foldRow("email", existingEmail.Value)},
+			want:   nil,
+		},
+		{
+			// Values are compared through the mirror, not raw. A pre-existing
+			// row reached by a differently-spelled but equivalently-normalizing
+			// value is NOT newly present.
+			name:   "a differently spelled handle resolving to the same key is not new",
+			before: []repository.ContactMethod{preStateRow("discord", "handle")},
+			after:  []*foldedMethod{foldRow("discord", "@@handle")},
+			want:   nil,
+		},
+		{
+			name:   "a removal reports nothing",
+			before: []repository.ContactMethod{existingEmail},
+			after:  nil,
+			want:   nil,
+		},
+		{
+			// Same type, genuinely different value: newly present alongside the
+			// one that was already there.
+			name:   "only the newly present value of a pair is reported",
+			before: []repository.ContactMethod{existingEmail},
+			after: []*foldedMethod{
+				foldRow("email", existingEmail.Value),
+				foldRow("email", "second@example.test"),
+			},
+			want: []Method{{Type: "email", Value: "second@example.test"}},
+		},
+		{
+			// A stored-value-only edit (the in-place update path) DOES change
+			// the key here, because case is part of neither normalizer for
+			// handles... but for email the mirror lowercases, so a case-only
+			// email edit is not newly present.
+			name:   "a case-only email edit is not newly present",
+			before: []repository.ContactMethod{preStateRow("email", "Person@Example.test")},
+			after:  []*foldedMethod{foldRow("email", "person@example.test")},
+			want:   nil,
+		},
+		{
+			name:   "a type change makes the value newly present under the new type",
+			before: []repository.ContactMethod{preStateRow("telegram", "handle")},
+			after:  []*foldedMethod{foldRow("discord", "handle")},
+			want:   []Method{{Type: "discord", Value: "handle"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := diffNewMethodsFromFold(tc.before, tc.after)
+			if len(tc.want) == 0 {
+				assert.Empty(t, got)
+				return
+			}
+			require.Len(t, got, len(tc.want))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -395,24 +395,6 @@ func (s *RematchService) GetJob(id uuid.UUID) (JobProgress, error) {
 	return v.(*job).snapshot(), nil
 }
 
-// diffNewMethods returns methods present in `after` whose (type,
-// value_normalized) pair is not in `before`. Order-insensitive.
-func diffNewMethods(before, after []repository.ContactMethod) []Method {
-	existing := make(map[string]struct{}, len(before))
-	for _, m := range before {
-		existing[m.Type+"|"+m.ValueNormalized] = struct{}{}
-	}
-	out := make([]Method, 0, len(after))
-	for _, m := range after {
-		key := m.Type + "|" + m.ValueNormalized
-		if _, ok := existing[key]; ok {
-			continue
-		}
-		out = append(out, Method{Type: m.Type, Value: m.ValueNormalized})
-	}
-	return out
-}
-
 // toRematchMethods converts a slice of ContactMethod to rematch Methods using
 // the normalized value.
 func toRematchMethods(methods []repository.ContactMethod) []Method {

--- a/backend/internal/service/rematch_publisher.go
+++ b/backend/internal/service/rematch_publisher.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// rematchMethodsToRefs converts service.Method (from diffNewMethods) to
-// the event-layer ref type.
+// rematchMethodsToRefs converts service.Method (from the contact-method
+// semantic diff) to the event-layer ref type.
 func rematchMethodsToRefs(methods []Method) []events.ContactMethodRef {
 	out := make([]events.ContactMethodRef, len(methods))
 	for i, m := range methods {

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -484,36 +484,6 @@ func TestPruneTerminalJobs_EvictsOldTerminalButKeepsFresh(t *testing.T) {
 	}
 }
 
-func TestDiffNewMethods_NormalizedKey(t *testing.T) {
-	before := []repository.ContactMethod{
-		{Type: "email", ValueNormalized: "alice@example.com"},
-	}
-	after := []repository.ContactMethod{
-		{Type: "email", ValueNormalized: "alice@example.com"}, // unchanged
-		{Type: "email", ValueNormalized: "bob@example.com"},   // new
-		{Type: "phone", ValueNormalized: "+15551212"},         // new
-	}
-	diff := diffNewMethods(before, after)
-	if len(diff) != 2 {
-		t.Fatalf("expected 2 new methods, got %d: %+v", len(diff), diff)
-	}
-	wantValues := map[string]bool{"bob@example.com": true, "+15551212": true}
-	for _, m := range diff {
-		if !wantValues[m.Value] {
-			t.Fatalf("unexpected method %+v", m)
-		}
-	}
-}
-
-func TestDiffNewMethods_EmptyInputs(t *testing.T) {
-	if got := diffNewMethods(nil, nil); len(got) != 0 {
-		t.Fatalf("expected empty diff, got %+v", got)
-	}
-	if got := diffNewMethods(nil, []repository.ContactMethod{{Type: "email", ValueNormalized: "a@b"}}); len(got) != 1 {
-		t.Fatalf("expected 1 new, got %d", len(got))
-	}
-}
-
 func TestToRematchMethods(t *testing.T) {
 	in := []repository.ContactMethod{
 		{Type: "email", ValueNormalized: "x@y.z"},

--- a/backend/tests/api/contact_method_operations_test.go
+++ b/backend/tests/api/contact_method_operations_test.go
@@ -539,11 +539,14 @@ func TestMethodOps_DuplicateFinalStateRejected(t *testing.T) {
 	// Updating B onto A's value would leave two rows with one key.
 	w, _ := f.post(updateOp(b.ID, "email", a.Value))
 	require.Equal(t, http.StatusBadRequest, w.Code)
+	// Naming the value is itself discriminating: the backstop deliberately
+	// returns its sentinel ONLY, because PostgreSQL's Detail for this violation
+	// embeds the contact id and the raw value and would put a real address into
+	// an HTTP response body. So only the fold can produce this.
 	assert.Contains(t, w.Body.String(), a.Value, "the rejection did not name the colliding value")
-	// The fold and the database backstop BOTH name the value — PostgreSQL's
-	// error detail embeds it too — so the value alone cannot tell them apart.
-	// The fold's phrasing is about the intended END STATE, which is the thing
-	// only a pre-SQL check can talk about.
+	// Kept alongside the value assertion because it pins a stronger property
+	// still: the fold's phrasing is about the intended END STATE, which is the
+	// thing only a pre-SQL check can talk about at all.
 	assert.Contains(t, w.Body.String(), "would contain a duplicate",
 		"the rejection came from the database index, not the fold: the request mutated and rolled back rather than being refused deterministically")
 	assert.Equal(t, b.Value, f.storedByID(b.ID).Value, "a rejected payload mutated a row")

--- a/backend/tests/api/contact_validation_test.go
+++ b/backend/tests/api/contact_validation_test.go
@@ -376,33 +376,128 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
 	})
 
-	t.Run("UpdateContact_InvalidEmail", func(t *testing.T) {
-		updateReq := handlers.UpdateContactRequest{
-			FullName: "Updated Name",
-			Methods: []handlers.ContactMethodRequest{
-				{
-					Type:  "email",
-					Value: "invalid-email",
-				},
-			},
+	// A `methods` key on the update payload is REJECTED, never ignored.
+	//
+	// Ignoring it is the failure this asserts against: a stale browser or a
+	// naive client sends a method addition, Gin drops the unknown key, the
+	// client receives 200 and believes the method landed. That is a
+	// silent-success failure — the same class the operations endpoint exists to
+	// eliminate, merely inverted from silent destruction.
+	t.Run("UpdateContact_RejectsLegacyMethodsField", func(t *testing.T) {
+		originalName := "Update Test User " + ns
+
+		cases := []struct {
+			name    string
+			methods any
+		}{
+			{"populated", []map[string]any{{"type": "email", "value": "legacy+" + ns + "@example.com"}}},
+			// An empty array is what a client sends to mean "remove them all" —
+			// exactly the destructive intent this endpoint must not accept.
+			{"empty array", []map[string]any{}},
+			// Load-bearing: this is the case a *json.RawMessage probe cannot
+			// distinguish from an absent key, so it is what pins the non-pointer
+			// requirement.
+			{"null", nil},
 		}
 
-		jsonBody, _ := json.Marshal(updateReq)
-		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+contactID, bytes.NewBuffer(jsonBody))
-		req.Header.Set("Content-Type", "application/json")
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				body, err := json.Marshal(map[string]any{
+					"full_name": "Should Not Be Applied",
+					"methods":   tc.methods,
+				})
+				require.NoError(t, err)
 
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
+				req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+contactID, bytes.NewBuffer(body))
+				req.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusBadRequest, w.Code)
+				require.Equal(t, http.StatusBadRequest, w.Code)
 
-		var response api.APIResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+				var response api.APIResponse
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+				assert.False(t, response.Success)
+				assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+				assert.Contains(t, response.Error.Details, "POST /contacts/{id}/methods",
+					"the rejection must name the endpoint that does accept methods")
 
-		assert.False(t, response.Success)
-		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+				// Nothing was mutated: a rejected request must not have applied
+				// the scalar fields it also carried.
+				getReq, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID, nil)
+				getW := httptest.NewRecorder()
+				router.ServeHTTP(getW, getReq)
+				require.Equal(t, http.StatusOK, getW.Code)
+
+				var getResponse api.APIResponse
+				require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &getResponse))
+				current := getResponse.Data.(map[string]interface{})
+				assert.Equal(t, originalName, current["full_name"])
+				methods, _ := current["methods"].([]interface{})
+				assert.Len(t, methods, 1, "the contact's methods must be untouched")
+			})
+		}
 	})
+}
+
+// The create path still accepts methods, and must: creation is not a
+// lost-update path, because there is nothing yet to lose. Only the UPDATE
+// request lost its methods field (CON-064), and a DTO change that took the
+// create field with it would silently stop persisting methods on every new
+// contact while every request still returned 201.
+func TestCreateContact_StillAcceptsMethods(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, cleanup := setupContactValidationTestRouter()
+	defer cleanup()
+
+	ns := uuid.New().String()[:8]
+	email := "create-methods+" + ns + "@example.com"
+	createReq := handlers.CreateContactRequest{
+		FullName: "Create Methods User " + ns,
+		Methods: []handlers.ContactMethodRequest{
+			{Type: "email", Value: email, IsPrimary: true},
+		},
+	}
+	body, err := json.Marshal(createReq)
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var createResponse api.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &createResponse))
+	created := createResponse.Data.(map[string]interface{})
+	contactID := created["id"].(string)
+	defer func() {
+		deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		router.ServeHTTP(httptest.NewRecorder(), deleteReq)
+	}()
+
+	// Asserted on the persisted contact, not the create response: a 201 alone
+	// would still be returned by a build that accepted the field and dropped it.
+	getReq, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID, nil)
+	getW := httptest.NewRecorder()
+	router.ServeHTTP(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+
+	var getResponse api.APIResponse
+	require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &getResponse))
+	methods, _ := getResponse.Data.(map[string]interface{})["methods"].([]interface{})
+	require.Len(t, methods, 1)
+	stored := methods[0].(map[string]interface{})
+	assert.Equal(t, "email", stored["type"])
+	assert.Equal(t, email, stored["value"])
+	assert.Equal(t, true, stored["is_primary"])
 }
 
 func TestContactAPI_QueryValidation(t *testing.T) {

--- a/backend/tests/contact_by_integration_test.go
+++ b/backend/tests/contact_by_integration_test.go
@@ -368,10 +368,10 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 		// Step 2: Update contact to CLEAR cadence. The service recomputes
 		// contact_by from the new cadence (nil → clear) and routes the
 		// contact_by write through CadenceUpdater.ApplyContactByOverride.
-		updatedContact, _, err := contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+		updatedContact, err := contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 			FullName: contact.FullName,
 			Cadence:  nil, // Clear cadence
-		}, nil, false)
+		})
 		require.NoError(t, err)
 		assert.Nil(t, updatedContact.ContactBy, "contact_by should be nil when cadence is cleared")
 
@@ -388,10 +388,10 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 			"returned updated_at should reflect post-override committed state")
 
 		// Step 3: Update contact to SET cadence again (different cadence)
-		updatedContact, _, err = contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+		updatedContact, err = contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 			FullName: contact.FullName,
 			Cadence:  &monthlyStr,
-		}, nil, false)
+		})
 		require.NoError(t, err)
 		require.NotNil(t, updatedContact.ContactBy, "contact_by should be set when cadence is re-enabled")
 
@@ -415,10 +415,10 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 		assert.Nil(t, contact.ContactBy, "contact_by should be nil initially")
 
 		// Update to add cadence through the service layer.
-		updatedContact, _, err := contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+		updatedContact, err := contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 			FullName: contact.FullName,
 			Cadence:  &weeklyStr,
-		}, nil, false)
+		})
 		require.NoError(t, err)
 		require.NotNil(t, updatedContact.ContactBy, "contact_by should be set when cadence is added")
 	})
@@ -443,10 +443,10 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 
 		// Change to annual cadence; the service recomputes contact_by
 		// from (new cadence, existing last_contacted).
-		updatedContact, _, err := contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+		updatedContact, err := contactService.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 			FullName: contact.FullName,
 			Cadence:  &annualStr,
-		}, nil, false)
+		})
 		require.NoError(t, err)
 		require.NotNil(t, updatedContact.ContactBy)
 

--- a/backend/tests/contact_knowledge_cutover_integration_test.go
+++ b/backend/tests/contact_knowledge_cutover_integration_test.go
@@ -225,10 +225,10 @@ func TestContactKnowledgeCutover_UpdateSupersedesAndClears(t *testing.T) {
 	require.NoError(t, err)
 	h.track(contact.ID)
 
-	updated, _, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+	updated, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 		FullName: contact.FullName,
 		Location: &la,
-	}, nil, false)
+	})
 	require.NoError(t, err)
 	require.NotNil(t, updated.Location)
 	assert.Equal(t, la, *updated.Location, "cache location follows the supersession")
@@ -242,10 +242,10 @@ func TestContactKnowledgeCutover_UpdateSupersedesAndClears(t *testing.T) {
 	assert.Equal(t, la, place.CanonicalLabel)
 
 	// Clear the location (closure): cache blanks to NULL.
-	cleared, _, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+	cleared, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 		FullName: contact.FullName,
 		Location: nil,
-	}, nil, false)
+	})
 	require.NoError(t, err)
 	assert.Nil(t, cleared.Location, "clearing the field blanks the cache to NULL")
 
@@ -594,10 +594,10 @@ func TestContactKnowledgeCutover_EmptyFieldNormalization(t *testing.T) {
 	// CLEAR (closure), cache blanks to NULL.
 	realLoc := "Phoenix " + ns
 	h.trackPlace(realLoc)
-	_, _, err = h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+	_, err = h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 		FullName: contact.FullName,
 		Location: &realLoc,
-	}, nil, false)
+	})
 	require.NoError(t, err)
 	withLoc, err := h.contactRepo.GetContact(ctx, contact.ID)
 	require.NoError(t, err)
@@ -605,10 +605,10 @@ func TestContactKnowledgeCutover_EmptyFieldNormalization(t *testing.T) {
 	assert.Equal(t, realLoc, *withLoc.Location)
 
 	empty := ""
-	cleared, _, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+	cleared, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 		FullName: contact.FullName,
 		Location: &empty,
-	}, nil, false)
+	})
 	require.NoError(t, err, "empty-string location must not error")
 	assert.Nil(t, cleared.Location, "empty-string update clears the location cache")
 	_, err = h.assertionRepo.GetCurrentAccepted(ctx, contact.ID, repository.PredicateLivesIn, now)
@@ -641,11 +641,11 @@ func TestContactKnowledgeCutover_HowMetPreservedWhenFormOmitsIt(t *testing.T) {
 	// set. how_met must be UNTOUCHED: no closure, the SAME assertion stays current,
 	// and the cache column still holds the value. (The form has no how_met input,
 	// so a nil how_met is "not managed by this edit," not a user clear.)
-	updated, _, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+	updated, err := h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 		FullName: "HowMet Keep Renamed " + ns,
 		Location: &loc, // an unrelated field changes
 		HowMet:   nil,  // the form omits how_met
-	}, nil, false)
+	})
 	require.NoError(t, err)
 	require.NotNil(t, updated.HowMet, "how_met cache must survive an edit that omits it")
 	assert.Equal(t, how, *updated.HowMet)
@@ -658,10 +658,10 @@ func TestContactKnowledgeCutover_HowMetPreservedWhenFormOmitsIt(t *testing.T) {
 
 	// Sanity: an EXPLICIT how_met value still asserts (changes the slot).
 	newHow := "actually met at work " + ns
-	_, _, err = h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+	_, err = h.contactSvc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 		FullName: updated.FullName,
 		HowMet:   &newHow,
-	}, nil, false)
+	})
 	require.NoError(t, err)
 	current, err := h.assertionRepo.GetCurrentAccepted(ctx, contact.ID, repository.PredicateHowMet, now)
 	require.NoError(t, err)

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -90,9 +90,9 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 
 		// Rename via the profile-update path: the node label must follow.
 		renamed := gen.Prefix() + "renamed-person"
-		_, _, err = svc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+		_, err = svc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 			FullName: renamed,
-		}, nil, false)
+		})
 		require.NoError(t, err)
 
 		node, err := support.GetNodeForContact(ctx, contact.ID)
@@ -126,10 +126,10 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		// fails if the in-tx sync regresses, unlike a same-name no-op.
 		renamed := gen.Prefix() + "renamed-with-cadence"
 		monthly := "monthly"
-		_, _, err = svc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+		_, err = svc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
 			FullName: renamed,
 			Cadence:  &monthly,
-		}, nil, false)
+		})
 		require.NoError(t, err)
 
 		node, err := support.GetNodeForContact(ctx, contact.ID)

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -789,7 +789,11 @@ func TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction(t *tes
 	waitForTelegramMessagesProcessed(t, env.ctx, env.database.Pool, peerUserID, contact.ID, 3, defaultInteractionWaitTimeout)
 }
 
-func TestRematch_ContactServiceUpdateContact_FiresForNewMethodOnly(t *testing.T) {
+// Rematch is dispatched for method values that are newly PRESENT, not for
+// every method named in the request. The trigger moved from the contact PUT to
+// the operations endpoint when the PUT's method-replacing branch was retired;
+// the diff behavior it asserts is unchanged.
+func TestRematch_ApplyMethodOperations_FiresForNewMethodOnly(t *testing.T) {
 	t.Parallel()
 	env := setupRematchEnv(t)
 
@@ -807,20 +811,22 @@ func TestRematch_ContactServiceUpdateContact_FiresForNewMethodOnly(t *testing.T)
 
 	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
 	// Event whose attendee matches the PRE-EXISTING email. Rematch should
-	// NOT link this on the update — diffNewMethods filters it out.
+	// NOT link this — the semantic diff filters an already-present value out.
 	_ = seedCalendarEventWithAttendee(t, env, accountID, existingEmail, pastEnd, "confirmed")
 	// Event whose attendee matches the NEWLY-ADDED email. Should be linked.
 	newEmail := "added@example.com"
 	newEvent := seedCalendarEventWithAttendee(t, env, accountID, newEmail, pastEnd, "confirmed")
 
-	_, jobID, err := env.contactSvc.UpdateContact(env.ctx, contact.ID, repository.UpdateContactRequest{
-		FullName: contact.FullName,
-	}, []service.ContactMethodInput{
-		{Type: "email", Value: existingEmail, IsPrimary: true},
-		{Type: "email", Value: newEmail, IsPrimary: false},
-	}, true)
+	methodSvc := service.NewContactMethodService(env.database, env.bus, env.rematchSvc)
+	result, err := methodSvc.ApplyOperations(env.ctx, contact.ID, []service.ContactMethodOperation{
+		// Already present: resolves to the existing row, so it is absent from
+		// the semantic diff and must not contribute a rematch.
+		{Op: service.MethodOpAdd, Type: "email", Value: existingEmail},
+		{Op: service.MethodOpAdd, Type: "email", Value: newEmail},
+	})
 	require.NoError(t, err)
-	require.NotEqual(t, uuid.Nil, jobID, "UpdateContact should dispatch rematch for newly-added email")
+	jobID := result.RematchJobID
+	require.NotEqual(t, uuid.Nil, jobID, "ApplyOperations should dispatch rematch for the newly-added email")
 
 	job := waitForRematchJob(t, env.rematchSvc, jobID)
 	assert.Equal(t, service.JobStatusCompleted, job.Status)

--- a/frontend/src/app/contacts/[id]/__tests__/save-sequence.test.tsx
+++ b/frontend/src/app/contacts/[id]/__tests__/save-sequence.test.tsx
@@ -461,6 +461,55 @@ describe('the acknowledged state is never re-derived from server data', () => {
     ])
   })
 
+  it('applies a primary-only result snapshot to the live row, not just the acknowledged state', async () => {
+    // set_primary and clear_primary results carry a FULL snapshot, and it is
+    // the only place the client learns that row's server-side state. If the
+    // acknowledged state applies it while the form does not, the two structures
+    // drift: the form keeps showing the stale value, and the next derivation
+    // emits an update nobody asked for — overwriting a value the form never
+    // displayed, on a row the user never edited.
+    //
+    // Here another writer changed A's value after edit-start. The user only
+    // toggles primary, so the sole operation is set_primary(A), and its
+    // snapshot reports the server's new value.
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    const serverValue = 'moved@example.test'
+    applyMethods.mockResolvedValueOnce({
+      methods: [{ ...methodA, value: serverValue, is_primary: true }],
+      results: [
+        {
+          index: 0,
+          outcome: 'updated',
+          method_id: METHOD_A,
+          method: { ...methodA, value: serverValue, is_primary: true },
+        },
+      ],
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.click(screen.getByRole('button', { name: 'Set as primary' }))
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    expect(operationsOfCall(0)).toEqual([{ op: 'set_primary', method_id: METHOD_A }])
+    // The live row learned the server's value.
+    await waitFor(() => expect(methodValueInputs()[0]).toHaveValue(serverValue))
+
+    // A form edit invalidates the session, forcing a fresh derivation.
+    applyMethods.mockResolvedValue({ methods: [methodA], results: [] })
+    saveNote.mockResolvedValue({})
+    await user.type(screen.getByLabelText(/Full Name/), '!')
+    await save(user)
+
+    await waitFor(() => expect(saveNote).toHaveBeenCalledTimes(2))
+    // No spurious update rewriting the server's value back to the stale one.
+    const second = applyMethods.mock.calls[1]
+    expect(second ? second[0].operations : []).toEqual([])
+  })
+
   it('restores the original value when a change is reverted after a partial failure', async () => {
     saveNote.mockRejectedValueOnce(new Error('notes failed'))
     applyMethods.mockResolvedValueOnce({

--- a/frontend/src/app/contacts/[id]/__tests__/save-sequence.test.tsx
+++ b/frontend/src/app/contacts/[id]/__tests__/save-sequence.test.tsx
@@ -1,0 +1,499 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { Contact } from '@/types/contact'
+
+vi.mock('@/hooks/use-contacts', () => ({
+  useContact: vi.fn(),
+  useContactIDs: vi.fn(),
+  usePrefetchContact: vi.fn(),
+  useUpdateContact: vi.fn(),
+  useApplyMethodOperations: vi.fn(),
+  useDeleteContact: vi.fn(),
+}))
+vi.mock('@/hooks/use-contact-note', () => ({
+  useContactNote: vi.fn(),
+  useSaveContactNote: vi.fn(),
+}))
+vi.mock('@/hooks/use-contact-tasks', () => ({ useContactTasks: vi.fn() }))
+vi.mock('@/hooks/use-keyboard-navigation', () => ({ useKeyboardNavigation: vi.fn() }))
+vi.mock('@/components/layout/navigation', () => ({ Navigation: () => <div /> }))
+vi.mock('@/components/contacts/meetings', () => ({ Meetings: () => <div /> }))
+vi.mock('@/components/contacts/tasks-section', () => ({ TasksSection: () => <div /> }))
+vi.mock('@/components/contacts/merge-contact-modal', () => ({ MergeContactModal: () => <div /> }))
+vi.mock('@/components/contacts/log-interaction-modal', () => ({
+  LogInteractionModal: () => <div />,
+}))
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: CONTACT_ID }),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+import ContactDetailPage from '../page'
+import {
+  useContact,
+  useContactIDs,
+  usePrefetchContact,
+  useUpdateContact,
+  useApplyMethodOperations,
+  useDeleteContact,
+} from '@/hooks/use-contacts'
+import { useContactNote, useSaveContactNote } from '@/hooks/use-contact-note'
+import { useContactTasks } from '@/hooks/use-contact-tasks'
+import { useKeyboardNavigation } from '@/hooks/use-keyboard-navigation'
+
+const CONTACT_ID = '11111111-0000-4000-8000-000000000000'
+const METHOD_A = 'aaaaaaaa-0000-4000-8000-000000000001'
+const METHOD_B = 'bbbbbbbb-0000-4000-8000-000000000002'
+const METHOD_C = 'cccccccc-0000-4000-8000-000000000003'
+
+function contactWith(methods: Contact['methods']): Contact {
+  return {
+    id: CONTACT_ID,
+    full_name: 'Test Person',
+    methods,
+    has_pending_followup: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  } as Contact
+}
+
+const methodA = { id: METHOD_A, type: 'email' as const, value: 'a@example.test', is_primary: false }
+const methodB = { id: METHOD_B, type: 'phone' as const, value: '5555550100', is_primary: false }
+
+let updateContact: ReturnType<typeof vi.fn>
+let applyMethods: ReturnType<typeof vi.fn>
+let saveNote: ReturnType<typeof vi.fn>
+
+function mutation(mutateAsync: ReturnType<typeof vi.fn>) {
+  return { mutateAsync, isPending: false, error: null }
+}
+
+function setContact(contact: Contact) {
+  ;(useContact as any).mockReturnValue({ data: contact, isLoading: false, error: null })
+}
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <ContactDetailPage />
+    </QueryClientProvider>
+  )
+}
+
+/** Opens edit mode and returns the value input for the first method row. */
+async function openEditMode(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /Edit/ }))
+  await screen.findByRole('heading', { name: 'Edit Contact' })
+}
+
+function methodValueInputs() {
+  return screen.getAllByRole('textbox', { name: 'Contact method value' })
+}
+
+async function save(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Update Contact' }))
+}
+
+/** The operations of the nth POST /methods call. */
+function operationsOfCall(n: number) {
+  return applyMethods.mock.calls[n][0].operations
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  updateContact = vi.fn().mockResolvedValue(contactWith([methodA]))
+  applyMethods = vi.fn().mockResolvedValue({ methods: [methodA], results: [] })
+  saveNote = vi.fn().mockResolvedValue({})
+
+  setContact(contactWith([methodA]))
+  ;(useContactIDs as any).mockReturnValue({ data: { ids: [CONTACT_ID] }, isLoading: false })
+  ;(usePrefetchContact as any).mockReturnValue(vi.fn())
+  ;(useUpdateContact as any).mockReturnValue(mutation(updateContact))
+  ;(useApplyMethodOperations as any).mockReturnValue(mutation(applyMethods))
+  ;(useDeleteContact as any).mockReturnValue(mutation(vi.fn()))
+  ;(useContactNote as any).mockReturnValue({ data: { body: '' } })
+  ;(useSaveContactNote as any).mockReturnValue(mutation(saveNote))
+  ;(useContactTasks as any).mockReturnValue({ data: [], isLoading: false })
+  ;(useKeyboardNavigation as any).mockReturnValue({
+    canGoBack: false,
+    canGoForward: false,
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    currentIndex: 0,
+    total: 1,
+  })
+})
+
+describe('the save sequence', () => {
+  it('skips the methods request when there are no operations', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.clear(screen.getByLabelText(/Full Name/))
+    await user.type(screen.getByLabelText(/Full Name/), 'Renamed')
+    await save(user)
+
+    await waitFor(() => expect(saveNote).toHaveBeenCalled())
+    expect(updateContact).toHaveBeenCalledTimes(1)
+    expect(applyMethods).not.toHaveBeenCalled()
+  })
+
+  it('sends no methods key on the scalar PUT', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+
+    await waitFor(() => expect(updateContact).toHaveBeenCalled())
+    expect(updateContact.mock.calls[0][0].data).not.toHaveProperty('methods')
+  })
+
+  it('stops at the failing step and does not attempt the next one', async () => {
+    applyMethods.mockRejectedValue(new Error('methods failed'))
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+
+    await waitFor(() => expect(applyMethods).toHaveBeenCalled())
+    expect(saveNote).not.toHaveBeenCalled()
+  })
+
+  it('reports partial success distinctly from total failure', async () => {
+    saveNote.mockRejectedValue(new Error('notes failed'))
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+
+    const report = await screen.findByTestId('save-report')
+    expect(report).toHaveTextContent(/Saved contact details and contact methods/)
+    expect(report).toHaveTextContent(/the note could not be saved/)
+    // Still in edit mode, so the user can retry.
+    expect(screen.getByRole('heading', { name: 'Edit Contact' })).toBeInTheDocument()
+  })
+
+  it('reports that nothing was saved when the first step fails', async () => {
+    updateContact.mockRejectedValue(new Error('contact failed'))
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+
+    const report = await screen.findByTestId('save-report')
+    expect(report).toHaveTextContent(/Nothing was saved/)
+  })
+
+  it('resumes an unedited retry from the first unsucceeded step', async () => {
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    saveNote.mockResolvedValue({})
+    await save(user)
+
+    await waitFor(() => expect(saveNote).toHaveBeenCalledTimes(2))
+    // The landed steps stay landed rather than being re-issued.
+    expect(updateContact).toHaveBeenCalledTimes(1)
+    expect(applyMethods).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports cumulative progress when a retry lands a further step', async () => {
+    // Attempt one saves scalars and fails at methods; attempt two saves methods
+    // and fails at notes. The report must then name BOTH earlier steps — a
+    // scenario that fails at the same step twice never advances the state
+    // machine and cannot observe this.
+    applyMethods.mockRejectedValueOnce(new Error('methods failed'))
+    saveNote.mockRejectedValue(new Error('notes failed'))
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+
+    let report = await screen.findByTestId('save-report')
+    expect(report).toHaveTextContent(
+      /Saved contact details, but contact methods could not be saved/
+    )
+
+    await save(user)
+    report = await screen.findByTestId('save-report')
+    await waitFor(() =>
+      expect(report).toHaveTextContent(/Saved contact details and contact methods/)
+    )
+    expect(updateContact).toHaveBeenCalledTimes(1)
+    expect(applyMethods).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts a fresh attempt chain from step one after a form edit', async () => {
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    // Editing after a partial success must not be dropped by resume-from-notes.
+    await user.type(screen.getByLabelText(/Full Name/), '!')
+    saveNote.mockResolvedValue({})
+    await save(user)
+
+    await waitFor(() => expect(saveNote).toHaveBeenCalledTimes(2))
+    expect(updateContact).toHaveBeenCalledTimes(2)
+    expect(updateContact.mock.calls[1][0].data.full_name).toContain('!')
+  })
+})
+
+describe('the acknowledged state is never re-derived from server data', () => {
+  it('is unaffected when the contact prop changes mid-save', async () => {
+    // The scalar PUT refreshes the detail cache, so an unseen method can appear
+    // in `contact` while the form is still open. Nothing derived from it may
+    // change.
+    let releaseUpdate: (value: unknown) => void = () => {}
+    updateContact.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          releaseUpdate = resolve
+        })
+    )
+
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+    await waitFor(() => expect(updateContact).toHaveBeenCalled())
+
+    // Another writer's method lands in the cache mid-flight.
+    setContact(contactWith([methodA, methodB]))
+    releaseUpdate(contactWith([methodA, methodB]))
+
+    await waitFor(() => expect(applyMethods).toHaveBeenCalled())
+    const operations = operationsOfCall(0)
+    expect(JSON.stringify(operations)).not.toContain(METHOD_B)
+    expect(operations).toEqual([
+      { op: 'update', method_id: METHOD_A, type: 'email', value: 'a@example.testx' },
+    ])
+  })
+
+  it('does not re-derive after an edit that follows a partial failure', async () => {
+    // The round-3 sequence, and the only one that drives it: an UNEDITED retry
+    // resumes at notes and never re-derives operations at all, so it stays
+    // green against a dynamic baseline. The edit is what forces a fresh
+    // derivation.
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    applyMethods.mockResolvedValue({
+      methods: [{ ...methodA, value: 'a@example.testx' }],
+      results: [
+        {
+          index: 0,
+          outcome: 'updated',
+          method_id: METHOD_A,
+          method: { ...methodA, value: 'a@example.testx' },
+        },
+      ],
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    // The successful scalar PUT refreshed the detail cache to A + B.
+    setContact(contactWith([methodA, methodB]))
+
+    // Any form edit invalidates the session — but must NOT rebuild the
+    // acknowledged state from that refreshed cache.
+    await user.type(screen.getByLabelText(/Full Name/), '!')
+    saveNote.mockResolvedValue({})
+    await save(user)
+
+    await waitFor(() => expect(saveNote).toHaveBeenCalledTimes(2))
+    const named = applyMethods.mock.calls.map(call => JSON.stringify(call[0].operations)).join('|')
+    expect(named).not.toContain(METHOD_B)
+  })
+
+  it('never names a method the response carried but no operation addressed', async () => {
+    // The OTHER channel by which unseen server state can reach the acknowledged
+    // state, and the one that is the original incident wearing a new name:
+    // assigning the response's `methods` array instead of applying `results`.
+    // The cache-refresh test above cannot see this — its response carries no
+    // unseen row, so a response-absorbing implementation passes it.
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    applyMethods.mockResolvedValueOnce({
+      // B is present on the server and in this response, but NO operation
+      // addressed it. It must never enter the client's picture.
+      methods: [{ ...methodA, value: 'a@example.testx' }, methodB],
+      results: [
+        {
+          index: 0,
+          outcome: 'updated',
+          method_id: METHOD_A,
+          method: { ...methodA, value: 'a@example.testx' },
+        },
+      ],
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    applyMethods.mockResolvedValue({ methods: [methodA], results: [] })
+    saveNote.mockResolvedValue({})
+    await user.type(screen.getByLabelText(/Full Name/), '!')
+    await save(user)
+
+    await waitFor(() => expect(saveNote).toHaveBeenCalledTimes(2))
+    const named = applyMethods.mock.calls.map(call => JSON.stringify(call[0].operations)).join('|')
+    expect(named).not.toContain(METHOD_B)
+  })
+
+  it('lets a row added in a partially failed save be removed by the next save', async () => {
+    // This pins the acknowledged-state ADVANCE, not the form write-back: the
+    // deleted row is absent from the submitted set either way, so the removal
+    // derives from the acknowledged state alone. The write-back's pin is the
+    // edit case below, where identity is at stake.
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    applyMethods.mockResolvedValueOnce({
+      methods: [methodA, { id: METHOD_C, type: 'phone', value: '5555550199', is_primary: false }],
+      results: [
+        {
+          index: 0,
+          outcome: 'created',
+          method_id: METHOD_C,
+          method: { id: METHOD_C, type: 'phone', value: '5555550199', is_primary: false },
+        },
+      ],
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.click(screen.getByRole('button', { name: 'Add method' }))
+    const typeSelects = screen.getAllByRole('combobox', { name: 'Contact method type' })
+    await user.selectOptions(typeSelects[1], 'phone')
+    await user.type(methodValueInputs()[1], '5555550199')
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    expect(operationsOfCall(0)).toEqual([{ op: 'add', type: 'phone', value: '5555550199' }])
+
+    // Delete the row that was just created, then save again.
+    applyMethods.mockResolvedValue({ methods: [methodA], results: [] })
+    saveNote.mockResolvedValue({})
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' })
+    await user.click(removeButtons[1])
+    await save(user)
+
+    await waitFor(() => expect(applyMethods).toHaveBeenCalledTimes(2))
+    expect(operationsOfCall(1)).toEqual([{ op: 'remove', method_id: METHOD_C }])
+  })
+
+  it('lets a row added in a partially failed save be edited, keeping its method_id', async () => {
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    applyMethods.mockResolvedValueOnce({
+      methods: [methodA, { id: METHOD_C, type: 'phone', value: '5555550199', is_primary: false }],
+      results: [
+        {
+          index: 0,
+          outcome: 'created',
+          method_id: METHOD_C,
+          method: { id: METHOD_C, type: 'phone', value: '5555550199', is_primary: false },
+        },
+      ],
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.click(screen.getByRole('button', { name: 'Add method' }))
+    await user.selectOptions(
+      screen.getAllByRole('combobox', { name: 'Contact method type' })[1],
+      'phone'
+    )
+    await user.type(methodValueInputs()[1], '5555550199')
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    applyMethods.mockResolvedValue({ methods: [methodA], results: [] })
+    saveNote.mockResolvedValue({})
+    await user.type(methodValueInputs()[1], '9')
+    await save(user)
+
+    await waitFor(() => expect(applyMethods).toHaveBeenCalledTimes(2))
+    // An update on the SAME id — not remove + add, which would mint a new id
+    // and destroy the row's created_at, the forensic tell that made the
+    // original incident diagnosable.
+    expect(operationsOfCall(1)).toEqual([
+      { op: 'update', method_id: METHOD_C, type: 'phone', value: '55555501999' },
+    ])
+  })
+
+  it('restores the original value when a change is reverted after a partial failure', async () => {
+    saveNote.mockRejectedValueOnce(new Error('notes failed'))
+    applyMethods.mockResolvedValueOnce({
+      methods: [{ ...methodA, value: 'a@example.testx' }],
+      results: [
+        {
+          index: 0,
+          outcome: 'updated',
+          method_id: METHOD_A,
+          method: { ...methodA, value: 'a@example.testx' },
+        },
+      ],
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+    await openEditMode(user)
+
+    await user.type(methodValueInputs()[0], 'x')
+    await save(user)
+    await screen.findByTestId('save-report')
+
+    // Revert. A frozen edit-start baseline emits nothing here and leaves the
+    // intermediate value on the server while reporting success.
+    saveNote.mockResolvedValue({})
+    applyMethods.mockResolvedValue({ methods: [methodA], results: [] })
+    await user.clear(methodValueInputs()[0])
+    await user.type(methodValueInputs()[0], 'a@example.test')
+    await save(user)
+
+    await waitFor(() => expect(applyMethods).toHaveBeenCalledTimes(2))
+    expect(operationsOfCall(1)).toEqual([
+      { op: 'update', method_id: METHOD_A, type: 'email', value: 'a@example.test' },
+    ])
+  })
+})

--- a/frontend/src/app/contacts/[id]/page.tsx
+++ b/frontend/src/app/contacts/[id]/page.tsx
@@ -3,13 +3,14 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { Navigation } from '@/components/layout/navigation'
-import { ContactForm } from '@/components/contacts/contact-form'
+import { ContactForm, type MethodsReconciler } from '@/components/contacts/contact-form'
 import { Button } from '@/components/ui/button'
 import {
   useContact,
   useContactIDs,
   usePrefetchContact,
   useUpdateContact,
+  useApplyMethodOperations,
   useDeleteContact,
 } from '@/hooks/use-contacts'
 import { useContactNote, useSaveContactNote } from '@/hooks/use-contact-note'
@@ -36,6 +37,15 @@ import {
   sortContactMethods,
 } from '@/lib/contact-methods'
 import type { ContactSubmitData } from '@/lib/validations/contact'
+import type { UpdateContactRequest } from '@/types/contact'
+import {
+  advanceAcknowledgedMethods,
+  deriveMethodOperationsWithOrigins,
+  initializeAcknowledgedMethods,
+  reconciliationsFromResults,
+  type AcknowledgedMethod,
+} from '@/lib/contact-method-operations'
+import type { ContactMethodOperation } from '@/types/generated/contact'
 import {
   buildContactDetailUrl,
   buildContactListUrl,
@@ -44,6 +54,53 @@ import {
 import { MergeContactModal } from '@/components/contacts/merge-contact-modal'
 import { TasksSection } from '@/components/contacts/tasks-section'
 import { LogInteractionModal } from '@/components/contacts/log-interaction-modal'
+
+type SaveStep = 'contact' | 'methods' | 'notes'
+
+const SAVE_STEP_LABELS: Record<SaveStep, string> = {
+  contact: 'contact details',
+  methods: 'contact methods',
+  notes: 'the note',
+}
+
+/**
+ * One attempt chain over an immutable submitted payload.
+ *
+ * A retry resumes from the first step that has not yet succeeded, so a step
+ * that landed stays landed and the report can never say "nothing was saved"
+ * when something was. Resume applies only to an UNEDITED retry: any form edit
+ * discards the session, and the next save is a fresh chain from step one with a
+ * fresh payload — otherwise resuming would silently drop the new edit.
+ *
+ * The acknowledged method state is deliberately NOT part of this. Rebuilding it
+ * on session invalidation is the original defect: a successful scalar PUT
+ * refreshes the detail cache, so a rebuilt picture would include a method the
+ * form never showed, and the next payload would name it for removal.
+ */
+interface SaveSession {
+  payload: ContactSubmitData
+  operations: ContactMethodOperation[]
+  submittedIndexes: number[]
+  completed: SaveStep[]
+}
+
+interface SaveReport {
+  saved: SaveStep[]
+  failed: SaveStep
+}
+
+function describeSaveReport({ saved, failed }: SaveReport): string {
+  const failedLabel = SAVE_STEP_LABELS[failed]
+  if (saved.length === 0) {
+    return `Nothing was saved — ${failedLabel} could not be saved. Try again.`
+  }
+  const savedLabels = saved.map(step => SAVE_STEP_LABELS[step])
+  const savedText =
+    savedLabels.length === 1
+      ? savedLabels[0]
+      : `${savedLabels.slice(0, -1).join(', ')} and ${savedLabels[savedLabels.length - 1]}`
+  return `Saved ${savedText}, but ${failedLabel} could not be saved. Try again to save the rest.`
+}
 
 export default function ContactDetailPage() {
   const params = useParams()
@@ -82,7 +139,41 @@ export default function ContactDetailPage() {
   const { data: contactNote } = useContactNote(contactId)
   const { data: navigationData, isLoading: isLoadingIDs } = useContactIDs(listContext)
   const updateContactMutation = useUpdateContact()
+  const applyMethodOperationsMutation = useApplyMethodOperations()
   const saveContactNoteMutation = useSaveContactNote()
+
+  // The client's picture of the server's methods, and the only left-hand side
+  // any operation is derived against.
+  const acknowledgedMethodsRef = useRef<AcknowledgedMethod[] | null>(null)
+  const saveSessionRef = useRef<SaveSession | null>(null)
+  const methodsReconcilerRef = useRef<MethodsReconciler | null>(null)
+  const [saveReport, setSaveReport] = useState<SaveReport | null>(null)
+
+  useEffect(() => {
+    if (!isEditing) {
+      acknowledgedMethodsRef.current = null
+      saveSessionRef.current = null
+      setSaveReport(null)
+      return
+    }
+    if (!contact) return
+    // Captured ONCE, at edit-start, and never re-read from server data
+    // afterwards — not on session invalidation, not on retry, not when the
+    // detail cache refreshes underneath the open form. This guard is what makes
+    // that true; deleting it re-derives the picture from whatever the cache
+    // holds now, which is how a method the form never showed gets named for
+    // removal.
+    if (acknowledgedMethodsRef.current) return
+    acknowledgedMethodsRef.current = initializeAcknowledgedMethods(contact.methods)
+  }, [isEditing, contact])
+
+  // A user edit invalidates the payload and the step progress. It does NOT
+  // touch the acknowledged state, which carries forward including whatever this
+  // client's confirmed operations have already taught it.
+  const handleFormEdit = useCallback(() => {
+    saveSessionRef.current = null
+    setSaveReport(null)
+  }, [])
 
   // Fetch tasks at page level to start loading in parallel with contact.
   // Post-046, the lifecycle filter is the natural axis: lifecycle=manual
@@ -195,17 +286,87 @@ export default function ContactDetailPage() {
   }, [contactNote?.body, notesExpanded])
   const deleteContactMutation = useDeleteContact()
 
+  // Three sequential requests, never Promise.all: on failure at step n, stop
+  // and do not attempt n+1. Every step tolerates replay — operations fold to a
+  // no-op, the notes PUT is a full-document replace, and the scalar PUT
+  // converges — so resuming an unedited retry is safe. That is safe replay with
+  // defined side effects, not strict idempotency: a replayed scalar PUT still
+  // advances timestamps and re-runs cadence work.
   const handleUpdateContact = async (data: ContactSubmitData) => {
+    const acknowledged = acknowledgedMethodsRef.current ?? []
+
+    let session = saveSessionRef.current
+    if (!session) {
+      const derived = deriveMethodOperationsWithOrigins(acknowledged, data.methods)
+      session = {
+        payload: data,
+        operations: derived.operations,
+        submittedIndexes: derived.submittedIndexes,
+        completed: [],
+      }
+      saveSessionRef.current = session
+    }
+
+    // Built field by field rather than by spreading the payload, so the absence
+    // of `methods` is visible at the call site: PUT /contacts/:id no longer
+    // accepts them, and sending a desired set is the defect this arc removes.
+    const notes = session.payload.notes
+    const contactData: UpdateContactRequest = {
+      full_name: session.payload.full_name,
+      location: session.payload.location,
+      birthday: session.payload.birthday,
+      cadence: session.payload.cadence,
+    }
+
+    let step: SaveStep = 'contact'
     try {
-      // Extract notes from form data and save separately
-      const { notes, ...contactData } = data
-      await Promise.all([
-        updateContactMutation.mutateAsync({ id: contactId, data: contactData }),
-        saveContactNoteMutation.mutateAsync({ contactId, body: notes || '' }),
-      ])
+      if (!session.completed.includes('contact')) {
+        await updateContactMutation.mutateAsync({ id: contactId, data: contactData })
+        session.completed = [...session.completed, 'contact']
+      }
+
+      step = 'methods'
+      if (!session.completed.includes('methods')) {
+        // An empty derivation skips the request entirely.
+        if (session.operations.length > 0) {
+          const response = await applyMethodOperationsMutation.mutateAsync({
+            id: contactId,
+            operations: session.operations,
+          })
+          // Advance by applying THIS CLIENT'S OWN confirmed operations. The
+          // response's `methods` array is never read here: taking it wholesale
+          // would let rows no operation addressed enter the picture, which is
+          // the original incident with extra steps.
+          acknowledgedMethodsRef.current = advanceAcknowledgedMethods(
+            acknowledged,
+            session.operations,
+            response.results
+          )
+          // The live form rows need the same ids, or a row created here would
+          // still be id-less and the next save would derive remove + add,
+          // silently changing the row's identity.
+          methodsReconcilerRef.current?.(
+            reconciliationsFromResults(
+              session.operations,
+              response.results,
+              session.submittedIndexes
+            )
+          )
+        }
+        session.completed = [...session.completed, 'methods']
+      }
+
+      step = 'notes'
+      if (!session.completed.includes('notes')) {
+        await saveContactNoteMutation.mutateAsync({ contactId, body: notes || '' })
+        session.completed = [...session.completed, 'notes']
+      }
+
+      saveSessionRef.current = null
+      setSaveReport(null)
       setIsEditing(false)
     } catch {
-      // Error handled by TanStack Query error state
+      setSaveReport({ saved: session.completed, failed: step })
     }
   }
 
@@ -304,11 +465,32 @@ export default function ContactDetailPage() {
                 contact={contact}
                 initialNotes={contactNote?.body || ''}
                 onSubmit={handleUpdateContact}
-                loading={updateContactMutation.isPending || saveContactNoteMutation.isPending}
+                loading={
+                  updateContactMutation.isPending ||
+                  applyMethodOperationsMutation.isPending ||
+                  saveContactNoteMutation.isPending
+                }
                 submitText="Update Contact"
+                reconcilerRef={methodsReconcilerRef}
+                onFormEdit={handleFormEdit}
               />
             </div>
           </div>
+
+          {/* A partial save is a different situation from a total failure, and
+              the user's next action differs — so say which parts landed rather
+              than reporting a generic failure. */}
+          {saveReport && (
+            <div
+              className="mt-4 bg-amber-50 border border-amber-200 rounded-md p-4"
+              data-testid="save-report"
+            >
+              <h3 className="text-sm font-medium text-amber-800">
+                {saveReport.saved.length > 0 ? 'Partially saved' : 'Not saved'}
+              </h3>
+              <p className="mt-1 text-sm text-amber-700">{describeSaveReport(saveReport)}</p>
+            </div>
+          )}
 
           {updateContactMutation.error && (
             <div className="mt-4 bg-red-50 border border-red-200 rounded-md p-4">

--- a/frontend/src/app/contacts/[id]/page.tsx
+++ b/frontend/src/app/contacts/[id]/page.tsx
@@ -153,7 +153,12 @@ export default function ContactDetailPage() {
     if (!isEditing) {
       acknowledgedMethodsRef.current = null
       saveSessionRef.current = null
-      setSaveReport(null)
+      // Functional form so an already-null report is a true bail-out. A plain
+      // setSaveReport(null) can still cost a render pass before React compares,
+      // and this effect runs on mount and on every contact change on the
+      // read-only detail view — where a stray render perturbs the notes
+      // overflow measurement (a ResizeObserver reading scrollHeight).
+      setSaveReport(current => (current === null ? current : null))
       return
     }
     if (!contact) return

--- a/frontend/src/components/contacts/__tests__/contact-form-acknowledged-state.test.tsx
+++ b/frontend/src/components/contacts/__tests__/contact-form-acknowledged-state.test.tsx
@@ -4,11 +4,15 @@ import { act, createRef } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ContactForm, type MethodsReconciler } from '@/components/contacts/contact-form'
-import type { MethodReconciliation } from '@/lib/contact-method-operations'
+import {
+  deriveMethodOperations,
+  initializeAcknowledgedMethods,
+} from '@/lib/contact-method-operations'
 import type { Contact } from '@/types/contact'
 
 const METHOD_A = 'aaaaaaaa-0000-4000-8000-000000000001'
 const METHOD_B = 'bbbbbbbb-0000-4000-8000-000000000002'
+const METHOD_E = 'eeeeeeee-0000-4000-8000-000000000005'
 
 function contactWith(methods: Contact['methods']): Contact {
   return {
@@ -54,13 +58,21 @@ describe('ContactForm method identity', () => {
     ])
   })
 
-  it('collapses two live rows that reconcile to one method_id', async () => {
-    // A stored value and a submitted respelling can normalize alike under the
-    // database trigger but not under the client's normalizer, so both rows are
-    // valid client-side and both resolve to one server row. Stamping the id
-    // onto both leaves the form showing one domain row twice; the next save
-    // then derives two operations against one id, which the endpoint rejects as
-    // a conflict the user can neither understand nor act on.
+  it("collapses a new row that resolves to an existing row's method_id", async () => {
+    // The REAL collision sequence, and the fixture matters more than the
+    // assertions here. A stored '5555550100' and a submitted '+5555550100'
+    // normalize alike under the database trigger but not under the client's
+    // normalizer, so frontend validation accepts both and the endpoint resolves
+    // the add to the existing row.
+    //
+    // Critically, the existing row is UNCHANGED, so it emits no operation and
+    // therefore receives no result and no reconciliation. Only the add is
+    // reconciled. An earlier version of this test hand-supplied a
+    // reconciliation for the unchanged row too — an input the endpoint cannot
+    // produce — and so could not see that ownership was never seeded from the
+    // live rows. Both rows kept the id, and deleting either one then emitted no
+    // removal at all: the save reported success while the deletion silently did
+    // not persist.
     const onSubmit = vi.fn()
     const reconcilerRef = createRef<MethodsReconciler | null>() as any
     const user = userEvent.setup()
@@ -68,6 +80,7 @@ describe('ContactForm method identity', () => {
     render(
       <ContactForm
         contact={contactWith([
+          { id: METHOD_E, type: 'email', value: 'e@example.test', is_primary: false },
           { id: METHOD_A, type: 'phone', value: '5555550100', is_primary: false },
         ])}
         onSubmit={onSubmit}
@@ -75,49 +88,105 @@ describe('ContactForm method identity', () => {
       />
     )
 
+    // Rows sort email-then-phone, so the stored phone row is index 1.
+    expect(methodValueInputs()).toHaveLength(2)
     await user.click(screen.getByRole('button', { name: 'Add method' }))
     await user.selectOptions(
-      screen.getAllByRole('combobox', { name: 'Contact method type' })[1],
+      screen.getAllByRole('combobox', { name: 'Contact method type' })[2],
       'phone'
     )
-    await user.type(methodValueInputs()[1], '+5555550100')
+    await user.type(methodValueInputs()[2], '+5555550100')
     await user.click(screen.getByRole('button', { name: 'Save Contact' }))
     await waitFor(() => expect(onSubmit).toHaveBeenCalled())
 
-    expect(methodValueInputs()).toHaveLength(2)
+    // Only the add produced an operation, so only the add gets a result.
+    act(() =>
+      reconcilerRef.current?.([
+        {
+          submittedIndex: 2,
+          method_id: METHOD_A,
+          type: 'phone',
+          value: '5555550100',
+          is_primary: false,
+        },
+      ])
+    )
 
-    // Both submitted rows resolved to METHOD_A, whose stored value is the one
-    // that was already there.
-    const reconciliations: MethodReconciliation[] = [
-      {
-        submittedIndex: 0,
-        method_id: METHOD_A,
-        type: 'phone',
-        value: '5555550100',
-        is_primary: true,
-      },
-      {
-        submittedIndex: 1,
-        method_id: METHOD_A,
-        type: 'phone',
-        value: '5555550100',
-        is_primary: true,
-      },
-    ]
-    act(() => reconcilerRef.current?.(reconciliations))
+    await waitFor(() => expect(methodValueInputs()).toHaveLength(2))
+    // The survivor is the EARLIER row carrying that id — the pre-existing one,
+    // not the row the result addressed — carrying the resolved snapshot.
+    expect(methodValueInputs()[1]).toHaveValue('5555550100')
 
-    await waitFor(() => expect(methodValueInputs()).toHaveLength(1))
-    // The survivor is the earlier row, carrying the RESOLVED snapshot rather
-    // than either submitted value.
-    expect(methodValueInputs()[0]).toHaveValue('5555550100')
-
-    // And exactly one operation targets that id on the next save.
+    // And the collapse is what makes deletion expressible again: removing the
+    // one remaining phone row leaves no submitted method carrying METHOD_A, so
+    // the derivation can emit remove(METHOD_A).
     onSubmit.mockClear()
+    await user.click(screen.getAllByRole('button', { name: 'Remove' })[1])
     await user.click(screen.getByRole('button', { name: 'Save Contact' }))
     await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+
     const methods = onSubmit.mock.calls[0][0].methods
-    expect(methods).toHaveLength(1)
-    expect(methods[0]).toMatchObject({ method_id: METHOD_A, is_primary: true })
+    expect(methods.map((m: { method_id?: string }) => m.method_id)).not.toContain(METHOD_A)
+    expect(
+      deriveMethodOperations(
+        initializeAcknowledgedMethods([
+          { id: METHOD_E, type: 'email', value: 'e@example.test', is_primary: false },
+          { id: METHOD_A, type: 'phone', value: '5555550100', is_primary: false },
+        ]),
+        methods
+      )
+    ).toEqual([{ op: 'remove', method_id: METHOD_A }])
+  })
+
+  it('keeps the collapsed row at the earlier form position', async () => {
+    // The survivor rule is "earliest form row", and it needs a configuration
+    // where first-vs-last is observable: the colliding pair must not be the
+    // last rows in the list. A PRIMARY phone sorts ahead of the email, so the
+    // pre-existing alias sits at index 0 and the new one at index 2. Keeping
+    // the last row instead would drop index 0 and leave the list reordered.
+    const onSubmit = vi.fn()
+    const reconcilerRef = createRef<MethodsReconciler | null>() as any
+    const user = userEvent.setup()
+
+    render(
+      <ContactForm
+        contact={contactWith([
+          { id: METHOD_A, type: 'phone', value: '5555550100', is_primary: true },
+          { id: METHOD_E, type: 'email', value: 'e@example.test', is_primary: false },
+        ])}
+        onSubmit={onSubmit}
+        reconcilerRef={reconcilerRef}
+      />
+    )
+
+    expect(methodValueInputs()[0]).toHaveValue('5555550100')
+    expect(methodValueInputs()[1]).toHaveValue('e@example.test')
+
+    await user.click(screen.getByRole('button', { name: 'Add method' }))
+    await user.selectOptions(
+      screen.getAllByRole('combobox', { name: 'Contact method type' })[2],
+      'phone'
+    )
+    await user.type(methodValueInputs()[2], '+5555550100')
+    await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+
+    act(() =>
+      reconcilerRef.current?.([
+        {
+          submittedIndex: 2,
+          method_id: METHOD_A,
+          type: 'phone',
+          value: '5555550100',
+          is_primary: true,
+        },
+      ])
+    )
+
+    await waitFor(() => expect(methodValueInputs()).toHaveLength(2))
+    // Order preserved: the survivor is the row that was already at index 0.
+    expect(methodValueInputs()[0]).toHaveValue('5555550100')
+    expect(methodValueInputs()[1]).toHaveValue('e@example.test')
   })
 
   it('writes back a confirmed id without counting as a user edit', async () => {

--- a/frontend/src/components/contacts/__tests__/contact-form-acknowledged-state.test.tsx
+++ b/frontend/src/components/contacts/__tests__/contact-form-acknowledged-state.test.tsx
@@ -189,6 +189,71 @@ describe('ContactForm method identity', () => {
     expect(methodValueInputs()[1]).toHaveValue('e@example.test')
   })
 
+  it('demotes the visible primary when a result reports a different row primary', async () => {
+    // The promotion here comes from the SERVER, not the user. The form still
+    // shows A starred from edit-start; meanwhile another writer promoted an
+    // unseen row B, and the user's new row resolves to B. The result snapshot
+    // reports B primary.
+    //
+    // Writing that onto B without demoting A leaves the form with two starred
+    // rows: it contradicts the server, and the form's own one-primary rule
+    // then rejects the next submit — so an unedited retry after the methods
+    // step already landed cannot be saved at all.
+    const onSubmit = vi.fn()
+    const reconcilerRef = createRef<MethodsReconciler | null>() as any
+    const user = userEvent.setup()
+
+    render(
+      <ContactForm
+        contact={contactWith([
+          { id: METHOD_A, type: 'email', value: 'a@example.test', is_primary: true },
+        ])}
+        onSubmit={onSubmit}
+        reconcilerRef={reconcilerRef}
+      />
+    )
+
+    expect(screen.getAllByRole('button', { name: 'Primary contact method' })).toHaveLength(1)
+
+    await user.click(screen.getByRole('button', { name: 'Add method' }))
+    await user.selectOptions(
+      screen.getAllByRole('combobox', { name: 'Contact method type' })[1],
+      'phone'
+    )
+    await user.type(methodValueInputs()[1], '5555550100')
+    await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+
+    act(() =>
+      reconcilerRef.current?.([
+        {
+          submittedIndex: 1,
+          method_id: METHOD_B,
+          type: 'phone',
+          value: '5555550100',
+          is_primary: true,
+        },
+      ])
+    )
+
+    // Exactly one primary, and it is the row the server says is primary.
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: 'Primary contact method' })).toHaveLength(1)
+    )
+    const submittedAfter = await (async () => {
+      onSubmit.mockClear()
+      await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+      await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+      return onSubmit.mock.calls[0][0].methods
+    })()
+
+    // The submit was accepted at all — two primaries would fail validation and
+    // onSubmit would never fire.
+    const primaries = submittedAfter.filter((m: { is_primary: boolean }) => m.is_primary)
+    expect(primaries).toHaveLength(1)
+    expect(primaries[0].method_id).toBe(METHOD_B)
+  })
+
   it('writes back a confirmed id without counting as a user edit', async () => {
     // A programmatic reconciliation is not a form change. Treating it as one
     // would invalidate the save session it just completed, and could loop.

--- a/frontend/src/components/contacts/__tests__/contact-form-acknowledged-state.test.tsx
+++ b/frontend/src/components/contacts/__tests__/contact-form-acknowledged-state.test.tsx
@@ -1,0 +1,220 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi } from 'vitest'
+import { act, createRef } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ContactForm, type MethodsReconciler } from '@/components/contacts/contact-form'
+import type { MethodReconciliation } from '@/lib/contact-method-operations'
+import type { Contact } from '@/types/contact'
+
+const METHOD_A = 'aaaaaaaa-0000-4000-8000-000000000001'
+const METHOD_B = 'bbbbbbbb-0000-4000-8000-000000000002'
+
+function contactWith(methods: Contact['methods']): Contact {
+  return {
+    id: '11111111-0000-4000-8000-000000000000',
+    full_name: 'Test Person',
+    methods,
+    has_pending_followup: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  } as Contact
+}
+
+function methodValueInputs() {
+  return screen.getAllByRole('textbox', { name: 'Contact method value' })
+}
+
+describe('ContactForm method identity', () => {
+  it('carries the server id through mount, edit, and submit', async () => {
+    // The collision this pins is quiet: useFieldArray is called without a
+    // custom keyName, so react-hook-form OVERWRITES fields[].id with its own
+    // generated key. A server id threaded as `id` would arrive here as that
+    // generated key, name a method that does not exist, and turn every update
+    // and removal into a 400. A derivation-only test cannot see this — the
+    // collision happens inside the form.
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ContactForm
+        contact={contactWith([
+          { id: METHOD_A, type: 'email', value: 'a@example.test', is_primary: false },
+        ])}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await user.type(methodValueInputs()[0], 'x')
+    await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+    expect(onSubmit.mock.calls[0][0].methods).toEqual([
+      { method_id: METHOD_A, type: 'email', value: 'a@example.testx', is_primary: false },
+    ])
+  })
+
+  it('collapses two live rows that reconcile to one method_id', async () => {
+    // A stored value and a submitted respelling can normalize alike under the
+    // database trigger but not under the client's normalizer, so both rows are
+    // valid client-side and both resolve to one server row. Stamping the id
+    // onto both leaves the form showing one domain row twice; the next save
+    // then derives two operations against one id, which the endpoint rejects as
+    // a conflict the user can neither understand nor act on.
+    const onSubmit = vi.fn()
+    const reconcilerRef = createRef<MethodsReconciler | null>() as any
+    const user = userEvent.setup()
+
+    render(
+      <ContactForm
+        contact={contactWith([
+          { id: METHOD_A, type: 'phone', value: '5555550100', is_primary: false },
+        ])}
+        onSubmit={onSubmit}
+        reconcilerRef={reconcilerRef}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Add method' }))
+    await user.selectOptions(
+      screen.getAllByRole('combobox', { name: 'Contact method type' })[1],
+      'phone'
+    )
+    await user.type(methodValueInputs()[1], '+5555550100')
+    await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+
+    expect(methodValueInputs()).toHaveLength(2)
+
+    // Both submitted rows resolved to METHOD_A, whose stored value is the one
+    // that was already there.
+    const reconciliations: MethodReconciliation[] = [
+      {
+        submittedIndex: 0,
+        method_id: METHOD_A,
+        type: 'phone',
+        value: '5555550100',
+        is_primary: true,
+      },
+      {
+        submittedIndex: 1,
+        method_id: METHOD_A,
+        type: 'phone',
+        value: '5555550100',
+        is_primary: true,
+      },
+    ]
+    act(() => reconcilerRef.current?.(reconciliations))
+
+    await waitFor(() => expect(methodValueInputs()).toHaveLength(1))
+    // The survivor is the earlier row, carrying the RESOLVED snapshot rather
+    // than either submitted value.
+    expect(methodValueInputs()[0]).toHaveValue('5555550100')
+
+    // And exactly one operation targets that id on the next save.
+    onSubmit.mockClear()
+    await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+    const methods = onSubmit.mock.calls[0][0].methods
+    expect(methods).toHaveLength(1)
+    expect(methods[0]).toMatchObject({ method_id: METHOD_A, is_primary: true })
+  })
+
+  it('writes back a confirmed id without counting as a user edit', async () => {
+    // A programmatic reconciliation is not a form change. Treating it as one
+    // would invalidate the save session it just completed, and could loop.
+    const onSubmit = vi.fn()
+    const onFormEdit = vi.fn()
+    const reconcilerRef = createRef<MethodsReconciler | null>() as any
+    const user = userEvent.setup()
+
+    render(
+      <ContactForm
+        contact={contactWith([])}
+        onSubmit={onSubmit}
+        reconcilerRef={reconcilerRef}
+        onFormEdit={onFormEdit}
+      />
+    )
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Contact method type' }), 'email')
+    await user.type(methodValueInputs()[0], 'new@example.test')
+    await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+
+    onFormEdit.mockClear()
+    act(() =>
+      reconcilerRef.current?.([
+        {
+          submittedIndex: 0,
+          method_id: METHOD_B,
+          type: 'email',
+          value: 'new@example.test',
+          is_primary: false,
+        },
+      ])
+    )
+
+    await waitFor(() => expect(methodValueInputs()[0]).toHaveValue('new@example.test'))
+    expect(onFormEdit).not.toHaveBeenCalled()
+
+    // The id did land — otherwise "no edit reported" would be trivially true.
+    onSubmit.mockClear()
+    await user.click(screen.getByRole('button', { name: 'Save Contact' }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+    expect(onSubmit.mock.calls[0][0].methods[0].method_id).toBe(METHOD_B)
+
+    // A real user edit still reports.
+    await user.type(methodValueInputs()[0], 'x')
+    expect(onFormEdit).toHaveBeenCalled()
+  })
+
+  it('does not report the late-arriving notes sync as a user edit', async () => {
+    // initialNotes lands when the note query resolves, which can be after edit
+    // mode opened and after a save has begun. It is server data, not a user
+    // edit; reporting it would invalidate a save session for a keystroke the
+    // user never made.
+    const onFormEdit = vi.fn()
+    const { rerender } = render(
+      <ContactForm
+        contact={contactWith([])}
+        onSubmit={vi.fn()}
+        onFormEdit={onFormEdit}
+        initialNotes=""
+      />
+    )
+    onFormEdit.mockClear()
+
+    rerender(
+      <ContactForm
+        contact={contactWith([])}
+        onSubmit={vi.fn()}
+        onFormEdit={onFormEdit}
+        initialNotes="a note that arrived late"
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Notes/)).toHaveValue('a note that arrived late')
+    )
+    expect(onFormEdit).not.toHaveBeenCalled()
+  })
+
+  it('reports array-shape edits the user makes, which are not input change events', async () => {
+    const onFormEdit = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ContactForm contact={contactWith([])} onSubmit={vi.fn()} onFormEdit={onFormEdit} />)
+
+    await user.click(screen.getByRole('button', { name: 'Add method' }))
+    expect(onFormEdit).toHaveBeenCalled()
+
+    onFormEdit.mockClear()
+    await user.click(screen.getAllByRole('button', { name: 'Remove' })[1])
+    expect(onFormEdit).toHaveBeenCalled()
+
+    onFormEdit.mockClear()
+    await user.click(screen.getByRole('button', { name: /Set as primary|Primary contact method/ }))
+    expect(onFormEdit).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/contacts/contact-form.tsx
+++ b/frontend/src/components/contacts/contact-form.tsx
@@ -198,6 +198,7 @@ export function ContactForm({
 
       const options = { shouldDirty: false, shouldTouch: false } as const
       const duplicateIndexes: number[] = []
+      let promotedIndex: number | null = null
 
       for (const [methodID, indexes] of rowsById) {
         // Deterministic survivor: the EARLIEST form row carrying this id,
@@ -220,6 +221,24 @@ export function ContactForm({
           options
         )
         setValue(`methods.${survivor}.is_primary`, snapshot.is_primary, options)
+        if (snapshot.is_primary) promotedIndex = survivor
+      }
+
+      // A snapshot reporting is_primary demotes every other live row.
+      //
+      // The promotion can come from the SERVER rather than from the user's
+      // designation: an add can resolve to a row another writer made primary
+      // after edit-start, so the row this reconciliation just starred is one
+      // the form never showed as primary, while the row the form DOES show
+      // starred was never addressed. Leaving both set contradicts the server,
+      // and — because the form rejects more than one primary — it also blocks
+      // the next save outright, including an unedited retry after the methods
+      // step already landed.
+      if (promotedIndex !== null) {
+        fields.forEach((_field, index) => {
+          if (index === promotedIndex || duplicateIndexes.includes(index)) return
+          setValue(`methods.${index}.is_primary`, false, options)
+        })
       }
 
       // Descending, so each index is still valid when its turn comes.

--- a/frontend/src/components/contacts/contact-form.tsx
+++ b/frontend/src/components/contacts/contact-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef, type MutableRefObject } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Button } from '@/components/ui/button'
@@ -10,11 +10,13 @@ import { Textarea } from '@/components/ui/textarea'
 import { FORM_CONTROL_BASE } from '@/lib/form-classes'
 import {
   contactSchema,
+  submittedMethodSourceRows,
   transformContactFormData,
   type ContactFormData,
   type ContactFormInput,
   type ContactSubmitData,
 } from '@/lib/validations/contact'
+import type { MethodReconciliation } from '@/lib/contact-method-operations'
 import {
   CONTACT_METHOD_OPTIONS,
   formatContactMethodValue,
@@ -23,12 +25,23 @@ import {
 import type { Contact } from '@/types/contact'
 import { clsx } from 'clsx'
 
+/**
+ * Writes confirmed server results back into the live form rows. Programmatic —
+ * it must never count as a user edit, which would invalidate the save session
+ * it just completed and could loop.
+ */
+export type MethodsReconciler = (reconciliations: MethodReconciliation[]) => void
+
 interface ContactFormProps {
   contact?: Contact
   initialNotes?: string
   onSubmit: (data: ContactSubmitData) => void | Promise<void>
   loading?: boolean
   submitText?: string
+  /** Populated by the form with a reconciler the page calls after a successful methods step. */
+  reconcilerRef?: MutableRefObject<MethodsReconciler | null>
+  /** Fired on a user edit, so the page can invalidate an in-progress save session. */
+  onFormEdit?: () => void
 }
 
 const cadenceOptions = [
@@ -47,14 +60,17 @@ export function ContactForm({
   onSubmit,
   loading,
   submitText = 'Save Contact',
+  reconcilerRef,
+  onFormEdit,
 }: ContactFormProps) {
   const defaultMethods = contact?.methods?.length
     ? sortContactMethods(contact.methods).map(method => ({
+        method_id: method.id,
         type: method.type,
         value: formatContactMethodValue(method.type, method.value),
         is_primary: method.is_primary,
       }))
-    : [{ type: '', value: '', is_primary: false }]
+    : [{ method_id: undefined, type: '', value: '', is_primary: false }]
 
   const {
     register,
@@ -90,11 +106,104 @@ export function ContactForm({
     name: 'methods',
   })
 
+  // Programmatic writes must not read as user edits. An explicit flag is the
+  // only reliable discriminator: react-hook-form reports setValue with the same
+  // `change` event type as a real input event (verified against 7.62), so the
+  // subscription metadata cannot tell the two apart.
+  const programmaticWriteRef = useRef(false)
+  const withoutReportingEdit = (write: () => void) => {
+    programmaticWriteRef.current = true
+    try {
+      write()
+    } finally {
+      programmaticWriteRef.current = false
+    }
+  }
+
   // Sync notes field when initialNotes changes (e.g., when async query resolves)
   // This prevents stale empty notes from being saved if edit mode is opened before query resolves
   useEffect(() => {
-    setValue('notes', initialNotes, { shouldDirty: false })
+    programmaticWriteRef.current = true
+    try {
+      setValue('notes', initialNotes, { shouldDirty: false })
+    } finally {
+      programmaticWriteRef.current = false
+    }
   }, [initialNotes, setValue])
+
+  const onFormEditRef = useRef(onFormEdit)
+  useEffect(() => {
+    onFormEditRef.current = onFormEdit
+  })
+
+  // Report user edits so the page can invalidate an in-progress save session.
+  // Array-shape edits — adding, removing, or re-designating a row — also report
+  // explicitly at their call sites, since a field-array mutation is not
+  // guaranteed to surface here. A duplicate report is harmless: invalidation is
+  // idempotent.
+  useEffect(() => {
+    const subscription = watch(() => {
+      if (programmaticWriteRef.current) return
+      onFormEditRef.current?.()
+    })
+    return () => subscription.unsubscribe()
+  }, [watch])
+
+  // The form-row key behind each method of the most recent submission, so a
+  // result can be written back into the row that produced it. Keys rather than
+  // indexes: react-hook-form's generated key survives rows being added or
+  // removed while the request is in flight.
+  const submittedRowKeysRef = useRef<Array<string | null>>([])
+
+  useEffect(() => {
+    if (!reconcilerRef) return
+    reconcilerRef.current = (reconciliations: MethodReconciliation[]) =>
+      withoutReportingEdit(() => reconcileRows(reconciliations))
+
+    function reconcileRows(reconciliations: MethodReconciliation[]) {
+      const rowKeys = submittedRowKeysRef.current
+      const claimedBy = new Map<string, string>()
+      const duplicateRowKeys: string[] = []
+
+      for (const entry of reconciliations) {
+        const rowKey = rowKeys[entry.submittedIndex]
+        if (!rowKey) continue
+
+        // Two live rows resolving to one method_id are one domain row shown
+        // twice. Stamping both would derive two operations against one id on
+        // the next save, which the endpoint rejects as a conflict — leaving a
+        // duplicate the user cannot delete. Keep the earlier row (results
+        // arrive in submitted order, which is form order) and drop the later.
+        const owner = claimedBy.get(entry.method_id)
+        if (owner && owner !== rowKey) {
+          duplicateRowKeys.push(rowKey)
+          continue
+        }
+        claimedBy.set(entry.method_id, rowKey)
+
+        const index = fields.findIndex(field => field.id === rowKey)
+        if (index < 0) continue
+        const options = { shouldDirty: false, shouldTouch: false } as const
+        setValue(`methods.${index}.method_id`, entry.method_id, options)
+        setValue(`methods.${index}.type`, entry.type, options)
+        setValue(
+          `methods.${index}.value`,
+          formatContactMethodValue(entry.type, entry.value),
+          options
+        )
+        setValue(`methods.${index}.is_primary`, entry.is_primary, options)
+      }
+
+      // Descending, so each index is still valid when its turn comes.
+      const duplicateIndexes = duplicateRowKeys
+        .map(rowKey => fields.findIndex(field => field.id === rowKey))
+        .filter(index => index >= 0)
+        .sort((a, b) => b - a)
+      for (const index of duplicateIndexes) {
+        remove(index)
+      }
+    }
+  })
 
   const watchedMethods = watch('methods')
 
@@ -108,15 +217,25 @@ export function ContactForm({
         shouldValidate: true,
       })
     })
+    onFormEditRef.current?.()
   }
 
   const handleAddMethod = () => {
-    append({ type: '', value: '', is_primary: false })
+    append({ method_id: undefined, type: '', value: '', is_primary: false })
+    onFormEditRef.current?.()
+  }
+
+  const handleRemoveMethod = (index: number) => {
+    remove(index)
+    onFormEditRef.current?.()
   }
 
   const handleFormSubmit = async (data: ContactFormData) => {
     try {
       const transformedData = transformContactFormData(data)
+      submittedRowKeysRef.current = submittedMethodSourceRows(data).map(
+        rowIndex => fields[rowIndex]?.id ?? null
+      )
       await onSubmit(transformedData)
       if (!contact) {
         // Reset form after creating new contact
@@ -213,7 +332,7 @@ export function ContactForm({
                     {/* Remove button - X icon, visible on hover */}
                     <button
                       type="button"
-                      onClick={() => remove(index)}
+                      onClick={() => handleRemoveMethod(index)}
                       disabled={isLoading || fields.length === 1}
                       className="p-1.5 text-gray-300 opacity-0 group-hover:opacity-100 hover:text-red-500 transition-all disabled:opacity-0"
                       title="Remove"

--- a/frontend/src/components/contacts/contact-form.tsx
+++ b/frontend/src/components/contacts/contact-form.tsx
@@ -79,6 +79,7 @@ export function ContactForm({
     reset,
     control,
     setValue,
+    getValues,
     watch,
   } = useForm<ContactFormInput, unknown, ContactFormData>({
     resolver: zodResolver(contactSchema),
@@ -162,44 +163,67 @@ export function ContactForm({
 
     function reconcileRows(reconciliations: MethodReconciliation[]) {
       const rowKeys = submittedRowKeysRef.current
-      const claimedBy = new Map<string, string>()
-      const duplicateRowKeys: string[] = []
 
+      // What each result assigned, keyed by the form row that produced it.
+      const assignedIdByRowKey = new Map<string, string>()
+      const snapshotById = new Map<string, MethodReconciliation>()
       for (const entry of reconciliations) {
         const rowKey = rowKeys[entry.submittedIndex]
         if (!rowKey) continue
+        assignedIdByRowKey.set(rowKey, entry.method_id)
+        snapshotById.set(entry.method_id, entry)
+      }
 
-        // Two live rows resolving to one method_id are one domain row shown
-        // twice. Stamping both would derive two operations against one id on
-        // the next save, which the endpoint rejects as a conflict — leaving a
-        // duplicate the user cannot delete. Keep the earlier row (results
-        // arrive in submitted order, which is form order) and drop the later.
-        const owner = claimedBy.get(entry.method_id)
-        if (owner && owner !== rowKey) {
-          duplicateRowKeys.push(rowKey)
-          continue
-        }
-        claimedBy.set(entry.method_id, rowKey)
+      // Ownership is seeded from EVERY live row's id, not only from the rows a
+      // result addressed. In the real collision sequence the pre-existing row
+      // is unchanged, so it emits no operation and receives no result — but it
+      // already owns the id the new row just resolved to. Considering only
+      // reconciled rows leaves both rows carrying that id, and then deleting
+      // either one emits no `remove` (the other alias still submits the id),
+      // so the save reports success while the deletion silently does not
+      // persist. That is the original defect's own signature.
+      //
+      // Read through getValues rather than `fields`: useFieldArray refreshes
+      // `fields` only on array operations, so an id written by an earlier
+      // reconciliation's setValue would not be visible there.
+      const currentMethods = getValues('methods') ?? []
+      const rowsById = new Map<string, number[]>()
+      fields.forEach((field, index) => {
+        const methodID = assignedIdByRowKey.get(field.id) ?? currentMethods[index]?.method_id
+        if (!methodID) return
+        const rows = rowsById.get(methodID) ?? []
+        rows.push(index)
+        rowsById.set(methodID, rows)
+      })
 
-        const index = fields.findIndex(field => field.id === rowKey)
-        if (index < 0) continue
-        const options = { shouldDirty: false, shouldTouch: false } as const
-        setValue(`methods.${index}.method_id`, entry.method_id, options)
-        setValue(`methods.${index}.type`, entry.type, options)
+      const options = { shouldDirty: false, shouldTouch: false } as const
+      const duplicateIndexes: number[] = []
+
+      for (const [methodID, indexes] of rowsById) {
+        // Deterministic survivor: the EARLIEST form row carrying this id,
+        // whichever row a result happened to address. Ordering by form position
+        // rather than by payload position is what makes the outcome
+        // independent of the order operations were submitted in.
+        const [survivor, ...duplicates] = indexes
+        duplicateIndexes.push(...duplicates)
+
+        // A row whose id no result addressed is left alone — there is nothing
+        // authoritative to write into it.
+        const snapshot = snapshotById.get(methodID)
+        if (!snapshot) continue
+
+        setValue(`methods.${survivor}.method_id`, methodID, options)
+        setValue(`methods.${survivor}.type`, snapshot.type, options)
         setValue(
-          `methods.${index}.value`,
-          formatContactMethodValue(entry.type, entry.value),
+          `methods.${survivor}.value`,
+          formatContactMethodValue(snapshot.type, snapshot.value),
           options
         )
-        setValue(`methods.${index}.is_primary`, entry.is_primary, options)
+        setValue(`methods.${survivor}.is_primary`, snapshot.is_primary, options)
       }
 
       // Descending, so each index is still valid when its turn comes.
-      const duplicateIndexes = duplicateRowKeys
-        .map(rowKey => fields.findIndex(field => field.id === rowKey))
-        .filter(index => index >= 0)
-        .sort((a, b) => b - a)
-      for (const index of duplicateIndexes) {
+      for (const index of duplicateIndexes.sort((a, b) => b - a)) {
         remove(index)
       }
     }

--- a/frontend/src/components/contacts/contact-form.tsx
+++ b/frontend/src/components/contacts/contact-form.tsx
@@ -234,8 +234,13 @@ export function ContactForm({
       // and — because the form rejects more than one primary — it also blocks
       // the next save outright, including an unedited retry after the methods
       // step already landed.
+      // Enumerated over the getValues snapshot rather than `fields` for the
+      // same reason the ownership map is: `fields` refreshes only on array
+      // operations, so a flag an earlier reconciliation wrote through setValue
+      // is not visible there. The write is unconditional rather than guarded on
+      // the current flag, so a stale read cannot leave a row starred.
       if (promotedIndex !== null) {
-        fields.forEach((_field, index) => {
+        currentMethods.forEach((_method, index) => {
           if (index === promotedIndex || duplicateIndexes.includes(index)) return
           setValue(`methods.${index}.is_primary`, false, options)
         })

--- a/frontend/src/hooks/__tests__/use-contacts-methods.test.tsx
+++ b/frontend/src/hooks/__tests__/use-contacts-methods.test.tsx
@@ -1,0 +1,129 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+const registerJob = vi.fn()
+
+vi.mock('@/components/providers/rematch-jobs-provider', () => ({
+  useRegisterRematchJob: () => registerJob,
+}))
+vi.mock('@/lib/contacts-api', () => ({
+  contactsApi: {
+    updateContact: vi.fn(),
+    applyMethodOperations: vi.fn(),
+  },
+}))
+vi.mock('@/lib/query-invalidation', async () => {
+  const actual = await vi.importActual<any>('@/lib/query-invalidation')
+  return { ...actual, invalidateFor: vi.fn() }
+})
+
+import { useUpdateContact, useApplyMethodOperations } from '@/hooks/use-contacts'
+import { contactsApi } from '@/lib/contacts-api'
+
+const CONTACT_ID = '11111111-0000-4000-8000-000000000000'
+const JOB_ID = '99999999-0000-4000-8000-000000000009'
+
+let queryClient: QueryClient
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+})
+
+// Once the PUT's method branch is gone, a rematch can only be triggered by the
+// operations endpoint: a rematch fires on newly-present method VALUES, and the
+// scalar PUT no longer writes any. A registration left on the PUT would be a
+// contract that can never fire.
+describe('rematch registration follows the methods', () => {
+  it('registers the job from the methods response', async () => {
+    ;(contactsApi.applyMethodOperations as any).mockResolvedValue({
+      methods: [],
+      results: [],
+      rematch_job_id: JOB_ID,
+    })
+
+    const { result } = renderHook(() => useApplyMethodOperations(), { wrapper })
+    await result.current.mutateAsync({
+      id: CONTACT_ID,
+      operations: [{ op: 'add', type: 'email', value: 'new@example.test' }],
+    })
+
+    await waitFor(() =>
+      expect(registerJob).toHaveBeenCalledWith({ jobId: JOB_ID, contactId: CONTACT_ID })
+    )
+  })
+
+  it('does not register a job from the scalar PUT', async () => {
+    // Seeded with a rematch_job_id the update path must ignore: if the hook
+    // still read the field, this would register and the assertion would fail.
+    ;(contactsApi.updateContact as any).mockResolvedValue({
+      id: CONTACT_ID,
+      full_name: 'Test Person',
+      rematch_job_id: JOB_ID,
+    })
+
+    const { result } = renderHook(() => useUpdateContact(), { wrapper })
+    await result.current.mutateAsync({ id: CONTACT_ID, data: { full_name: 'Test Person' } })
+
+    expect(registerJob).not.toHaveBeenCalled()
+  })
+
+  it('leaves the methods request off entirely when it has no operations to send', async () => {
+    // Guards the API surface rather than the caller: an operations array is the
+    // only thing this client may send, and it must reach the endpoint verbatim.
+    ;(contactsApi.applyMethodOperations as any).mockResolvedValue({ methods: [], results: [] })
+
+    const { result } = renderHook(() => useApplyMethodOperations(), { wrapper })
+    const operations = [{ op: 'remove' as const, method_id: 'x' }]
+    await result.current.mutateAsync({ id: CONTACT_ID, operations })
+
+    expect(contactsApi.applyMethodOperations).toHaveBeenCalledWith(CONTACT_ID, operations)
+    expect(registerJob).not.toHaveBeenCalled()
+  })
+})
+
+describe('the detail cache', () => {
+  it('is still written from the scalar PUT response', async () => {
+    // Retiring the methods branch must not take the detail-cache refresh with
+    // it: the detail view reads scalars from this cache, and the edit form
+    // closing onto a stale name would look like the save had not happened.
+    const updated = { id: CONTACT_ID, full_name: 'Renamed Person' }
+    ;(contactsApi.updateContact as any).mockResolvedValue(updated)
+
+    const { result } = renderHook(() => useUpdateContact(), { wrapper })
+    await result.current.mutateAsync({ id: CONTACT_ID, data: { full_name: 'Renamed Person' } })
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(['contacts', 'detail', CONTACT_ID])).toEqual(updated)
+    )
+  })
+
+  it('takes its methods from the operations response', async () => {
+    const methods = [{ id: 'm1', type: 'email', value: 'a@example.test', is_primary: false }]
+    queryClient.setQueryData(['contacts', 'detail', CONTACT_ID], {
+      id: CONTACT_ID,
+      full_name: 'Test Person',
+      methods: [],
+    })
+    ;(contactsApi.applyMethodOperations as any).mockResolvedValue({ methods, results: [] })
+
+    const { result } = renderHook(() => useApplyMethodOperations(), { wrapper })
+    await result.current.mutateAsync({
+      id: CONTACT_ID,
+      operations: [{ op: 'add', type: 'email', value: 'a@example.test' }],
+    })
+
+    await waitFor(() =>
+      expect((queryClient.getQueryData(['contacts', 'detail', CONTACT_ID]) as any).methods).toEqual(
+        methods
+      )
+    )
+  })
+})

--- a/frontend/src/hooks/use-contacts.ts
+++ b/frontend/src/hooks/use-contacts.ts
@@ -2,7 +2,13 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { contactsApi, type ContactIDsParams } from '@/lib/contacts-api'
 import { contactKeys, invalidateFor } from '@/lib/query-invalidation'
 import { useRegisterRematchJob } from '@/components/providers/rematch-jobs-provider'
-import type { CreateContactRequest, UpdateContactRequest, ContactListParams } from '@/types/contact'
+import type {
+  Contact,
+  CreateContactRequest,
+  UpdateContactRequest,
+  ContactListParams,
+} from '@/types/contact'
+import type { ContactMethodOperation } from '@/types/generated/contact'
 
 // Re-export contactKeys for backward compatibility
 export { contactKeys }
@@ -76,10 +82,13 @@ export function useCreateContact() {
   })
 }
 
-// Update contact mutation
+// Update contact mutation.
+//
+// No rematch registration here: a rematch is triggered by newly-present method
+// values, and this request no longer carries methods at all. That job is minted
+// by the operations endpoint, so useApplyMethodOperations registers it.
 export function useUpdateContact() {
   const queryClient = useQueryClient()
-  const registerJob = useRegisterRematchJob()
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateContactRequest }) =>
@@ -87,8 +96,31 @@ export function useUpdateContact() {
     onSuccess: updatedContact => {
       queryClient.setQueryData(contactKeys.detail(updatedContact.id), updatedContact)
       invalidateFor('contact:updated')
-      if (updatedContact.rematch_job_id) {
-        registerJob({ jobId: updatedContact.rematch_job_id, contactId: updatedContact.id })
+    },
+  })
+}
+
+// Apply contact-method operations.
+//
+// Owns rematch registration for the edit path. The detail cache is refreshed
+// from the response so the detail view shows the saved methods; that cache
+// feeds DISPLAY only and must never feed operation derivation — the caller's
+// acknowledged state is a separate, explicitly held value for exactly that
+// reason.
+export function useApplyMethodOperations() {
+  const queryClient = useQueryClient()
+  const registerJob = useRegisterRematchJob()
+
+  return useMutation({
+    mutationFn: ({ id, operations }: { id: string; operations: ContactMethodOperation[] }) =>
+      contactsApi.applyMethodOperations(id, operations),
+    onSuccess: (response, { id }) => {
+      queryClient.setQueryData<Contact>(contactKeys.detail(id), previous =>
+        previous ? { ...previous, methods: response.methods } : previous
+      )
+      invalidateFor('contact:updated')
+      if (response.rematch_job_id) {
+        registerJob({ jobId: response.rematch_job_id, contactId: id })
       }
     },
   })

--- a/frontend/src/lib/__tests__/contact-method-operations.test.ts
+++ b/frontend/src/lib/__tests__/contact-method-operations.test.ts
@@ -16,6 +16,7 @@ import type {
 const A = 'aaaaaaaa-0000-4000-8000-000000000001'
 const B = 'bbbbbbbb-0000-4000-8000-000000000002'
 const C = 'cccccccc-0000-4000-8000-000000000003'
+const D = 'dddddddd-0000-4000-8000-000000000004'
 
 function ack(
   method_id: string,
@@ -300,12 +301,33 @@ describe('advanceAcknowledgedMethods', () => {
       expect(next[0]).toEqual(ack(A, 'phone', '5555550100', true))
     })
 
-    it('keeps the earlier position and is independent of submission order', () => {
-      const acknowledged = [ack(C, 'email', 'c@example.test'), ack(A, 'phone', 'old')]
+    it('upserts in place rather than moving the row to the end', () => {
+      // The collapsing row must NOT be last, or position is unobservable:
+      // with [C, A] an implementation that removes and re-appends also yields
+      // [C, A], and the assertion cannot distinguish it from upsert-in-place.
+      const acknowledged = [
+        ack(C, 'email', 'c@example.test'),
+        ack(A, 'phone', 'old'),
+        ack(D, 'telegram', 'handle'),
+      ]
+      const next = advanceAcknowledgedMethods(acknowledged, operations, results)
+      expect(next.map(m => m.method_id)).toEqual([C, A, D])
+    })
+
+    it('is insensitive to result order, which the identical-snapshot contract makes safe', () => {
+      // Narrowed deliberately. This permutes the RESULTS array only, and both
+      // results for one id carry the same snapshot by the backend contract
+      // (they are read from a single post-apply state), so last-wins,
+      // first-wins, and index-ordered implementations are all equivalent here.
+      // Claiming "independent of submission order" would overstate it — that
+      // property is carried by the position test above plus the server's own
+      // order-independence, not by this assertion.
+      expect(results[0].method).toEqual(results[1].method)
+
+      const acknowledged = [ack(A, 'phone', 'old')]
       const forward = advanceAcknowledgedMethods(acknowledged, operations, results)
       const reversed = advanceAcknowledgedMethods(acknowledged, operations, [...results].reverse())
       expect(forward).toEqual(reversed)
-      expect(forward.map(m => m.method_id)).toEqual([C, A])
     })
 
     it('never lets a method_id appear twice, for any payload order', () => {

--- a/frontend/src/lib/__tests__/contact-method-operations.test.ts
+++ b/frontend/src/lib/__tests__/contact-method-operations.test.ts
@@ -289,10 +289,28 @@ describe('advanceAcknowledgedMethods', () => {
     ]
     const results = [result(0, 'updated', A, snapshot), result(1, 'matched_existing', A, snapshot)]
 
-    it('collapses two adds resolving to one method_id into a single row', () => {
+    it('collapses an update and an add resolving to one method_id', () => {
+      // Named for the fixture it actually uses. The two-adds case is below.
       const next = advanceAcknowledgedMethods([ack(A, 'phone', 'old')], operations, results)
       expect(next).toHaveLength(1)
       expect(next[0].method_id).toBe(A)
+    })
+
+    it('collapses two coalesced adds resolving to one method_id', () => {
+      // The case the endpoint produces when two submitted values normalize
+      // alike under the trigger: both adds resolve to one row. An
+      // implementation handling only update+add would miss this entirely.
+      const addOps: ContactMethodOperation[] = [
+        { op: 'add', type: 'phone', value: '5555550100' },
+        { op: 'add', type: 'phone', value: '+5555550100' },
+      ]
+      const addResults = [
+        result(0, 'created', A, snapshot),
+        result(1, 'matched_existing', A, snapshot),
+      ]
+      const next = advanceAcknowledgedMethods([], addOps, addResults)
+      expect(next).toHaveLength(1)
+      expect(next[0]).toEqual(ack(A, 'phone', '5555550100', true))
     })
 
     it('takes the surviving row’s value and primary flag from the resolved snapshot', () => {
@@ -330,13 +348,37 @@ describe('advanceAcknowledgedMethods', () => {
       expect(forward).toEqual(reversed)
     })
 
-    it('never lets a method_id appear twice, for any payload order', () => {
+    it('never lets a method_id appear twice, for either payload order', () => {
+      // Genuinely permutes the OPERATIONS and reindexes the results to match,
+      // rather than reversing the results against a fixed payload. An
+      // implementation that collapses update-then-add but not add-then-update
+      // passes the weaker version.
       const acknowledged = [ack(A, 'phone', 'old')]
-      const permutations = [results, [...results].reverse()]
-      for (const ordered of permutations) {
-        const next = advanceAcknowledgedMethods(acknowledged, operations, ordered)
+
+      const updateThenAdd: ContactMethodOperation[] = [
+        { op: 'update', method_id: A, type: 'phone', value: '5555550100' },
+        { op: 'add', type: 'phone', value: '+5555550100' },
+      ]
+      const addThenUpdate: ContactMethodOperation[] = [
+        { op: 'add', type: 'phone', value: '+5555550100' },
+        { op: 'update', method_id: A, type: 'phone', value: '5555550100' },
+      ]
+      const payloads: Array<[ContactMethodOperation[], ContactMethodOperationResult[]]> = [
+        [
+          updateThenAdd,
+          [result(0, 'updated', A, snapshot), result(1, 'matched_existing', A, snapshot)],
+        ],
+        [
+          addThenUpdate,
+          [result(0, 'matched_existing', A, snapshot), result(1, 'updated', A, snapshot)],
+        ],
+      ]
+
+      for (const [ops, res] of payloads) {
+        const next = advanceAcknowledgedMethods(acknowledged, ops, res)
         const ids = next.map(m => m.method_id)
         expect(new Set(ids).size).toBe(ids.length)
+        expect(next).toHaveLength(1)
       }
     })
 
@@ -390,13 +432,16 @@ describe('advanceAcknowledgedMethods', () => {
 })
 
 describe('reconciliationsFromResults', () => {
-  it('resolves snapshot-bearing results back to their submitted rows', () => {
+  it('resolves every snapshot-bearing result back to its submitted row', () => {
+    // A primary designation's origin is the row it addresses, NOT -1. This test
+    // previously encoded the opposite and so positively endorsed the defect it
+    // was meant to guard: deleting primary-result reconciliation left it green.
     const operations: ContactMethodOperation[] = [
       { op: 'remove', method_id: C },
       { op: 'add', type: 'phone', value: '5555550100' },
       { op: 'set_primary', method_id: A },
     ]
-    const submittedIndexes = [-1, 1, -1]
+    const submittedIndexes = [-1, 1, 0]
     const results = [
       result(0, 'removed', C),
       result(1, 'created', B, { id: B, type: 'phone', value: '5555550100', is_primary: false }),
@@ -405,7 +450,108 @@ describe('reconciliationsFromResults', () => {
 
     expect(reconciliationsFromResults(operations, results, submittedIndexes)).toEqual([
       { submittedIndex: 1, method_id: B, type: 'phone', value: '5555550100', is_primary: false },
+      // The primary designation's snapshot reaches the live row too. Dropping
+      // it is what let the form and the acknowledged state hold different
+      // values for one row.
+      { submittedIndex: 0, method_id: A, type: 'email', value: 'a@example.test', is_primary: true },
     ])
+  })
+
+  it('carries a clear_primary snapshot to its row as well', () => {
+    const operations: ContactMethodOperation[] = [{ op: 'clear_primary', method_id: A }]
+    const results = [
+      result(0, 'updated', A, { id: A, type: 'email', value: 'a@example.test', is_primary: false }),
+    ]
+    expect(reconciliationsFromResults(operations, results, [0])).toEqual([
+      {
+        submittedIndex: 0,
+        method_id: A,
+        type: 'email',
+        value: 'a@example.test',
+        is_primary: false,
+      },
+    ])
+  })
+
+  it('drops only removals, whose row is absent from the submitted set', () => {
+    const operations: ContactMethodOperation[] = [{ op: 'remove', method_id: C }]
+    expect(reconciliationsFromResults(operations, [result(0, 'removed', C)], [-1])).toEqual([])
+  })
+})
+
+// The class-level invariant behind three consecutive review findings. Each was
+// the same defect: a path that updates ONE of the two structures that must
+// agree. Server data reaches them at exactly two points — edit-start (both
+// seeded together from contact.methods) and result snapshots — and a snapshot
+// reaches the live rows only when its operation reports a submitted index. So
+// the whole class reduces to one checkable rule.
+describe('the submitted-index contract', () => {
+  it('reports -1 only for remove, across every derivation shape', () => {
+    const scenarios: Array<{
+      name: string
+      acknowledged: AcknowledgedMethod[]
+      submitted: SubmittedMethod[]
+    }> = [
+      { name: 'pure add', acknowledged: [], submitted: [row('email', 'n@example.test')] },
+      {
+        name: 'pure update',
+        acknowledged: [ack(A, 'email', 'old@example.test')],
+        submitted: [row('email', 'new@example.test', { method_id: A })],
+      },
+      { name: 'pure remove', acknowledged: [ack(A, 'email', 'a@example.test')], submitted: [] },
+      {
+        name: 'set_primary onto an existing row',
+        acknowledged: [ack(A, 'email', 'a@example.test', true), ack(B, 'phone', '5555550100')],
+        submitted: [
+          row('email', 'a@example.test', { method_id: A }),
+          row('phone', '5555550100', { method_id: B, is_primary: true }),
+        ],
+      },
+      {
+        name: 'clear_primary on the sole primary',
+        acknowledged: [ack(A, 'email', 'a@example.test', true)],
+        submitted: [row('email', 'a@example.test', { method_id: A })],
+      },
+      {
+        name: 'primary designation on a brand-new row',
+        acknowledged: [ack(A, 'email', 'a@example.test', true)],
+        submitted: [
+          row('email', 'a@example.test', { method_id: A }),
+          row('phone', '5555550100', { is_primary: true }),
+        ],
+      },
+      {
+        name: 'remove alongside an add and an update',
+        acknowledged: [ack(A, 'email', 'a@example.test'), ack(B, 'phone', '5555550100')],
+        submitted: [
+          row('email', 'edited@example.test', { method_id: A }),
+          row('telegram', 'handle'),
+        ],
+      },
+      {
+        name: 'submitted row carrying an id the acknowledged state does not know',
+        acknowledged: [],
+        submitted: [row('email', 'x@example.test', { method_id: C })],
+      },
+    ]
+
+    for (const { name, acknowledged, submitted } of scenarios) {
+      const { operations, submittedIndexes } = deriveMethodOperationsWithOrigins(
+        acknowledged,
+        submitted
+      )
+      expect(operations.length, `${name}: produced no operations to check`).toBeGreaterThan(0)
+      operations.forEach((operation, index) => {
+        if (operation.op === 'remove') {
+          expect(submittedIndexes[index], `${name}: remove must be -1`).toBe(-1)
+        } else {
+          expect(
+            submittedIndexes[index],
+            `${name}: ${operation.op} must name the live row it addresses, or its snapshot never reaches the form`
+          ).toBeGreaterThanOrEqual(0)
+        }
+      })
+    }
   })
 })
 

--- a/frontend/src/lib/__tests__/contact-method-operations.test.ts
+++ b/frontend/src/lib/__tests__/contact-method-operations.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect } from 'vitest'
+import {
+  advanceAcknowledgedMethods,
+  deriveMethodOperations,
+  deriveMethodOperationsWithOrigins,
+  initializeAcknowledgedMethods,
+  reconciliationsFromResults,
+  type AcknowledgedMethod,
+  type SubmittedMethod,
+} from '@/lib/contact-method-operations'
+import type {
+  ContactMethodOperation,
+  ContactMethodOperationResult,
+} from '@/types/generated/contact'
+
+const A = 'aaaaaaaa-0000-4000-8000-000000000001'
+const B = 'bbbbbbbb-0000-4000-8000-000000000002'
+const C = 'cccccccc-0000-4000-8000-000000000003'
+
+function ack(
+  method_id: string,
+  type: AcknowledgedMethod['type'],
+  value: string,
+  is_primary = false
+): AcknowledgedMethod {
+  return { method_id, type, value, is_primary }
+}
+
+function row(
+  type: SubmittedMethod['type'],
+  value: string,
+  extra: Partial<SubmittedMethod> = {}
+): SubmittedMethod {
+  return { type, value, is_primary: false, ...extra }
+}
+
+function result(
+  index: number,
+  outcome: string,
+  method_id: string,
+  method?: { id: string; type: string; value: string; is_primary: boolean }
+): ContactMethodOperationResult {
+  return {
+    index,
+    outcome,
+    method_id,
+    ...(method ? { method: method as ContactMethodOperationResult['method'] } : {}),
+  }
+}
+
+describe('deriveMethodOperations', () => {
+  it('emits add for a new row', () => {
+    expect(deriveMethodOperations([], [row('email', 'new@example.test')])).toEqual([
+      { op: 'add', type: 'email', value: 'new@example.test' },
+    ])
+  })
+
+  it('emits remove for a deleted row', () => {
+    expect(deriveMethodOperations([ack(A, 'email', 'a@example.test')], [])).toEqual([
+      { op: 'remove', method_id: A },
+    ])
+  })
+
+  it('emits update for a changed value', () => {
+    expect(
+      deriveMethodOperations(
+        [ack(A, 'email', 'old@example.test')],
+        [row('email', 'new@example.test', { method_id: A })]
+      )
+    ).toEqual([{ op: 'update', method_id: A, type: 'email', value: 'new@example.test' }])
+  })
+
+  it('emits update when only the type changed', () => {
+    expect(
+      deriveMethodOperations(
+        [ack(A, 'telegram', 'handle')],
+        [row('discord', 'handle', { method_id: A })]
+      )
+    ).toEqual([{ op: 'update', method_id: A, type: 'discord', value: 'handle' }])
+  })
+
+  it('emits no operation for an untouched row', () => {
+    expect(
+      deriveMethodOperations(
+        [ack(A, 'email', 'a@example.test')],
+        [row('email', 'a@example.test', { method_id: A })]
+      )
+    ).toEqual([])
+  })
+
+  it('emits an empty result when nothing changed', () => {
+    const acknowledged = [ack(A, 'email', 'a@example.test', true), ack(B, 'phone', '5555550100')]
+    const submitted = [
+      row('email', 'a@example.test', { method_id: A, is_primary: true }),
+      row('phone', '5555550100', { method_id: B }),
+    ]
+    expect(deriveMethodOperations(acknowledged, submitted)).toEqual([])
+  })
+
+  it('emits set_primary only when the designation changed', () => {
+    const acknowledged = [ack(A, 'email', 'a@example.test', true), ack(B, 'phone', '5555550100')]
+
+    // Designation unchanged.
+    expect(
+      deriveMethodOperations(acknowledged, [
+        row('email', 'a@example.test', { method_id: A, is_primary: true }),
+        row('phone', '5555550100', { method_id: B }),
+      ])
+    ).toEqual([])
+
+    // Moved to B.
+    expect(
+      deriveMethodOperations(acknowledged, [
+        row('email', 'a@example.test', { method_id: A }),
+        row('phone', '5555550100', { method_id: B, is_primary: true }),
+      ])
+    ).toEqual([{ op: 'set_primary', method_id: B }])
+  })
+
+  it('emits clear_primary when the sole primary is toggled off', () => {
+    expect(
+      deriveMethodOperations(
+        [ack(A, 'email', 'a@example.test', true)],
+        [row('email', 'a@example.test', { method_id: A })]
+      )
+    ).toEqual([{ op: 'clear_primary', method_id: A }])
+  })
+
+  it('suppresses clear_primary when the same row is being removed', () => {
+    // remove(A) already leaves no primary, so a clear alongside it is
+    // redundant AND rejected by the endpoint as self-conflicting.
+    expect(deriveMethodOperations([ack(A, 'email', 'a@example.test', true)], [])).toEqual([
+      { op: 'remove', method_id: A },
+    ])
+  })
+
+  it('carries is_primary on an add, since a new row has no id to name', () => {
+    expect(
+      deriveMethodOperations(
+        [ack(A, 'email', 'a@example.test', true)],
+        [
+          row('email', 'a@example.test', { method_id: A }),
+          row('phone', '5555550100', { is_primary: true }),
+        ]
+      )
+    ).toEqual([{ op: 'add', type: 'phone', value: '5555550100', is_primary: true }])
+  })
+
+  it('never names a method absent from the acknowledged state', () => {
+    // The structural guarantee. An unseen server method B is simply not in the
+    // acknowledged state, so no operation can mention it whatever the form does.
+    const acknowledged = [ack(A, 'email', 'a@example.test')]
+    const operations = deriveMethodOperations(acknowledged, [
+      row('email', 'edited@example.test', { method_id: A }),
+      row('phone', '5555550100'),
+    ])
+    expect(JSON.stringify(operations)).not.toContain(B)
+    expect(operations).toEqual([
+      { op: 'update', method_id: A, type: 'email', value: 'edited@example.test' },
+      { op: 'add', type: 'phone', value: '5555550100' },
+    ])
+  })
+
+  it('treats a submitted id the acknowledged state does not know as a new row', () => {
+    expect(deriveMethodOperations([], [row('email', 'x@example.test', { method_id: C })])).toEqual([
+      { op: 'add', type: 'email', value: 'x@example.test' },
+    ])
+  })
+
+  // --- comparison representation --------------------------------------------
+
+  it('emits no operation when a stored @-prefixed handle round-trips unchanged', () => {
+    // Stored '@foo' is displayed '@foo' and submitted 'foo'. Normalizing the
+    // acknowledged side at initialization absorbs the difference; without it
+    // this manufactures a spurious update on every save.
+    const acknowledged = initializeAcknowledgedMethods([
+      { id: A, type: 'telegram', value: '@foo', is_primary: false },
+    ])
+    expect(acknowledged[0].value).toBe('foo')
+    expect(
+      deriveMethodOperations(acknowledged, [row('telegram', 'foo', { method_id: A })])
+    ).toEqual([])
+  })
+
+  it('emits update when the value differs only by letter case', () => {
+    // The intent question, not the collision question. An equivalence
+    // normalizer would call these identical and silently discard the edit.
+    expect(
+      deriveMethodOperations(
+        [ack(A, 'email', 'Case@Example.test')],
+        [row('email', 'case@example.test', { method_id: A })]
+      )
+    ).toEqual([{ op: 'update', method_id: A, type: 'email', value: 'case@example.test' }])
+  })
+
+  it('emits update when a phone is respelled equivalently', () => {
+    expect(
+      deriveMethodOperations(
+        [ack(A, 'phone', '5555550100')],
+        [row('phone', '(555) 555-0100', { method_id: A })]
+      )
+    ).toEqual([{ op: 'update', method_id: A, type: 'phone', value: '(555) 555-0100' }])
+  })
+})
+
+describe('deriveMethodOperationsWithOrigins', () => {
+  it('reports the submitted row behind each add and update, and -1 otherwise', () => {
+    const { operations, submittedIndexes } = deriveMethodOperationsWithOrigins(
+      [ack(A, 'email', 'a@example.test', true), ack(B, 'phone', '5555550100')],
+      [
+        row('email', 'edited@example.test', { method_id: A }),
+        row('discord', 'handle', { is_primary: true }),
+      ]
+    )
+    expect(operations.map(op => op.op)).toEqual(['remove', 'update', 'add'])
+    expect(submittedIndexes).toEqual([-1, 0, 1])
+  })
+})
+
+describe('advanceAcknowledgedMethods', () => {
+  it('advances from results for this client’s own operations', () => {
+    const operations: ContactMethodOperation[] = [{ op: 'add', type: 'phone', value: '5555550100' }]
+    const next = advanceAcknowledgedMethods([ack(A, 'email', 'a@example.test')], operations, [
+      result(0, 'created', B, { id: B, type: 'phone', value: '5555550100', is_primary: false }),
+    ])
+    expect(next).toEqual([ack(A, 'email', 'a@example.test'), ack(B, 'phone', '5555550100')])
+  })
+
+  it('does not absorb response methods no operation resolved to', () => {
+    // The response's `methods` array carries an unseen row. Only `results` may
+    // teach the acknowledged state anything, so the unseen row must never
+    // appear — and therefore can never be named for removal later.
+    const operations: ContactMethodOperation[] = [
+      { op: 'update', method_id: A, type: 'email', value: 'edited@example.test' },
+    ]
+    const next = advanceAcknowledgedMethods([ack(A, 'email', 'a@example.test')], operations, [
+      result(0, 'updated', A, {
+        id: A,
+        type: 'email',
+        value: 'edited@example.test',
+        is_primary: false,
+      }),
+    ])
+    expect(next.map(m => m.method_id)).toEqual([A])
+
+    // And the derivation that follows names nothing about the unseen row.
+    const operationsAfter = deriveMethodOperations(next, [
+      row('email', 'edited@example.test', { method_id: A }),
+    ])
+    expect(operationsAfter).toEqual([])
+  })
+
+  it('retires an id on a confirmed removal', () => {
+    const operations: ContactMethodOperation[] = [{ op: 'remove', method_id: B }]
+    const next = advanceAcknowledgedMethods(
+      [ack(A, 'email', 'a@example.test'), ack(B, 'phone', '5555550100')],
+      operations,
+      [result(0, 'removed', B)]
+    )
+    expect(next.map(m => m.method_id)).toEqual([A])
+  })
+
+  it('demotes the previous primary when a snapshot promotes another row', () => {
+    const operations: ContactMethodOperation[] = [{ op: 'set_primary', method_id: B }]
+    const next = advanceAcknowledgedMethods(
+      [ack(A, 'email', 'a@example.test', true), ack(B, 'phone', '5555550100')],
+      operations,
+      [result(0, 'updated', B, { id: B, type: 'phone', value: '5555550100', is_primary: true })]
+    )
+    expect(next).toEqual([
+      ack(A, 'email', 'a@example.test', false),
+      ack(B, 'phone', '5555550100', true),
+    ])
+  })
+
+  // --- same-id collapse, stated as a property -------------------------------
+
+  describe('same-id collapse', () => {
+    // Two form rows resolve to one server row: a stored '1234567890' and a
+    // submitted '+1234567890' normalize alike under the database trigger but
+    // NOT under the client's own normalizer, so frontend validation sees two
+    // distinct values and the endpoint resolves the add to the existing row.
+    const snapshot = { id: A, type: 'phone', value: '5555550100', is_primary: true }
+
+    const operations: ContactMethodOperation[] = [
+      { op: 'update', method_id: A, type: 'phone', value: '5555550100' },
+      { op: 'add', type: 'phone', value: '+5555550100' },
+    ]
+    const results = [result(0, 'updated', A, snapshot), result(1, 'matched_existing', A, snapshot)]
+
+    it('collapses two adds resolving to one method_id into a single row', () => {
+      const next = advanceAcknowledgedMethods([ack(A, 'phone', 'old')], operations, results)
+      expect(next).toHaveLength(1)
+      expect(next[0].method_id).toBe(A)
+    })
+
+    it('takes the surviving row’s value and primary flag from the resolved snapshot', () => {
+      const next = advanceAcknowledgedMethods([ack(A, 'phone', 'old')], operations, results)
+      // Neither submitted value: '5555550100' is what the server stored.
+      expect(next[0]).toEqual(ack(A, 'phone', '5555550100', true))
+    })
+
+    it('keeps the earlier position and is independent of submission order', () => {
+      const acknowledged = [ack(C, 'email', 'c@example.test'), ack(A, 'phone', 'old')]
+      const forward = advanceAcknowledgedMethods(acknowledged, operations, results)
+      const reversed = advanceAcknowledgedMethods(acknowledged, operations, [...results].reverse())
+      expect(forward).toEqual(reversed)
+      expect(forward.map(m => m.method_id)).toEqual([C, A])
+    })
+
+    it('never lets a method_id appear twice, for any payload order', () => {
+      const acknowledged = [ack(A, 'phone', 'old')]
+      const permutations = [results, [...results].reverse()]
+      for (const ordered of permutations) {
+        const next = advanceAcknowledgedMethods(acknowledged, operations, ordered)
+        const ids = next.map(m => m.method_id)
+        expect(new Set(ids).size).toBe(ids.length)
+      }
+    })
+
+    it('coalesces duplicate removes of one id without leaving a stray row', () => {
+      const removeOps: ContactMethodOperation[] = [
+        { op: 'remove', method_id: A },
+        { op: 'remove', method_id: A },
+      ]
+      const next = advanceAcknowledgedMethods(
+        [ack(A, 'phone', '5555550100'), ack(B, 'email', 'b@example.test')],
+        removeOps,
+        [result(0, 'removed', A), result(1, 'no_op', A)]
+      )
+      expect(next.map(m => m.method_id)).toEqual([B])
+    })
+  })
+
+  // --- the revert pins ------------------------------------------------------
+
+  it('emits an update back to the original value after a reverted change', () => {
+    // Acknowledged A = x. The user saves A -> y; the methods step succeeds and
+    // notes fail. The user reverts to x. A frozen edit-start baseline would see
+    // x == x, emit nothing, report success, and leave y on the server.
+    const acknowledged = [ack(A, 'email', 'x@example.test')]
+    const operations: ContactMethodOperation[] = [
+      { op: 'update', method_id: A, type: 'email', value: 'y@example.test' },
+    ]
+    const advanced = advanceAcknowledgedMethods(acknowledged, operations, [
+      result(0, 'updated', A, { id: A, type: 'email', value: 'y@example.test', is_primary: false }),
+    ])
+
+    expect(
+      deriveMethodOperations(advanced, [row('email', 'x@example.test', { method_id: A })])
+    ).toEqual([{ op: 'update', method_id: A, type: 'email', value: 'x@example.test' }])
+  })
+
+  it('emits the primary designation back after a reverted designation', () => {
+    const acknowledged = [ack(A, 'email', 'a@example.test', true), ack(B, 'phone', '5555550100')]
+    const operations: ContactMethodOperation[] = [{ op: 'set_primary', method_id: B }]
+    const advanced = advanceAcknowledgedMethods(acknowledged, operations, [
+      result(0, 'updated', B, { id: B, type: 'phone', value: '5555550100', is_primary: true }),
+    ])
+
+    expect(
+      deriveMethodOperations(advanced, [
+        row('email', 'a@example.test', { method_id: A, is_primary: true }),
+        row('phone', '5555550100', { method_id: B }),
+      ])
+    ).toEqual([{ op: 'set_primary', method_id: A }])
+  })
+})
+
+describe('reconciliationsFromResults', () => {
+  it('resolves snapshot-bearing results back to their submitted rows', () => {
+    const operations: ContactMethodOperation[] = [
+      { op: 'remove', method_id: C },
+      { op: 'add', type: 'phone', value: '5555550100' },
+      { op: 'set_primary', method_id: A },
+    ]
+    const submittedIndexes = [-1, 1, -1]
+    const results = [
+      result(0, 'removed', C),
+      result(1, 'created', B, { id: B, type: 'phone', value: '5555550100', is_primary: false }),
+      result(2, 'updated', A, { id: A, type: 'email', value: 'a@example.test', is_primary: true }),
+    ]
+
+    expect(reconciliationsFromResults(operations, results, submittedIndexes)).toEqual([
+      { submittedIndex: 1, method_id: B, type: 'phone', value: '5555550100', is_primary: false },
+    ])
+  })
+})
+
+describe('initializeAcknowledgedMethods', () => {
+  it('drops methods with no server id', () => {
+    expect(
+      initializeAcknowledgedMethods([
+        { id: A, type: 'email', value: 'a@example.test', is_primary: true },
+        { type: 'phone', value: '5555550100', is_primary: false },
+      ])
+    ).toEqual([ack(A, 'email', 'a@example.test', true)])
+  })
+})

--- a/frontend/src/lib/__tests__/contact-method-operations.test.ts
+++ b/frontend/src/lib/__tests__/contact-method-operations.test.ts
@@ -508,9 +508,31 @@ describe('the submitted-index contract', () => {
         ],
       },
       {
+        // Addressed row is neither first nor last, so a constant index fails.
+        name: 'set_primary on a middle row',
+        acknowledged: [
+          ack(A, 'email', 'a@example.test', true),
+          ack(B, 'phone', '5555550100'),
+          ack(C, 'telegram', 'handle'),
+        ],
+        submitted: [
+          row('email', 'a@example.test', { method_id: A }),
+          row('phone', '5555550100', { method_id: B, is_primary: true }),
+          row('telegram', 'handle', { method_id: C }),
+        ],
+      },
+      {
         name: 'clear_primary on the sole primary',
         acknowledged: [ack(A, 'email', 'a@example.test', true)],
         submitted: [row('email', 'a@example.test', { method_id: A })],
+      },
+      {
+        name: 'clear_primary where the cleared row is not first',
+        acknowledged: [ack(B, 'phone', '5555550100'), ack(A, 'email', 'a@example.test', true)],
+        submitted: [
+          row('phone', '5555550100', { method_id: B }),
+          row('email', 'a@example.test', { method_id: A }),
+        ],
       },
       {
         name: 'primary designation on a brand-new row',
@@ -542,13 +564,31 @@ describe('the submitted-index contract', () => {
       )
       expect(operations.length, `${name}: produced no operations to check`).toBeGreaterThan(0)
       operations.forEach((operation, index) => {
+        const origin = submittedIndexes[index]
         if (operation.op === 'remove') {
-          expect(submittedIndexes[index], `${name}: remove must be -1`).toBe(-1)
+          expect(origin, `${name}: remove must be -1`).toBe(-1)
+          return
+        }
+
+        // Non-negative is necessary but NOT sufficient: it says an index
+        // exists, not that it points at the right row. Mapping every non-remove
+        // to 0 — or to 999 — would satisfy a range check while reconciling one
+        // row's snapshot into a DIFFERENT row, which is the divergence this
+        // contract exists to prevent. So assert OWNERSHIP, not just presence.
+        expect(origin, `${name}: ${operation.op} must name a live row`).toBeGreaterThanOrEqual(0)
+        expect(origin, `${name}: ${operation.op} index out of range`).toBeLessThan(submitted.length)
+
+        const addressed = submitted[origin]
+        if (operation.op === 'add') {
+          expect(
+            { type: addressed.type, value: addressed.value },
+            `${name}: add must point at the submitted row carrying its own type and value`
+          ).toEqual({ type: operation.type, value: operation.value })
         } else {
           expect(
-            submittedIndexes[index],
-            `${name}: ${operation.op} must name the live row it addresses, or its snapshot never reaches the form`
-          ).toBeGreaterThanOrEqual(0)
+            addressed.method_id,
+            `${name}: ${operation.op} must point at the row carrying method_id ${operation.method_id}`
+          ).toBe(operation.method_id)
         }
       })
     }

--- a/frontend/src/lib/__tests__/contact-transform-create.test.ts
+++ b/frontend/src/lib/__tests__/contact-transform-create.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { submittedMethodSourceRows, transformContactFormData } from '@/lib/validations/contact'
+import type { ContactFormData } from '@/lib/validations/contact'
+
+// ContactForm and transformContactFormData are SHARED with contact creation:
+// frontend/src/app/contacts/new/page.tsx passes the transformed `methods`
+// straight into CreateContactRequest. "Stop emitting methods for the PUT" is an
+// edit-path change only — removing methods from the shared transform would
+// silently break creation, and no backend DTO test can see that.
+//
+// This test passes against the pre-change tree by design. Its discrimination
+// gate is mutating transformContactFormData to drop methods, not reverting the
+// feature.
+function formData(overrides: Partial<ContactFormData> = {}): ContactFormData {
+  return {
+    full_name: 'New Person',
+    methods: [{ type: 'email', value: 'new@example.test', is_primary: true }],
+    location: '',
+    birthday: '',
+    notes: '',
+    cadence: '',
+    ...overrides,
+  } as ContactFormData
+}
+
+describe('transformContactFormData on the create path', () => {
+  it('still emits methods', () => {
+    expect(transformContactFormData(formData()).methods).toEqual([
+      { type: 'email', value: 'new@example.test', is_primary: true },
+    ])
+  })
+
+  it('omits method_id entirely for rows that have none', () => {
+    // A create payload must not carry the key at all — CreateContactRequest has
+    // no such field, and an always-present null would be a wire contract nobody
+    // asked for.
+    const [method] = transformContactFormData(formData()).methods
+    expect('method_id' in method).toBe(false)
+  })
+
+  it('normalizes handle values and drops blank rows', () => {
+    const data = formData({
+      methods: [
+        { type: 'telegram', value: '  @handle ', is_primary: false },
+        { type: '', value: '', is_primary: false },
+        { type: 'email', value: '   ', is_primary: false },
+      ],
+    } as Partial<ContactFormData>)
+
+    expect(transformContactFormData(data).methods).toEqual([
+      { type: 'telegram', value: 'handle', is_primary: false },
+    ])
+  })
+
+  it('reports the source row behind each emitted method', () => {
+    // The mapping the form uses to write a confirmed server id back into the
+    // right row. Blank rows are filtered out, so emitted index != row index.
+    const data = formData({
+      methods: [
+        { type: '', value: '', is_primary: false },
+        { type: 'email', value: 'a@example.test', is_primary: false },
+        { type: 'phone', value: '', is_primary: false },
+        { type: 'phone', value: '5555550100', is_primary: false },
+      ],
+    } as Partial<ContactFormData>)
+
+    expect(submittedMethodSourceRows(data)).toEqual([1, 3])
+    expect(transformContactFormData(data).methods).toHaveLength(2)
+  })
+
+  it('carries method_id through on the edit path', () => {
+    const data = formData({
+      methods: [
+        {
+          method_id: 'aaaaaaaa-0000-4000-8000-000000000001',
+          type: 'email',
+          value: 'a@example.test',
+          is_primary: false,
+        },
+      ],
+    } as Partial<ContactFormData>)
+
+    expect(transformContactFormData(data).methods[0]).toEqual({
+      method_id: 'aaaaaaaa-0000-4000-8000-000000000001',
+      type: 'email',
+      value: 'a@example.test',
+      is_primary: false,
+    })
+  })
+})

--- a/frontend/src/lib/contact-method-operations.ts
+++ b/frontend/src/lib/contact-method-operations.ts
@@ -41,9 +41,13 @@ export interface SubmittedMethod {
 export interface DerivedMethodOperations {
   operations: ContactMethodOperation[]
   /**
-   * `submittedIndexes[i]` is the index into `submitted` whose row produced
-   * `operations[i]`, or -1 for an operation that names an acknowledged row
-   * rather than a submitted one (removals and primary designations).
+   * `submittedIndexes[i]` is the index into `submitted` whose live row the
+   * operation addresses, or -1 when no live row corresponds — which is only
+   * `remove`, whose row is by definition absent from the submitted set.
+   *
+   * Primary designations DO carry their row's index: their results include a
+   * full snapshot, and that snapshot has to reach the live row or the form and
+   * the acknowledged state drift apart.
    *
    * This is what lets a successful result be written back into the live form
    * row that produced it, without re-deriving server identity from the
@@ -147,17 +151,28 @@ export function deriveMethodOperationsWithOrigins(
   })
 
   const acknowledgedPrimary = acknowledged.find(method => method.is_primary)
-  const submittedPrimary = submitted.find(row => row.is_primary)
+  const submittedPrimaryIndex = submitted.findIndex(row => row.is_primary)
+  const submittedPrimary = submittedPrimaryIndex >= 0 ? submitted[submittedPrimaryIndex] : undefined
 
+  // A primary designation is reported with the live row it addresses, NOT -1.
+  // Its result carries a full snapshot (the row survives), and that snapshot is
+  // the only place the client learns the row's server-side state. Dropping it
+  // from reconciliation while the acknowledged state applies it splits the two
+  // structures apart: the form keeps showing a stale value while the
+  // acknowledged state holds the server's, and the next derivation then emits
+  // an update nobody asked for, overwriting a value the form never displayed.
   if (submittedPrimary) {
     const id = knownId(submittedPrimary)
     if (id && acknowledgedPrimary?.method_id !== id) {
-      push({ op: 'set_primary', method_id: id }, -1)
+      push({ op: 'set_primary', method_id: id }, submittedPrimaryIndex)
     }
   } else if (acknowledgedPrimary && !removedIds.has(acknowledgedPrimary.method_id)) {
     // Suppressed when the same row is being removed: removal already leaves no
     // primary, so the clear is redundant AND rejected as self-conflicting.
-    push({ op: 'clear_primary', method_id: acknowledgedPrimary.method_id }, -1)
+    // The row is still submitted (it was not removed), so its live index is
+    // known and the snapshot can reach it.
+    const clearedIndex = submitted.findIndex(row => knownId(row) === acknowledgedPrimary.method_id)
+    push({ op: 'clear_primary', method_id: acknowledgedPrimary.method_id }, clearedIndex)
   }
 
   return { operations, submittedIndexes }

--- a/frontend/src/lib/contact-method-operations.ts
+++ b/frontend/src/lib/contact-method-operations.ts
@@ -1,3 +1,34 @@
+/**
+ * Contact-method operation derivation, and the two client structures it runs
+ * between.
+ *
+ * THE INVARIANT THAT MATTERS HERE. The client keeps two pictures of the same
+ * confirmed truth — the acknowledged state (this module) and the live
+ * react-hook-form rows (`contact-form.tsx`). Three consecutive review rounds
+ * each found the same defect: a path that updated one without the other. So the
+ * places server data can enter them are enumerated, and the list is short:
+ *
+ *   1. EDIT-START — `contact.methods` seeds `initializeAcknowledgedMethods` and
+ *      the form's `defaultValues` at the same moment from the same source.
+ *      Both, together, by construction.
+ *   2. RESULT SNAPSHOTS — `advanceAcknowledgedMethods` applies every
+ *      snapshot-bearing result; `reconciliationsFromResults` forwards the same
+ *      ones to the live rows. They agree only because every non-`remove`
+ *      operation reports the submitted row it addresses. A `remove` reports -1
+ *      and carries no snapshot, so both structures drop that row.
+ *
+ * Everything else server-originated — `setQueryData` on the detail cache after
+ * either mutation, `usePrefetchContact`, `RematchJobWatcher`'s invalidation,
+ * any ordinary refetch — reaches NEITHER structure, deliberately. Those feed
+ * display only. That is what makes the acknowledged state safe to hold across a
+ * cache refresh, and it is the whole defense against the original incident.
+ *
+ * The checkable form of rule 2 is: `submittedIndexes[i] < 0` if and only if
+ * `operations[i].op === 'remove'`. It is pinned by "the submitted-index
+ * contract" test, which is the class-level guard — any operation type added
+ * later that forgets to thread its row index fails it, without anyone having to
+ * rediscover this reasoning.
+ */
 import { normalizeContactMethodValue } from '@/lib/contact-methods'
 import type { ContactMethod, ContactMethodType } from '@/types/contact'
 import type {

--- a/frontend/src/lib/contact-method-operations.ts
+++ b/frontend/src/lib/contact-method-operations.ts
@@ -23,11 +23,23 @@
  * display only. That is what makes the acknowledged state safe to hold across a
  * cache refresh, and it is the whole defense against the original incident.
  *
- * The checkable form of rule 2 is: `submittedIndexes[i] < 0` if and only if
- * `operations[i].op === 'remove'`. It is pinned by "the submitted-index
- * contract" test, which is the class-level guard — any operation type added
- * later that forgets to thread its row index fails it, without anyone having to
- * rediscover this reasoning.
+ * The checkable form of rule 2 has two halves, and the first alone is NOT
+ * sufficient — stating it as if it were is how this doc originally overstated
+ * the guarantee:
+ *
+ *   a. `submittedIndexes[i] < 0` if and only if `operations[i].op === 'remove'`.
+ *   b. every other index identifies the row the operation actually addresses —
+ *      an `add` points at the submitted row carrying its own type and value; an
+ *      `update`, `set_primary`, or `clear_primary` points at the row carrying
+ *      its `method_id`.
+ *
+ * (a) alone would be satisfied by mapping every non-removal to index 0, which
+ * reconciles one row's snapshot into a different row — the same
+ * acknowledged-vs-live divergence, reached by a new route. Both halves are
+ * pinned by "the submitted-index contract" test, which is the class-level
+ * guard: any operation type added later that forgets to thread its row index,
+ * or threads the wrong one, fails without anyone having to rediscover this
+ * reasoning.
  */
 import { normalizeContactMethodValue } from '@/lib/contact-methods'
 import type { ContactMethod, ContactMethodType } from '@/types/contact'

--- a/frontend/src/lib/contact-method-operations.ts
+++ b/frontend/src/lib/contact-method-operations.ts
@@ -1,0 +1,252 @@
+import { normalizeContactMethodValue } from '@/lib/contact-methods'
+import type { ContactMethod, ContactMethodType } from '@/types/contact'
+import type {
+  ContactMethodOperation,
+  ContactMethodOperationResult,
+} from '@/types/generated/contact'
+
+/**
+ * A method this client asserted and had confirmed on the server.
+ *
+ * The acknowledged state is the left-hand side of every derivation. It is
+ * initialized once at edit-start and thereafter advances ONLY by applying this
+ * client's own confirmed operations — never by absorbing a server response.
+ * Both rules are load-bearing in opposite directions: re-reading server data
+ * lets a method the form never showed enter a diff (and be destroyed), while
+ * freezing it for the whole edit session silently discards a value the user
+ * reverts after a partially successful save.
+ *
+ * `value` is held in the SUBMISSION representation (see
+ * `normalizeContactMethodValue`) so the diff can be a plain equality against
+ * what the form submits. It is deliberately NOT the comparison/uniqueness
+ * representation: that answers "would these collide?", and the diff asks "did
+ * the user change this?". Answering the second question with the first makes
+ * case-only and respelling edits vanish.
+ */
+export interface AcknowledgedMethod {
+  method_id: string
+  type: ContactMethodType
+  value: string
+  is_primary: boolean
+}
+
+/** A method row as the form submits it. A row with no `method_id` is new. */
+export interface SubmittedMethod {
+  method_id?: string
+  type: ContactMethodType
+  value: string
+  is_primary: boolean
+}
+
+export interface DerivedMethodOperations {
+  operations: ContactMethodOperation[]
+  /**
+   * `submittedIndexes[i]` is the index into `submitted` whose row produced
+   * `operations[i]`, or -1 for an operation that names an acknowledged row
+   * rather than a submitted one (removals and primary designations).
+   *
+   * This is what lets a successful result be written back into the live form
+   * row that produced it, without re-deriving server identity from the
+   * response.
+   */
+  submittedIndexes: number[]
+}
+
+/** A confirmed result, resolved back to the submitted row that produced it. */
+export interface MethodReconciliation {
+  submittedIndex: number
+  method_id: string
+  type: ContactMethodType
+  value: string
+  is_primary: boolean
+}
+
+/**
+ * Builds the acknowledged state at edit-start from the contact's methods.
+ *
+ * Values are normalized into the submission representation here, which is what
+ * makes a stored `@foo` (displayed `@foo`, submitted `foo`) produce no
+ * operation on an untouched round trip.
+ */
+export function initializeAcknowledgedMethods(
+  methods: ContactMethod[] | undefined
+): AcknowledgedMethod[] {
+  return (methods ?? [])
+    .filter((method): method is ContactMethod & { id: string } => Boolean(method.id))
+    .map(method => ({
+      method_id: method.id,
+      type: method.type,
+      value: normalizeContactMethodValue(method.type, method.value),
+      is_primary: Boolean(method.is_primary),
+    }))
+}
+
+/**
+ * Derives the operations that carry the acknowledged state to what the form is
+ * asking for.
+ *
+ * A method absent from the acknowledged state is never named by any operation,
+ * which is the structural reason a save cannot remove a method the form did not
+ * show.
+ */
+export function deriveMethodOperations(
+  acknowledged: AcknowledgedMethod[],
+  submitted: SubmittedMethod[]
+): ContactMethodOperation[] {
+  return deriveMethodOperationsWithOrigins(acknowledged, submitted).operations
+}
+
+export function deriveMethodOperationsWithOrigins(
+  acknowledged: AcknowledgedMethod[],
+  submitted: SubmittedMethod[]
+): DerivedMethodOperations {
+  const acknowledgedById = new Map(acknowledged.map(method => [method.method_id, method]))
+
+  // An id the acknowledged state does not know is not a row this client can
+  // safely name: naming it would assert an identity we never confirmed. Treat
+  // the row as new instead — the server resolves it to whichever row satisfies
+  // the value, and tells us which one.
+  const knownId = (row: SubmittedMethod) =>
+    row.method_id && acknowledgedById.has(row.method_id) ? row.method_id : undefined
+
+  const submittedIds = new Set<string>()
+  for (const row of submitted) {
+    const id = knownId(row)
+    if (id) submittedIds.add(id)
+  }
+
+  const operations: ContactMethodOperation[] = []
+  const submittedIndexes: number[] = []
+  const push = (operation: ContactMethodOperation, submittedIndex: number) => {
+    operations.push(operation)
+    submittedIndexes.push(submittedIndex)
+  }
+
+  const removedIds = new Set<string>()
+  for (const method of acknowledged) {
+    if (submittedIds.has(method.method_id)) continue
+    removedIds.add(method.method_id)
+    push({ op: 'remove', method_id: method.method_id }, -1)
+  }
+
+  submitted.forEach((row, index) => {
+    const id = knownId(row)
+    if (!id) {
+      const add: ContactMethodOperation = { op: 'add', type: row.type, value: row.value }
+      // A row that does not exist yet has no id for set_primary to name, so a
+      // new row's designation necessarily travels on its own add.
+      if (row.is_primary) add.is_primary = true
+      push(add, index)
+      return
+    }
+    const acknowledgedRow = acknowledgedById.get(id)
+    if (!acknowledgedRow) return
+    if (acknowledgedRow.type !== row.type || acknowledgedRow.value !== row.value) {
+      push({ op: 'update', method_id: id, type: row.type, value: row.value }, index)
+    }
+  })
+
+  const acknowledgedPrimary = acknowledged.find(method => method.is_primary)
+  const submittedPrimary = submitted.find(row => row.is_primary)
+
+  if (submittedPrimary) {
+    const id = knownId(submittedPrimary)
+    if (id && acknowledgedPrimary?.method_id !== id) {
+      push({ op: 'set_primary', method_id: id }, -1)
+    }
+  } else if (acknowledgedPrimary && !removedIds.has(acknowledgedPrimary.method_id)) {
+    // Suppressed when the same row is being removed: removal already leaves no
+    // primary, so the clear is redundant AND rejected as self-conflicting.
+    push({ op: 'clear_primary', method_id: acknowledgedPrimary.method_id }, -1)
+  }
+
+  return { operations, submittedIndexes }
+}
+
+/**
+ * Advances the acknowledged state by applying this client's own confirmed
+ * operations.
+ *
+ * The response's `methods` array is deliberately never read here. The test is
+ * "did MY operation address this row?", not "did the server send it?" — taking
+ * the list wholesale is how state the client never saw enters its picture,
+ * which is the original defect. A per-result snapshot cannot do that: a result
+ * only ever arrives for an operation this client submitted.
+ *
+ * Upserting by `method_id` is what satisfies the same-id collapse property: two
+ * rows whose results resolve to one id become one row, at the earlier position,
+ * carrying the resolved snapshot rather than either submitted value.
+ */
+export function advanceAcknowledgedMethods(
+  acknowledged: AcknowledgedMethod[],
+  operations: ContactMethodOperation[],
+  results: ContactMethodOperationResult[]
+): AcknowledgedMethod[] {
+  let next = acknowledged.map(method => ({ ...method }))
+  let promotedId: string | null = null
+
+  for (const result of results) {
+    const operation = operations[result.index]
+    if (!operation) continue
+
+    if (operation.op === 'remove') {
+      next = next.filter(method => method.method_id !== result.method_id)
+      continue
+    }
+
+    // No snapshot means the operation left no surviving row to learn about.
+    if (!result.method) continue
+
+    const snapshot: AcknowledgedMethod = {
+      method_id: result.method.id,
+      type: result.method.type,
+      value: normalizeContactMethodValue(result.method.type, result.method.value),
+      is_primary: result.method.is_primary,
+    }
+    if (snapshot.is_primary) promotedId = snapshot.method_id
+
+    const at = next.findIndex(method => method.method_id === snapshot.method_id)
+    if (at >= 0) next[at] = snapshot
+    else next.push(snapshot)
+  }
+
+  // A promotion demotes every other row. Rows no operation addressed keep their
+  // edit-start flag otherwise, and would leave the state with two primaries —
+  // which makes the next derivation's primary comparison ambiguous.
+  if (promotedId) {
+    next = next.map(method => ({ ...method, is_primary: method.method_id === promotedId }))
+  }
+
+  return next
+}
+
+/**
+ * Resolves confirmed results back to the submitted rows that produced them, so
+ * the live form rows can learn the ids and stored values the server assigned.
+ *
+ * Without this the acknowledged state and the form disagree: a row added in a
+ * save whose later step failed would still be id-less in the form, and the next
+ * save would derive `remove` + `add` — changing the row's identity, which is
+ * the forensic evidence this whole workstream exists to protect.
+ */
+export function reconciliationsFromResults(
+  operations: ContactMethodOperation[],
+  results: ContactMethodOperationResult[],
+  submittedIndexes: number[]
+): MethodReconciliation[] {
+  const out: MethodReconciliation[] = []
+  for (const result of results) {
+    const operation = operations[result.index]
+    if (!operation || operation.op === 'remove' || !result.method) continue
+    const submittedIndex = submittedIndexes[result.index] ?? -1
+    if (submittedIndex < 0) continue
+    out.push({
+      submittedIndex,
+      method_id: result.method.id,
+      type: result.method.type,
+      value: result.method.value,
+      is_primary: result.method.is_primary,
+    })
+  }
+  return out
+}

--- a/frontend/src/lib/contacts-api.ts
+++ b/frontend/src/lib/contacts-api.ts
@@ -7,6 +7,11 @@ import type {
   OverdueContact,
 } from '@/types/contact'
 import type { CadenceFilter, FollowupFilter, SortField, SortOrder } from './contact-list-params'
+import type {
+  ContactMethodOperation,
+  ContactMethodOperationsRequest,
+  ContactMethodOperationsResponse,
+} from '@/types/generated/contact'
 
 export interface ContactsListResponse {
   contacts: Contact[]
@@ -66,6 +71,23 @@ export const contactsApi = {
   // Update contact
   updateContact: async (id: string, data: UpdateContactRequest): Promise<Contact> => {
     return apiClient.put<Contact>(`/api/v1/contacts/${id}`, data)
+  },
+
+  // Apply contact-method operations.
+  //
+  // Returns the whole response, `results` included: the caller needs the
+  // per-operation results to advance its acknowledged state and to learn the
+  // ids the server assigned. Dropping them here would force the client to
+  // re-derive server identity from the method list, which cannot be done
+  // correctly — the client's normalizer and the database trigger are different
+  // functions.
+  applyMethodOperations: async (
+    id: string,
+    operations: ContactMethodOperation[]
+  ): Promise<ContactMethodOperationsResponse> => {
+    return apiClient.post<ContactMethodOperationsResponse>(`/api/v1/contacts/${id}/methods`, {
+      operations,
+    } satisfies ContactMethodOperationsRequest)
   },
 
   // Delete contact (soft delete)

--- a/frontend/src/lib/validations/contact.ts
+++ b/frontend/src/lib/validations/contact.ts
@@ -8,6 +8,13 @@ import {
 import type { ContactMethodType } from '@/types/contact'
 
 const contactMethodSchema = z.object({
+  // The server's id for this row, carried through the form so an edit can name
+  // the row it is changing. Deliberately `method_id` and never `id`:
+  // `useFieldArray` is called without a custom `keyName` and react-hook-form
+  // OVERWRITES `fields[].id` with its own generated key, so a server id
+  // threaded as `id` is silently replaced — and only becomes visible once it is
+  // submitted, naming a method that does not exist. Never rendered.
+  method_id: z.string().optional(),
   type: z.string().optional().or(z.literal('')),
   value: z.string().optional().or(z.literal('')),
   is_primary: z.boolean().optional().default(false),
@@ -143,26 +150,52 @@ export type ContactFormInput = z.input<typeof contactSchema>
 // Validated form values (schema output)
 export type ContactFormData = z.output<typeof contactSchema>
 
+// Emits one entry per form row that survives normalization, remembering which
+// row each came from. The mapping is the single source of truth for "which form
+// row produced this submitted method" — the form needs it to write a confirmed
+// server id back into the right row, and recomputing it with a second copy of
+// the filter rule is how the two would drift apart.
+function emitMethodRows(methods: ContactFormData['methods']) {
+  const emitted: Array<{
+    method_id?: string
+    type: ContactMethodType
+    value: string
+    is_primary: boolean
+  }> = []
+  const sourceRowIndexes: number[] = []
+
+  ;(methods ?? []).forEach((method, sourceRowIndex) => {
+    const type = method.type?.trim() as ContactMethodType | ''
+    if (!type) {
+      return
+    }
+    const normalizedValue = normalizeContactMethodValue(type, method.value ?? '')
+    if (normalizedValue === '') {
+      return
+    }
+    emitted.push({
+      ...(method.method_id ? { method_id: method.method_id } : {}),
+      type,
+      value: normalizedValue,
+      is_primary: Boolean(method.is_primary),
+    })
+    sourceRowIndexes.push(sourceRowIndex)
+  })
+
+  return { methods: emitted, sourceRowIndexes }
+}
+
+/**
+ * The form-row index behind each submitted method, parallel to
+ * `transformContactFormData(data).methods`.
+ */
+export function submittedMethodSourceRows(data: ContactFormData): number[] {
+  return emitMethodRows(data.methods).sourceRowIndexes
+}
+
 // Transform form data to API format (convert empty strings to undefined)
 export function transformContactFormData(data: ContactFormData) {
-  const normalizedMethods = (data.methods ?? [])
-    .map(method => {
-      const type = method.type?.trim() as ContactMethodType | ''
-      const rawValue = method.value ?? ''
-      if (!type) {
-        return null
-      }
-      const normalizedValue = normalizeContactMethodValue(type, rawValue)
-      if (normalizedValue === '') {
-        return null
-      }
-      return {
-        type,
-        value: normalizedValue,
-        is_primary: Boolean(method.is_primary),
-      }
-    })
-    .filter((method): method is NonNullable<typeof method> => method !== null)
+  const normalizedMethods = emitMethodRows(data.methods).methods
 
   return {
     full_name: data.full_name,

--- a/frontend/src/types/generated/contact.ts
+++ b/frontend/src/types/generated/contact.ts
@@ -37,6 +37,13 @@ export interface ContactResponse {
   profile_photo?: string;
   created_at: string;
   updated_at: string;
+  /**
+   * RematchJobID is populated by the CREATE path only. A rematch is triggered
+   * by newly-present method values, and update no longer carries methods, so
+   * it has no job to report. This type is shared by create, get, update, list,
+   * merge, and overdue; the field is omitempty, so a path that leaves it unset
+   * simply omits the key rather than publishing an always-null contract.
+   */
   rematch_job_id?: string;
 }
 /**
@@ -72,11 +79,15 @@ export interface CreateContactRequest {
 }
 /**
  * UpdateContactRequest represents the request to update a contact
+ * Contact methods are NOT part of this request. A full methods array made
+ * absence mean "delete", so a client saving from a stale read destroyed every
+ * method it had never seen. Methods are mutated through
+ * POST /contacts/{id}/methods, which takes operations. A `methods` key on this
+ * payload is rejected rather than ignored — see UpdateContact.
  * @Description Update contact request
  */
 export interface UpdateContactRequest {
   full_name: string;
-  methods?: ContactMethodRequest[];
   location?: string;
   birthday?: string;
   how_met?: string;

--- a/frontend/tests/e2e/contact-method-preservation.spec.ts
+++ b/frontend/tests/e2e/contact-method-preservation.spec.ts
@@ -1,0 +1,341 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+
+// Plain @playwright/test, deliberately NOT the custom fixture: that fixture's
+// query client sets staleTime: 0, which refetches the contact detail constantly
+// and hands the form a fresh server picture — destroying the very staleness
+// these tests exist to survive.
+//
+// The incident: enrichment added a method server-side, the open edit form held
+// a stale list, and saving wholesale-deleted and recreated from that stale
+// list, permanently destroying the enriched method. @area:contacts
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
+const API_HEADERS = { 'X-API-Key': API_KEY, 'Content-Type': 'application/json' }
+
+interface MethodRow {
+  id: string
+  type: string
+  value: string
+  is_primary: boolean
+}
+
+async function getMethods(request: APIRequestContext, contactId: string): Promise<MethodRow[]> {
+  const res = await request.get(`${API_BASE_URL}/api/v1/contacts/${contactId}`, {
+    headers: API_HEADERS,
+  })
+  expect(res.ok()).toBe(true)
+  const body = await res.json()
+  return (body?.data?.methods ?? []) as MethodRow[]
+}
+
+/** Adds a method out of band, the way another writer (enrichment) would. */
+async function addMethodOutOfBand(
+  request: APIRequestContext,
+  contactId: string,
+  type: string,
+  value: string
+) {
+  const res = await request.post(`${API_BASE_URL}/api/v1/contacts/${contactId}/methods`, {
+    headers: API_HEADERS,
+    data: { operations: [{ op: 'add', type, value }] },
+  })
+  expect(res.ok(), 'out-of-band add should succeed').toBe(true)
+}
+
+async function openEditMode(page: Page, contactId: string) {
+  await page.goto(`/contacts/${contactId}?action=edit`)
+  await page.waitForLoadState('domcontentloaded')
+  await expect(page.getByRole('heading', { name: 'Edit Contact' })).toBeVisible({ timeout: 15000 })
+}
+
+function methodValues(page: Page) {
+  return page.getByRole('textbox', { name: 'Contact method value' })
+}
+
+/** Forces the notes step to fail, so the methods step lands and the form stays open. */
+async function failNotesStep(page: Page, contactId: string) {
+  await page.route(`**/api/v1/contacts/${contactId}/notes`, async route => {
+    if (route.request().method() === 'PUT') {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: false, error: { code: 'TEST', message: 'forced' } }),
+      })
+      return
+    }
+    await route.continue()
+  })
+}
+
+async function save(page: Page) {
+  await page.getByRole('button', { name: 'Update Contact' }).click()
+}
+
+// A second save must be observed by ITS OWN request landing. Asserting on the
+// save-report alone would pass trivially: the banner is still on screen from
+// the previous attempt, so the assertion can resolve before the retry has done
+// anything at all.
+async function saveAndAwait(page: Page, contactId: string, step: 'methods' | 'notes') {
+  const path =
+    step === 'methods'
+      ? `/api/v1/contacts/${contactId}/methods`
+      : `/api/v1/contacts/${contactId}/notes`
+  const method = step === 'methods' ? 'POST' : 'PUT'
+  const responsePromise = page.waitForResponse(res => {
+    return new URL(res.url()).pathname === path && res.request().method() === method
+  })
+  await save(page)
+  return responsePromise
+}
+
+test.describe('Contact method preservation @area:contacts', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  test('preserves an unseen method while the user edits a visible one', async ({
+    page,
+    request,
+  }) => {
+    // spec: CON-063[0]
+    const emailA = `pres-a-${Date.now()}@example.com`
+    const emailB = `pres-b-${Date.now()}@example.com`
+    const { ids } = await testApi.seedContacts([
+      { full_name: 'Preservation Target', methods: [{ type: 'email', value: emailA }] },
+    ])
+    const contactId = ids[0]
+
+    await openEditMode(page, contactId)
+
+    // Another writer adds B AFTER the form opened, so B is genuinely unseen.
+    await addMethodOutOfBand(request, contactId, 'phone', '5555550142')
+
+    // Edit the visible method. Changing only a scalar would skip the methods
+    // request entirely, and the test would pass even against a derivation that
+    // deletes unseen methods whenever any method is edited.
+    await methodValues(page).first().fill(emailB)
+    await save(page)
+
+    await expect(page.getByRole('heading', { name: 'Edit Contact' })).toBeHidden({ timeout: 15000 })
+
+    const methods = await getMethods(request, contactId)
+    expect(methods.map(m => m.value).sort()).toEqual([emailB, '5555550142'].sort())
+  })
+
+  test('removes a method the user deleted in the form', async ({ page, request }) => {
+    // spec: CON-063[1]
+    const emailA = `del-a-${Date.now()}@example.com`
+    const { ids } = await testApi.seedContacts([
+      {
+        full_name: 'Deletion Target',
+        methods: [
+          { type: 'email', value: emailA },
+          { type: 'phone', value: '5555550143' },
+        ],
+      },
+    ])
+    const contactId = ids[0]
+
+    await openEditMode(page, contactId)
+    await expect(methodValues(page)).toHaveCount(2)
+
+    // Located by live input VALUE, not by a [value=...] CSS selector: React
+    // sets the value as a DOM property and never writes the attribute, so the
+    // attribute selector matches nothing.
+    const rowIndex = await methodValues(page).evaluateAll(
+      (inputs, target) => inputs.findIndex(i => (i as HTMLInputElement).value === target),
+      '5555550143'
+    )
+    expect(rowIndex, 'the seeded phone row should be on screen').toBeGreaterThanOrEqual(0)
+    await page.getByRole('button', { name: 'Remove' }).nth(rowIndex).click()
+    await save(page)
+
+    await expect(page.getByRole('heading', { name: 'Edit Contact' })).toBeHidden({ timeout: 15000 })
+
+    const methods = await getMethods(request, contactId)
+    expect(methods.map(m => m.value)).toEqual([emailA])
+  })
+
+  test('reports which parts of the save succeeded when one step fails', async ({ page }) => {
+    // spec: CON-063[2]
+    const emailA = `part-a-${Date.now()}@example.com`
+    const { ids } = await testApi.seedContacts([
+      { full_name: 'Partial Target', methods: [{ type: 'email', value: emailA }] },
+    ])
+    const contactId = ids[0]
+
+    await openEditMode(page, contactId)
+    await failNotesStep(page, contactId)
+
+    await methodValues(page).first().fill(`part-b-${Date.now()}@example.com`)
+    await save(page)
+
+    const report = page.getByTestId('save-report')
+    await expect(report).toBeVisible({ timeout: 15000 })
+    // Names what landed rather than reporting a generic failure — the user's
+    // next action differs between "nothing saved" and "the note did not save".
+    await expect(report).toContainText('contact methods')
+    await expect(report).toContainText('the note could not be saved')
+    await expect(report).not.toContainText('Nothing was saved')
+  })
+
+  test('a retry after a partial failure does not undo the saved parts', async ({
+    page,
+    request,
+  }) => {
+    // spec: CON-063[3]
+    const emailA = `retry-a-${Date.now()}@example.com`
+    const emailB = `retry-b-${Date.now()}@example.com`
+    const { ids } = await testApi.seedContacts([
+      { full_name: 'Retry Target', methods: [{ type: 'email', value: emailA }] },
+    ])
+    const contactId = ids[0]
+
+    await openEditMode(page, contactId)
+    await failNotesStep(page, contactId)
+
+    await methodValues(page).first().fill(emailB)
+    await save(page)
+    await expect(page.getByTestId('save-report')).toBeVisible({ timeout: 15000 })
+
+    // Retry unedited. The methods step already landed and must stay landed, so
+    // the retry resumes at notes and issues no methods request at all.
+    await saveAndAwait(page, contactId, 'notes')
+    await expect(page.getByTestId('save-report')).toBeVisible({ timeout: 15000 })
+
+    const methods = await getMethods(request, contactId)
+    expect(methods.map(m => m.value)).toEqual([emailB])
+  })
+
+  test('a method added in a partially failed save can then be removed', async ({
+    page,
+    request,
+  }) => {
+    // spec: CON-063[4]
+    //
+    // The ordering here is load-bearing. B is added AFTER edit mode opens, so it
+    // is genuinely unseen; adding it before would make it legitimately part of
+    // the acknowledged state, and an implementation that assigns the whole
+    // response method list would pass the pin written to catch it.
+    const emailA = `addrm-a-${Date.now()}@example.com`
+    const phoneC = '5555550144'
+    const { ids } = await testApi.seedContacts([
+      { full_name: 'Add Remove Target', methods: [{ type: 'email', value: emailA }] },
+    ])
+    const contactId = ids[0]
+
+    await openEditMode(page, contactId)
+    await addMethodOutOfBand(request, contactId, 'phone', '5555550145')
+    await failNotesStep(page, contactId)
+
+    // Add C in the form; the methods step lands, notes fails, form stays open.
+    await page.getByRole('button', { name: 'Add method' }).click()
+    await page.getByRole('combobox', { name: 'Contact method type' }).nth(1).selectOption('phone')
+    await methodValues(page).nth(1).fill(phoneC)
+    await save(page)
+    await expect(page.getByTestId('save-report')).toBeVisible({ timeout: 15000 })
+
+    const afterFirst = await getMethods(request, contactId)
+    expect(afterFirst.map(m => m.value).sort()).toEqual([emailA, '5555550145', phoneC].sort())
+
+    // Now delete C and save again. The client learned C's id from `results`.
+    const cIndex = await methodValues(page).evaluateAll(
+      (inputs, target) => inputs.findIndex(i => (i as HTMLInputElement).value === target),
+      phoneC
+    )
+    expect(
+      cIndex,
+      'the row added in the failed save should still be on screen'
+    ).toBeGreaterThanOrEqual(0)
+    await page.getByRole('button', { name: 'Remove' }).nth(cIndex).click()
+    await saveAndAwait(page, contactId, 'methods')
+
+    const methods = await getMethods(request, contactId)
+    const values = methods.map(m => m.value)
+    expect(values).not.toContain(phoneC)
+    // And the unseen B survived: the acknowledged state absorbed only the rows
+    // this client's own operations resolved to.
+    expect(values.sort()).toEqual([emailA, '5555550145'].sort())
+  })
+
+  test('a method added in a partially failed save can then be edited, keeping its identity', async ({
+    page,
+    request,
+  }) => {
+    // spec: CON-063[5]
+    const emailA = `addedit-a-${Date.now()}@example.com`
+    const phoneC = '5555550146'
+    const phoneCEdited = '5555550147'
+    const { ids } = await testApi.seedContacts([
+      { full_name: 'Add Edit Target', methods: [{ type: 'email', value: emailA }] },
+    ])
+    const contactId = ids[0]
+
+    await openEditMode(page, contactId)
+    await failNotesStep(page, contactId)
+
+    await page.getByRole('button', { name: 'Add method' }).click()
+    await page.getByRole('combobox', { name: 'Contact method type' }).nth(1).selectOption('phone')
+    await methodValues(page).nth(1).fill(phoneC)
+    await save(page)
+    await expect(page.getByTestId('save-report')).toBeVisible({ timeout: 15000 })
+
+    const created = (await getMethods(request, contactId)).find(m => m.value === phoneC)
+    expect(created, 'the added method should exist after the methods step landed').toBeTruthy()
+
+    const cIndex = await methodValues(page).evaluateAll(
+      (inputs, target) => inputs.findIndex(i => (i as HTMLInputElement).value === target),
+      phoneC
+    )
+    expect(
+      cIndex,
+      'the row added in the failed save should still be on screen'
+    ).toBeGreaterThanOrEqual(0)
+    await methodValues(page).nth(cIndex).fill(phoneCEdited)
+    await saveAndAwait(page, contactId, 'methods')
+
+    const edited = (await getMethods(request, contactId)).find(m => m.value === phoneCEdited)
+    expect(edited, 'the edit should have landed').toBeTruthy()
+    // Identity preserved. Skipping the results write-back turns this into a
+    // remove + add and mints a new id — a mild instance of the incident's own
+    // signature, and it would destroy the forensic evidence a future
+    // investigation would need.
+    expect(edited!.id).toBe(created!.id)
+  })
+
+  test('reverting a value after a partially failed save restores it on the server', async ({
+    page,
+    request,
+  }) => {
+    // spec: CON-063[6]
+    const emailA = `revert-a-${Date.now()}@example.com`
+    const emailIntermediate = `revert-b-${Date.now()}@example.com`
+    const { ids } = await testApi.seedContacts([
+      { full_name: 'Revert Target', methods: [{ type: 'email', value: emailA }] },
+    ])
+    const contactId = ids[0]
+
+    await openEditMode(page, contactId)
+    await failNotesStep(page, contactId)
+
+    await methodValues(page).first().fill(emailIntermediate)
+    await save(page)
+    await expect(page.getByTestId('save-report')).toBeVisible({ timeout: 15000 })
+    expect((await getMethods(request, contactId)).map(m => m.value)).toEqual([emailIntermediate])
+
+    // Revert. Against a frozen edit-start baseline this emits nothing, the save
+    // reports success, and the server silently keeps the intermediate value.
+    await methodValues(page).first().fill(emailA)
+    await saveAndAwait(page, contactId, 'methods')
+
+    expect((await getMethods(request, contactId)).map(m => m.value)).toEqual([emailA])
+  })
+})

--- a/frontend/tests/e2e/contacts.spec.ts
+++ b/frontend/tests/e2e/contacts.spec.ts
@@ -649,6 +649,32 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
   })
 
+  // spec: CON-055[0]
+  //
+  // ContactForm and transformContactFormData are SHARED with the edit path, and
+  // the edit path stopped sending `methods` on the contact PUT. Creation still
+  // must: there is nothing yet to lose, so CreateContactRequest keeps its
+  // methods field. This test passes against the pre-change tree by design — it
+  // guards a behavior that must not break, and its discrimination gate is
+  // mutating the shared transform to drop methods, not reverting the feature.
+  test('creates a contact with a contact method', async ({ page }) => {
+    const fullName = `${testApi.prefix}-Create With Method`
+    const email = `create-method-${Date.now()}@example.com`
+
+    await page.goto('/contacts/new')
+    await page.getByLabel('Full Name').fill(fullName)
+    await page.getByRole('combobox', { name: 'Contact method type' }).first().selectOption('email')
+    await page.getByRole('textbox', { name: 'Contact method value' }).first().fill(email)
+
+    await Promise.all([
+      page.waitForURL(/\/contacts\/[A-Za-z0-9-]+$/),
+      page.getByRole('button', { name: 'Create Contact' }).click(),
+    ])
+
+    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(email)).toBeVisible({ timeout: 15000 })
+  })
+
   // spec: NTS-008[2]
   test('should edit contact notes', async ({ page }) => {
     const notes =

--- a/frontend/tests/e2e/rematch-on-add-email.spec.ts
+++ b/frontend/tests/e2e/rematch-on-add-email.spec.ts
@@ -72,21 +72,23 @@ test.describe('Rematch on add email @area:contacts', () => {
     await expect(valueInput).toHaveAttribute('type', 'email')
     await valueInput.fill(attendeeEmail)
 
-    // The edit form also saves notes via PUT /contacts/:id/notes in parallel,
-    // so match the exact contact update route before reading rematch_job_id.
-    const contactUpdatePath = `/api/v1/contacts/${contactId}`
-    const updateResponsePromise = page.waitForResponse(res => {
+    // The rematch job is minted by the operations endpoint, not the contact
+    // PUT: a rematch fires on newly-present method VALUES, and the scalar PUT
+    // no longer carries methods at all.
+    const methodsPath = `/api/v1/contacts/${contactId}/methods`
+    const methodsResponsePromise = page.waitForResponse(res => {
       const { pathname } = new URL(res.url())
-      return (
-        pathname === contactUpdatePath && res.request().method() === 'PUT' && res.status() === 200
-      )
+      return pathname === methodsPath && res.request().method() === 'POST' && res.status() === 200
     })
     await page.getByRole('button', { name: 'Update Contact' }).click()
-    const updateResponse = await updateResponsePromise
-    expect(updateResponse.ok()).toBe(true)
-    const updateBody = await updateResponse.json()
-    const rematchJobId: string | undefined = updateBody?.data?.rematch_job_id
-    expect(rematchJobId, 'PUT /contacts response should carry rematch_job_id').toBeTruthy()
+    const methodsResponse = await methodsResponsePromise
+    expect(methodsResponse.ok()).toBe(true)
+    const methodsBody = await methodsResponse.json()
+    const rematchJobId: string | undefined = methodsBody?.data?.rematch_job_id
+    expect(
+      rematchJobId,
+      'POST /contacts/:id/methods response should carry rematch_job_id'
+    ).toBeTruthy()
 
     // The frontend polls the job silently; poll the backend directly here so
     // the test observes the pollable job endpoint (IMP-021) and fails fast.

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -509,6 +509,14 @@
     "tags": ["@area:contacts", "@area:meetings"]
   },
   {
+    "pattern": "^frontend/tests/e2e/contact-method-preservation\\.spec\\.ts$",
+    "tags": ["@area:contacts"]
+  },
+  {
+    "pattern": "^frontend/src/lib/contact-method-operations\\.ts$",
+    "tags": ["@area:contacts"]
+  },
+  {
     "pattern": "^backend/internal/service/rematch\\.go$",
     "tags": ["@area:contacts", "@area:meetings"]
   },

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -102,7 +102,7 @@ behaviors:
   - id: CON-008
     title: Method replacement is gated on the methods field being present
     type: business-logic
-    status: current
+    status: retired
     surface: none
     given: an existing contact with contact methods
     when: an update request is applied
@@ -110,6 +110,14 @@ behaviors:
       - if the methods field is omitted, existing methods are untouched
       - if the methods field is provided (including as an empty list), the method set is fully replaced
     provenance: [ContactHandler.UpdateContact, ContactService.replaceMethods]
+    notes: >
+      Retired rather than amended, because the behavior REVERSES: a methods
+      field on the update request is now rejected outright (CON-064) instead of
+      replacing the method set. Amending in place would leave any citation
+      pointing at inverted meaning. Wholesale replacement made absence read as
+      "delete", so a client saving from a stale read destroyed every method it
+      had never seen; methods are now mutated only through explicit operations
+      (CON-062), where absence expresses nothing.
 
   - id: CON-009
     title: Renaming a contact syncs its person-node label
@@ -191,11 +199,12 @@ behaviors:
     type: api
     status: current
     surface: api
-    given: a create request, a legacy update request carrying contact methods, or a method operations request
+    given: a create request or a method operations request
     when: methods are validated
     then:
-      - blank-valued entries are dropped rather than rejected on the create and legacy update paths
+      - blank-valued entries are dropped rather than rejected on the create path
       - an add or update operation naming a blank value is rejected rather than dropped
+      - an add or update operation whose value is empty once normalized is rejected rather than stored
       - email-family values must be valid email addresses
       - phone-family values are limited to 50 characters
       - two entries with the same type and normalized value are rejected as duplicates
@@ -762,6 +771,54 @@ behaviors:
       - a contact with a computed next-contact date renders that date, and one without renders a placeholder
     provenance: [contacts page table cells, formatCadence, contact_by]
     notes: The contact_by computation itself is backend-owned (CON-001); this row pins only the list's rendering of the derived values.
+
+  - id: CON-063
+    title: Saving a contact edit never removes methods the form did not show
+    type: ux
+    status: current
+    surface: ui
+    given: a contact edit form opened on a contact that has contact methods
+    when: the user edits and saves
+    then:
+      - a method added by another writer since the form opened is still present after the save, including when the user edited a different method in the same save
+      - a method the user explicitly deleted in the form is removed
+      - if part of the save fails, the user is told which parts were saved rather than being shown a generic failure
+      - retrying after a partial failure does not undo what already saved
+      - a method added in a save whose later step failed can still be removed by a follow-up save
+      - a method added in a save whose later step failed can still be edited by a follow-up save, keeping the same method
+      - reverting a method's value after a partially failed save restores the original value on the server
+    provenance: [deriveMethodOperations, ContactMethodService.ApplyOperations]
+    notes: >
+      The form derives operations against a client-known acknowledged state,
+      initialized at edit-start, so a method it never showed cannot appear in
+      any operation. That state must not be re-derived from server data
+      mid-save: a successful scalar PUT refreshes the detail cache, and a
+      re-derived picture would name the newly-visible method on a retry. It
+      does advance, but only by applying this client's own confirmed
+      operations using the ids the server reports per operation — without
+      which a row added in a partially failed save could not be edited or
+      removed afterwards, and a value reverted after a partial failure would
+      silently keep the intermediate value.
+
+  - id: CON-064
+    title: A methods field on the contact update request is rejected
+    type: api
+    status: current
+    surface: api
+    given: an update request for an existing contact
+    when: the request body carries a methods key
+    then:
+      - the request is rejected, naming the operations endpoint that does accept methods
+      - an explicit null and an empty list are rejected the same as a populated list
+      - none of the request's other fields are applied
+    provenance: [ContactHandler.UpdateContact, legacyContactMethodsProbe]
+    notes: >
+      Rejected rather than ignored. Dropping the now-unknown key would let a
+      stale browser or a naive client send a method addition, receive 200, and
+      believe it landed — a silent-success failure, the same class this work
+      eliminates, merely inverted from silent destruction. The empty list is the
+      destructive intent specifically: under the retired CON-008 it meant
+      "remove them all".
 
   - id: CON-062
     title: Contact methods are mutated by explicit operations

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -255,7 +255,7 @@ behaviors:
     type: business-logic
     status: current
     surface: api
-    given: new methods appearing on a CRM contact (create, method-replacing update, a method operations request, enrichment, or suggestion resolve)
+    given: new methods appearing on a CRM contact (create, a method operations request, enrichment, or suggestion resolve)
     when: the write commits
     then:
       - a rematch event is published for the methods that have a registered handler


### PR DESCRIPTION
## What

The contact edit form now derives **operations** from an acknowledged-state baseline and posts them to `POST /contacts/:id/methods`. The `methods` branch of `PUT /contacts/:id` is retired, and `CON-008` retires with it.

Final PR of a three-part arc. After this, no code path in the repository can delete a contact method that the client did not explicitly name.

## Why

A contact method added server-side by import-link enrichment was permanently destroyed by a subsequent edit-form save. `PUT /contacts/:id` treated a supplied `methods` array as a wholesale delete-and-recreate: absence implied deletion, so a client saving a stale list silently destroyed what it never knew about.

- **PR1** (#693) fixed the stale display — linking now invalidates the contact detail cache.
- **PR2** (#695) added the operations endpoint, purely additive.
- **This PR** switches the form over and removes the destructive primitive. Retirement lands here rather than later so that no released state has the form migrated while the branch is still reachable.

Design: `.ai/spec/2026-07-18-contact-method-lost-update-design.md`.

## The load-bearing idea

Two structures must agree: the **live form rows** and the **acknowledged state** (what the client knows the server has confirmed). Server data reaches them at exactly two points — edit-start, and per-operation result snapshots. Everything else server-originated (`setQueryData` after a mutation, prefetch, `RematchJobWatcher` invalidation, ordinary refetches) reaches **neither**, deliberately: those feed display only, which is what makes the acknowledged state safe to hold across a cache refresh.

The acknowledged baseline is captured at edit-start and survives session invalidation, retries, and cache refreshes; only payload and step progress reset on a form edit. It advances by applying **this client's own confirmed operations** — never by absorbing a server response wholesale, since that is how unseen server state contaminates a later derivation, which is the original incident.

That class is now pinned by a mechanical contract: every operation's submitted index must be in range and must **own** its row (an `add` points at the row carrying its own type and value; `update`/`set_primary`/`clear_primary` point at the row carrying their `method_id`), and only `remove` may be `-1`. The module documents both halves and why the index-exists half alone is insufficient.

## Review

Five Codex rounds, eight real findings: one P0, three P1, four test-quality. The last two rounds cleared the blocking bar.

The three sequential defects all had one shape — a path updating one structure without the other:

| Round | Defect | Consequence |
|---|---|---|
| R1 (P0) | collapse ownership seeded only from reconciliations | deleting a row reported success and did not persist |
| R2 (P1) | survivor promoted without demoting other live rows | two primaries; form validation then blocked an unedited retry |
| R3 (P1) | primary snapshots reached acknowledged state but not live rows | a later save emitted `update(id, stale)`, overwriting server state the form never displayed |

Patching each instance produced the next one. Enumerating the class — every point where server data enters the client — is what stopped it, and R4 was the first round with no finding in that path. R5 then found the enumeration's own invariant was *necessary but not sufficient*: it proved an index existed, not that it was the right one. Both the contract and its documentation now state what is actually pinned.

## Tests

30 mutations run, 3 discarded as defective (build failures are not discrimination) and redone. Every banked mutation failed on its intended assertion.

**Three mutations survived**, each revealing a fixture that could not observe the property it named:

- **survivor-is-last-row** — the collapsing pair sat at the end of the list, where first-survivor and last-survivor produce identical arrays. Re-fixtured off the end; now fails.
- **absorb-response-methods-wholesale** — *the original incident itself* — passed all 13 page tests, because no fixture seeded an unseen row into the **response** channel; the existing pins covered only the cache-refresh channel. Closed with a response carrying a row no operation addressed.
- **omit-demotion-when-snapshot-is-primary** — survived all collapse tests: one used a non-primary snapshot, one started with the survivor already primary. Both are cases where retained and demoted coincide.

They share one shape, now recorded as a rule: **when a property has a discrete alternative, at least one fixture must differ along exactly that axis while holding the rest constant.**

Also fixed: a reconciliation test that encoded the *pre-fix* contract and so positively endorsed the defect corrected the round before — a test can be worse than absent when it argues for reintroducing a bug.

## Notes

- Empty-normalization gap carried from PR2's gate is fixed here — values normalizing to empty (`"@@@"`, whitespace) are now rejected via the C6 mirror rather than only the literal empty string.
- `CON-008` retires (retire-and-mint; its behavior reverses rather than narrows).
- One commit avoids a stray render on the read-only detail view. It was speculative when written — flagged as such in its message — and is correct on its own merits regardless.
