### PR TITLE
perf(test): parallelize make test-deploy-scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,23 +544,21 @@ test-api:
 # cross-platform python3 plistlib parse (the __INSTALL_PREFIX__ placeholder lives
 # inside <string> values, so it parses fine); plutil is macOS-only and not used here.
 test-deploy-scripts:
-	@echo "Running deploy-script shell tests..."
-	@bash scripts/deploy-artifact.test.sh
-	@bash scripts/backup-db.test.sh
-	@bash scripts/restore-db.test.sh
-	@bash scripts/deploy-staging.test.sh
-	@bash scripts/staging-reset.test.sh
-	@bash scripts/ci/staging-reseed-decision.test.sh
-	@bash scripts/ci/qa-round-cadence-gate.test.sh
-	@bash scripts/ci/qa-nightly-round.test.sh
-	@bash scripts/ci/qa-fn-backfill-guard.test.sh
-	@bash scripts/staging-deployed-sha.test.sh
-	@bash scripts/staging-reseed.test.sh
-	@bash scripts/admin/setup-staging-reseed-host.sh.test.sh
-	@bash scripts/run-tours.test.sh
-	@bash scripts/reconcile-mac-daemon.test.sh
-	@bash scripts/setup-mac-deploy.test.sh
-	@bash scripts/trigger-mac-deploy.test.sh
+	@echo "Running deploy-script shell tests (parallel)..."
+	@tests="scripts/deploy-artifact.test.sh scripts/backup-db.test.sh scripts/restore-db.test.sh scripts/deploy-staging.test.sh scripts/staging-reset.test.sh scripts/ci/staging-reseed-decision.test.sh scripts/ci/qa-round-cadence-gate.test.sh scripts/ci/qa-nightly-round.test.sh scripts/ci/qa-fn-backfill-guard.test.sh scripts/staging-deployed-sha.test.sh scripts/staging-reseed.test.sh scripts/admin/setup-staging-reseed-host.sh.test.sh scripts/run-tours.test.sh scripts/reconcile-mac-daemon.test.sh scripts/setup-mac-deploy.test.sh scripts/trigger-mac-deploy.test.sh"; \
+	tmp="$$(mktemp -d)"; \
+	for t in $$tests; do \
+	  ( bash "$$t" >"$$tmp/$$(echo "$$t" | tr / _).out" 2>&1; echo "$$?" >"$$tmp/$$(echo "$$t" | tr / _).rc" ) & \
+	done; \
+	wait; \
+	fail=0; \
+	for t in $$tests; do \
+	  b="$$tmp/$$(echo "$$t" | tr / _)"; rc="$$(cat "$$b.rc" 2>/dev/null || echo 1)"; \
+	  if [ "$$rc" = 0 ]; then echo "  OK   $$t"; else echo "  FAIL $$t (exit $$rc):"; sed "s/^/      /" "$$b.out"; fail=1; fi; \
+	done; \
+	rm -rf "$$tmp"; \
+	[ "$$fail" = 0 ] || { echo "deploy-script shell tests FAILED"; exit 1; }; \
+	echo "All deploy-script shell tests passed."
 	@echo "Validating the committed timer template (plistlib parse)..."
 	@python3 -c "import plistlib,sys; plistlib.loads(open(sys.argv[1],'rb').read()); print('  timer template OK')" \
 		infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template


### PR DESCRIPTION
## What

Run the 16 deploy-script shell suites in `make test-deploy-scripts` **concurrently** (background + `wait`) and aggregate results, instead of 16 sequential `@bash x.test.sh` invocations.

## Why

The sequential form serializes 16 independent shell test suites. On this machine that's ~258s wall; the parallel form is **~116s (~2.2× faster)**, measured across two independent runs. This target runs in the pre-push LINT/FILTER lane and in CI's `backend-tests`, so the saving lands on every push and PR.

## How

- Collect the 16 test paths into a space-separated list.
- Fork each `bash "$t"` into a background subshell that captures its stdout+stderr to `$tmp/<key>.out` and its exit code to `$tmp/<key>.rc` (key = path with `/`→`_`; all 16 keys are distinct, so no clobbering).
- `wait` for all, then aggregate: print `OK`/`FAIL` per suite (FAIL echoes the captured output indented), set `fail=1` on any non-zero rc, and `exit 1` if any suite failed.
- The committed-timer-template plistlib validation step is unchanged.

## Verification

- **Timing:** 116s vs ~258s sequential, all 16 suites `OK` (two independent runs agree).
- **Fail-path (mutation test):** injected a stub suite that `exit 7` → target reports `FAIL ... (exit 7)`, prints its captured output, and exits `1`. A passing suite alongside it still reports `OK`. So failures are surfaced per-suite and the target fails loud.
- Full pre-push suite green (Lint + Go + Frontend + E2E).

Scripts/Makefile-only change; no product code touched.