### PR TITLE
fix(api): unblock make api-docs and regenerate the stale spec

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -24,9 +24,669 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/auth/google": {
+            "get": {
+                "description": "Get the URL to redirect user to for Google authorization",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Google OAuth authorization URL",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.GetGoogleAuthURLResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/accounts": {
+            "get": {
+                "description": "Get list of all connected Google accounts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "List connected Google accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.GoogleAccountResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/accounts/{id}/revoke": {
+            "post": {
+                "description": "Disconnect a Google account and revoke OAuth tokens",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Revoke Google account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/accounts/{id}/status": {
+            "get": {
+                "description": "Get the status of a specific connected Google account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Google account status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.GoogleAccountResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/callback": {
+            "get": {
+                "description": "Handle the OAuth callback from Google (redirects to frontend)",
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Google OAuth callback",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization code",
+                        "name": "code",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "State for CSRF protection",
+                        "name": "state",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Error from Google",
+                        "name": "error",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Redirect to frontend"
+                    }
+                }
+            }
+        },
+        "/auth/todoist": {
+            "get": {
+                "description": "Get the URL to redirect user to for Todoist authorization",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Todoist OAuth authorization URL",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.GetTodoistAuthURLResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/accounts": {
+            "get": {
+                "description": "Get list of all connected Todoist accounts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "List connected Todoist accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TodoistAccountResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/accounts/{id}/revoke": {
+            "post": {
+                "description": "Disconnect a Todoist account and revoke OAuth tokens",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Revoke Todoist account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/accounts/{id}/status": {
+            "get": {
+                "description": "Get the status of a specific connected Todoist account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Todoist account status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.TodoistAccountResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/callback": {
+            "get": {
+                "description": "Handle the OAuth callback from Todoist (redirects to frontend)",
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Todoist OAuth callback",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization code",
+                        "name": "code",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "State for CSRF protection",
+                        "name": "state",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Error from Todoist",
+                        "name": "error",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Redirect to frontend"
+                    }
+                }
+            }
+        },
         "/contacts": {
             "get": {
-                "description": "Get a paginated list of contacts with optional search",
+                "description": "Get a paginated list of contacts with optional search and sorting. Use ids_only=true to get just IDs for navigation.",
                 "produces": [
                     "application/json"
                 ],
@@ -55,8 +715,42 @@ const docTemplate = `{
                     {
                         "maxLength": 255,
                         "type": "string",
-                        "description": "Search term (name or email)",
+                        "description": "Search term (name or contact methods)",
                         "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "name",
+                            "location",
+                            "birthday",
+                            "last_contacted",
+                            "last_response_at",
+                            "contact_by",
+                            "cadence"
+                        ],
+                        "type": "string",
+                        "default": "\"\"",
+                        "description": "Sort by field",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "default": "\"asc\"",
+                        "description": "Sort order",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Return only contact IDs (for navigation)",
+                        "name": "ids_only",
                         "in": "query"
                     }
                 ],
@@ -183,8 +877,8 @@ const docTemplate = `{
                             ]
                         }
                     },
-                    "409": {
-                        "description": "Contact already exists",
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "allOf": [
                                 {
@@ -195,6 +889,41 @@ const docTemplate = `{
                                     "properties": {
                                         "error": {
                                             "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/overdue": {
+            "get": {
+                "description": "Get contacts that are overdue based on their cadence settings",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "List overdue contacts",
+                "responses": {
+                    "200": {
+                        "description": "Overdue contacts retrieved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.OverdueContactResponse"
+                                            }
                                         }
                                     }
                                 }
@@ -403,24 +1132,6 @@ const docTemplate = `{
                             ]
                         }
                     },
-                    "409": {
-                        "description": "Email already exists",
-                        "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/api.APIResponse"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "$ref": "#/definitions/api.APIError"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
@@ -520,9 +1231,4027 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/contacts/{id}/events": {
+            "get": {
+                "description": "Get calendar events involving a specific contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "calendar"
+                ],
+                "summary": "List calendar events for a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.CalendarEventResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/events/upcoming": {
+            "get": {
+                "description": "Get upcoming calendar events involving a specific contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "calendar"
+                ],
+                "summary": "List upcoming calendar events for a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Max items",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.CalendarEventResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/identities": {
+            "get": {
+                "description": "Get all external identities linked to a contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "List identities for contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.ExternalIdentity"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/interactions": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "List contact interactions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.InteractionResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "Create interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Interaction details",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.InteractionResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/merge": {
+            "post": {
+                "description": "Merge one contact into another. The source contact will be archived.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "Merge contacts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target Contact ID (contact to keep)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Merge request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.MergeContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Contacts merged successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ContactResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/merge/preview": {
+            "get": {
+                "description": "Get a preview of what will be merged when combining two contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "Preview contact merge",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target Contact ID (contact to keep)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Source Contact ID (contact to merge from)",
+                        "name": "source_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Merge preview retrieved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.MergePreviewResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid contact ID",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/methods": {
+            "post": {
+                "description": "Apply a batch of add/update/remove/set_primary/clear_primary operations to a contact's methods in one transaction. Absence expresses nothing: a method no operation names is never removed or altered.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "Apply contact-method operations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Operations to apply",
+                        "name": "operations",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ContactMethodOperationsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ContactMethodOperationsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed, conflicting, or unsatisfiable operations",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found, or an operation names a method owned by another contact",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/notes": {
+            "get": {
+                "description": "Get the notepad note for a contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "Get contact notepad",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Note retrieved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.NoteResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "204": {
+                        "description": "No note exists for this contact"
+                    },
+                    "400": {
+                        "description": "Invalid contact ID",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Create or update the notepad note for a contact. If body is empty or whitespace-only, deletes the note.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "Save contact notepad",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Note content",
+                        "name": "note",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SaveNoteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Note saved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.NoteResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "204": {
+                        "description": "Note deleted (empty body)"
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/tasks": {
+            "get": {
+                "description": "List all tasks for a contact with optional state, kind, and lifecycle filters.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contact-tasks"
+                ],
+                "summary": "List contact tasks",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by state (managed, completed, unmanaged, dismissed, pending_remote_create)",
+                        "name": "state",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by kind (reach_out, send, reminder, meet, action)",
+                        "name": "kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by lifecycle (manual, cadence_due, followup_loop)",
+                        "name": "lifecycle",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.ContactTaskResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new one-off task for a contact using Todoist Quick Add. Kind must be one of reach_out / send / reminder.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contact-tasks"
+                ],
+                "summary": "Create manual task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateManualTaskRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ContactTaskResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/tasks/{taskId}": {
+            "delete": {
+                "description": "Remove CRM tracking for a task (does not delete from Todoist)",
+                "tags": [
+                    "contact-tasks"
+                ],
+                "summary": "Delete task link",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/events/upcoming": {
+            "get": {
+                "description": "Get upcoming calendar events that have matched CRM contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "calendar"
+                ],
+                "summary": "List upcoming calendar events with CRM contacts",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.CalendarEventResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/unmatched": {
+            "get": {
+                "description": "Get external identities that couldn't be matched to CRM contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "List unmatched identities",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.ExternalIdentity"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/{id}": {
+            "get": {
+                "description": "Get an external identity by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Get identity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalIdentity"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete an external identity",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Delete identity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/{id}/link": {
+            "post": {
+                "description": "Manually link an external identity to a CRM contact",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Link identity to contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/LinkIdentityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalIdentity"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/{id}/unlink": {
+            "post": {
+                "description": "Unlink an external identity from its CRM contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Unlink identity from contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalIdentity"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/candidates": {
+            "get": {
+                "description": "Get unmatched external contacts that can be imported as CRM contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "List import candidates",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source filter (e.g., gcontacts)",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.ImportCandidateResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/suggestions": {
+            "get": {
+                "description": "Method-suggestion group + confidence-ranked import candidates as a SuggestionItem union",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "List suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source filter",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.SuggestionItemResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/suggestions/{id}/methods/dismiss": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Dismiss method suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Selected methods (empty = all)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DismissMethodSuggestionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.DismissMethodSuggestionsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/suggestions/{id}/methods/resolve": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Resolve method suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Selected methods (empty = all)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ResolveMethodSuggestionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ResolveMethodSuggestionsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}": {
+            "get": {
+                "description": "Get details of a specific import candidate",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Get import candidate",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalContact"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}/ignore": {
+            "post": {
+                "description": "Mark an external contact as ignored (won't appear in candidates)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Ignore contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}/import": {
+            "post": {
+                "description": "Create a new CRM contact from an external contact",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Import contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional method selection",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ImportRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ImportContactResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}/link": {
+            "post": {
+                "description": "Link an external contact to an existing CRM contact and enrich it",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Link to existing contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.LinkRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.LinkContactResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{id}": {
+            "delete": {
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "Delete interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Interaction ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Interaction deleted"
+                    }
+                }
+            }
+        },
+        "/rematch/contacts/{id}/rescan": {
+            "post": {
+                "description": "Re-runs rematch handlers for every method currently on the contact.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rematch"
+                ],
+                "summary": "Trigger rematch for a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.RescanResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/rematch/jobs/{jobID}": {
+            "get": {
+                "description": "Returns the progress of a rematch job by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rematch"
+                ],
+                "summary": "Get rematch job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Rematch job ID",
+                        "name": "jobID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.RematchJobResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/logs": {
+            "get": {
+                "description": "Get the most recent sync operation logs across all sources",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get recent sync logs",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Number of logs to return",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.SyncLog"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/providers": {
+            "get": {
+                "description": "Get list of registered sync providers and their configurations",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "List available sync providers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/sync.SourceConfig"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/staleness": {
+            "get": {
+                "description": "Get the sync sources currently breaching their freshness thresholds",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "List active sync-staleness breaches",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.StalenessBreach"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/status": {
+            "get": {
+                "description": "Get the current sync status for all external data sources",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get sync status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.SyncState"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{id}/enable": {
+            "patch": {
+                "description": "Enable or disable sync for an external data source",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Enable/disable sync",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sync state ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable or disable",
+                        "name": "enabled",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.SyncState"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{id}/logs": {
+            "get": {
+                "description": "Get sync operation logs for an external data source",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get sync logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sync state ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.SyncLog"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{source}/status": {
+            "get": {
+                "description": "Get the sync state for a specific external data source",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get sync state for a source",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name (e.g., gmail, imessage)",
+                        "name": "source",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account ID (for multi-account sources)",
+                        "name": "account_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.SyncState"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{source}/trigger": {
+            "post": {
+                "description": "Manually trigger a sync operation for an external data source",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Trigger sync for a source",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name (e.g., gmail, imessage)",
+                        "name": "source",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sync trigger options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/TriggerSyncRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/cleanup": {
+            "post": {
+                "description": "Delete test data (contacts and external contacts) by prefix",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Cleanup test data",
+                "parameters": [
+                    {
+                        "description": "Cleanup request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CleanupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.CleanupResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/calendar-events": {
+            "post": {
+                "description": "Create calendar events linked to a contact for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed calendar events for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedCalendarEventsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedCalendarEventsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/contacts": {
+            "post": {
+                "description": "Create contacts with optional methods, location, notes, and cadence for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed contacts for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedContactsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/external-contacts": {
+            "post": {
+                "description": "Create import candidates in the external_contact table for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed external contacts for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedExternalContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedExternalContactsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/meeting-notes": {
+            "post": {
+                "description": "Create orphan_needs_review meeting_note rows for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed orphan meeting notes for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedMeetingNotesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedMeetingNotesResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/method-suggestions": {
+            "post": {
+                "description": "Create a linked imported address-book row with pending_method_suggestions for e2e",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed method suggestions for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedMethodSuggestionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedMethodSuggestionsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/overdue-contacts": {
+            "post": {
+                "description": "Create contacts with backdated last_contacted for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed overdue contacts for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedOverdueContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedOverdueContactsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/trigger-error": {
+            "post": {
+                "description": "Trigger a server error for error boundary testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Trigger error for testing",
+                "parameters": [
+                    {
+                        "description": "Error request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.TriggerErrorRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/todoist/labels": {
+            "get": {
+                "description": "Get all labels from the connected Todoist account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "List Todoist labels",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TodoistLabelResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/todoist/projects": {
+            "get": {
+                "description": "Get all projects from the connected Todoist account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "List Todoist projects",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TodoistProjectResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/todoist/settings": {
+            "get": {
+                "description": "Get the current Todoist integration settings (project, label)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "Get Todoist settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.TodoistSettingsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Update the Todoist integration settings (project, label)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "Update Todoist settings",
+                "parameters": [
+                    {
+                        "description": "Settings update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.TodoistSettingsUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.TodoistSettingsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "LinkIdentityRequest": {
+            "description": "Request body for manually linking an identity to a contact",
+            "type": "object",
+            "required": [
+                "contact_id"
+            ],
+            "properties": {
+                "contact_id": {
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                }
+            }
+        },
+        "TriggerSyncRequest": {
+            "description": "Request body for triggering a sync operation",
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "user@gmail.com"
+                }
+            }
+        },
         "api.APIError": {
             "type": "object",
             "properties": {
@@ -555,17 +5284,305 @@ const docTemplate = `{
         "api.Meta": {
             "type": "object",
             "properties": {
+                "hidden_unresolved_telegram_count": {
+                    "type": "integer"
+                },
+                "pagination": {
+                    "$ref": "#/definitions/api.PaginationMeta"
+                }
+            }
+        },
+        "api.PaginationMeta": {
+            "type": "object",
+            "properties": {
                 "limit": {
                     "type": "integer"
                 },
                 "page": {
                     "type": "integer"
                 },
-                "total": {
+                "pages": {
                     "type": "integer"
                 },
-                "total_pages": {
+                "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "handlers.CalendarEventResponse": {
+            "type": "object",
+            "properties": {
+                "attendee_count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "html_link": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CandidateSuggestionResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "allowed_actions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "photo_url": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "suggested_match": {
+                    "$ref": "#/definitions/handlers.SuggestedMatch"
+                }
+            }
+        },
+        "handlers.CleanupRequest": {
+            "type": "object",
+            "required": [
+                "prefix"
+            ],
+            "properties": {
+                "host_id": {
+                    "description": "HostID, when set, also hard-deletes every meeting_note owned by that\nmac_host (seeded session UUIDs are random, so there is no prefix to\nmatch on — cleanup is by host instead).",
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.CleanupResponse": {
+            "type": "object",
+            "properties": {
+                "deleted_calendar_events": {
+                    "type": "integer"
+                },
+                "deleted_contacts": {
+                    "type": "integer"
+                },
+                "deleted_external_contacts": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.ContactMethodOperation": {
+            "description": "A single contact-method operation",
+            "type": "object",
+            "required": [
+                "op"
+            ],
+            "properties": {
+                "is_primary": {
+                    "description": "IsPrimary is a pointer so the handler can tell \"absent\" from \"present and\nfalse\". The field is forbidden on update, which is a presence test — a\nplain bool would silently accept an explicit false.",
+                    "type": "boolean",
+                    "example": true
+                },
+                "method_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "op": {
+                    "type": "string",
+                    "enum": [
+                        "add",
+                        "update",
+                        "remove",
+                        "set_primary",
+                        "clear_primary"
+                    ],
+                    "example": "add"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ],
+                    "example": "email"
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "example": "john.doe@example.com"
+                }
+            }
+        },
+        "handlers.ContactMethodOperationResult": {
+            "description": "Result of a single contact-method operation",
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "method": {
+                    "$ref": "#/definitions/handlers.ContactMethodResponse"
+                },
+                "method_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "outcome": {
+                    "type": "string",
+                    "example": "created"
+                }
+            }
+        },
+        "handlers.ContactMethodOperationsRequest": {
+            "description": "Contact-method operations request",
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodOperation"
+                    }
+                }
+            }
+        },
+        "handlers.ContactMethodOperationsResponse": {
+            "description": "Contact-method operations response",
+            "type": "object",
+            "properties": {
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodResponse"
+                    }
+                },
+                "rematch_job_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodOperationResult"
+                    }
+                }
+            }
+        },
+        "handlers.ContactMethodRequest": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "is_primary": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "type": {
+                    "description": "Note: legacy email_personal/email_work are no longer accepted; clients should send \"email\".",
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ],
+                    "example": "email"
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "example": "john.doe@example.com"
+                }
+            }
+        },
+        "handlers.ContactMethodResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "is_primary": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "type": {
+                    "type": "string",
+                    "example": "email"
+                },
+                "value": {
+                    "type": "string",
+                    "example": "john.doe@example.com"
                 }
             }
         },
@@ -588,17 +5605,20 @@ const docTemplate = `{
                     ],
                     "example": "monthly"
                 },
+                "contact_by": {
+                    "type": "string",
+                    "example": "2024-02-15T00:00:00Z"
+                },
                 "created_at": {
                     "type": "string",
                     "example": "2024-01-01T00:00:00Z"
                 },
-                "email": {
-                    "type": "string",
-                    "example": "john.doe@example.com"
-                },
                 "full_name": {
                     "type": "string",
                     "example": "John Doe"
+                },
+                "has_pending_followup": {
+                    "type": "boolean"
                 },
                 "how_met": {
                     "type": "string",
@@ -612,17 +5632,35 @@ const docTemplate = `{
                     "type": "string",
                     "example": "2024-01-15T10:30:00Z"
                 },
+                "last_interaction_at": {
+                    "type": "string"
+                },
+                "last_outreach_at": {
+                    "type": "string"
+                },
+                "last_response_at": {
+                    "type": "string"
+                },
                 "location": {
                     "type": "string",
                     "example": "San Francisco, CA"
                 },
-                "phone": {
-                    "type": "string",
-                    "example": "+1-555-0123"
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodResponse"
+                    }
+                },
+                "primary_method": {
+                    "$ref": "#/definitions/handlers.ContactMethodResponse"
                 },
                 "profile_photo": {
                     "type": "string",
                     "example": "https://example.com/photo.jpg"
+                },
+                "rematch_job_id": {
+                    "description": "RematchJobID is populated by the CREATE path only. A rematch is triggered\nby newly-present method values, and update no longer carries methods, so\nit has no job to report. This type is shared by create, get, update, list,\nmerge, and overdue; the field is omitempty, so a path that leaves it unset\nsimply omits the key rather than publishing an always-null contract.",
+                    "type": "string"
                 },
                 "updated_at": {
                     "type": "string",
@@ -630,12 +5668,492 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.ContactTaskResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "due_date": {
+                    "type": "string"
+                },
+                "external_task_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "lifecycle": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.CreateContactRequest": {
-            "description": "Create contact request",
+            "type": "object"
+        },
+        "handlers.CreateInteractionRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "direction": {
+                    "type": "string"
+                },
+                "occurred_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CreateManualTaskRequest": {
             "type": "object",
             "required": [
-                "full_name"
+                "kind",
+                "text"
             ],
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "reach_out",
+                        "send",
+                        "reminder"
+                    ]
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "text": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.DateOnly": {
+            "type": "object",
+            "properties": {
+                "time.Time": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.DismissMethodSuggestionsRequest": {
+            "type": "object",
+            "properties": {
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MethodSuggestionSelectionInput"
+                    }
+                }
+            }
+        },
+        "handlers.DismissMethodSuggestionsResponse": {
+            "type": "object",
+            "properties": {
+                "dismissed_count": {
+                    "type": "integer"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.GetGoogleAuthURLResponse": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.GetTodoistAuthURLResponse": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.GoogleAccountResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "account_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ImportCandidateResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "photo_url": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "suggested_match": {
+                    "$ref": "#/definitions/handlers.SuggestedMatch"
+                }
+            }
+        },
+        "handlers.ImportContactResponse": {
+            "type": "object",
+            "properties": {
+                "contact": {
+                    "$ref": "#/definitions/handlers.ContactResponse"
+                },
+                "rematch_job_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ImportRequest": {
+            "type": "object",
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "selected_methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.SelectedMethodInput"
+                    }
+                }
+            }
+        },
+        "handlers.InteractionResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "direction": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "occurred_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "source_ref": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.LinkContactResponse": {
+            "type": "object",
+            "properties": {
+                "external_contact": {
+                    "$ref": "#/definitions/repository.ExternalContact"
+                },
+                "rematch_job_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.LinkRequest": {
+            "type": "object",
+            "required": [
+                "crm_contact_id"
+            ],
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
+                },
+                "conflict_resolutions": {
+                    "description": "value -\u003e \"use_crm\" | \"use_external\"",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "crm_contact_id": {
+                    "type": "string"
+                },
+                "methods_curated": {
+                    "description": "MethodsCurated is true when the candidate offered methods to select\n(the modal rendered the method-selection UI) and the user made a\nselection decision — even if SelectedMethods ends up empty (user\ndeselected all). It distinguishes an explicit empty selection from a\nbare auto-match, since a nil slice and an explicit [] are\nindistinguishable in Go after JSON unmarshal. The frontend sets it\nONLY when the candidate actually had methods to curate (a\nzero-method candidate offered no curation choice → false → stays\nmatched).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "selected_methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.SelectedMethodInput"
+                    }
+                }
+            }
+        },
+        "handlers.MergeContactsRequest": {
+            "description": "Merge contacts request",
+            "type": "object",
+            "required": [
+                "source_contact_id"
+            ],
+            "properties": {
+                "field_selections": {
+                    "$ref": "#/definitions/handlers.MergeFieldSelectionsRequest"
+                },
+                "new_name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "example": "John Smith"
+                },
+                "source_contact_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                }
+            }
+        },
+        "handlers.MergeFieldSelectionsRequest": {
+            "type": "object",
+            "properties": {
+                "birthday": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target"
+                    ],
+                    "example": "target"
+                },
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target"
+                    ],
+                    "example": "target"
+                },
+                "location": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target"
+                    ],
+                    "example": "source"
+                }
+            }
+        },
+        "handlers.MergePreviewResponse": {
+            "description": "Merge preview response",
+            "type": "object",
+            "properties": {
+                "calendar_events_to_update": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "duplicate_methods": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "interactions_to_transfer": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "methods_to_transfer": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "notes_to_transfer": {
+                    "type": "integer",
+                    "example": 5
+                },
+                "source_contact": {
+                    "$ref": "#/definitions/handlers.ContactResponse"
+                },
+                "target_contact": {
+                    "$ref": "#/definitions/handlers.ContactResponse"
+                }
+            }
+        },
+        "handlers.MethodSuggestionMethodDTO": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.MethodSuggestionResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "contact_name": {
+                    "type": "string"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                },
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MethodSuggestionMethodDTO"
+                    }
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.MethodSuggestionSelectionInput": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.NoteResponse": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "contact_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.OverdueContactResponse": {
+            "description": "Overdue contact information with action metadata",
+            "type": "object",
             "properties": {
                 "birthday": {
                     "type": "string",
@@ -652,91 +6170,1241 @@ const docTemplate = `{
                     ],
                     "example": "monthly"
                 },
-                "email": {
+                "contact_by": {
+                    "type": "string",
+                    "example": "2024-02-15T00:00:00Z"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00Z"
+                },
+                "days_overdue": {
+                    "type": "integer",
+                    "example": 5
+                },
+                "full_name": {
+                    "type": "string",
+                    "example": "John Doe"
+                },
+                "has_pending_followup": {
+                    "type": "boolean"
+                },
+                "how_met": {
+                    "type": "string",
+                    "example": "Met at tech conference"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "last_contacted": {
+                    "type": "string",
+                    "example": "2024-01-15T10:30:00Z"
+                },
+                "last_interaction_at": {
+                    "type": "string"
+                },
+                "last_outreach_at": {
+                    "type": "string"
+                },
+                "last_response_at": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string",
+                    "example": "San Francisco, CA"
+                },
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodResponse"
+                    }
+                },
+                "next_due_date": {
+                    "type": "string",
+                    "example": "2024-01-15T00:00:00Z"
+                },
+                "primary_method": {
+                    "$ref": "#/definitions/handlers.ContactMethodResponse"
+                },
+                "profile_photo": {
+                    "type": "string",
+                    "example": "https://example.com/photo.jpg"
+                },
+                "rematch_job_id": {
+                    "description": "RematchJobID is populated by the CREATE path only. A rematch is triggered\nby newly-present method values, and update no longer carries methods, so\nit has no job to report. This type is shared by create, get, update, list,\nmerge, and overdue; the field is omitempty, so a path that leaves it unset\nsimply omits the key rather than publishing an always-null contract.",
+                    "type": "string"
+                },
+                "suggested_action": {
+                    "type": "string",
+                    "example": "Send a quick check-in message"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2024-01-15T10:30:00Z"
+                }
+            }
+        },
+        "handlers.RematchJobMethod": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.RematchJobResponse": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "contact_id": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "matched": {
+                    "type": "integer"
+                },
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.RematchJobMethod"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.RescanResponse": {
+            "type": "object",
+            "properties": {
+                "rematch_job_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ResolveMethodSuggestionsRequest": {
+            "type": "object",
+            "properties": {
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MethodSuggestionSelectionInput"
+                    }
+                }
+            }
+        },
+        "handlers.ResolveMethodSuggestionsResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                },
+                "rematch_job_id": {
+                    "type": "string"
+                },
+                "resolved_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.SaveNoteRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "maxLength": 50000
+                }
+            }
+        },
+        "handlers.SeedCalendarEventInput": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "attendee_emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "days_ago": {
+                    "description": "If is_past, how many days ago (default: 7)",
+                    "type": "integer"
+                },
+                "days_ahead": {
+                    "description": "If not is_past, how many days ahead (default: 7)",
+                    "type": "integer"
+                },
+                "html_link": {
+                    "type": "string"
+                },
+                "is_past": {
+                    "description": "If true, event is set in the past",
+                    "type": "boolean"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "title": {
                     "type": "string",
                     "maxLength": 255,
-                    "example": "john.doe@example.com"
+                    "minLength": 1
+                },
+                "unmatched": {
+                    "description": "Unmatched, when true, seeds the event with attendee emails but does NOT\nadd contact_id to matched_contact_ids. Used for rematch E2E tests.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "handlers.SeedCalendarEventsRequest": {
+            "type": "object",
+            "required": [
+                "contact_id",
+                "events",
+                "prefix"
+            ],
+            "properties": {
+                "contact_id": {
+                    "description": "Primary contact to link events to",
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "maxItems": 50,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedCalendarEventInput"
+                    }
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedCalendarEventsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedContactInput": {
+            "type": "object",
+            "required": [
+                "full_name"
+            ],
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
                 },
                 "full_name": {
                     "type": "string",
                     "maxLength": 255,
-                    "minLength": 1,
-                    "example": "John Doe"
+                    "minLength": 1
                 },
-                "how_met": {
-                    "type": "string",
-                    "maxLength": 500,
-                    "example": "Met at tech conference"
+                "last_contacted_days_ago": {
+                    "type": "integer",
+                    "maximum": 3650,
+                    "minimum": 0
                 },
                 "location": {
                     "type": "string",
-                    "maxLength": 255,
-                    "example": "San Francisco, CA"
+                    "maxLength": 255
                 },
-                "phone": {
+                "methods": {
+                    "type": "array",
+                    "maxItems": 20,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedContactMethodInput"
+                    }
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 2000
+                }
+            }
+        },
+        "handlers.SeedContactMethodInput": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "is_primary": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ]
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "handlers.SeedContactsRequest": {
+            "type": "object",
+            "required": [
+                "contacts",
+                "prefix"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedContactInput"
+                    }
+                },
+                "prefix": {
                     "type": "string",
                     "maxLength": 50,
-                    "example": "+1-555-0123"
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedContactsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
                 },
-                "profile_photo": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedExternalContactInput": {
+            "type": "object",
+            "properties": {
+                "display_name": {
                     "type": "string",
-                    "maxLength": 500,
-                    "example": "https://example.com/photo.jpg"
+                    "maxLength": 255
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "first_name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "test",
+                        "telegram",
+                        "gcontacts",
+                        "gcal_attendee",
+                        "icloud_contacts",
+                        "anarlog_humans",
+                        "anarlog_title",
+                        "gmail_correspondence"
+                    ]
+                }
+            }
+        },
+        "handlers.SeedExternalContactsRequest": {
+            "type": "object",
+            "required": [
+                "contacts",
+                "prefix"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedExternalContactInput"
+                    }
+                },
+                "host_id": {
+                    "description": "HostID associates the seeded rows with a specific mac_host. Used\nby host-scoped tests (e.g., the GET /host/:id/source-counts\nendpoint). Optional — when unset, rows are seeded with NULL\nhost_id.",
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedExternalContactsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedMeetingNoteInput": {
+            "type": "object",
+            "required": [
+                "anarlog_session_id"
+            ],
+            "properties": {
+                "anarlog_session_id": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 500
+                }
+            }
+        },
+        "handlers.SeedMeetingNotesRequest": {
+            "type": "object",
+            "required": [
+                "host_id",
+                "notes"
+            ],
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "array",
+                    "maxItems": 50,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedMeetingNoteInput"
+                    }
+                }
+            }
+        },
+        "handlers.SeedMeetingNotesResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedMethodSuggestionMethodInput": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ]
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "handlers.SeedMethodSuggestionsRequest": {
+            "type": "object",
+            "required": [
+                "contact_name",
+                "pending",
+                "prefix"
+            ],
+            "properties": {
+                "contact_name": {
+                    "description": "ContactName is the linked contact's name (prefix is prepended for\ncleanup). The seeded contact carries no methods, so the pending\nsuggestions are not pre-applied.",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                },
+                "dismissed": {
+                    "type": "array",
+                    "maxItems": 20,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedMethodSuggestionMethodInput"
+                    }
+                },
+                "pending": {
+                    "type": "array",
+                    "maxItems": 20,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedMethodSuggestionMethodInput"
+                    }
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                },
+                "source": {
+                    "description": "Source must be an address-book source (the suggestion surface is\nv1-scoped to these).",
+                    "type": "string",
+                    "enum": [
+                        "gcontacts",
+                        "icloud_contacts"
+                    ]
+                }
+            }
+        },
+        "handlers.SeedMethodSuggestionsResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.SeedOverdueContactInput": {
+            "type": "object",
+            "required": [
+                "cadence",
+                "days_overdue",
+                "full_name"
+            ],
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
+                },
+                "days_overdue": {
+                    "type": "integer",
+                    "maximum": 365,
+                    "minimum": 1
+                },
+                "email": {
+                    "type": "string"
+                },
+                "full_name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedOverdueContactsRequest": {
+            "type": "object",
+            "required": [
+                "contacts",
+                "prefix"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedOverdueContactInput"
+                    }
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedOverdueContactsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SelectedMethodInput": {
+            "type": "object",
+            "required": [
+                "original_value",
+                "type"
+            ],
+            "properties": {
+                "is_primary": {
+                    "type": "boolean"
+                },
+                "original_value": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "signal",
+                        "discord",
+                        "twitter",
+                        "gchat",
+                        "whatsapp"
+                    ]
+                }
+            }
+        },
+        "handlers.SuggestedMatch": {
+            "type": "object",
+            "properties": {
+                "confidence": {
+                    "type": "number"
+                },
+                "contact_id": {
+                    "type": "string"
+                },
+                "contact_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.SuggestionItemResponse": {
+            "type": "object",
+            "properties": {
+                "candidate": {
+                    "$ref": "#/definitions/handlers.CandidateSuggestionResponse"
+                },
+                "kind": {
+                    "description": "\"contact\" | \"method\"",
+                    "type": "string"
+                },
+                "suggestion": {
+                    "$ref": "#/definitions/handlers.MethodSuggestionResponse"
+                }
+            }
+        },
+        "handlers.TodoistAccountResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "account_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistLabelResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistProjectResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistSettingsResponse": {
+            "type": "object",
+            "properties": {
+                "integration_instance_id": {
+                    "type": "string"
+                },
+                "label_id": {
+                    "type": "string"
+                },
+                "label_name": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "user_timezone": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistSettingsUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "label_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TriggerErrorRequest": {
+            "type": "object",
+            "required": [
+                "error_type"
+            ],
+            "properties": {
+                "error_type": {
+                    "type": "string",
+                    "enum": [
+                        "500",
+                        "panic"
+                    ]
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },
         "handlers.UpdateContactRequest": {
-            "description": "Update contact request",
-            "type": "object",
-            "required": [
-                "full_name"
+            "type": "object"
+        },
+        "identity.IdentifierType": {
+            "type": "string",
+            "enum": [
+                "email",
+                "phone",
+                "telegram",
+                "imessage_email",
+                "imessage_phone",
+                "whatsapp",
+                "gchat",
+                "anarlog_human_id"
             ],
+            "x-enum-varnames": [
+                "IdentifierTypeEmail",
+                "IdentifierTypePhone",
+                "IdentifierTypeTelegram",
+                "IdentifierTypeIMessageEmail",
+                "IdentifierTypeIMessagePhone",
+                "IdentifierTypeWhatsApp",
+                "IdentifierTypeGChat",
+                "IdentifierTypeAnarlogHuman"
+            ]
+        },
+        "repository.AddressEntry": {
+            "type": "object",
             "properties": {
+                "formatted": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.EmailEntry": {
+            "type": "object",
+            "properties": {
+                "primary": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.ExternalContact": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.AddressEntry"
+                    }
+                },
                 "birthday": {
-                    "type": "string",
-                    "example": "1990-01-15T00:00:00Z"
+                    "type": "string"
                 },
-                "cadence": {
-                    "type": "string",
-                    "enum": [
-                        "weekly",
-                        "monthly",
-                        "quarterly",
-                        "biannual",
-                        "annual"
-                    ],
-                    "example": "monthly"
+                "created_at": {
+                    "type": "string"
                 },
-                "email": {
-                    "type": "string",
-                    "maxLength": 255,
-                    "example": "john.doe@example.com"
+                "crm_contact_id": {
+                    "type": "string"
                 },
-                "full_name": {
-                    "type": "string",
-                    "maxLength": 255,
-                    "minLength": 1,
-                    "example": "John Doe"
+                "deleted_at": {
+                    "description": "DeletedAt is set when a soft-delete tombstones the row. Production\nread queries filter ` + "`" + `deleted_at IS NULL` + "`" + ` so a tombstoned row only\nsurfaces through GetBySource (intentionally tombstone-aware for the\nmac-daemon revive path).",
+                    "type": "string"
                 },
-                "how_met": {
-                    "type": "string",
-                    "maxLength": 500,
-                    "example": "Met at tech conference"
+                "display_name": {
+                    "type": "string"
                 },
-                "location": {
-                    "type": "string",
-                    "maxLength": 255,
-                    "example": "San Francisco, CA"
+                "duplicate_of_id": {
+                    "type": "string"
                 },
-                "phone": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "example": "+1-555-0123"
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.EmailEntry"
+                    }
                 },
-                "profile_photo": {
-                    "type": "string",
-                    "maxLength": 500,
-                    "example": "https://example.com/photo.jpg"
+                "etag": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "host_id": {
+                    "description": "HostID is the paired Mac host that claimed this row (mac-daemon\nsources only). Written on INSERT and on UPDATE via\nCOALESCE(existing, EXCLUDED) — a NULL row (legacy or never-claimed)\nis claimed by the next non-NULL emit; non-NULL ownership is\npreserved thereafter across all subsequent upserts.",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_content_hash": {
+                    "description": "LastContentHash is the lowercase-hex SHA-256 of the JCS-\ncanonicalized payload (minus host_id) that produced this row's\ncurrent content. Written on every UPSERT for mac-daemon sources;\npreserved on soft-delete so a future delete-event can validate\nagainst the prior hash. Powers GET /sync/:source/known-ids.",
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "match_status": {
+                    "$ref": "#/definitions/repository.MatchStatus"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.PhoneEntry"
+                    }
+                },
+                "photo_url": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "synced_at": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.ExternalIdentity": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "identifier": {
+                    "type": "string"
+                },
+                "identifier_type": {
+                    "$ref": "#/definitions/identity.IdentifierType"
+                },
+                "last_seen_at": {
+                    "type": "string"
+                },
+                "match_confidence": {
+                    "type": "number"
+                },
+                "match_type": {
+                    "$ref": "#/definitions/repository.MatchType"
+                },
+                "message_count": {
+                    "type": "integer"
+                },
+                "raw_identifier": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.MatchStatus": {
+            "type": "string",
+            "enum": [
+                "matched",
+                "unmatched",
+                "ignored",
+                "imported"
+            ],
+            "x-enum-varnames": [
+                "MatchStatusMatched",
+                "MatchStatusUnmatched",
+                "MatchStatusIgnored",
+                "MatchStatusImported"
+            ]
+        },
+        "repository.MatchType": {
+            "type": "string",
+            "enum": [
+                "exact",
+                "fuzzy",
+                "manual",
+                "unmatched"
+            ],
+            "x-enum-varnames": [
+                "MatchTypeExact",
+                "MatchTypeFuzzy",
+                "MatchTypeManual",
+                "MatchTypeUnmatched"
+            ]
+        },
+        "repository.PhoneEntry": {
+            "type": "object",
+            "properties": {
+                "primary": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.StalenessBreach": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "breach_type": {
+                    "type": "string"
+                },
+                "details": {
+                    "type": "string"
+                },
+                "detected_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_observed_at": {
+                    "type": "string"
+                },
+                "resolved_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "stale_since": {
+                    "type": "string"
+                },
+                "threshold_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "repository.SyncLog": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "items_created": {
+                    "type": "integer"
+                },
+                "items_matched": {
+                    "type": "integer"
+                },
+                "items_processed": {
+                    "type": "integer"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "source": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "sync_state_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.SyncState": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "error_count": {
+                    "type": "integer"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_successful_sync_at": {
+                    "type": "string"
+                },
+                "last_sync_at": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "next_sync_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/repository.SyncStatus"
+                },
+                "strategy": {
+                    "$ref": "#/definitions/repository.SyncStrategy"
+                },
+                "sync_cursor": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.SyncStatus": {
+            "type": "string",
+            "enum": [
+                "idle",
+                "error",
+                "disabled"
+            ],
+            "x-enum-varnames": [
+                "SyncStatusIdle",
+                "SyncStatusError",
+                "SyncStatusDisabled"
+            ]
+        },
+        "repository.SyncStrategy": {
+            "type": "string",
+            "enum": [
+                "contact_driven",
+                "fetch_all",
+                "fetch_filtered",
+                "push"
+            ],
+            "x-enum-varnames": [
+                "SyncStrategyContactDriven",
+                "SyncStrategyFetchAll",
+                "SyncStrategyFetchFiltered",
+                "SyncStrategyPush"
+            ]
+        },
+        "sync.SourceConfig": {
+            "type": "object",
+            "properties": {
+                "default_interval": {
+                    "description": "swaggertype is required: swag cannot resolve time.Duration and fails the\nwhole generation, which silently left the spec stale (see the handler\nannotation that exposes this struct). It marshals as an integer\nnanosecond count, so that is what the spec must declare.",
+                    "type": "integer"
+                },
+                "display_name": {
+                    "description": "e.g., \"Gmail\", \"iMessage\", \"Telegram\"",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "e.g., \"gmail\", \"imessage\", \"telegram\"",
+                    "type": "string"
+                },
+                "requires_account": {
+                    "description": "RequiresAccount declares that this provider's Sync requires a non-nil,\nnon-empty account ID (e.g. its OAuth token is keyed by account). When\ntrue, TriggerSync rejects a nil/empty account instead of bootstrapping a\nsync_state row that would error on every dispatch. Defaults to false\n(the correct value for push providers whose Sync is account-agnostic).",
+                    "type": "boolean"
+                },
+                "strategy": {
+                    "description": "contact_driven, fetch_all, fetch_filtered",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/repository.SyncStrategy"
+                        }
+                    ]
+                },
+                "supports_discovery": {
+                    "description": "true if can discover new contacts",
+                    "type": "boolean"
+                },
+                "supports_multi_account": {
+                    "description": "true for Google/Telegram, false for iMessage",
+                    "type": "boolean"
                 }
             }
         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -22,9 +22,669 @@
     "host": "localhost:8080",
     "basePath": "/api/v1",
     "paths": {
+        "/auth/google": {
+            "get": {
+                "description": "Get the URL to redirect user to for Google authorization",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Google OAuth authorization URL",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.GetGoogleAuthURLResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/accounts": {
+            "get": {
+                "description": "Get list of all connected Google accounts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "List connected Google accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.GoogleAccountResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/accounts/{id}/revoke": {
+            "post": {
+                "description": "Disconnect a Google account and revoke OAuth tokens",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Revoke Google account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/accounts/{id}/status": {
+            "get": {
+                "description": "Get the status of a specific connected Google account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Google account status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.GoogleAccountResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/google/callback": {
+            "get": {
+                "description": "Handle the OAuth callback from Google (redirects to frontend)",
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Google OAuth callback",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization code",
+                        "name": "code",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "State for CSRF protection",
+                        "name": "state",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Error from Google",
+                        "name": "error",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Redirect to frontend"
+                    }
+                }
+            }
+        },
+        "/auth/todoist": {
+            "get": {
+                "description": "Get the URL to redirect user to for Todoist authorization",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Todoist OAuth authorization URL",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.GetTodoistAuthURLResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/accounts": {
+            "get": {
+                "description": "Get list of all connected Todoist accounts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "List connected Todoist accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TodoistAccountResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/accounts/{id}/revoke": {
+            "post": {
+                "description": "Disconnect a Todoist account and revoke OAuth tokens",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Revoke Todoist account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/accounts/{id}/status": {
+            "get": {
+                "description": "Get the status of a specific connected Todoist account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Get Todoist account status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.TodoistAccountResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/todoist/callback": {
+            "get": {
+                "description": "Handle the OAuth callback from Todoist (redirects to frontend)",
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Todoist OAuth callback",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authorization code",
+                        "name": "code",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "State for CSRF protection",
+                        "name": "state",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Error from Todoist",
+                        "name": "error",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Redirect to frontend"
+                    }
+                }
+            }
+        },
         "/contacts": {
             "get": {
-                "description": "Get a paginated list of contacts with optional search",
+                "description": "Get a paginated list of contacts with optional search and sorting. Use ids_only=true to get just IDs for navigation.",
                 "produces": [
                     "application/json"
                 ],
@@ -53,8 +713,42 @@
                     {
                         "maxLength": 255,
                         "type": "string",
-                        "description": "Search term (name or email)",
+                        "description": "Search term (name or contact methods)",
                         "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "name",
+                            "location",
+                            "birthday",
+                            "last_contacted",
+                            "last_response_at",
+                            "contact_by",
+                            "cadence"
+                        ],
+                        "type": "string",
+                        "default": "\"\"",
+                        "description": "Sort by field",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "default": "\"asc\"",
+                        "description": "Sort order",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Return only contact IDs (for navigation)",
+                        "name": "ids_only",
                         "in": "query"
                     }
                 ],
@@ -181,8 +875,8 @@
                             ]
                         }
                     },
-                    "409": {
-                        "description": "Contact already exists",
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "allOf": [
                                 {
@@ -193,6 +887,41 @@
                                     "properties": {
                                         "error": {
                                             "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/overdue": {
+            "get": {
+                "description": "Get contacts that are overdue based on their cadence settings",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "List overdue contacts",
+                "responses": {
+                    "200": {
+                        "description": "Overdue contacts retrieved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.OverdueContactResponse"
+                                            }
                                         }
                                     }
                                 }
@@ -401,24 +1130,6 @@
                             ]
                         }
                     },
-                    "409": {
-                        "description": "Email already exists",
-                        "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/api.APIResponse"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "$ref": "#/definitions/api.APIError"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
@@ -518,9 +1229,4027 @@
                     }
                 }
             }
+        },
+        "/contacts/{id}/events": {
+            "get": {
+                "description": "Get calendar events involving a specific contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "calendar"
+                ],
+                "summary": "List calendar events for a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.CalendarEventResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/events/upcoming": {
+            "get": {
+                "description": "Get upcoming calendar events involving a specific contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "calendar"
+                ],
+                "summary": "List upcoming calendar events for a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Max items",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.CalendarEventResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/identities": {
+            "get": {
+                "description": "Get all external identities linked to a contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "List identities for contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.ExternalIdentity"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/interactions": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "List contact interactions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.InteractionResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "Create interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Interaction details",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.InteractionResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/merge": {
+            "post": {
+                "description": "Merge one contact into another. The source contact will be archived.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "Merge contacts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target Contact ID (contact to keep)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Merge request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.MergeContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Contacts merged successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ContactResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/merge/preview": {
+            "get": {
+                "description": "Get a preview of what will be merged when combining two contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "Preview contact merge",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target Contact ID (contact to keep)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Source Contact ID (contact to merge from)",
+                        "name": "source_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Merge preview retrieved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.MergePreviewResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid contact ID",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/methods": {
+            "post": {
+                "description": "Apply a batch of add/update/remove/set_primary/clear_primary operations to a contact's methods in one transaction. Absence expresses nothing: a method no operation names is never removed or altered.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contacts"
+                ],
+                "summary": "Apply contact-method operations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Operations to apply",
+                        "name": "operations",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ContactMethodOperationsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ContactMethodOperationsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed, conflicting, or unsatisfiable operations",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found, or an operation names a method owned by another contact",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/notes": {
+            "get": {
+                "description": "Get the notepad note for a contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "Get contact notepad",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Note retrieved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.NoteResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "204": {
+                        "description": "No note exists for this contact"
+                    },
+                    "400": {
+                        "description": "Invalid contact ID",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Create or update the notepad note for a contact. If body is empty or whitespace-only, deletes the note.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "Save contact notepad",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Note content",
+                        "name": "note",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SaveNoteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Note saved successfully",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.NoteResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "204": {
+                        "description": "Note deleted (empty body)"
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Contact not found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/tasks": {
+            "get": {
+                "description": "List all tasks for a contact with optional state, kind, and lifecycle filters.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contact-tasks"
+                ],
+                "summary": "List contact tasks",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by state (managed, completed, unmanaged, dismissed, pending_remote_create)",
+                        "name": "state",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by kind (reach_out, send, reminder, meet, action)",
+                        "name": "kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by lifecycle (manual, cadence_due, followup_loop)",
+                        "name": "lifecycle",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.ContactTaskResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new one-off task for a contact using Todoist Quick Add. Kind must be one of reach_out / send / reminder.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "contact-tasks"
+                ],
+                "summary": "Create manual task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task creation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateManualTaskRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ContactTaskResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{id}/tasks/{taskId}": {
+            "delete": {
+                "description": "Remove CRM tracking for a task (does not delete from Todoist)",
+                "tags": [
+                    "contact-tasks"
+                ],
+                "summary": "Delete task link",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/events/upcoming": {
+            "get": {
+                "description": "Get upcoming calendar events that have matched CRM contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "calendar"
+                ],
+                "summary": "List upcoming calendar events with CRM contacts",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.CalendarEventResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/unmatched": {
+            "get": {
+                "description": "Get external identities that couldn't be matched to CRM contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "List unmatched identities",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.ExternalIdentity"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/{id}": {
+            "get": {
+                "description": "Get an external identity by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Get identity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalIdentity"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete an external identity",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Delete identity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/{id}/link": {
+            "post": {
+                "description": "Manually link an external identity to a CRM contact",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Link identity to contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/LinkIdentityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalIdentity"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/identities/{id}/unlink": {
+            "post": {
+                "description": "Unlink an external identity from its CRM contact",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "identities"
+                ],
+                "summary": "Unlink identity from contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identity ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalIdentity"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/candidates": {
+            "get": {
+                "description": "Get unmatched external contacts that can be imported as CRM contacts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "List import candidates",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source filter (e.g., gcontacts)",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.ImportCandidateResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/suggestions": {
+            "get": {
+                "description": "Method-suggestion group + confidence-ranked import candidates as a SuggestionItem union",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "List suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source filter",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.SuggestionItemResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/suggestions/{id}/methods/dismiss": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Dismiss method suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Selected methods (empty = all)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DismissMethodSuggestionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.DismissMethodSuggestionsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/suggestions/{id}/methods/resolve": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Resolve method suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Selected methods (empty = all)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ResolveMethodSuggestionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ResolveMethodSuggestionsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}": {
+            "get": {
+                "description": "Get details of a specific import candidate",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Get import candidate",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.ExternalContact"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}/ignore": {
+            "post": {
+                "description": "Mark an external contact as ignored (won't appear in candidates)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Ignore contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}/import": {
+            "post": {
+                "description": "Create a new CRM contact from an external contact",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Import contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional method selection",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ImportRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.ImportContactResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/imports/{id}/link": {
+            "post": {
+                "description": "Link an external contact to an existing CRM contact and enrich it",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "imports"
+                ],
+                "summary": "Link to existing contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "External contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.LinkRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.LinkContactResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{id}": {
+            "delete": {
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "Delete interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Interaction ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Interaction deleted"
+                    }
+                }
+            }
+        },
+        "/rematch/contacts/{id}/rescan": {
+            "post": {
+                "description": "Re-runs rematch handlers for every method currently on the contact.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rematch"
+                ],
+                "summary": "Trigger rematch for a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Contact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.RescanResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/rematch/jobs/{jobID}": {
+            "get": {
+                "description": "Returns the progress of a rematch job by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rematch"
+                ],
+                "summary": "Get rematch job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Rematch job ID",
+                        "name": "jobID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.RematchJobResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/logs": {
+            "get": {
+                "description": "Get the most recent sync operation logs across all sources",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get recent sync logs",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Number of logs to return",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.SyncLog"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/providers": {
+            "get": {
+                "description": "Get list of registered sync providers and their configurations",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "List available sync providers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/sync.SourceConfig"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/staleness": {
+            "get": {
+                "description": "Get the sync sources currently breaching their freshness thresholds",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "List active sync-staleness breaches",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.StalenessBreach"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/status": {
+            "get": {
+                "description": "Get the current sync status for all external data sources",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get sync status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.SyncState"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{id}/enable": {
+            "patch": {
+                "description": "Enable or disable sync for an external data source",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Enable/disable sync",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sync state ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Enable or disable",
+                        "name": "enabled",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.SyncState"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{id}/logs": {
+            "get": {
+                "description": "Get sync operation logs for an external data source",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get sync logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sync state ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repository.SyncLog"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{source}/status": {
+            "get": {
+                "description": "Get the sync state for a specific external data source",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Get sync state for a source",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name (e.g., gmail, imessage)",
+                        "name": "source",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Account ID (for multi-account sources)",
+                        "name": "account_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/repository.SyncState"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/{source}/trigger": {
+            "post": {
+                "description": "Manually trigger a sync operation for an external data source",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Trigger sync for a source",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source name (e.g., gmail, imessage)",
+                        "name": "source",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Sync trigger options",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/TriggerSyncRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/cleanup": {
+            "post": {
+                "description": "Delete test data (contacts and external contacts) by prefix",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Cleanup test data",
+                "parameters": [
+                    {
+                        "description": "Cleanup request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CleanupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.CleanupResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/calendar-events": {
+            "post": {
+                "description": "Create calendar events linked to a contact for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed calendar events for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedCalendarEventsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedCalendarEventsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/contacts": {
+            "post": {
+                "description": "Create contacts with optional methods, location, notes, and cadence for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed contacts for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedContactsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/external-contacts": {
+            "post": {
+                "description": "Create import candidates in the external_contact table for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed external contacts for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedExternalContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedExternalContactsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/meeting-notes": {
+            "post": {
+                "description": "Create orphan_needs_review meeting_note rows for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed orphan meeting notes for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedMeetingNotesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedMeetingNotesResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/method-suggestions": {
+            "post": {
+                "description": "Create a linked imported address-book row with pending_method_suggestions for e2e",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed method suggestions for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedMethodSuggestionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedMethodSuggestionsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/seed/overdue-contacts": {
+            "post": {
+                "description": "Create contacts with backdated last_contacted for e2e testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Seed overdue contacts for testing",
+                "parameters": [
+                    {
+                        "description": "Seed request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.SeedOverdueContactsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.SeedOverdueContactsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/test/trigger-error": {
+            "post": {
+                "description": "Trigger a server error for error boundary testing",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Trigger error for testing",
+                "parameters": [
+                    {
+                        "description": "Error request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.TriggerErrorRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/todoist/labels": {
+            "get": {
+                "description": "Get all labels from the connected Todoist account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "List Todoist labels",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TodoistLabelResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/todoist/projects": {
+            "get": {
+                "description": "Get all projects from the connected Todoist account",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "List Todoist projects",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TodoistProjectResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/todoist/settings": {
+            "get": {
+                "description": "Get the current Todoist integration settings (project, label)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "Get Todoist settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.TodoistSettingsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Update the Todoist integration settings (project, label)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "todoist"
+                ],
+                "summary": "Update Todoist settings",
+                "parameters": [
+                    {
+                        "description": "Settings update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.TodoistSettingsUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/handlers.TodoistSettingsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "$ref": "#/definitions/api.APIError"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "LinkIdentityRequest": {
+            "description": "Request body for manually linking an identity to a contact",
+            "type": "object",
+            "required": [
+                "contact_id"
+            ],
+            "properties": {
+                "contact_id": {
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                }
+            }
+        },
+        "TriggerSyncRequest": {
+            "description": "Request body for triggering a sync operation",
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "example": "user@gmail.com"
+                }
+            }
+        },
         "api.APIError": {
             "type": "object",
             "properties": {
@@ -553,17 +5282,305 @@
         "api.Meta": {
             "type": "object",
             "properties": {
+                "hidden_unresolved_telegram_count": {
+                    "type": "integer"
+                },
+                "pagination": {
+                    "$ref": "#/definitions/api.PaginationMeta"
+                }
+            }
+        },
+        "api.PaginationMeta": {
+            "type": "object",
+            "properties": {
                 "limit": {
                     "type": "integer"
                 },
                 "page": {
                     "type": "integer"
                 },
-                "total": {
+                "pages": {
                     "type": "integer"
                 },
-                "total_pages": {
+                "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "handlers.CalendarEventResponse": {
+            "type": "object",
+            "properties": {
+                "attendee_count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "html_link": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CandidateSuggestionResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "allowed_actions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "photo_url": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "suggested_match": {
+                    "$ref": "#/definitions/handlers.SuggestedMatch"
+                }
+            }
+        },
+        "handlers.CleanupRequest": {
+            "type": "object",
+            "required": [
+                "prefix"
+            ],
+            "properties": {
+                "host_id": {
+                    "description": "HostID, when set, also hard-deletes every meeting_note owned by that\nmac_host (seeded session UUIDs are random, so there is no prefix to\nmatch on — cleanup is by host instead).",
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.CleanupResponse": {
+            "type": "object",
+            "properties": {
+                "deleted_calendar_events": {
+                    "type": "integer"
+                },
+                "deleted_contacts": {
+                    "type": "integer"
+                },
+                "deleted_external_contacts": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.ContactMethodOperation": {
+            "description": "A single contact-method operation",
+            "type": "object",
+            "required": [
+                "op"
+            ],
+            "properties": {
+                "is_primary": {
+                    "description": "IsPrimary is a pointer so the handler can tell \"absent\" from \"present and\nfalse\". The field is forbidden on update, which is a presence test — a\nplain bool would silently accept an explicit false.",
+                    "type": "boolean",
+                    "example": true
+                },
+                "method_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "op": {
+                    "type": "string",
+                    "enum": [
+                        "add",
+                        "update",
+                        "remove",
+                        "set_primary",
+                        "clear_primary"
+                    ],
+                    "example": "add"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ],
+                    "example": "email"
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "example": "john.doe@example.com"
+                }
+            }
+        },
+        "handlers.ContactMethodOperationResult": {
+            "description": "Result of a single contact-method operation",
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "method": {
+                    "$ref": "#/definitions/handlers.ContactMethodResponse"
+                },
+                "method_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "outcome": {
+                    "type": "string",
+                    "example": "created"
+                }
+            }
+        },
+        "handlers.ContactMethodOperationsRequest": {
+            "description": "Contact-method operations request",
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodOperation"
+                    }
+                }
+            }
+        },
+        "handlers.ContactMethodOperationsResponse": {
+            "description": "Contact-method operations response",
+            "type": "object",
+            "properties": {
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodResponse"
+                    }
+                },
+                "rematch_job_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodOperationResult"
+                    }
+                }
+            }
+        },
+        "handlers.ContactMethodRequest": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "is_primary": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "type": {
+                    "description": "Note: legacy email_personal/email_work are no longer accepted; clients should send \"email\".",
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ],
+                    "example": "email"
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "example": "john.doe@example.com"
+                }
+            }
+        },
+        "handlers.ContactMethodResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "is_primary": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "type": {
+                    "type": "string",
+                    "example": "email"
+                },
+                "value": {
+                    "type": "string",
+                    "example": "john.doe@example.com"
                 }
             }
         },
@@ -586,17 +5603,20 @@
                     ],
                     "example": "monthly"
                 },
+                "contact_by": {
+                    "type": "string",
+                    "example": "2024-02-15T00:00:00Z"
+                },
                 "created_at": {
                     "type": "string",
                     "example": "2024-01-01T00:00:00Z"
                 },
-                "email": {
-                    "type": "string",
-                    "example": "john.doe@example.com"
-                },
                 "full_name": {
                     "type": "string",
                     "example": "John Doe"
+                },
+                "has_pending_followup": {
+                    "type": "boolean"
                 },
                 "how_met": {
                     "type": "string",
@@ -610,17 +5630,35 @@
                     "type": "string",
                     "example": "2024-01-15T10:30:00Z"
                 },
+                "last_interaction_at": {
+                    "type": "string"
+                },
+                "last_outreach_at": {
+                    "type": "string"
+                },
+                "last_response_at": {
+                    "type": "string"
+                },
                 "location": {
                     "type": "string",
                     "example": "San Francisco, CA"
                 },
-                "phone": {
-                    "type": "string",
-                    "example": "+1-555-0123"
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodResponse"
+                    }
+                },
+                "primary_method": {
+                    "$ref": "#/definitions/handlers.ContactMethodResponse"
                 },
                 "profile_photo": {
                     "type": "string",
                     "example": "https://example.com/photo.jpg"
+                },
+                "rematch_job_id": {
+                    "description": "RematchJobID is populated by the CREATE path only. A rematch is triggered\nby newly-present method values, and update no longer carries methods, so\nit has no job to report. This type is shared by create, get, update, list,\nmerge, and overdue; the field is omitempty, so a path that leaves it unset\nsimply omits the key rather than publishing an always-null contract.",
+                    "type": "string"
                 },
                 "updated_at": {
                     "type": "string",
@@ -628,12 +5666,492 @@
                 }
             }
         },
+        "handlers.ContactTaskResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "due_date": {
+                    "type": "string"
+                },
+                "external_task_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "lifecycle": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.CreateContactRequest": {
-            "description": "Create contact request",
+            "type": "object"
+        },
+        "handlers.CreateInteractionRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "direction": {
+                    "type": "string"
+                },
+                "occurred_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CreateManualTaskRequest": {
             "type": "object",
             "required": [
-                "full_name"
+                "kind",
+                "text"
             ],
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "reach_out",
+                        "send",
+                        "reminder"
+                    ]
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 5000
+                },
+                "text": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.DateOnly": {
+            "type": "object",
+            "properties": {
+                "time.Time": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.DismissMethodSuggestionsRequest": {
+            "type": "object",
+            "properties": {
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MethodSuggestionSelectionInput"
+                    }
+                }
+            }
+        },
+        "handlers.DismissMethodSuggestionsResponse": {
+            "type": "object",
+            "properties": {
+                "dismissed_count": {
+                    "type": "integer"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.GetGoogleAuthURLResponse": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.GetTodoistAuthURLResponse": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.GoogleAccountResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "account_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ImportCandidateResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "photo_url": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "suggested_match": {
+                    "$ref": "#/definitions/handlers.SuggestedMatch"
+                }
+            }
+        },
+        "handlers.ImportContactResponse": {
+            "type": "object",
+            "properties": {
+                "contact": {
+                    "$ref": "#/definitions/handlers.ContactResponse"
+                },
+                "rematch_job_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ImportRequest": {
+            "type": "object",
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "selected_methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.SelectedMethodInput"
+                    }
+                }
+            }
+        },
+        "handlers.InteractionResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "direction": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "occurred_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "source_ref": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.LinkContactResponse": {
+            "type": "object",
+            "properties": {
+                "external_contact": {
+                    "$ref": "#/definitions/repository.ExternalContact"
+                },
+                "rematch_job_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.LinkRequest": {
+            "type": "object",
+            "required": [
+                "crm_contact_id"
+            ],
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
+                },
+                "conflict_resolutions": {
+                    "description": "value -\u003e \"use_crm\" | \"use_external\"",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "crm_contact_id": {
+                    "type": "string"
+                },
+                "methods_curated": {
+                    "description": "MethodsCurated is true when the candidate offered methods to select\n(the modal rendered the method-selection UI) and the user made a\nselection decision — even if SelectedMethods ends up empty (user\ndeselected all). It distinguishes an explicit empty selection from a\nbare auto-match, since a nil slice and an explicit [] are\nindistinguishable in Go after JSON unmarshal. The frontend sets it\nONLY when the candidate actually had methods to curate (a\nzero-method candidate offered no curation choice → false → stays\nmatched).",
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "selected_methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.SelectedMethodInput"
+                    }
+                }
+            }
+        },
+        "handlers.MergeContactsRequest": {
+            "description": "Merge contacts request",
+            "type": "object",
+            "required": [
+                "source_contact_id"
+            ],
+            "properties": {
+                "field_selections": {
+                    "$ref": "#/definitions/handlers.MergeFieldSelectionsRequest"
+                },
+                "new_name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "example": "John Smith"
+                },
+                "source_contact_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440001"
+                }
+            }
+        },
+        "handlers.MergeFieldSelectionsRequest": {
+            "type": "object",
+            "properties": {
+                "birthday": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target"
+                    ],
+                    "example": "target"
+                },
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target"
+                    ],
+                    "example": "target"
+                },
+                "location": {
+                    "type": "string",
+                    "enum": [
+                        "source",
+                        "target"
+                    ],
+                    "example": "source"
+                }
+            }
+        },
+        "handlers.MergePreviewResponse": {
+            "description": "Merge preview response",
+            "type": "object",
+            "properties": {
+                "calendar_events_to_update": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "duplicate_methods": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "interactions_to_transfer": {
+                    "type": "integer",
+                    "example": 12
+                },
+                "methods_to_transfer": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "notes_to_transfer": {
+                    "type": "integer",
+                    "example": 5
+                },
+                "source_contact": {
+                    "$ref": "#/definitions/handlers.ContactResponse"
+                },
+                "target_contact": {
+                    "$ref": "#/definitions/handlers.ContactResponse"
+                }
+            }
+        },
+        "handlers.MethodSuggestionMethodDTO": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.MethodSuggestionResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "contact_name": {
+                    "type": "string"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                },
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MethodSuggestionMethodDTO"
+                    }
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.MethodSuggestionSelectionInput": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.NoteResponse": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "contact_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.OverdueContactResponse": {
+            "description": "Overdue contact information with action metadata",
+            "type": "object",
             "properties": {
                 "birthday": {
                     "type": "string",
@@ -650,91 +6168,1241 @@
                     ],
                     "example": "monthly"
                 },
-                "email": {
+                "contact_by": {
+                    "type": "string",
+                    "example": "2024-02-15T00:00:00Z"
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00Z"
+                },
+                "days_overdue": {
+                    "type": "integer",
+                    "example": 5
+                },
+                "full_name": {
+                    "type": "string",
+                    "example": "John Doe"
+                },
+                "has_pending_followup": {
+                    "type": "boolean"
+                },
+                "how_met": {
+                    "type": "string",
+                    "example": "Met at tech conference"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "last_contacted": {
+                    "type": "string",
+                    "example": "2024-01-15T10:30:00Z"
+                },
+                "last_interaction_at": {
+                    "type": "string"
+                },
+                "last_outreach_at": {
+                    "type": "string"
+                },
+                "last_response_at": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string",
+                    "example": "San Francisco, CA"
+                },
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ContactMethodResponse"
+                    }
+                },
+                "next_due_date": {
+                    "type": "string",
+                    "example": "2024-01-15T00:00:00Z"
+                },
+                "primary_method": {
+                    "$ref": "#/definitions/handlers.ContactMethodResponse"
+                },
+                "profile_photo": {
+                    "type": "string",
+                    "example": "https://example.com/photo.jpg"
+                },
+                "rematch_job_id": {
+                    "description": "RematchJobID is populated by the CREATE path only. A rematch is triggered\nby newly-present method values, and update no longer carries methods, so\nit has no job to report. This type is shared by create, get, update, list,\nmerge, and overdue; the field is omitempty, so a path that leaves it unset\nsimply omits the key rather than publishing an always-null contract.",
+                    "type": "string"
+                },
+                "suggested_action": {
+                    "type": "string",
+                    "example": "Send a quick check-in message"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2024-01-15T10:30:00Z"
+                }
+            }
+        },
+        "handlers.RematchJobMethod": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.RematchJobResponse": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "contact_id": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "matched": {
+                    "type": "integer"
+                },
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.RematchJobMethod"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.RescanResponse": {
+            "type": "object",
+            "properties": {
+                "rematch_job_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ResolveMethodSuggestionsRequest": {
+            "type": "object",
+            "properties": {
+                "methods": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MethodSuggestionSelectionInput"
+                    }
+                }
+            }
+        },
+        "handlers.ResolveMethodSuggestionsResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                },
+                "rematch_job_id": {
+                    "type": "string"
+                },
+                "resolved_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.SaveNoteRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "maxLength": 50000
+                }
+            }
+        },
+        "handlers.SeedCalendarEventInput": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "attendee_emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "days_ago": {
+                    "description": "If is_past, how many days ago (default: 7)",
+                    "type": "integer"
+                },
+                "days_ahead": {
+                    "description": "If not is_past, how many days ahead (default: 7)",
+                    "type": "integer"
+                },
+                "html_link": {
+                    "type": "string"
+                },
+                "is_past": {
+                    "description": "If true, event is set in the past",
+                    "type": "boolean"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "title": {
                     "type": "string",
                     "maxLength": 255,
-                    "example": "john.doe@example.com"
+                    "minLength": 1
+                },
+                "unmatched": {
+                    "description": "Unmatched, when true, seeds the event with attendee emails but does NOT\nadd contact_id to matched_contact_ids. Used for rematch E2E tests.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "handlers.SeedCalendarEventsRequest": {
+            "type": "object",
+            "required": [
+                "contact_id",
+                "events",
+                "prefix"
+            ],
+            "properties": {
+                "contact_id": {
+                    "description": "Primary contact to link events to",
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "maxItems": 50,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedCalendarEventInput"
+                    }
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedCalendarEventsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedContactInput": {
+            "type": "object",
+            "required": [
+                "full_name"
+            ],
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
                 },
                 "full_name": {
                     "type": "string",
                     "maxLength": 255,
-                    "minLength": 1,
-                    "example": "John Doe"
+                    "minLength": 1
                 },
-                "how_met": {
-                    "type": "string",
-                    "maxLength": 500,
-                    "example": "Met at tech conference"
+                "last_contacted_days_ago": {
+                    "type": "integer",
+                    "maximum": 3650,
+                    "minimum": 0
                 },
                 "location": {
                     "type": "string",
-                    "maxLength": 255,
-                    "example": "San Francisco, CA"
+                    "maxLength": 255
                 },
-                "phone": {
+                "methods": {
+                    "type": "array",
+                    "maxItems": 20,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedContactMethodInput"
+                    }
+                },
+                "notes": {
+                    "type": "string",
+                    "maxLength": 2000
+                }
+            }
+        },
+        "handlers.SeedContactMethodInput": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "is_primary": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ]
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "handlers.SeedContactsRequest": {
+            "type": "object",
+            "required": [
+                "contacts",
+                "prefix"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedContactInput"
+                    }
+                },
+                "prefix": {
                     "type": "string",
                     "maxLength": 50,
-                    "example": "+1-555-0123"
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedContactsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
                 },
-                "profile_photo": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedExternalContactInput": {
+            "type": "object",
+            "properties": {
+                "display_name": {
                     "type": "string",
-                    "maxLength": 500,
-                    "example": "https://example.com/photo.jpg"
+                    "maxLength": 255
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "first_name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "test",
+                        "telegram",
+                        "gcontacts",
+                        "gcal_attendee",
+                        "icloud_contacts",
+                        "anarlog_humans",
+                        "anarlog_title",
+                        "gmail_correspondence"
+                    ]
+                }
+            }
+        },
+        "handlers.SeedExternalContactsRequest": {
+            "type": "object",
+            "required": [
+                "contacts",
+                "prefix"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedExternalContactInput"
+                    }
+                },
+                "host_id": {
+                    "description": "HostID associates the seeded rows with a specific mac_host. Used\nby host-scoped tests (e.g., the GET /host/:id/source-counts\nendpoint). Optional — when unset, rows are seeded with NULL\nhost_id.",
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedExternalContactsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedMeetingNoteInput": {
+            "type": "object",
+            "required": [
+                "anarlog_session_id"
+            ],
+            "properties": {
+                "anarlog_session_id": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 500
+                }
+            }
+        },
+        "handlers.SeedMeetingNotesRequest": {
+            "type": "object",
+            "required": [
+                "host_id",
+                "notes"
+            ],
+            "properties": {
+                "host_id": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "array",
+                    "maxItems": 50,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedMeetingNoteInput"
+                    }
+                }
+            }
+        },
+        "handlers.SeedMeetingNotesResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SeedMethodSuggestionMethodInput": {
+            "type": "object",
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "discord",
+                        "twitter",
+                        "signal",
+                        "gchat",
+                        "whatsapp"
+                    ]
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "handlers.SeedMethodSuggestionsRequest": {
+            "type": "object",
+            "required": [
+                "contact_name",
+                "pending",
+                "prefix"
+            ],
+            "properties": {
+                "contact_name": {
+                    "description": "ContactName is the linked contact's name (prefix is prepended for\ncleanup). The seeded contact carries no methods, so the pending\nsuggestions are not pre-applied.",
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                },
+                "dismissed": {
+                    "type": "array",
+                    "maxItems": 20,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedMethodSuggestionMethodInput"
+                    }
+                },
+                "pending": {
+                    "type": "array",
+                    "maxItems": 20,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedMethodSuggestionMethodInput"
+                    }
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                },
+                "source": {
+                    "description": "Source must be an address-book source (the suggestion surface is\nv1-scoped to these).",
+                    "type": "string",
+                    "enum": [
+                        "gcontacts",
+                        "icloud_contacts"
+                    ]
+                }
+            }
+        },
+        "handlers.SeedMethodSuggestionsResponse": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "external_contact_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.SeedOverdueContactInput": {
+            "type": "object",
+            "required": [
+                "cadence",
+                "days_overdue",
+                "full_name"
+            ],
+            "properties": {
+                "cadence": {
+                    "type": "string",
+                    "enum": [
+                        "weekly",
+                        "biweekly",
+                        "monthly",
+                        "quarterly",
+                        "biannual",
+                        "annual"
+                    ]
+                },
+                "days_overdue": {
+                    "type": "integer",
+                    "maximum": 365,
+                    "minimum": 1
+                },
+                "email": {
+                    "type": "string"
+                },
+                "full_name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedOverdueContactsRequest": {
+            "type": "object",
+            "required": [
+                "contacts",
+                "prefix"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/handlers.SeedOverdueContactInput"
+                    }
+                },
+                "prefix": {
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 1
+                }
+            }
+        },
+        "handlers.SeedOverdueContactsResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.SelectedMethodInput": {
+            "type": "object",
+            "required": [
+                "original_value",
+                "type"
+            ],
+            "properties": {
+                "is_primary": {
+                    "type": "boolean"
+                },
+                "original_value": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "email",
+                        "phone",
+                        "telegram",
+                        "signal",
+                        "discord",
+                        "twitter",
+                        "gchat",
+                        "whatsapp"
+                    ]
+                }
+            }
+        },
+        "handlers.SuggestedMatch": {
+            "type": "object",
+            "properties": {
+                "confidence": {
+                    "type": "number"
+                },
+                "contact_id": {
+                    "type": "string"
+                },
+                "contact_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.SuggestionItemResponse": {
+            "type": "object",
+            "properties": {
+                "candidate": {
+                    "$ref": "#/definitions/handlers.CandidateSuggestionResponse"
+                },
+                "kind": {
+                    "description": "\"contact\" | \"method\"",
+                    "type": "string"
+                },
+                "suggestion": {
+                    "$ref": "#/definitions/handlers.MethodSuggestionResponse"
+                }
+            }
+        },
+        "handlers.TodoistAccountResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "account_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistLabelResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistProjectResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistSettingsResponse": {
+            "type": "object",
+            "properties": {
+                "integration_instance_id": {
+                    "type": "string"
+                },
+                "label_id": {
+                    "type": "string"
+                },
+                "label_name": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "user_timezone": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TodoistSettingsUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "label_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TriggerErrorRequest": {
+            "type": "object",
+            "required": [
+                "error_type"
+            ],
+            "properties": {
+                "error_type": {
+                    "type": "string",
+                    "enum": [
+                        "500",
+                        "panic"
+                    ]
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },
         "handlers.UpdateContactRequest": {
-            "description": "Update contact request",
-            "type": "object",
-            "required": [
-                "full_name"
+            "type": "object"
+        },
+        "identity.IdentifierType": {
+            "type": "string",
+            "enum": [
+                "email",
+                "phone",
+                "telegram",
+                "imessage_email",
+                "imessage_phone",
+                "whatsapp",
+                "gchat",
+                "anarlog_human_id"
             ],
+            "x-enum-varnames": [
+                "IdentifierTypeEmail",
+                "IdentifierTypePhone",
+                "IdentifierTypeTelegram",
+                "IdentifierTypeIMessageEmail",
+                "IdentifierTypeIMessagePhone",
+                "IdentifierTypeWhatsApp",
+                "IdentifierTypeGChat",
+                "IdentifierTypeAnarlogHuman"
+            ]
+        },
+        "repository.AddressEntry": {
+            "type": "object",
             "properties": {
+                "formatted": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.EmailEntry": {
+            "type": "object",
+            "properties": {
+                "primary": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.ExternalContact": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.AddressEntry"
+                    }
+                },
                 "birthday": {
-                    "type": "string",
-                    "example": "1990-01-15T00:00:00Z"
+                    "type": "string"
                 },
-                "cadence": {
-                    "type": "string",
-                    "enum": [
-                        "weekly",
-                        "monthly",
-                        "quarterly",
-                        "biannual",
-                        "annual"
-                    ],
-                    "example": "monthly"
+                "created_at": {
+                    "type": "string"
                 },
-                "email": {
-                    "type": "string",
-                    "maxLength": 255,
-                    "example": "john.doe@example.com"
+                "crm_contact_id": {
+                    "type": "string"
                 },
-                "full_name": {
-                    "type": "string",
-                    "maxLength": 255,
-                    "minLength": 1,
-                    "example": "John Doe"
+                "deleted_at": {
+                    "description": "DeletedAt is set when a soft-delete tombstones the row. Production\nread queries filter `deleted_at IS NULL` so a tombstoned row only\nsurfaces through GetBySource (intentionally tombstone-aware for the\nmac-daemon revive path).",
+                    "type": "string"
                 },
-                "how_met": {
-                    "type": "string",
-                    "maxLength": 500,
-                    "example": "Met at tech conference"
+                "display_name": {
+                    "type": "string"
                 },
-                "location": {
-                    "type": "string",
-                    "maxLength": 255,
-                    "example": "San Francisco, CA"
+                "duplicate_of_id": {
+                    "type": "string"
                 },
-                "phone": {
-                    "type": "string",
-                    "maxLength": 50,
-                    "example": "+1-555-0123"
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.EmailEntry"
+                    }
                 },
-                "profile_photo": {
-                    "type": "string",
-                    "maxLength": 500,
-                    "example": "https://example.com/photo.jpg"
+                "etag": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "host_id": {
+                    "description": "HostID is the paired Mac host that claimed this row (mac-daemon\nsources only). Written on INSERT and on UPDATE via\nCOALESCE(existing, EXCLUDED) — a NULL row (legacy or never-claimed)\nis claimed by the next non-NULL emit; non-NULL ownership is\npreserved thereafter across all subsequent upserts.",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "job_title": {
+                    "type": "string"
+                },
+                "last_content_hash": {
+                    "description": "LastContentHash is the lowercase-hex SHA-256 of the JCS-\ncanonicalized payload (minus host_id) that produced this row's\ncurrent content. Written on every UPSERT for mac-daemon sources;\npreserved on soft-delete so a future delete-event can validate\nagainst the prior hash. Powers GET /sync/:source/known-ids.",
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "match_status": {
+                    "$ref": "#/definitions/repository.MatchStatus"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "organization": {
+                    "type": "string"
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repository.PhoneEntry"
+                    }
+                },
+                "photo_url": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "synced_at": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.ExternalIdentity": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "identifier": {
+                    "type": "string"
+                },
+                "identifier_type": {
+                    "$ref": "#/definitions/identity.IdentifierType"
+                },
+                "last_seen_at": {
+                    "type": "string"
+                },
+                "match_confidence": {
+                    "type": "number"
+                },
+                "match_type": {
+                    "$ref": "#/definitions/repository.MatchType"
+                },
+                "message_count": {
+                    "type": "integer"
+                },
+                "raw_identifier": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.MatchStatus": {
+            "type": "string",
+            "enum": [
+                "matched",
+                "unmatched",
+                "ignored",
+                "imported"
+            ],
+            "x-enum-varnames": [
+                "MatchStatusMatched",
+                "MatchStatusUnmatched",
+                "MatchStatusIgnored",
+                "MatchStatusImported"
+            ]
+        },
+        "repository.MatchType": {
+            "type": "string",
+            "enum": [
+                "exact",
+                "fuzzy",
+                "manual",
+                "unmatched"
+            ],
+            "x-enum-varnames": [
+                "MatchTypeExact",
+                "MatchTypeFuzzy",
+                "MatchTypeManual",
+                "MatchTypeUnmatched"
+            ]
+        },
+        "repository.PhoneEntry": {
+            "type": "object",
+            "properties": {
+                "primary": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.StalenessBreach": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "breach_type": {
+                    "type": "string"
+                },
+                "details": {
+                    "type": "string"
+                },
+                "detected_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_observed_at": {
+                    "type": "string"
+                },
+                "resolved_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "stale_since": {
+                    "type": "string"
+                },
+                "threshold_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "repository.SyncLog": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "items_created": {
+                    "type": "integer"
+                },
+                "items_matched": {
+                    "type": "integer"
+                },
+                "items_processed": {
+                    "type": "integer"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "source": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "sync_state_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.SyncState": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "error_count": {
+                    "type": "integer"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_successful_sync_at": {
+                    "type": "string"
+                },
+                "last_sync_at": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "next_sync_at": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/repository.SyncStatus"
+                },
+                "strategy": {
+                    "$ref": "#/definitions/repository.SyncStrategy"
+                },
+                "sync_cursor": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "repository.SyncStatus": {
+            "type": "string",
+            "enum": [
+                "idle",
+                "error",
+                "disabled"
+            ],
+            "x-enum-varnames": [
+                "SyncStatusIdle",
+                "SyncStatusError",
+                "SyncStatusDisabled"
+            ]
+        },
+        "repository.SyncStrategy": {
+            "type": "string",
+            "enum": [
+                "contact_driven",
+                "fetch_all",
+                "fetch_filtered",
+                "push"
+            ],
+            "x-enum-varnames": [
+                "SyncStrategyContactDriven",
+                "SyncStrategyFetchAll",
+                "SyncStrategyFetchFiltered",
+                "SyncStrategyPush"
+            ]
+        },
+        "sync.SourceConfig": {
+            "type": "object",
+            "properties": {
+                "default_interval": {
+                    "description": "swaggertype is required: swag cannot resolve time.Duration and fails the\nwhole generation, which silently left the spec stale (see the handler\nannotation that exposes this struct). It marshals as an integer\nnanosecond count, so that is what the spec must declare.",
+                    "type": "integer"
+                },
+                "display_name": {
+                    "description": "e.g., \"Gmail\", \"iMessage\", \"Telegram\"",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "e.g., \"gmail\", \"imessage\", \"telegram\"",
+                    "type": "string"
+                },
+                "requires_account": {
+                    "description": "RequiresAccount declares that this provider's Sync requires a non-nil,\nnon-empty account ID (e.g. its OAuth token is keyed by account). When\ntrue, TriggerSync rejects a nil/empty account instead of bootstrapping a\nsync_state row that would error on every dispatch. Defaults to false\n(the correct value for push providers whose Sync is account-agnostic).",
+                    "type": "boolean"
+                },
+                "strategy": {
+                    "description": "contact_driven, fetch_all, fetch_filtered",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/repository.SyncStrategy"
+                        }
+                    ]
+                },
+                "supports_discovery": {
+                    "description": "true if can discover new contacts",
+                    "type": "boolean"
+                },
+                "supports_multi_account": {
+                    "description": "true for Google/Telegram, false for iMessage",
+                    "type": "boolean"
                 }
             }
         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,5 +1,21 @@
 basePath: /api/v1
 definitions:
+  LinkIdentityRequest:
+    description: Request body for manually linking an identity to a contact
+    properties:
+      contact_id:
+        example: 123e4567-e89b-12d3-a456-426614174000
+        type: string
+    required:
+    - contact_id
+    type: object
+  TriggerSyncRequest:
+    description: Request body for triggering a sync operation
+    properties:
+      account_id:
+        example: user@gmail.com
+        type: string
+    type: object
   api.APIError:
     properties:
       code:
@@ -21,14 +37,225 @@ definitions:
     type: object
   api.Meta:
     properties:
+      hidden_unresolved_telegram_count:
+        type: integer
+      pagination:
+        $ref: '#/definitions/api.PaginationMeta'
+    type: object
+  api.PaginationMeta:
+    properties:
       limit:
         type: integer
       page:
         type: integer
+      pages:
+        type: integer
       total:
         type: integer
-      total_pages:
+    type: object
+  handlers.CalendarEventResponse:
+    properties:
+      attendee_count:
         type: integer
+      description:
+        type: string
+      end_time:
+        type: string
+      html_link:
+        type: string
+      id:
+        type: string
+      location:
+        type: string
+      start_time:
+        type: string
+      status:
+        type: string
+      title:
+        type: string
+    type: object
+  handlers.CandidateSuggestionResponse:
+    properties:
+      account_id:
+        type: string
+      allowed_actions:
+        items:
+          type: string
+        type: array
+      display_name:
+        type: string
+      emails:
+        items:
+          type: string
+        type: array
+      first_name:
+        type: string
+      id:
+        type: string
+      job_title:
+        type: string
+      last_name:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      organization:
+        type: string
+      phones:
+        items:
+          type: string
+        type: array
+      photo_url:
+        type: string
+      source:
+        type: string
+      suggested_match:
+        $ref: '#/definitions/handlers.SuggestedMatch'
+    type: object
+  handlers.CleanupRequest:
+    properties:
+      host_id:
+        description: |-
+          HostID, when set, also hard-deletes every meeting_note owned by that
+          mac_host (seeded session UUIDs are random, so there is no prefix to
+          match on — cleanup is by host instead).
+        type: string
+      prefix:
+        maxLength: 50
+        minLength: 1
+        type: string
+    required:
+    - prefix
+    type: object
+  handlers.CleanupResponse:
+    properties:
+      deleted_calendar_events:
+        type: integer
+      deleted_contacts:
+        type: integer
+      deleted_external_contacts:
+        type: integer
+    type: object
+  handlers.ContactMethodOperation:
+    description: A single contact-method operation
+    properties:
+      is_primary:
+        description: |-
+          IsPrimary is a pointer so the handler can tell "absent" from "present and
+          false". The field is forbidden on update, which is a presence test — a
+          plain bool would silently accept an explicit false.
+        example: true
+        type: boolean
+      method_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      op:
+        enum:
+        - add
+        - update
+        - remove
+        - set_primary
+        - clear_primary
+        example: add
+        type: string
+      type:
+        enum:
+        - email
+        - phone
+        - telegram
+        - discord
+        - twitter
+        - signal
+        - gchat
+        - whatsapp
+        example: email
+        type: string
+      value:
+        example: john.doe@example.com
+        maxLength: 255
+        type: string
+    required:
+    - op
+    type: object
+  handlers.ContactMethodOperationResult:
+    description: Result of a single contact-method operation
+    properties:
+      index:
+        example: 0
+        type: integer
+      method:
+        $ref: '#/definitions/handlers.ContactMethodResponse'
+      method_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      outcome:
+        example: created
+        type: string
+    type: object
+  handlers.ContactMethodOperationsRequest:
+    description: Contact-method operations request
+    properties:
+      operations:
+        items:
+          $ref: '#/definitions/handlers.ContactMethodOperation'
+        type: array
+    type: object
+  handlers.ContactMethodOperationsResponse:
+    description: Contact-method operations response
+    properties:
+      methods:
+        items:
+          $ref: '#/definitions/handlers.ContactMethodResponse'
+        type: array
+      rematch_job_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      results:
+        items:
+          $ref: '#/definitions/handlers.ContactMethodOperationResult'
+        type: array
+    type: object
+  handlers.ContactMethodRequest:
+    properties:
+      is_primary:
+        example: true
+        type: boolean
+      type:
+        description: 'Note: legacy email_personal/email_work are no longer accepted;
+          clients should send "email".'
+        enum:
+        - email
+        - phone
+        - telegram
+        - discord
+        - twitter
+        - signal
+        - gchat
+        - whatsapp
+        example: email
+        type: string
+      value:
+        example: john.doe@example.com
+        maxLength: 255
+        type: string
+    required:
+    - type
+    - value
+    type: object
+  handlers.ContactMethodResponse:
+    properties:
+      id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      is_primary:
+        example: true
+        type: boolean
+      type:
+        example: email
+        type: string
+      value:
+        example: john.doe@example.com
+        type: string
     type: object
   handlers.ContactResponse:
     description: Contact information
@@ -45,15 +272,17 @@ definitions:
         - annual
         example: monthly
         type: string
+      contact_by:
+        example: "2024-02-15T00:00:00Z"
+        type: string
       created_at:
         example: "2024-01-01T00:00:00Z"
-        type: string
-      email:
-        example: john.doe@example.com
         type: string
       full_name:
         example: John Doe
         type: string
+      has_pending_followup:
+        type: boolean
       how_met:
         example: Met at tech conference
         type: string
@@ -63,21 +292,374 @@ definitions:
       last_contacted:
         example: "2024-01-15T10:30:00Z"
         type: string
+      last_interaction_at:
+        type: string
+      last_outreach_at:
+        type: string
+      last_response_at:
+        type: string
       location:
         example: San Francisco, CA
         type: string
-      phone:
-        example: +1-555-0123
-        type: string
+      methods:
+        items:
+          $ref: '#/definitions/handlers.ContactMethodResponse'
+        type: array
+      primary_method:
+        $ref: '#/definitions/handlers.ContactMethodResponse'
       profile_photo:
         example: https://example.com/photo.jpg
+        type: string
+      rematch_job_id:
+        description: |-
+          RematchJobID is populated by the CREATE path only. A rematch is triggered
+          by newly-present method values, and update no longer carries methods, so
+          it has no job to report. This type is shared by create, get, update, list,
+          merge, and overdue; the field is omitempty, so a path that leaves it unset
+          simply omits the key rather than publishing an always-null contract.
         type: string
       updated_at:
         example: "2024-01-15T10:30:00Z"
         type: string
     type: object
+  handlers.ContactTaskResponse:
+    properties:
+      contact_id:
+        type: string
+      content:
+        type: string
+      created_at:
+        type: string
+      due_date:
+        type: string
+      external_task_id:
+        type: string
+      id:
+        type: string
+      kind:
+        type: string
+      lifecycle:
+        type: string
+      project_id:
+        type: string
+      state:
+        type: string
+    type: object
   handlers.CreateContactRequest:
-    description: Create contact request
+    type: object
+  handlers.CreateInteractionRequest:
+    properties:
+      description:
+        type: string
+      direction:
+        type: string
+      occurred_at:
+        type: string
+    type: object
+  handlers.CreateManualTaskRequest:
+    properties:
+      kind:
+        enum:
+        - reach_out
+        - send
+        - reminder
+        type: string
+      notes:
+        maxLength: 5000
+        type: string
+      text:
+        maxLength: 1000
+        minLength: 1
+        type: string
+    required:
+    - kind
+    - text
+    type: object
+  handlers.DateOnly:
+    properties:
+      time.Time:
+        type: string
+    type: object
+  handlers.DismissMethodSuggestionsRequest:
+    properties:
+      methods:
+        items:
+          $ref: '#/definitions/handlers.MethodSuggestionSelectionInput'
+        type: array
+    type: object
+  handlers.DismissMethodSuggestionsResponse:
+    properties:
+      dismissed_count:
+        type: integer
+      external_contact_id:
+        type: string
+    type: object
+  handlers.GetGoogleAuthURLResponse:
+    properties:
+      state:
+        type: string
+      url:
+        type: string
+    type: object
+  handlers.GetTodoistAuthURLResponse:
+    properties:
+      state:
+        type: string
+      url:
+        type: string
+    type: object
+  handlers.GoogleAccountResponse:
+    properties:
+      account_id:
+        type: string
+      account_name:
+        type: string
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+      scopes:
+        items:
+          type: string
+        type: array
+      updated_at:
+        type: string
+    type: object
+  handlers.ImportCandidateResponse:
+    properties:
+      account_id:
+        type: string
+      display_name:
+        type: string
+      emails:
+        items:
+          type: string
+        type: array
+      first_name:
+        type: string
+      id:
+        type: string
+      job_title:
+        type: string
+      last_name:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      organization:
+        type: string
+      phones:
+        items:
+          type: string
+        type: array
+      photo_url:
+        type: string
+      source:
+        type: string
+      suggested_match:
+        $ref: '#/definitions/handlers.SuggestedMatch'
+    type: object
+  handlers.ImportContactResponse:
+    properties:
+      contact:
+        $ref: '#/definitions/handlers.ContactResponse'
+      rematch_job_id:
+        type: string
+    type: object
+  handlers.ImportRequest:
+    properties:
+      cadence:
+        enum:
+        - weekly
+        - biweekly
+        - monthly
+        - quarterly
+        - biannual
+        - annual
+        type: string
+      name:
+        type: string
+      selected_methods:
+        items:
+          $ref: '#/definitions/handlers.SelectedMethodInput'
+        type: array
+    type: object
+  handlers.InteractionResponse:
+    properties:
+      contact_id:
+        type: string
+      created_at:
+        type: string
+      description:
+        type: string
+      direction:
+        type: string
+      id:
+        type: string
+      occurred_at:
+        type: string
+      source:
+        type: string
+      source_ref:
+        type: string
+    type: object
+  handlers.LinkContactResponse:
+    properties:
+      external_contact:
+        $ref: '#/definitions/repository.ExternalContact'
+      rematch_job_id:
+        type: string
+    type: object
+  handlers.LinkRequest:
+    properties:
+      cadence:
+        enum:
+        - weekly
+        - biweekly
+        - monthly
+        - quarterly
+        - biannual
+        - annual
+        type: string
+      conflict_resolutions:
+        additionalProperties:
+          type: string
+        description: value -> "use_crm" | "use_external"
+        type: object
+      crm_contact_id:
+        type: string
+      methods_curated:
+        description: |-
+          MethodsCurated is true when the candidate offered methods to select
+          (the modal rendered the method-selection UI) and the user made a
+          selection decision — even if SelectedMethods ends up empty (user
+          deselected all). It distinguishes an explicit empty selection from a
+          bare auto-match, since a nil slice and an explicit [] are
+          indistinguishable in Go after JSON unmarshal. The frontend sets it
+          ONLY when the candidate actually had methods to curate (a
+          zero-method candidate offered no curation choice → false → stays
+          matched).
+        type: boolean
+      name:
+        type: string
+      selected_methods:
+        items:
+          $ref: '#/definitions/handlers.SelectedMethodInput'
+        type: array
+    required:
+    - crm_contact_id
+    type: object
+  handlers.MergeContactsRequest:
+    description: Merge contacts request
+    properties:
+      field_selections:
+        $ref: '#/definitions/handlers.MergeFieldSelectionsRequest'
+      new_name:
+        example: John Smith
+        maxLength: 255
+        minLength: 1
+        type: string
+      source_contact_id:
+        example: 550e8400-e29b-41d4-a716-446655440001
+        type: string
+    required:
+    - source_contact_id
+    type: object
+  handlers.MergeFieldSelectionsRequest:
+    properties:
+      birthday:
+        enum:
+        - source
+        - target
+        example: target
+        type: string
+      cadence:
+        enum:
+        - source
+        - target
+        example: target
+        type: string
+      location:
+        enum:
+        - source
+        - target
+        example: source
+        type: string
+    type: object
+  handlers.MergePreviewResponse:
+    description: Merge preview response
+    properties:
+      calendar_events_to_update:
+        example: 3
+        type: integer
+      duplicate_methods:
+        example: 1
+        type: integer
+      interactions_to_transfer:
+        example: 12
+        type: integer
+      methods_to_transfer:
+        example: 3
+        type: integer
+      notes_to_transfer:
+        example: 5
+        type: integer
+      source_contact:
+        $ref: '#/definitions/handlers.ContactResponse'
+      target_contact:
+        $ref: '#/definitions/handlers.ContactResponse'
+    type: object
+  handlers.MethodSuggestionMethodDTO:
+    properties:
+      type:
+        type: string
+      value:
+        type: string
+    type: object
+  handlers.MethodSuggestionResponse:
+    properties:
+      contact_id:
+        type: string
+      contact_name:
+        type: string
+      external_contact_id:
+        type: string
+      methods:
+        items:
+          $ref: '#/definitions/handlers.MethodSuggestionMethodDTO'
+        type: array
+      source:
+        type: string
+    type: object
+  handlers.MethodSuggestionSelectionInput:
+    properties:
+      type:
+        type: string
+      value:
+        type: string
+    required:
+    - type
+    - value
+    type: object
+  handlers.NoteResponse:
+    properties:
+      body:
+        type: string
+      category:
+        type: string
+      contact_id:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  handlers.OverdueContactResponse:
+    description: Overdue contact information with action metadata
     properties:
       birthday:
         example: "1990-01-15T00:00:00Z"
@@ -91,76 +673,910 @@ definitions:
         - annual
         example: monthly
         type: string
-      email:
-        example: john.doe@example.com
-        maxLength: 255
+      contact_by:
+        example: "2024-02-15T00:00:00Z"
         type: string
+      created_at:
+        example: "2024-01-01T00:00:00Z"
+        type: string
+      days_overdue:
+        example: 5
+        type: integer
       full_name:
         example: John Doe
-        maxLength: 255
-        minLength: 1
         type: string
+      has_pending_followup:
+        type: boolean
       how_met:
         example: Met at tech conference
-        maxLength: 500
+        type: string
+      id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      last_contacted:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      last_interaction_at:
+        type: string
+      last_outreach_at:
+        type: string
+      last_response_at:
         type: string
       location:
         example: San Francisco, CA
-        maxLength: 255
         type: string
-      phone:
-        example: +1-555-0123
-        maxLength: 50
+      methods:
+        items:
+          $ref: '#/definitions/handlers.ContactMethodResponse'
+        type: array
+      next_due_date:
+        example: "2024-01-15T00:00:00Z"
         type: string
+      primary_method:
+        $ref: '#/definitions/handlers.ContactMethodResponse'
       profile_photo:
         example: https://example.com/photo.jpg
-        maxLength: 500
+        type: string
+      rematch_job_id:
+        description: |-
+          RematchJobID is populated by the CREATE path only. A rematch is triggered
+          by newly-present method values, and update no longer carries methods, so
+          it has no job to report. This type is shared by create, get, update, list,
+          merge, and overdue; the field is omitempty, so a path that leaves it unset
+          simply omits the key rather than publishing an always-null contract.
+        type: string
+      suggested_action:
+        example: Send a quick check-in message
+        type: string
+      updated_at:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+    type: object
+  handlers.RematchJobMethod:
+    properties:
+      type:
+        type: string
+      value:
+        type: string
+    type: object
+  handlers.RematchJobResponse:
+    properties:
+      completed_at:
+        type: string
+      contact_id:
+        type: string
+      error:
+        type: string
+      id:
+        type: string
+      matched:
+        type: integer
+      methods:
+        items:
+          $ref: '#/definitions/handlers.RematchJobMethod'
+        type: array
+      started_at:
+        type: string
+      status:
+        type: string
+    type: object
+  handlers.RescanResponse:
+    properties:
+      rematch_job_id:
+        type: string
+    type: object
+  handlers.ResolveMethodSuggestionsRequest:
+    properties:
+      methods:
+        items:
+          $ref: '#/definitions/handlers.MethodSuggestionSelectionInput'
+        type: array
+    type: object
+  handlers.ResolveMethodSuggestionsResponse:
+    properties:
+      contact_id:
+        type: string
+      external_contact_id:
+        type: string
+      rematch_job_id:
+        type: string
+      resolved_count:
+        type: integer
+    type: object
+  handlers.SaveNoteRequest:
+    properties:
+      body:
+        maxLength: 50000
+        type: string
+    type: object
+  handlers.SeedCalendarEventInput:
+    properties:
+      attendee_emails:
+        items:
+          type: string
+        type: array
+      days_ago:
+        description: 'If is_past, how many days ago (default: 7)'
+        type: integer
+      days_ahead:
+        description: 'If not is_past, how many days ahead (default: 7)'
+        type: integer
+      html_link:
+        type: string
+      is_past:
+        description: If true, event is set in the past
+        type: boolean
+      location:
+        type: string
+      title:
+        maxLength: 255
+        minLength: 1
+        type: string
+      unmatched:
+        description: |-
+          Unmatched, when true, seeds the event with attendee emails but does NOT
+          add contact_id to matched_contact_ids. Used for rematch E2E tests.
+        type: boolean
+    required:
+    - title
+    type: object
+  handlers.SeedCalendarEventsRequest:
+    properties:
+      contact_id:
+        description: Primary contact to link events to
+        type: string
+      events:
+        items:
+          $ref: '#/definitions/handlers.SeedCalendarEventInput'
+        maxItems: 50
+        minItems: 1
+        type: array
+      prefix:
+        maxLength: 50
+        minLength: 1
+        type: string
+    required:
+    - contact_id
+    - events
+    - prefix
+    type: object
+  handlers.SeedCalendarEventsResponse:
+    properties:
+      created:
+        type: integer
+      ids:
+        items:
+          type: string
+        type: array
+    type: object
+  handlers.SeedContactInput:
+    properties:
+      cadence:
+        enum:
+        - weekly
+        - biweekly
+        - monthly
+        - quarterly
+        - biannual
+        - annual
+        type: string
+      full_name:
+        maxLength: 255
+        minLength: 1
+        type: string
+      last_contacted_days_ago:
+        maximum: 3650
+        minimum: 0
+        type: integer
+      location:
+        maxLength: 255
+        type: string
+      methods:
+        items:
+          $ref: '#/definitions/handlers.SeedContactMethodInput'
+        maxItems: 20
+        type: array
+      notes:
+        maxLength: 2000
         type: string
     required:
     - full_name
     type: object
-  handlers.UpdateContactRequest:
-    description: Update contact request
+  handlers.SeedContactMethodInput:
     properties:
-      birthday:
-        example: "1990-01-15T00:00:00Z"
+      is_primary:
+        type: boolean
+      type:
+        enum:
+        - email
+        - phone
+        - telegram
+        - discord
+        - twitter
+        - signal
+        - gchat
+        - whatsapp
         type: string
+      value:
+        maxLength: 255
+        type: string
+    required:
+    - type
+    - value
+    type: object
+  handlers.SeedContactsRequest:
+    properties:
+      contacts:
+        items:
+          $ref: '#/definitions/handlers.SeedContactInput'
+        maxItems: 100
+        minItems: 1
+        type: array
+      prefix:
+        maxLength: 50
+        minLength: 1
+        type: string
+    required:
+    - contacts
+    - prefix
+    type: object
+  handlers.SeedContactsResponse:
+    properties:
+      created:
+        type: integer
+      ids:
+        items:
+          type: string
+        type: array
+    type: object
+  handlers.SeedExternalContactInput:
+    properties:
+      display_name:
+        maxLength: 255
+        type: string
+      emails:
+        items:
+          type: string
+        type: array
+      first_name:
+        maxLength: 255
+        type: string
+      job_title:
+        type: string
+      last_name:
+        maxLength: 255
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      organization:
+        type: string
+      phones:
+        items:
+          type: string
+        type: array
+      source:
+        enum:
+        - test
+        - telegram
+        - gcontacts
+        - gcal_attendee
+        - icloud_contacts
+        - anarlog_humans
+        - anarlog_title
+        - gmail_correspondence
+        type: string
+    type: object
+  handlers.SeedExternalContactsRequest:
+    properties:
+      contacts:
+        items:
+          $ref: '#/definitions/handlers.SeedExternalContactInput'
+        maxItems: 100
+        minItems: 1
+        type: array
+      host_id:
+        description: |-
+          HostID associates the seeded rows with a specific mac_host. Used
+          by host-scoped tests (e.g., the GET /host/:id/source-counts
+          endpoint). Optional — when unset, rows are seeded with NULL
+          host_id.
+        type: string
+      prefix:
+        maxLength: 50
+        minLength: 1
+        type: string
+    required:
+    - contacts
+    - prefix
+    type: object
+  handlers.SeedExternalContactsResponse:
+    properties:
+      created:
+        type: integer
+      ids:
+        items:
+          type: string
+        type: array
+    type: object
+  handlers.SeedMeetingNoteInput:
+    properties:
+      anarlog_session_id:
+        type: string
+      summary:
+        maxLength: 2000
+        type: string
+      title:
+        maxLength: 500
+        type: string
+    required:
+    - anarlog_session_id
+    type: object
+  handlers.SeedMeetingNotesRequest:
+    properties:
+      host_id:
+        type: string
+      notes:
+        items:
+          $ref: '#/definitions/handlers.SeedMeetingNoteInput'
+        maxItems: 50
+        minItems: 1
+        type: array
+    required:
+    - host_id
+    - notes
+    type: object
+  handlers.SeedMeetingNotesResponse:
+    properties:
+      created:
+        type: integer
+      ids:
+        items:
+          type: string
+        type: array
+    type: object
+  handlers.SeedMethodSuggestionMethodInput:
+    properties:
+      type:
+        enum:
+        - email
+        - phone
+        - telegram
+        - discord
+        - twitter
+        - signal
+        - gchat
+        - whatsapp
+        type: string
+      value:
+        maxLength: 255
+        type: string
+    required:
+    - type
+    - value
+    type: object
+  handlers.SeedMethodSuggestionsRequest:
+    properties:
+      contact_name:
+        description: |-
+          ContactName is the linked contact's name (prefix is prepended for
+          cleanup). The seeded contact carries no methods, so the pending
+          suggestions are not pre-applied.
+        maxLength: 255
+        minLength: 1
+        type: string
+      dismissed:
+        items:
+          $ref: '#/definitions/handlers.SeedMethodSuggestionMethodInput'
+        maxItems: 20
+        type: array
+      pending:
+        items:
+          $ref: '#/definitions/handlers.SeedMethodSuggestionMethodInput'
+        maxItems: 20
+        minItems: 1
+        type: array
+      prefix:
+        maxLength: 50
+        minLength: 1
+        type: string
+      source:
+        description: |-
+          Source must be an address-book source (the suggestion surface is
+          v1-scoped to these).
+        enum:
+        - gcontacts
+        - icloud_contacts
+        type: string
+    required:
+    - contact_name
+    - pending
+    - prefix
+    type: object
+  handlers.SeedMethodSuggestionsResponse:
+    properties:
+      contact_id:
+        type: string
+      external_contact_id:
+        type: string
+    type: object
+  handlers.SeedOverdueContactInput:
+    properties:
       cadence:
         enum:
         - weekly
+        - biweekly
         - monthly
         - quarterly
         - biannual
         - annual
-        example: monthly
         type: string
+      days_overdue:
+        maximum: 365
+        minimum: 1
+        type: integer
       email:
-        example: john.doe@example.com
-        maxLength: 255
         type: string
       full_name:
-        example: John Doe
         maxLength: 255
         minLength: 1
         type: string
-      how_met:
-        example: Met at tech conference
-        maxLength: 500
-        type: string
-      location:
-        example: San Francisco, CA
-        maxLength: 255
-        type: string
-      phone:
-        example: +1-555-0123
+    required:
+    - cadence
+    - days_overdue
+    - full_name
+    type: object
+  handlers.SeedOverdueContactsRequest:
+    properties:
+      contacts:
+        items:
+          $ref: '#/definitions/handlers.SeedOverdueContactInput'
+        maxItems: 100
+        minItems: 1
+        type: array
+      prefix:
         maxLength: 50
-        type: string
-      profile_photo:
-        example: https://example.com/photo.jpg
-        maxLength: 500
+        minLength: 1
         type: string
     required:
-    - full_name
+    - contacts
+    - prefix
+    type: object
+  handlers.SeedOverdueContactsResponse:
+    properties:
+      created:
+        type: integer
+      ids:
+        items:
+          type: string
+        type: array
+    type: object
+  handlers.SelectedMethodInput:
+    properties:
+      is_primary:
+        type: boolean
+      original_value:
+        type: string
+      type:
+        enum:
+        - email
+        - phone
+        - telegram
+        - signal
+        - discord
+        - twitter
+        - gchat
+        - whatsapp
+        type: string
+    required:
+    - original_value
+    - type
+    type: object
+  handlers.SuggestedMatch:
+    properties:
+      confidence:
+        type: number
+      contact_id:
+        type: string
+      contact_name:
+        type: string
+    type: object
+  handlers.SuggestionItemResponse:
+    properties:
+      candidate:
+        $ref: '#/definitions/handlers.CandidateSuggestionResponse'
+      kind:
+        description: '"contact" | "method"'
+        type: string
+      suggestion:
+        $ref: '#/definitions/handlers.MethodSuggestionResponse'
+    type: object
+  handlers.TodoistAccountResponse:
+    properties:
+      account_id:
+        type: string
+      account_name:
+        type: string
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+      scopes:
+        items:
+          type: string
+        type: array
+      updated_at:
+        type: string
+    type: object
+  handlers.TodoistLabelResponse:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  handlers.TodoistProjectResponse:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  handlers.TodoistSettingsResponse:
+    properties:
+      integration_instance_id:
+        type: string
+      label_id:
+        type: string
+      label_name:
+        type: string
+      project_id:
+        type: string
+      user_timezone:
+        type: string
+    type: object
+  handlers.TodoistSettingsUpdateRequest:
+    properties:
+      label_id:
+        type: string
+      project_id:
+        type: string
+    type: object
+  handlers.TriggerErrorRequest:
+    properties:
+      error_type:
+        enum:
+        - "500"
+        - panic
+        type: string
+      message:
+        type: string
+    required:
+    - error_type
+    type: object
+  handlers.UpdateContactRequest:
+    type: object
+  identity.IdentifierType:
+    enum:
+    - email
+    - phone
+    - telegram
+    - imessage_email
+    - imessage_phone
+    - whatsapp
+    - gchat
+    - anarlog_human_id
+    type: string
+    x-enum-varnames:
+    - IdentifierTypeEmail
+    - IdentifierTypePhone
+    - IdentifierTypeTelegram
+    - IdentifierTypeIMessageEmail
+    - IdentifierTypeIMessagePhone
+    - IdentifierTypeWhatsApp
+    - IdentifierTypeGChat
+    - IdentifierTypeAnarlogHuman
+  repository.AddressEntry:
+    properties:
+      formatted:
+        type: string
+      type:
+        type: string
+    type: object
+  repository.EmailEntry:
+    properties:
+      primary:
+        type: boolean
+      type:
+        type: string
+      value:
+        type: string
+    type: object
+  repository.ExternalContact:
+    properties:
+      account_id:
+        type: string
+      addresses:
+        items:
+          $ref: '#/definitions/repository.AddressEntry'
+        type: array
+      birthday:
+        type: string
+      created_at:
+        type: string
+      crm_contact_id:
+        type: string
+      deleted_at:
+        description: |-
+          DeletedAt is set when a soft-delete tombstones the row. Production
+          read queries filter `deleted_at IS NULL` so a tombstoned row only
+          surfaces through GetBySource (intentionally tombstone-aware for the
+          mac-daemon revive path).
+        type: string
+      display_name:
+        type: string
+      duplicate_of_id:
+        type: string
+      emails:
+        items:
+          $ref: '#/definitions/repository.EmailEntry'
+        type: array
+      etag:
+        type: string
+      first_name:
+        type: string
+      host_id:
+        description: |-
+          HostID is the paired Mac host that claimed this row (mac-daemon
+          sources only). Written on INSERT and on UPDATE via
+          COALESCE(existing, EXCLUDED) — a NULL row (legacy or never-claimed)
+          is claimed by the next non-NULL emit; non-NULL ownership is
+          preserved thereafter across all subsequent upserts.
+        type: string
+      id:
+        type: string
+      job_title:
+        type: string
+      last_content_hash:
+        description: |-
+          LastContentHash is the lowercase-hex SHA-256 of the JCS-
+          canonicalized payload (minus host_id) that produced this row's
+          current content. Written on every UPSERT for mac-daemon sources;
+          preserved on soft-delete so a future delete-event can validate
+          against the prior hash. Powers GET /sync/:source/known-ids.
+        type: string
+      last_name:
+        type: string
+      match_status:
+        $ref: '#/definitions/repository.MatchStatus'
+      metadata:
+        additionalProperties: {}
+        type: object
+      organization:
+        type: string
+      phones:
+        items:
+          $ref: '#/definitions/repository.PhoneEntry'
+        type: array
+      photo_url:
+        type: string
+      source:
+        type: string
+      source_id:
+        type: string
+      synced_at:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  repository.ExternalIdentity:
+    properties:
+      contact_id:
+        type: string
+      created_at:
+        type: string
+      display_name:
+        type: string
+      id:
+        type: string
+      identifier:
+        type: string
+      identifier_type:
+        $ref: '#/definitions/identity.IdentifierType'
+      last_seen_at:
+        type: string
+      match_confidence:
+        type: number
+      match_type:
+        $ref: '#/definitions/repository.MatchType'
+      message_count:
+        type: integer
+      raw_identifier:
+        type: string
+      source:
+        type: string
+      source_id:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  repository.MatchStatus:
+    enum:
+    - matched
+    - unmatched
+    - ignored
+    - imported
+    type: string
+    x-enum-varnames:
+    - MatchStatusMatched
+    - MatchStatusUnmatched
+    - MatchStatusIgnored
+    - MatchStatusImported
+  repository.MatchType:
+    enum:
+    - exact
+    - fuzzy
+    - manual
+    - unmatched
+    type: string
+    x-enum-varnames:
+    - MatchTypeExact
+    - MatchTypeFuzzy
+    - MatchTypeManual
+    - MatchTypeUnmatched
+  repository.PhoneEntry:
+    properties:
+      primary:
+        type: boolean
+      type:
+        type: string
+      value:
+        type: string
+    type: object
+  repository.StalenessBreach:
+    properties:
+      account_id:
+        type: string
+      breach_type:
+        type: string
+      details:
+        type: string
+      detected_at:
+        type: string
+      id:
+        type: string
+      last_observed_at:
+        type: string
+      resolved_at:
+        type: string
+      source:
+        type: string
+      stale_since:
+        type: string
+      threshold_seconds:
+        type: integer
+    type: object
+  repository.SyncLog:
+    properties:
+      account_id:
+        type: string
+      completed_at:
+        type: string
+      created_at:
+        type: string
+      error_message:
+        type: string
+      id:
+        type: string
+      items_created:
+        type: integer
+      items_matched:
+        type: integer
+      items_processed:
+        type: integer
+      metadata:
+        additionalProperties: {}
+        type: object
+      source:
+        type: string
+      started_at:
+        type: string
+      status:
+        type: string
+      sync_state_id:
+        type: string
+    type: object
+  repository.SyncState:
+    properties:
+      account_id:
+        type: string
+      created_at:
+        type: string
+      enabled:
+        type: boolean
+      error_count:
+        type: integer
+      error_message:
+        type: string
+      id:
+        type: string
+      last_successful_sync_at:
+        type: string
+      last_sync_at:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      next_sync_at:
+        type: string
+      source:
+        type: string
+      status:
+        $ref: '#/definitions/repository.SyncStatus'
+      strategy:
+        $ref: '#/definitions/repository.SyncStrategy'
+      sync_cursor:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  repository.SyncStatus:
+    enum:
+    - idle
+    - error
+    - disabled
+    type: string
+    x-enum-varnames:
+    - SyncStatusIdle
+    - SyncStatusError
+    - SyncStatusDisabled
+  repository.SyncStrategy:
+    enum:
+    - contact_driven
+    - fetch_all
+    - fetch_filtered
+    - push
+    type: string
+    x-enum-varnames:
+    - SyncStrategyContactDriven
+    - SyncStrategyFetchAll
+    - SyncStrategyFetchFiltered
+    - SyncStrategyPush
+  sync.SourceConfig:
+    properties:
+      default_interval:
+        description: |-
+          swaggertype is required: swag cannot resolve time.Duration and fails the
+          whole generation, which silently left the spec stale (see the handler
+          annotation that exposes this struct). It marshals as an integer
+          nanosecond count, so that is what the spec must declare.
+        type: integer
+      display_name:
+        description: e.g., "Gmail", "iMessage", "Telegram"
+        type: string
+      name:
+        description: e.g., "gmail", "imessage", "telegram"
+        type: string
+      requires_account:
+        description: |-
+          RequiresAccount declares that this provider's Sync requires a non-nil,
+          non-empty account ID (e.g. its OAuth token is keyed by account). When
+          true, TriggerSync rejects a nil/empty account instead of bootstrapping a
+          sync_state row that would error on every dispatch. Defaults to false
+          (the correct value for push providers whose Sync is account-agnostic).
+        type: boolean
+      strategy:
+        allOf:
+        - $ref: '#/definitions/repository.SyncStrategy'
+        description: contact_driven, fetch_all, fetch_filtered
+      supports_discovery:
+        description: true if can discover new contacts
+        type: boolean
+      supports_multi_account:
+        description: true for Google/Telegram, false for iMessage
+        type: boolean
     type: object
 host: localhost:8080
 info:
@@ -176,9 +1592,374 @@ info:
   title: Personal CRM API
   version: "1.0"
 paths:
+  /auth/google:
+    get:
+      description: Get the URL to redirect user to for Google authorization
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.GetGoogleAuthURLResponse'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get Google OAuth authorization URL
+      tags:
+      - auth
+  /auth/google/accounts:
+    get:
+      description: Get list of all connected Google accounts
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.GoogleAccountResponse'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List connected Google accounts
+      tags:
+      - auth
+  /auth/google/accounts/{id}/revoke:
+    post:
+      description: Disconnect a Google account and revoke OAuth tokens
+      parameters:
+      - description: Account UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  additionalProperties:
+                    type: string
+                  type: object
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Revoke Google account
+      tags:
+      - auth
+  /auth/google/accounts/{id}/status:
+    get:
+      description: Get the status of a specific connected Google account
+      parameters:
+      - description: Account UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.GoogleAccountResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get Google account status
+      tags:
+      - auth
+  /auth/google/callback:
+    get:
+      description: Handle the OAuth callback from Google (redirects to frontend)
+      parameters:
+      - description: Authorization code
+        in: query
+        name: code
+        type: string
+      - description: State for CSRF protection
+        in: query
+        name: state
+        type: string
+      - description: Error from Google
+        in: query
+        name: error
+        type: string
+      responses:
+        "302":
+          description: Redirect to frontend
+      summary: Google OAuth callback
+      tags:
+      - auth
+  /auth/todoist:
+    get:
+      description: Get the URL to redirect user to for Todoist authorization
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.GetTodoistAuthURLResponse'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get Todoist OAuth authorization URL
+      tags:
+      - auth
+  /auth/todoist/accounts:
+    get:
+      description: Get list of all connected Todoist accounts
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.TodoistAccountResponse'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List connected Todoist accounts
+      tags:
+      - auth
+  /auth/todoist/accounts/{id}/revoke:
+    post:
+      description: Disconnect a Todoist account and revoke OAuth tokens
+      parameters:
+      - description: Account UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  additionalProperties:
+                    type: string
+                  type: object
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Revoke Todoist account
+      tags:
+      - auth
+  /auth/todoist/accounts/{id}/status:
+    get:
+      description: Get the status of a specific connected Todoist account
+      parameters:
+      - description: Account UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.TodoistAccountResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get Todoist account status
+      tags:
+      - auth
+  /auth/todoist/callback:
+    get:
+      description: Handle the OAuth callback from Todoist (redirects to frontend)
+      parameters:
+      - description: Authorization code
+        in: query
+        name: code
+        type: string
+      - description: State for CSRF protection
+        in: query
+        name: state
+        type: string
+      - description: Error from Todoist
+        in: query
+        name: error
+        type: string
+      responses:
+        "302":
+          description: Redirect to frontend
+      summary: Todoist OAuth callback
+      tags:
+      - auth
   /contacts:
     get:
-      description: Get a paginated list of contacts with optional search
+      description: Get a paginated list of contacts with optional search and sorting.
+        Use ids_only=true to get just IDs for navigation.
       parameters:
       - default: 1
         description: Page number
@@ -193,11 +1974,37 @@ paths:
         minimum: 1
         name: limit
         type: integer
-      - description: Search term (name or email)
+      - description: Search term (name or contact methods)
         in: query
         maxLength: 255
         name: search
         type: string
+      - default: '""'
+        description: Sort by field
+        enum:
+        - name
+        - location
+        - birthday
+        - last_contacted
+        - last_response_at
+        - contact_by
+        - cadence
+        in: query
+        name: sort
+        type: string
+      - default: '"asc"'
+        description: Sort order
+        enum:
+        - asc
+        - desc
+        in: query
+        name: order
+        type: string
+      - default: false
+        description: Return only contact IDs (for navigation)
+        in: query
+        name: ids_only
+        type: boolean
       produces:
       - application/json
       responses:
@@ -260,15 +2067,6 @@ paths:
               type: object
         "400":
           description: Invalid request
-          schema:
-            allOf:
-            - $ref: '#/definitions/api.APIResponse'
-            - properties:
-                error:
-                  $ref: '#/definitions/api.APIError'
-              type: object
-        "409":
-          description: Contact already exists
           schema:
             allOf:
             - $ref: '#/definitions/api.APIResponse'
@@ -431,8 +2229,272 @@ paths:
                 error:
                   $ref: '#/definitions/api.APIError'
               type: object
-        "409":
-          description: Email already exists
+        "500":
+          description: Internal server error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Update a contact
+      tags:
+      - contacts
+  /contacts/{id}/events:
+    get:
+      description: Get calendar events involving a specific contact
+      parameters:
+      - description: Contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - default: 20
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Offset
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.CalendarEventResponse'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List calendar events for a contact
+      tags:
+      - calendar
+  /contacts/{id}/events/upcoming:
+    get:
+      description: Get upcoming calendar events involving a specific contact
+      parameters:
+      - description: Contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - default: 10
+        description: Max items
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.CalendarEventResponse'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List upcoming calendar events for a contact
+      tags:
+      - calendar
+  /contacts/{id}/identities:
+    get:
+      description: Get all external identities linked to a contact
+      parameters:
+      - description: Contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/repository.ExternalIdentity'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List identities for contact
+      tags:
+      - identities
+  /contacts/{id}/interactions:
+    get:
+      parameters:
+      - description: Contact ID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      - default: 20
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.InteractionResponse'
+                  type: array
+              type: object
+      summary: List contact interactions
+      tags:
+      - interactions
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Contact ID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Interaction details
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/handlers.CreateInteractionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.InteractionResponse'
+              type: object
+      summary: Create interaction
+      tags:
+      - interactions
+  /contacts/{id}/merge:
+    post:
+      consumes:
+      - application/json
+      description: Merge one contact into another. The source contact will be archived.
+      parameters:
+      - description: Target Contact ID (contact to keep)
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Merge request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.MergeContactsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Contacts merged successfully
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.ContactResponse'
+              type: object
+        "400":
+          description: Invalid request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Contact not found
           schema:
             allOf:
             - $ref: '#/definitions/api.APIResponse'
@@ -449,9 +2511,2003 @@ paths:
                 error:
                   $ref: '#/definitions/api.APIError'
               type: object
-      summary: Update a contact
+      summary: Merge contacts
       tags:
       - contacts
+  /contacts/{id}/merge/preview:
+    get:
+      description: Get a preview of what will be merged when combining two contacts
+      parameters:
+      - description: Target Contact ID (contact to keep)
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Source Contact ID (contact to merge from)
+        format: uuid
+        in: query
+        name: source_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Merge preview retrieved successfully
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.MergePreviewResponse'
+              type: object
+        "400":
+          description: Invalid contact ID
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Contact not found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal server error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Preview contact merge
+      tags:
+      - contacts
+  /contacts/{id}/methods:
+    post:
+      consumes:
+      - application/json
+      description: 'Apply a batch of add/update/remove/set_primary/clear_primary operations
+        to a contact''s methods in one transaction. Absence expresses nothing: a method
+        no operation names is never removed or altered.'
+      parameters:
+      - description: Contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Operations to apply
+        in: body
+        name: operations
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.ContactMethodOperationsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.ContactMethodOperationsResponse'
+              type: object
+        "400":
+          description: Malformed, conflicting, or unsatisfiable operations
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Contact not found, or an operation names a method owned by
+            another contact
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal server error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Apply contact-method operations
+      tags:
+      - contacts
+  /contacts/{id}/notes:
+    get:
+      description: Get the notepad note for a contact
+      parameters:
+      - description: Contact ID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Note retrieved successfully
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.NoteResponse'
+              type: object
+        "204":
+          description: No note exists for this contact
+        "400":
+          description: Invalid contact ID
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Contact not found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal server error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get contact notepad
+      tags:
+      - notes
+    put:
+      consumes:
+      - application/json
+      description: Create or update the notepad note for a contact. If body is empty
+        or whitespace-only, deletes the note.
+      parameters:
+      - description: Contact ID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Note content
+        in: body
+        name: note
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SaveNoteRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Note saved successfully
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.NoteResponse'
+              type: object
+        "204":
+          description: Note deleted (empty body)
+        "400":
+          description: Invalid request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Contact not found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal server error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Save contact notepad
+      tags:
+      - notes
+  /contacts/{id}/tasks:
+    get:
+      description: List all tasks for a contact with optional state, kind, and lifecycle
+        filters.
+      parameters:
+      - description: Contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Filter by state (managed, completed, unmanaged, dismissed, pending_remote_create)
+        in: query
+        name: state
+        type: string
+      - description: Filter by kind (reach_out, send, reminder, meet, action)
+        in: query
+        name: kind
+        type: string
+      - description: Filter by lifecycle (manual, cadence_due, followup_loop)
+        in: query
+        name: lifecycle
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.ContactTaskResponse'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List contact tasks
+      tags:
+      - contact-tasks
+    post:
+      consumes:
+      - application/json
+      description: Create a new one-off task for a contact using Todoist Quick Add.
+        Kind must be one of reach_out / send / reminder.
+      parameters:
+      - description: Contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Task creation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.CreateManualTaskRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.ContactTaskResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Create manual task
+      tags:
+      - contact-tasks
+  /contacts/{id}/tasks/{taskId}:
+    delete:
+      description: Remove CRM tracking for a task (does not delete from Todoist)
+      parameters:
+      - description: Contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Task ID
+        in: path
+        name: taskId
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Delete task link
+      tags:
+      - contact-tasks
+  /contacts/overdue:
+    get:
+      description: Get contacts that are overdue based on their cadence settings
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Overdue contacts retrieved successfully
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.OverdueContactResponse'
+                  type: array
+              type: object
+        "500":
+          description: Internal server error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List overdue contacts
+      tags:
+      - contacts
+  /events/upcoming:
+    get:
+      description: Get upcoming calendar events that have matched CRM contacts
+      parameters:
+      - default: 20
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Offset
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.CalendarEventResponse'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List upcoming calendar events with CRM contacts
+      tags:
+      - calendar
+  /identities/{id}:
+    delete:
+      description: Delete an external identity
+      parameters:
+      - description: Identity ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Delete identity
+      tags:
+      - identities
+    get:
+      description: Get an external identity by ID
+      parameters:
+      - description: Identity ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/repository.ExternalIdentity'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get identity
+      tags:
+      - identities
+  /identities/{id}/link:
+    post:
+      consumes:
+      - application/json
+      description: Manually link an external identity to a CRM contact
+      parameters:
+      - description: Identity ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Link request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/LinkIdentityRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/repository.ExternalIdentity'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Link identity to contact
+      tags:
+      - identities
+  /identities/{id}/unlink:
+    post:
+      description: Unlink an external identity from its CRM contact
+      parameters:
+      - description: Identity ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/repository.ExternalIdentity'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Unlink identity from contact
+      tags:
+      - identities
+  /identities/unmatched:
+    get:
+      description: Get external identities that couldn't be matched to CRM contacts
+      parameters:
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      - default: 50
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/repository.ExternalIdentity'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List unmatched identities
+      tags:
+      - identities
+  /imports/{id}:
+    get:
+      description: Get details of a specific import candidate
+      parameters:
+      - description: External contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/repository.ExternalContact'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get import candidate
+      tags:
+      - imports
+  /imports/{id}/ignore:
+    post:
+      description: Mark an external contact as ignored (won't appear in candidates)
+      parameters:
+      - description: External contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  type: string
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Ignore contact
+      tags:
+      - imports
+  /imports/{id}/import:
+    post:
+      consumes:
+      - application/json
+      description: Create a new CRM contact from an external contact
+      parameters:
+      - description: External contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Optional method selection
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/handlers.ImportRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.ImportContactResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Import contact
+      tags:
+      - imports
+  /imports/{id}/link:
+    post:
+      consumes:
+      - application/json
+      description: Link an external contact to an existing CRM contact and enrich
+        it
+      parameters:
+      - description: External contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Link request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.LinkRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.LinkContactResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Link to existing contact
+      tags:
+      - imports
+  /imports/candidates:
+    get:
+      description: Get unmatched external contacts that can be imported as CRM contacts
+      parameters:
+      - description: Source filter (e.g., gcontacts)
+        in: query
+        name: source
+        type: string
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      - default: 20
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.ImportCandidateResponse'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List import candidates
+      tags:
+      - imports
+  /imports/suggestions:
+    get:
+      description: Method-suggestion group + confidence-ranked import candidates as
+        a SuggestionItem union
+      parameters:
+      - description: Source filter
+        in: query
+        name: source
+        type: string
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      - default: 20
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.SuggestionItemResponse'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List suggestions
+      tags:
+      - imports
+  /imports/suggestions/{id}/methods/dismiss:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: External contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Selected methods (empty = all)
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/handlers.DismissMethodSuggestionsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.DismissMethodSuggestionsResponse'
+              type: object
+      summary: Dismiss method suggestions
+      tags:
+      - imports
+  /imports/suggestions/{id}/methods/resolve:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: External contact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Selected methods (empty = all)
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/handlers.ResolveMethodSuggestionsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.ResolveMethodSuggestionsResponse'
+              type: object
+      summary: Resolve method suggestions
+      tags:
+      - imports
+  /interactions/{id}:
+    delete:
+      parameters:
+      - description: Interaction ID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: Interaction deleted
+      summary: Delete interaction
+      tags:
+      - interactions
+  /rematch/contacts/{id}/rescan:
+    post:
+      description: Re-runs rematch handlers for every method currently on the contact.
+      parameters:
+      - description: Contact ID
+        format: uuid
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.RescanResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Trigger rematch for a contact
+      tags:
+      - rematch
+  /rematch/jobs/{jobID}:
+    get:
+      description: Returns the progress of a rematch job by ID.
+      parameters:
+      - description: Rematch job ID
+        format: uuid
+        in: path
+        name: jobID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.RematchJobResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get rematch job
+      tags:
+      - rematch
+  /sync/{id}/enable:
+    patch:
+      description: Enable or disable sync for an external data source
+      parameters:
+      - description: Sync state ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Enable or disable
+        in: query
+        name: enabled
+        required: true
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/repository.SyncState'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Enable/disable sync
+      tags:
+      - sync
+  /sync/{id}/logs:
+    get:
+      description: Get sync operation logs for an external data source
+      parameters:
+      - description: Sync state ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      - default: 20
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/repository.SyncLog'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get sync logs
+      tags:
+      - sync
+  /sync/{source}/status:
+    get:
+      description: Get the sync state for a specific external data source
+      parameters:
+      - description: Source name (e.g., gmail, imessage)
+        in: path
+        name: source
+        required: true
+        type: string
+      - description: Account ID (for multi-account sources)
+        in: query
+        name: account_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/repository.SyncState'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get sync state for a source
+      tags:
+      - sync
+  /sync/{source}/trigger:
+    post:
+      consumes:
+      - application/json
+      description: Manually trigger a sync operation for an external data source
+      parameters:
+      - description: Source name (e.g., gmail, imessage)
+        in: path
+        name: source
+        required: true
+        type: string
+      - description: Sync trigger options
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/TriggerSyncRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  additionalProperties:
+                    type: string
+                  type: object
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Trigger sync for a source
+      tags:
+      - sync
+  /sync/logs:
+    get:
+      description: Get the most recent sync operation logs across all sources
+      parameters:
+      - default: 20
+        description: Number of logs to return
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/repository.SyncLog'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get recent sync logs
+      tags:
+      - sync
+  /sync/providers:
+    get:
+      description: Get list of registered sync providers and their configurations
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/sync.SourceConfig'
+                  type: array
+              type: object
+      summary: List available sync providers
+      tags:
+      - sync
+  /sync/staleness:
+    get:
+      description: Get the sync sources currently breaching their freshness thresholds
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/repository.StalenessBreach'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List active sync-staleness breaches
+      tags:
+      - sync
+  /sync/status:
+    get:
+      description: Get the current sync status for all external data sources
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/repository.SyncState'
+                  type: array
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get sync status
+      tags:
+      - sync
+  /test/cleanup:
+    post:
+      consumes:
+      - application/json
+      description: Delete test data (contacts and external contacts) by prefix
+      parameters:
+      - description: Cleanup request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.CleanupRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.CleanupResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Cleanup test data
+      tags:
+      - test
+  /test/seed/calendar-events:
+    post:
+      consumes:
+      - application/json
+      description: Create calendar events linked to a contact for e2e testing
+      parameters:
+      - description: Seed request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SeedCalendarEventsRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.SeedCalendarEventsResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Seed calendar events for testing
+      tags:
+      - test
+  /test/seed/contacts:
+    post:
+      consumes:
+      - application/json
+      description: Create contacts with optional methods, location, notes, and cadence
+        for e2e testing
+      parameters:
+      - description: Seed request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SeedContactsRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.SeedContactsResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Seed contacts for testing
+      tags:
+      - test
+  /test/seed/external-contacts:
+    post:
+      consumes:
+      - application/json
+      description: Create import candidates in the external_contact table for e2e
+        testing
+      parameters:
+      - description: Seed request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SeedExternalContactsRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.SeedExternalContactsResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Seed external contacts for testing
+      tags:
+      - test
+  /test/seed/meeting-notes:
+    post:
+      consumes:
+      - application/json
+      description: Create orphan_needs_review meeting_note rows for e2e testing
+      parameters:
+      - description: Seed request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SeedMeetingNotesRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.SeedMeetingNotesResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Seed orphan meeting notes for testing
+      tags:
+      - test
+  /test/seed/method-suggestions:
+    post:
+      consumes:
+      - application/json
+      description: Create a linked imported address-book row with pending_method_suggestions
+        for e2e
+      parameters:
+      - description: Seed request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SeedMethodSuggestionsRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.SeedMethodSuggestionsResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Seed method suggestions for testing
+      tags:
+      - test
+  /test/seed/overdue-contacts:
+    post:
+      consumes:
+      - application/json
+      description: Create contacts with backdated last_contacted for e2e testing
+      parameters:
+      - description: Seed request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SeedOverdueContactsRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.SeedOverdueContactsResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Seed overdue contacts for testing
+      tags:
+      - test
+  /test/trigger-error:
+    post:
+      consumes:
+      - application/json
+      description: Trigger a server error for error boundary testing
+      parameters:
+      - description: Error request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.TriggerErrorRequest'
+      produces:
+      - application/json
+      responses:
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Trigger error for testing
+      tags:
+      - test
+  /todoist/labels:
+    get:
+      description: Get all labels from the connected Todoist account
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.TodoistLabelResponse'
+                  type: array
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List Todoist labels
+      tags:
+      - todoist
+  /todoist/projects:
+    get:
+      description: Get all projects from the connected Todoist account
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.TodoistProjectResponse'
+                  type: array
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: List Todoist projects
+      tags:
+      - todoist
+  /todoist/settings:
+    get:
+      description: Get the current Todoist integration settings (project, label)
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.TodoistSettingsResponse'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Get Todoist settings
+      tags:
+      - todoist
+    patch:
+      consumes:
+      - application/json
+      description: Update the Todoist integration settings (project, label)
+      parameters:
+      - description: Settings update request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.TodoistSettingsUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/handlers.TodoistSettingsResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                error:
+                  $ref: '#/definitions/api.APIError'
+              type: object
+      summary: Update Todoist settings
+      tags:
+      - todoist
 schemes:
 - http
 - https

--- a/backend/internal/sync/provider.go
+++ b/backend/internal/sync/provider.go
@@ -16,7 +16,11 @@ type SourceConfig struct {
 	Strategy             repository.SyncStrategy `json:"strategy"`               // contact_driven, fetch_all, fetch_filtered
 	SupportsMultiAccount bool                    `json:"supports_multi_account"` // true for Google/Telegram, false for iMessage
 	SupportsDiscovery    bool                    `json:"supports_discovery"`     // true if can discover new contacts
-	DefaultInterval      time.Duration           `json:"default_interval"`       // e.g., 15 * time.Minute
+	// swaggertype is required: swag cannot resolve time.Duration and fails the
+	// whole generation, which silently left the spec stale (see the handler
+	// annotation that exposes this struct). It marshals as an integer
+	// nanosecond count, so that is what the spec must declare.
+	DefaultInterval time.Duration `json:"default_interval" swaggertype:"integer"` // e.g., 15 * time.Minute
 	// RequiresAccount declares that this provider's Sync requires a non-nil,
 	// non-empty account ID (e.g. its OAuth token is keyed by account). When
 	// true, TriggerSync rejects a nil/empty account instead of bootstrapping a


### PR DESCRIPTION
## What

Adds `swaggertype:"integer"` to `SourceConfig.DefaultInterval`, which unblocks `make api-docs`, then commits the regenerated spec.

Closes #694.

## Why

`swag` cannot resolve `time.Duration`, and the failure is fatal to the whole generation:

```
Error parsing type definition 'sync.SourceConfig': [default_interval]: cannot find type definition: time.Duration
ParseComment error ... for comment: '// @Success 200 {object} api.APIResponse{data=[]sync.SourceConfig}'
```

Neither CI nor the pre-push hook gates `make api-docs`, so this failed **silently**. Any PR adding or changing Swagger annotations believed it had regenerated the spec when it had not — the generated output simply stayed stale.

The committed spec last changed on **2026-04-28**. Everything annotated since then was missing from it, including the contact-method operations endpoint added last night.

The field marshals as an integer nanosecond count, so the tag declares what the JSON actually carries.

## Commits

Split deliberately so the real change is reviewable apart from generated output:

- `f65e8210` — the one-field fix
- `3b9b932e` — the regenerated spec (18k lines, entirely mechanical)

## Not included

**CI gating for `make api-docs`.** It is the part that stops this recurring, but it is a workflow decision rather than a fix: gating means every PR touching annotations must commit regenerated docs. Left for a separate call.
