### PR TITLE
fix(qa): unblock nightly clean-round predicate (#707, #708)

### DIFF
--- a/frontend/tests/tours/judge/doctor.test.ts
+++ b/frontend/tests/tours/judge/doctor.test.ts
@@ -201,6 +201,38 @@ describe('applyMutation — single-point, deterministic, non-mutating', () => {
     expect(items[0].body).toEqual({ data: { overdue: [] } }) // leading 200 untouched
   })
 
+  it('set_json_field itemMatch:all-errors rewrites every 500, leaving a leading 200 untouched', () => {
+    const reason = (m: string) => ({ error: { message: m } })
+    const base = [
+      cap({
+        behaviors: ['DSH-004'],
+        apiResponses: {
+          'GET /api/v1/contacts/overdue': [
+            apiItem({ status: 200, body: { data: { overdue: [] } } }),
+            apiItem({ status: 500, body: reason('retry-1') }),
+            apiItem({ status: 500, body: reason('retry-2') }),
+            apiItem({ status: 500, body: reason('retry-3') }),
+          ],
+        },
+      }),
+    ]
+    const out = applyMutation(base, {
+      op: 'set_json_field',
+      endpoint: 'GET /api/v1/contacts/overdue',
+      path: ['error', 'message'],
+      value: 'database connection refused',
+      itemMatch: 'all-errors',
+    })
+    const items = out[0].apiResponses['GET /api/v1/contacts/overdue']
+    const msg = (i: number) => (items[i].body as { error: { message: string } }).error.message
+    // Every 500 carries the doctored reason — no undoctored retry keeps the
+    // aria-shown reason faithful (gh #708).
+    expect(msg(1)).toBe('database connection refused')
+    expect(msg(2)).toBe('database connection refused')
+    expect(msg(3)).toBe('database connection refused')
+    expect(items[0].body).toEqual({ data: { overdue: [] } }) // leading 200 untouched
+  })
+
   it('is byte-stable across two runs', () => {
     const base = [cap({ behaviors: ['CON-041'], url: '/contacts/<id:1>' })]
     const m: Mutation = { op: 'inject_query', param: 'action', value: 'edit' }

--- a/frontend/tests/tours/judge/doctor.ts
+++ b/frontend/tests/tours/judge/doctor.ts
@@ -131,17 +131,26 @@ export function applyMutation(baseCaptures: Capture[], mutation: Mutation): Capt
       break
     }
     case 'set_json_field': {
-      // Target selection: itemMatch (dynamic) wins over itemIndex (fixed).
-      // 'last-error' finds the final >= 500 in the group — robust to a variable
-      // retry count or a leading success a fixed index would mistarget. A
-      // no-match / out-of-range index is a silent no-op HERE; the live self-test
-      // catches it via the rendered-prompt liveness guard (a mutation invisible
-      // to the judge fails loudly), so verify targeting against real captures.
+      // Target selection: itemMatch (dynamic) wins over itemIndex (fixed). Both
+      // dynamic modes are robust to a variable retry count or a leading success a
+      // fixed index would mistarget. A no-match / out-of-range index is a silent
+      // no-op HERE; the live self-test catches it via the rendered-prompt
+      // liveness guard (a mutation invisible to the judge fails loudly), so
+      // verify targeting against real captures.
       const group = cap.apiResponses[mutation.endpoint] ?? []
-      const idx =
-        mutation.itemMatch === 'last-error' ? lastErrorIndex(group) : (mutation.itemIndex ?? 0)
-      const item = group[idx]
-      if (item) setJsonPath(item.body, mutation.path, mutation.value)
+      if (mutation.itemMatch === 'all-errors') {
+        // Rewrite EVERY >= 500 so no undoctored retry keeps the aria-shown
+        // reason faithful — one semantic single-point change (the surfaced
+        // reason), like blank_dialog blanks the warning wherever it appears.
+        for (const item of group) {
+          if (item.status >= 500) setJsonPath(item.body, mutation.path, mutation.value)
+        }
+      } else {
+        const idx =
+          mutation.itemMatch === 'last-error' ? lastErrorIndex(group) : (mutation.itemIndex ?? 0)
+        const item = group[idx]
+        if (item) setJsonPath(item.body, mutation.path, mutation.value)
+      }
       break
     }
   }

--- a/frontend/tests/tours/judge/mutation.ts
+++ b/frontend/tests/tours/judge/mutation.ts
@@ -65,13 +65,19 @@ export const MutationSchema = z.discriminatedUnion('op', [
     // Which item in the endpoint group to mutate (default 0). Needed when the
     // meaningful body is not the first entry.
     itemIndex: z.number().int().nonnegative().optional(),
-    // Select the target item DYNAMICALLY instead of by fixed index (takes
-    // precedence over itemIndex). 'last-error' picks the LAST item in the
-    // endpoint group whose status >= 500 — the final failed response react-query
-    // surfaces. Use this over itemIndex for a retried failure bracket: the group
-    // length varies at capture time (a warm 200 hit may precede the retries), so
-    // a fixed index can land on a penultimate retry the UI never renders.
-    itemMatch: z.enum(['last-error']).optional(),
+    // Select the target item(s) DYNAMICALLY instead of by fixed index (takes
+    // precedence over itemIndex). Use this over itemIndex for a retried failure
+    // bracket: the group length varies at capture time (a warm 200 hit may
+    // precede the retries), so a fixed index can land on a penultimate retry the
+    // UI never renders.
+    //   'last-error' — the LAST item whose status >= 500 (the final failed
+    //     response react-query surfaces).
+    //   'all-errors' — EVERY item whose status >= 500. For a stale-reason trap:
+    //     rewriting only the final 500 leaves the earlier retries' reason still
+    //     matching the aria error state, so a single judge call can rationalize
+    //     the shown reason as faithful to one of them (the DSH-004 miss).
+    //     Corrupting all of them makes the contradiction unambiguous.
+    itemMatch: z.enum(['last-error', 'all-errors']).optional(),
   }),
 ])
 

--- a/frontend/tests/tours/judge/trap-config.ts
+++ b/frontend/tests/tours/judge/trap-config.ts
@@ -55,18 +55,19 @@ export const TRAPS: TrapSpec[] = [
       endpoint: 'GET /api/v1/contacts/overdue',
       path: ['error', 'message'],
       value: 'database connection refused',
-      // The FINAL 500 of the retried failure bracket — the response react-query
-      // actually surfaces. Selected DYNAMICALLY (last item with status >= 500)
-      // rather than a fixed index: a real capture may prepend a warm 200 hit
-      // before the retries, so a hardcoded index would land on a penultimate 500
-      // the UI never renders (the judge would then correctly PASS the unchanged
-      // final response → a false missed-trap). Corrupting the surfaced reason
-      // while the aria still shows the old one manufactures a stale-reason
-      // faithfulness fail on DSH-004[2].
-      itemMatch: 'last-error',
+      // EVERY 500 of the retried failure bracket — not just the final one.
+      // Doctoring only the last 500 left the earlier retries' reason still
+      // matching the aria error state, so a single judge call could rationalize
+      // the shown reason as faithful to one of the undoctored 500s and returned
+      // `unsure` — a deterministic missed trap (gh #708). Rewriting all of them
+      // makes the contradiction unambiguous: no response carries the reason the
+      // aria still shows, so DSH-004[2]'s faithfulness fails cleanly. Dynamic
+      // (status >= 500) rather than a fixed index because a real capture may
+      // prepend a warm 200 hit before the retries.
+      itemMatch: 'all-errors',
     },
     note:
-      'Rewrites the final overdue-fetch 500 reason so it no longer matches the reason shown in ' +
-      'the aria error state. The judge must fail DSH-004[2] — the shown reason is not faithful.',
+      'Rewrites every overdue-fetch 500 reason so none matches the reason shown in the aria ' +
+      'error state. The judge must fail DSH-004[2] — the shown reason is not faithful.',
   },
 ]

--- a/frontend/tests/tours/judge/trap-selftest.test.ts
+++ b/frontend/tests/tours/judge/trap-selftest.test.ts
@@ -29,10 +29,10 @@ function con042Captures(): Capture[] {
 // no-op, so the trap MUST select the error capture by role.
 //
 // The error capture's overdue group leads with a warm 200 hit, THEN the retried
-// 500 bracket (retry-1..retry-4). This is the length-varying shape that broke a
-// fixed itemIndex:3 — with the leading 200 the group has FIVE entries, so index
-// 3 lands on the PENULTIMATE 500 (retry-3), not the final one react-query
-// surfaces. The trap's 'last-error' selection corrects to retry-4.
+// 500 bracket (retry-1..retry-4). This is the length-varying shape a fixed
+// itemIndex would mistarget; the trap's 'all-errors' selection rewrites EVERY
+// 500 (retry-1..retry-4) and leaves the leading 200 untouched, so no undoctored
+// retry keeps the aria-shown reason faithful (gh #708).
 function dsh004Captures(): Capture[] {
   return [
     cap({
@@ -103,7 +103,7 @@ describe('runTrapSelfTest — the live detection self-test', () => {
     for (const input of calls) expect(input.images).toBeUndefined()
   })
 
-  it('CAUGHT: the DSH-004 trap corrupts the FINAL error response (last-error targeting, robust to a leading 200)', async () => {
+  it('CAUGHT: the DSH-004 trap corrupts EVERY error response (all-errors targeting, no faithful retry survives)', async () => {
     const { judge, calls } = mockJudge([v('fail', 'API overdue error.message', 2)])
     const [r] = await runTrapSelfTest(dsh004Captures(), [DSH004_TRAP], judge)
     // `caught` (not a no-op `error`) proves role:'error' selected the ERROR
@@ -116,16 +116,19 @@ describe('runTrapSelfTest — the live detection self-test', () => {
     const prompt = buildPrompt(calls[0])
     const doctored =
       DSH004_TRAP.mutation.op === 'set_json_field' ? String(DSH004_TRAP.mutation.value) : '<n/a>'
-    // The doctored reason lands EXACTLY ONCE — on the response the UI renders.
-    expect(prompt.split(doctored).length - 1).toBe(1)
-    // Targeting proof: the FINAL 500's original reason (retry-4) is overwritten
-    // and GONE, while the PENULTIMATE 500 (retry-3, which a fixed itemIndex:3
-    // would have hit given the leading 200) SURVIVES. A mis-targeted trap fails
-    // these two assertions.
+    // The doctored reason lands on ALL FOUR 500s (retry-1..retry-4) — every
+    // response the judge could ground on now carries it, so none matches the
+    // aria-shown reason (the DSH-004 ambiguity that let a single judge call
+    // rationalize the shown reason as faithful — gh #708).
+    expect(prompt.split(doctored).length - 1).toBe(4)
+    // Targeting proof: every original 500 reason is overwritten and GONE. A
+    // mis-targeted trap (e.g. landing on the loading capture) fails these.
+    expect(prompt).not.toContain('retry-1 failed')
+    expect(prompt).not.toContain('retry-3 failed')
     expect(prompt).not.toContain('retry-4 failed')
-    expect(prompt).toContain('retry-3 failed')
     // The aria-shown surfaced reason survives (JSON-only doctoring) — the
-    // manufactured contradiction the judge must fail on.
+    // manufactured contradiction the judge must fail on, now matched by NONE of
+    // the API responses.
     expect(prompt).toContain('overdue fetch failed')
   })
 

--- a/frontend/tests/tours/relationship-loop.tour.ts
+++ b/frontend/tests/tours/relationship-loop.tour.ts
@@ -70,6 +70,12 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
   test.setTimeout(480_000)
 
   // --- 1. Land: the app opens on the dashboard (DSH-001) ---
+  // Arm the overdue-fetch listener BEFORE navigating: the dashboard issues its
+  // overdue GET once, during landing, and the step-1 landing capture() below
+  // drains the response buffer before step 2's readiness gate — so a post-hoc
+  // waitForApi(OVERDUE_PATH) would wait for a second GET the page never issues
+  // (deterministic on slower ARM tenants, gh #707). Awaited at step 2.
+  const overdueLoaded = tour.expectApi(page, 'GET', OVERDUE_PATH, { timeout: 30_000 })
   await page.goto('/')
   await page.waitForURL(u => new URL(u).pathname === '/dashboard')
   await page.getByRole('heading', { name: 'Action Required' }).waitFor({ state: 'visible' })
@@ -90,7 +96,7 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
   }
 
   // --- 2. Read the needs-attention signal (CAD-026) ---
-  await tour.waitForApi(page, 'GET', OVERDUE_PATH)
+  await overdueLoaded // the landing overdue GET (armed pre-nav; race-safe, gh #707)
   await page
     .getByRole('button', { name: 'Mark as Contacted' })
     .first()

--- a/frontend/tests/tours/support/capture.ts
+++ b/frontend/tests/tours/support/capture.ts
@@ -187,6 +187,28 @@ export class TourApi {
     return page.waitForResponse(matches, { timeout })
   }
 
+  // Arm a listener for the NEXT matching response NOW, returning the pending
+  // promise WITHOUT awaiting — call before the navigation that triggers a
+  // fire-once fetch, then await the handle where readiness is needed.
+  //
+  // Unlike waitForApi (which peeks the shared buffer, then waits for a *new*
+  // response), this is immune to the buffer being drained by an intervening
+  // capture(): a fire-once fetch that lands during a landing capture would be
+  // spliced out before a later waitForApi peeks, leaving it waiting for a second
+  // fetch the page never issues (deterministic on slower tenants — gh #707).
+  // Arming before navigation catches the response whenever it fires.
+  expectApi(
+    page: Page,
+    method: string,
+    pathPattern: PathPattern,
+    opts: { timeout?: number } = {}
+  ): Promise<Response> {
+    const timeout = opts.timeout ?? 15000
+    const matches = (r: Response): boolean =>
+      r.request().method() === method && this.matchPath(r.url(), pathPattern)
+    return page.waitForResponse(matches, { timeout })
+  }
+
   // Deterministically hold a route until release() (for capturing a
   // loading/in-flight disabled state without timing luck).
   // The handler continues each intercepted route exactly once after the gate


### PR DESCRIPTION
Two deterministic QA-content blockers surfaced while validating the nightly QA runner on the `qa` tenant (stovepipes, ARM, tours against staging). Each fails the runner's clean-round predicate, so the watermark can never advance. Both are QA-program fixes (tour/trap robustness), not host-glue.

## #707 — relationship-loop tour: race-safe overdue-fetch gate

The step-1 landing `capture()` drains the response buffer *before* step 2's `waitForApi(OVERDUE_PATH)`, consuming the dashboard's fire-once overdue GET — so the readiness gate waits for a second GET the page never issues. Deterministic on slower ARM tenants because the pre-drain `ariaSnapshot()` await gives the GET time to land in the buffer first (intermittent elsewhere). `dashboard.tour.ts` never hit this: it has no `capture()` between its `goto` and `waitForApi`.

Fix: new `TourApi.expectApi()` arms the response listener *before* navigation and returns the pending promise; the tour awaits that handle at the readiness gate, immune to the intervening buffer drain.

## #708 — DSH-004 stale-reason trap: doctor every 500

`itemMatch: 'last-error'` doctored only the final overdue-fetch 500, leaving the earlier retries' reason still matching the aria error state — so a single judge call could rationalize the shown reason as faithful to one of the undoctored 500s and return `unsure` (a deterministic missed trap → `report_exit=2`).

Fix: new `itemMatch: 'all-errors'` for `set_json_field` rewrites every `>= 500` in the group (leaving a leading warm 200 untouched); the DSH-004 trap switches to it. No response now carries the aria-shown reason, so the faithfulness contradiction is unambiguous — one semantic single-point change (the surfaced reason), like `blank_dialog` blanks the warning wherever it appears.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check` all clean on touched files.
- All 379 judge vitest tests pass, including updated `doctor.test.ts` (new `all-errors` case) and `trap-selftest.test.ts` (DSH-004 now asserts all four 500s doctored, no faithful retry survives).
- Pre-push suite green.

The tours themselves run in the nightly E2E-against-staging path, not in CI — the judge/trap logic is covered by the vitest suites above.

Closes #707
Closes #708