### PR TITLE
feat(promote): pre-flight gate on stale refs and unbuilt SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
           filters: ./path-filters.yml
       - name: Check path-filters parity
         run: bash scripts/ci/path-filters-parity-guard.sh
+      # The local promote pre-flight and this repo's prod deploy gate must agree
+      # on "green"; they cannot share code (deploy-prod.yml runs with no checkout).
+      - name: Check promote gate parity
+        run: bash scripts/ci/promote-gate-parity-guard.sh
 
   backend-quality:
     name: Backend Quality

--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ test-api:
 # inside <string> values, so it parses fine); plutil is macOS-only and not used here.
 test-deploy-scripts:
 	@echo "Running deploy-script shell tests (parallel)..."
-	@tests="scripts/deploy-artifact.test.sh scripts/backup-db.test.sh scripts/restore-db.test.sh scripts/deploy-staging.test.sh scripts/staging-reset.test.sh scripts/ci/staging-reseed-decision.test.sh scripts/ci/qa-round-cadence-gate.test.sh scripts/ci/qa-nightly-round.test.sh scripts/ci/qa-fn-backfill-guard.test.sh scripts/staging-deployed-sha.test.sh scripts/staging-reseed.test.sh scripts/admin/setup-staging-reseed-host.sh.test.sh scripts/run-tours.test.sh scripts/reconcile-mac-daemon.test.sh scripts/setup-mac-deploy.test.sh scripts/trigger-mac-deploy.test.sh"; \
+	@tests="scripts/deploy-artifact.test.sh scripts/backup-db.test.sh scripts/restore-db.test.sh scripts/deploy-staging.test.sh scripts/staging-reset.test.sh scripts/ci/staging-reseed-decision.test.sh scripts/ci/qa-round-cadence-gate.test.sh scripts/ci/qa-nightly-round.test.sh scripts/ci/qa-fn-backfill-guard.test.sh scripts/staging-deployed-sha.test.sh scripts/staging-reseed.test.sh scripts/admin/setup-staging-reseed-host.sh.test.sh scripts/run-tours.test.sh scripts/reconcile-mac-daemon.test.sh scripts/setup-mac-deploy.test.sh scripts/trigger-mac-deploy.test.sh scripts/test/test-promote-preflight.sh"; \
 	tmp="$$(mktemp -d)"; \
 	for t in $$tests; do \
 	  ( bash "$$t" >"$$tmp/$$(echo "$$t" | tr / _).out" 2>&1; echo "$$?" >"$$tmp/$$(echo "$$t" | tr / _).rc" ) & \
@@ -953,7 +953,16 @@ deploy-mac:
 # :<sha> image is already built + CI-green; prod just pulls it. A non-fast-forward
 # push is rejected by the remote (no --force) — that rejection IS the ff-only
 # guarantee; if it fires, main has diverged and must be investigated, not forced.
+# Pre-flight refuses to advance main on a stale local ref or a SHA whose prod
+# gates are not already green — see scripts/promote-preflight.sh for why this is
+# checked locally when deploy-prod.yml checks it again server-side.
+# PROMOTE_SKIP_PREFLIGHT=1 is the deliberate escape hatch.
 promote:
+	@if [ "$(PROMOTE_SKIP_PREFLIGHT)" = "1" ]; then \
+		echo "⚠️  promote pre-flight SKIPPED (PROMOTE_SKIP_PREFLIGHT=1)"; \
+	else \
+		bash scripts/promote-preflight.sh; \
+	fi
 	@git push origin develop:main
 
 setup-pi:

--- a/scripts/ci/promote-gate-parity-guard.sh
+++ b/scripts/ci/promote-gate-parity-guard.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Asserts that the LOCAL promote pre-flight and the REMOTE prod deploy gate agree
+# on what "green" means.
+#
+# deploy-prod.yml runs on the Pi with no checkout and no `gh`, so it cannot call
+# scripts/promote-preflight.sh — the two necessarily reimplement the same queries.
+# Two divergent definitions of green is the worst outcome (promote says go, deploy
+# says no, and main has already moved), so this guard fails if one side changes
+# without the other.
+set -euo pipefail
+
+WF=".github/workflows/deploy-prod.yml"
+PF="scripts/promote-preflight.sh"
+
+for f in "$WF" "$PF"; do
+  [ -f "$f" ] || { echo "FAIL: missing $f"; exit 1; }
+done
+
+# Both gated workflows must appear on both sides. If deploy-prod grows a third
+# gate, the pre-flight must grow it too or it will let a doomed promote through.
+for wf in ci.yml build-images.yml; do
+  grep -qF "workflows/${wf}/runs" "$WF" \
+    || { echo "FAIL: $WF no longer queries ${wf} — update $PF and this guard"; exit 1; }
+  grep -qF "${wf}" "$PF" \
+    || { echo "FAIL: $PF does not gate on ${wf}, but $WF does"; exit 1; }
+done
+
+# status=completed is the filter that stops an in-progress run reading as success.
+# Losing it on either side turns the gate into a coin flip.
+for f in "$WF" "$PF"; do
+  grep -qF 'status=completed' "$f" \
+    || { echo "FAIL: $f dropped the status=completed filter (in-progress runs could read as success)"; exit 1; }
+done
+
+# Both sides must compare against a run CONCLUSION and require exactly "success",
+# with "missing" as the empty-result fallback.
+for f in "$WF" "$PF"; do
+  grep -qF '.workflow_runs[0].conclusion // "missing"' "$f" \
+    || { echo "FAIL: $f no longer reads .workflow_runs[0].conclusion with a \"missing\" fallback"; exit 1; }
+  grep -qF '!= "success"' "$f" \
+    || { echo "FAIL: $f no longer requires the conclusion to be exactly \"success\""; exit 1; }
+done
+
+echo "OK: promote gate parity"

--- a/scripts/promote-preflight.sh
+++ b/scripts/promote-preflight.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Pre-flight for `make promote`. Refuses to advance main unless the SHA about to
+# be promoted is the fetched develop tip AND both prod gates already record
+# success for it.
+#
+# Why this exists locally at all, when deploy-prod.yml re-checks the same things:
+# by the time deploy-prod aborts, main has ALREADY moved (the push succeeded; the
+# workflow refuses afterward), leaving main ahead of what is actually deployed.
+# Refusing here keeps main from moving in the first place.
+#
+# MIRROR, not shared code: deploy-prod.yml runs on the Pi with no checkout, so it
+# cannot call this script — it reimplements these queries with curl+jq. The two
+# copies are kept honest by scripts/ci/promote-gate-parity-guard.sh, which fails
+# if either side changes its notion of "green" without the other.
+#
+# Fails CLOSED: any gh/network/auth failure blocks the promote rather than
+# assuming green. Matches deploy-prod.yml's posture (it aborts on "missing").
+set -euo pipefail
+
+BRANCH="${PROMOTE_SOURCE_BRANCH:-develop}"
+TARGET="${PROMOTE_TARGET_BRANCH:-main}"
+
+command -v gh >/dev/null 2>&1 \
+  || { echo "❌ promote pre-flight: gh is not installed (required to read CI status)"; exit 1; }
+
+echo "→ Fetching origin/$BRANCH..."
+git fetch --quiet origin "$BRANCH" \
+  || { echo "❌ promote pre-flight: git fetch failed"; exit 1; }
+
+local_sha=$(git rev-parse "$BRANCH")
+remote_sha=$(git rev-parse "origin/$BRANCH")
+
+# `make promote` pushes the LOCAL ref, so a stale checkout silently promotes an
+# older SHA than intended. Refuse rather than retarget: promoting origin/$BRANCH
+# automatically would ship commits the operator has never looked at, which is a
+# worse failure than stopping.
+if [ "$local_sha" != "$remote_sha" ]; then
+  echo "❌ promote pre-flight: local $BRANCH does not match origin/$BRANCH"
+  echo "   local:  $local_sha"
+  echo "   remote: $remote_sha"
+  if git merge-base --is-ancestor "$local_sha" "$remote_sha"; then
+    echo "   Local is BEHIND by $(git rev-list --count "$local_sha..$remote_sha") commit(s):"
+    git log --oneline "$local_sha..$remote_sha" | sed 's/^/     /'
+    echo "   Fast-forward first, then re-run: git branch -f $BRANCH origin/$BRANCH"
+  else
+    echo "   Branches have DIVERGED — reconcile before promoting."
+  fi
+  exit 1
+fi
+
+sha="$local_sha"
+echo "→ Promoting $sha ($(git log -1 --format=%s "$sha"))"
+
+# Gate on a workflow RUN's conclusion, not on individual check-runs: a run whose
+# jobs are all path-filtered to `skipped` still concludes `success`, which is the
+# correct answer for a docs-only commit. Reading check-runs would reject it.
+#
+# status=completed is load-bearing (same as deploy-prod.yml): it excludes any
+# still-running run so in-progress can never read as success. If CI has not
+# finished for this SHA the query returns nothing and we block.
+gate_workflow() {
+  local wf="$1" label="$2" conclusion
+  if ! conclusion=$(gh api \
+      "repos/{owner}/{repo}/actions/workflows/${wf}/runs?head_sha=${sha}&status=completed&per_page=1" \
+      --jq '.workflow_runs[0].conclusion // "missing"' 2>/dev/null); then
+    echo "❌ promote pre-flight: could not read ${label} status for $sha (gh auth/network?)"
+    echo "   Blocking rather than assuming green."
+    exit 1
+  fi
+  if [ "$conclusion" != "success" ]; then
+    echo "❌ promote pre-flight: ${label} for $sha is '${conclusion}', not success."
+    if [ "$conclusion" = "missing" ]; then
+      echo "   No COMPLETED ${label} run for this SHA — it may still be running. Wait and retry."
+    fi
+    exit 1
+  fi
+  echo "✅ ${label}: success"
+}
+
+# Both gates deploy-prod.yml enforces. build-images is the one most likely to
+# lag: it runs async on the develop push and takes longer than CI, so a promote
+# fired right after a merge can pass CI and still have no :<sha> image.
+gate_workflow "ci.yml" "CI"
+gate_workflow "build-images.yml" "image build"
+
+echo "✅ promote pre-flight passed — advancing $TARGET to $sha"

--- a/scripts/test/test-promote-preflight.sh
+++ b/scripts/test/test-promote-preflight.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Unit tests for scripts/promote-preflight.sh.
+#
+# Git-fixture hygiene: the pre-push hook exports GIT_DIR/GIT_WORK_TREE/
+# GIT_INDEX_FILE, and a fixture's `git init`/`git config` would otherwise hit the
+# REAL repo (work-tree fatals AND identity pollution). Unset them up front.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/promote-preflight.sh"
+PASS=0; FAIL=0
+ok()   { echo "ok: $1"; PASS=$((PASS+1)); }
+bad()  { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# A throwaway repo with a fake `gh` and a fake `origin`, so nothing touches the
+# network or the real checkout.
+setup_repo() {
+  REPO=$(mktemp -d); BIN=$(mktemp -d)
+  git init -q "$REPO/origin.git" --bare
+  git init -q "$REPO/wt"
+  cd "$REPO/wt"
+  git config user.email t@example.com; git config user.name t
+  git config commit.gpgsign false
+  git remote add origin "$REPO/origin.git"
+  echo one > f && git add f && git commit -qm one
+  git branch -M develop && git push -q origin develop
+  export PATH="$BIN:$PATH"
+}
+teardown() { cd /; rm -rf "$REPO" "$BIN"; }
+
+# $1 = conclusion the fake gh reports; "ERR" makes it exit non-zero.
+fake_gh() {
+  cat > "$BIN/gh" <<EOF
+#!/bin/bash
+[ "$1" = "ERR" ] && exit 1
+echo "$1"
+EOF
+  chmod +x "$BIN/gh"
+}
+
+run_pf() { bash "$SCRIPT" >"$REPO/out" 2>&1; echo $?; }
+
+# --- both gates green, refs in sync -> pass ---
+setup_repo; fake_gh success
+[ "$(run_pf)" = "0" ] && ok "in-sync + green -> exit 0" || bad "in-sync + green should pass ($(cat "$REPO/out"))"
+teardown
+
+# --- stale local ref -> refuse, and NAME the missing commits ---
+setup_repo; fake_gh success
+echo two > f2 && git add f2 && git commit -qm "second commit"
+git push -q origin develop
+git reset -q --hard HEAD~1          # local now BEHIND origin
+rc=$(run_pf)
+[ "$rc" != "0" ] && ok "stale local ref -> non-zero" || bad "stale local ref should refuse"
+grep -q "BEHIND by 1" "$REPO/out" && ok "stale ref names the gap" || bad "stale ref should report how far behind"
+grep -q "second commit" "$REPO/out" && ok "stale ref lists the unshipped commit" || bad "should list missing commits"
+teardown
+
+# --- CI not finished ("missing") -> refuse ---
+setup_repo; fake_gh missing
+rc=$(run_pf)
+[ "$rc" != "0" ] && ok "missing CI run -> non-zero" || bad "missing CI should refuse"
+grep -q "still be running" "$REPO/out" && ok "missing CI explains it may still be running" || bad "missing CI needs a wait hint"
+teardown
+
+# --- CI failed -> refuse ---
+setup_repo; fake_gh failure
+[ "$(run_pf)" != "0" ] && ok "failed CI -> non-zero" || bad "failed CI should refuse"
+teardown
+
+# --- gh unavailable/unauthenticated -> FAIL CLOSED (the key property) ---
+setup_repo; fake_gh ERR
+rc=$(run_pf)
+[ "$rc" != "0" ] && ok "gh error -> non-zero (fails closed)" || bad "gh error must BLOCK, not assume green"
+grep -q "Blocking rather than assuming green" "$REPO/out" && ok "gh error says it is blocking" || bad "gh error needs a clear message"
+teardown
+
+# --- gh absent entirely -> refuse ---
+setup_repo
+cd "$REPO/wt"
+rc=$(PATH="/usr/bin:/bin" bash "$SCRIPT" >"$REPO/out" 2>&1; echo $?)
+[ "$rc" != "0" ] && ok "gh not installed -> non-zero" || bad "missing gh should refuse"
+teardown
+
+echo "---"; echo "pass=$PASS fail=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "ALL PASS (promote pre-flight)"


### PR DESCRIPTION
`make promote` pushes the **local** `develop` ref, so a checkout that has not fetched silently promotes an older SHA than intended. That happened today — prod went to a commit three behind `develop`. Nothing broke (the missing commits were all docs/CI tooling, and the push is fast-forward-only so it can never ship something *wrong*, just something *older*), but the failure mode is silent, which is the problem.

## What it does

Before pushing, refuse unless:

1. local `develop` == `origin/develop` — and if not, name the commits that would be left behind
2. `ci.yml` records `success` for that SHA
3. `build-images.yml` records `success` for that SHA

`PROMOTE_SKIP_PREFLIGHT=1` bypasses it.

## Design notes

**Why check locally when `deploy-prod.yml` checks again server-side.** When `deploy-prod` aborts, `main` has *already moved* — the push succeeded and the workflow refused afterward, stranding `main` ahead of what is deployed. Refusing here keeps `main` from moving at all, which is a materially better failure mode than cleaning up after.

**Refuses on a stale ref rather than retargeting `origin/develop`.** Auto-retargeting would ship commits the operator has never looked at. In this repo `develop` moves from other worktrees and agent sessions, so that is a live scenario — trading "sometimes ships too little" for "sometimes ships more than you looked at" is a bad trade for a prod deploy.

**Gates on the workflow RUN conclusion, not check-runs.** A run whose jobs are all path-filtered to `skipped` still concludes `success`, which is the correct answer for a docs-only commit. Reading individual check-runs would reject it.

**`build-images.yml` is the likelier stranding cause**, and the gate I would have missed without reading `deploy-prod.yml`: image builds run async on the develop push and take longer than CI, so a promote fired right after a merge can pass CI and still have no `:<sha>` image.

**Fails closed** on any `gh`/network/auth error, matching `deploy-prod`'s posture of aborting when it reads CI as `missing`.

## Parity

`deploy-prod.yml` runs on the Pi with no checkout and no `gh`, so it cannot call this script — the two necessarily reimplement the same queries. Two divergent definitions of "green" is the worst outcome (promote says go, deploy says no, main has moved), so `scripts/ci/promote-gate-parity-guard.sh` fails if either side changes without the other. It runs in the always-on `changes` job, alongside the existing path-filters parity guard whose idiom it follows.

Like that guard, it is grep-based and a stale comment could in principle satisfy it — accepted to keep it LCD, consistent with the existing check.

## Verification

10 unit tests in `scripts/test/test-promote-preflight.sh`, wired into `make test-deploy-scripts` (already in pre-push and CI). They use a throwaway repo and a fake `gh`, so nothing touches the network or the real checkout, and they unset the `GIT_*` vars the pre-push hook exports.

Both guards were verified by **mutation**, not just by passing:

- deleting the `build-images` gate → parity guard fails
- making `gh` errors fall through instead of exiting → the fail-closed test fails (single semantic change, syntax still valid)

And run against live repo state it reproduced today's incident exactly: refused, and listed the three commits that had not shipped.