### PR TITLE
fix(imports): guard resolver modal against emptied queue crash

### DIFF
--- a/frontend/src/components/imports/__tests__/suggestion-modal.test.tsx
+++ b/frontend/src/components/imports/__tests__/suggestion-modal.test.tsx
@@ -89,8 +89,12 @@ beforeEach(() => {
   vi.mocked(useIgnoreCandidate).mockReturnValue(inertMutation)
 })
 
-function renderModal(candidates: ImportCandidate[], initialCandidateId: string) {
-  const item = { kind: 'contact' as const, candidates, initialCandidateId }
+function renderModal(
+  candidates: ImportCandidate[],
+  initialCandidateId: string,
+  opts?: { initialMode?: 'import' | 'link' }
+) {
+  const item = { kind: 'contact' as const, candidates, initialCandidateId, ...opts }
   const props = { onClose: vi.fn(), onSuccess: vi.fn(), onError: vi.fn() }
   const view = render(<SuggestionModal item={item} {...props} />)
   return {
@@ -264,6 +268,27 @@ describe('ContactCandidateResolver candidate tracking', () => {
     // left to act on, even though the page snapshot still has candidates.
     mockCandidatesQuery([])
     const { props } = renderModal([X, Y], X.id)
+
+    expect(props.onClose).toHaveBeenCalled()
+  })
+
+  it('unwinds without crashing when the last candidate is resolved in link mode', () => {
+    // Resolving the FINAL candidate empties the queue, so `candidate` becomes
+    // undefined. In link mode with a CRM contact selected, methodComparisons
+    // dereferenced the missing candidate (candidate.emails) BEFORE the modal's
+    // `if (!candidate) return null` guard could run, dropping the app into the
+    // React error boundary. The modal must unwind cleanly instead.
+    vi.mocked(useContact).mockReturnValue({
+      data: { id: 'contact-1', full_name: 'Real Person', methods: [], cadence: '' },
+    } as any)
+
+    mockCandidatesQuery([X])
+    const { props, rerenderModal } = renderModal([X], X.id, { initialMode: 'link' })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // The last candidate is resolved: an authoritative fetch returns empty.
+    mockCandidatesQuery([])
+    rerenderModal()
 
     expect(props.onClose).toHaveBeenCalled()
   })

--- a/frontend/src/components/imports/suggestion-modal.tsx
+++ b/frontend/src/components/imports/suggestion-modal.tsx
@@ -421,7 +421,11 @@ function ContactCandidateResolver({
 
   // Detect conflicts when in link mode and CRM contact is selected
   const methodComparisons = useMemo<MethodComparison[]>(() => {
-    if (mode !== 'link' || !selectedContact) {
+    // Guard `candidate`: resolving the last queue item empties the effective
+    // list, so `candidate` is momentarily undefined while `mode`/`selectedContact`
+    // still hold. This memo runs before the `if (!candidate) return null` guard
+    // below, so without the check detectMethodConflicts dereferences undefined.
+    if (mode !== 'link' || !selectedContact || !candidate) {
       return []
     }
     // If selectedContact exists but has no methods, pass an empty array

--- a/frontend/tests/e2e/imports-link-invalidation.spec.ts
+++ b/frontend/tests/e2e/imports-link-invalidation.spec.ts
@@ -79,14 +79,12 @@ test.describe('Import link invalidates contact detail @area:imports', () => {
     ])
     const contactId = contactIds[0]
 
-    // A second candidate keeps the review queue non-empty after the link. On a
-    // clean E2E database the seeded candidate would otherwise be the last one,
-    // and the resolver modal crashes its host page while unwinding an emptied
-    // queue — a pre-existing defect unrelated to cache invalidation, which
-    // would take the nav with it and strand the rest of this test.
+    // A single candidate: linking it empties the review queue, so this run
+    // exercises the resolver modal's empty-queue unwind. That path used to
+    // dereference the now-absent candidate and crash the host page; the
+    // error-boundary assertion below now guards it.
     const { ids: externalIds } = await testApi.seedExternalContacts([
       { display_name: 'Invalidation Candidate', emails: [candidateEmail] },
-      { display_name: 'Invalidation Bystander', emails: [`${prefix}-bystander@example.test`] },
     ])
     const externalId = externalIds[0]
 


### PR DESCRIPTION
## Summary

Fixes #692 — resolving the **last** import candidate (import, link, or ignore) dropped the whole app into the React error boundary with `TypeError: Cannot read properties of undefined (reading 'emails')`. Hit in prod while linking a contact method from discovery into an existing contact; the backend link succeeded, but the frontend crashed on unwind.

## Root cause

When the final candidate resolves, the effective queue empties and the resolver modal's `candidate` is `undefined` for one render. The component has a `if (!candidate) return null` safety guard, but the `methodComparisons` `useMemo` runs earlier in the render's hook phase. Its guard only checked `mode !== 'link' || !selectedContact` — so in link mode with a contact selected it called `detectMethodConflicts(undefined, ...)`, which dereferences `candidate.emails` and throws before the safety guard is ever reached.

## Fix

Add the missing `!candidate` guard to the memo so it bails to `[]` and the render falls through to the existing `return null`, letting the modal unwind cleanly. Mirrors the sibling guard the initialization effect already has.

## Tests

- **Unit** (`suggestion-modal.test.tsx`): new regression test reproduces the exact prod stack trace (`detectMethodConflicts` ← `methodComparisons` memo) — fails without the fix, passes with it. All 21 modal tests green.
- **E2E** (`imports-link-invalidation.spec.ts`): removed the "bystander" candidate that was seeded purely to keep the queue non-empty and dodge this crash (see #692). The spec now links a single candidate, empties the queue, and exercises the unwind path directly; its existing error-boundary assertion now regression-guards the fix. Verified passing locally.

Closes #692