### PR TITLE
feat(contacts): add visible "Back to list" control that keeps your place

### DIFF
--- a/.ai/spec/2026-07-21-contact-list-back-navigation-design.md
+++ b/.ai/spec/2026-07-21-contact-list-back-navigation-design.md
@@ -1,0 +1,78 @@
+# Design: a visible "Back to list" control that keeps the user's place
+
+- **Date:** 2026-07-21
+- **Status:** approved (brainstorming)
+- **Source:** GitHub issue #712 (label `ux-qa-agent` + `enhancement`); UXQA judge trace `judge-CON-051-2936fb4315716b37-item0` (runId `20260721T092414Z`, gitSha `8695685`)
+- **Intent served:** CON-051 — *"Browsing contacts never loses the user's place"*
+
+## Problem
+
+The contact detail page carries list context (sort, order, search, two filters) correctly into prev/next navigation, and the keyboard **Escape** key returns to the list with that context preserved. But there is **no visible, clickable affordance** to return to the list. The `ContactNavigationBar` renders only `‹ N of M ›`. The single visible route back is the top navigation's "Contacts" link, which resets sort/search/filter to defaults. This breaks CON-051's "keyboard and mouse as equals" clause on the return trip: a mouse user who sorted/filtered/searched, opened a contact, and wants to go back has no discoverable way to return to the exact list state they left. Additionally, the list's page position is lost even via Escape, because page is not part of the carried context.
+
+## Goal & scope
+
+**In scope**
+1. A visible "Back to list" control on the contact detail page that returns to the list with sort, order, search, and both filters preserved — at parity with the existing keyboard Escape route.
+2. **Page restoration:** returning also lands the user on the list page that contains the contact they were viewing, rather than page 1.
+
+**Explicitly out of scope (not planned)**
+- Scroll-into-view and a transient highlight of the originating row on return. Considered and excluded — not planned.
+- Any change to the top navigation's "Contacts" link — it deliberately stays a context-free reset.
+- Slide-over/peek record browsing (a larger architectural direction surfaced in research) — not pursued.
+
+## Design decisions
+
+Decisions were validated against research into leading apps (Linear, Gmail, Airtable, Notion, Salesforce, HubSpot, Attio) and design-system guidance (Material 3, Apple HIG, Shopify Polaris, NN/g, Atlassian). The consistent finding: back-to-list belongs on the **leading (left) edge** and is a distinct affordance from prev/next paging ("leave this level" vs "next sibling"); it is semantically an **Up** action (a known parent with state restored), best presented as a **labeled** control rather than a bare arrow (a lone `←` collides visually with the pager's `‹`).
+
+- **Layout — column-aligned bar.** The navigation bar's contents are constrained to the same `max-w-4xl` (~900px) column as the detail body. "Back to list" sits at the column's left edge (aligned with the contact name); the `‹ N of M ›` pager sits at the column's right edge (aligned with the action buttons). The grey background stays full-bleed; only its inner content is column-constrained. This resolves the original disharmony where bar items floated to the screen edges, unrelated to the centered content.
+- **Icon — back arrow** (`M19 12H5M12 19l-7-7 7-7`, lucide `arrow-left`), not a list glyph (which competes with the adjacent pager chevron).
+- **Label — static "Back to list."** The honest right-generic label: correct whether or not a filter/search is active. Dynamic per-context labels ("Search results", etc.) were considered and rejected as unnecessary complexity.
+- **Alignment detail:** the control is a single flex row — `display:inline-flex; align-items:center; gap:6px; line-height:1`, with the SVG and text span both `display:block` — so the arrow and label share one centered baseline and cannot drift vertically.
+
+## Technical design
+
+### Which page "Back to list" targets
+
+The detail page already loads the **full ordered ID list** for the current context via `useContactIDs(listContext)` and computes `currentIndex` / `total`. The target page is therefore computed, not carried: `page = Math.floor(currentIndex / PAGE_SIZE) + 1`, with `PAGE_SIZE = 20` (the list's `limit`). This needs no "entry page" plumbing and has a better property than carrying an entry page: after the user arrows prev/next across a page boundary, "Back to list" follows the contact currently in view. When `currentIndex < 0` (ID list not yet loaded), the page is omitted and the list opens on page 1 (graceful degradation).
+
+### Page as a URL parameter on the list
+
+Today the list's page is ephemeral local state (`useState(1)` in `contacts/page.tsx`); it is never reflected in the URL, so nothing downstream can restore it. The fix makes `?page=N` the source of truth for the list surface, mirroring how sort/search/filters already work:
+- The list reads its initial page from `searchParams` on mount and writes it back via `router.replace(..., { scroll: false })` on page change (same pattern as the existing search sync).
+- Page is **not** added to `ContactListContext`. It is meaningful only for the list surface and the back-target, never for prev/next or detail URLs. Keeping it out of the context means detail and prev/next URLs stay page-free.
+- `buildContactListUrl(context, page?)` gains an optional `page` argument and appends `&page=N` only when `page > 1`. `parseListContext` is unchanged (page is read directly by the list, not through the context type).
+- On sort/order/search/filter change the list already resets to page 1; those call sites pass no page (→ omitted → page 1), which stays correct.
+
+Bonus: URL-syncing page also makes the contact list linkable and refresh-stable (today a refresh silently snaps back to page 1).
+
+### Return-to-list call sites
+
+The only return-to-list path today is the Escape handler (`contacts/[id]/page.tsx` → `buildNavigationUrl()` → `buildContactListUrl(listContext)`). Both the new button and Escape should share one page-aware helper:
+- Add `buildBackToListUrl()` = `buildContactListUrl(listContext, pageFromIndex(currentIndex))`.
+- The new "Back to list" button `onClick` calls `router.push(buildBackToListUrl())`.
+- The Escape handler's no-id branch calls the same helper (so keyboard and mouse restore identically, including page).
+- `buildContactDetailUrl` (prev/next, with an id) is unchanged.
+
+### `ContactNavigationBar`
+
+Add a left-aligned "Back to list" control and restructure the bar into `back-left / pager-right` within a column-constrained inner wrapper. The control takes an `onBack` callback and is hidden/disabled in edit mode (consistent with how prev/next is disabled while editing). Accessibility: it is a real `<button>` with visible text (no `aria-label` override needed), a visible focus ring, and the arrow marked decorative.
+
+## Files to change
+
+- `frontend/src/lib/contact-list-params.ts` — `buildContactListUrl` optional `page` param.
+- `frontend/src/components/contacts/contact-navigation-bar.tsx` — add back control; column-constrained back-left/pager-right layout.
+- `frontend/src/app/contacts/[id]/page.tsx` — `pageFromIndex` + `buildBackToListUrl`; wire button `onBack`; update Escape handler.
+- `frontend/src/app/contacts/page.tsx` — read/write `?page` from/to the URL instead of pure local state.
+- `spec/contacts.yaml` — new behavior (next free id **CON-065**) serving CON-051 covering the visible context-preserving return control + page restoration.
+- `frontend/tests/e2e/test-map.json` — map the new/updated E2E spec to `@area` if needed.
+- `frontend/tests/tours/judge/README.md` — add the `ux-qa-agent` label convention note (see below).
+
+## Spec & test obligations
+
+- **Behavior (SSOT):** add CON-065 to `spec/contacts.yaml`, `type: ux`, `status: current`, `surface: ui`, `serves: [CON-051]`, then-list covering (a) a visible control returns to the list with sort/order/search/filter preserved, and (b) it lands on the page containing the current contact. Run `make spec-lint` + `make spec-coverage`. Because the domain is `e2e_settled: true`, the new `surface: ui` behavior must land with its citing E2E test in the same PR.
+- **E2E:** a Playwright test that sorts/filters the list, opens a contact from a non-first page, clicks "Back to list", and asserts the list request carries the same `sort`/`order`/filter params and the correct `page` (assert via `page.waitForResponse` params, not row positions — accelerated dates collapse). Add a keyboard-parity assertion that Escape restores identically.
+- **Unit:** `contact-list-params.test.ts` for `buildContactListUrl` with/without `page`.
+
+## Side task in this PR — `ux-qa-agent` label convention
+
+Per the issue-triage convention established alongside #712, add a short note to `frontend/tests/tours/judge/README.md`: issues filed from a UXQA judge finding should carry the **`ux-qa-agent`** source label plus a type label (`bug` or `enhancement`) — the source label is orthogonal to type, matching the existing `improvement-audit` precedent; filter judge-derived work with `label:ux-qa-agent`.

--- a/frontend/src/app/contacts/[id]/page.tsx
+++ b/frontend/src/app/contacts/[id]/page.tsx
@@ -49,6 +49,7 @@ import type { ContactMethodOperation } from '@/types/generated/contact'
 import {
   buildContactDetailUrl,
   buildContactListUrl,
+  pageFromIndex,
   parseListContext,
 } from '@/lib/contact-list-params'
 import { MergeContactModal } from '@/components/contacts/merge-contact-modal'
@@ -205,10 +206,9 @@ export default function ContactDetailPage() {
   const activeTasks = [...followUpTasks, ...activeManualTasks]
   const completedTasks = completedManualTasks
 
-  // Build URL preserving list context params
+  // Build a detail URL for an adjacent contact, preserving list context params.
   const buildNavigationUrl = useCallback(
-    (newId?: string) =>
-      newId ? buildContactDetailUrl(listContext, newId) : buildContactListUrl(listContext),
+    (newId: string) => buildContactDetailUrl(listContext, newId),
     [listContext]
   )
 
@@ -221,6 +221,16 @@ export default function ContactDetailPage() {
       onNavigate: id => router.push(buildNavigationUrl(id)),
       enabled: !isEditing && !isLoading && !isLoadingIDs,
     }
+  )
+
+  // Return to the list at the user's place: the same context prev/next carries,
+  // plus the page holding the contact currently in view (computed from its
+  // global index). Shared by the "Back to list" button and the Escape key so
+  // mouse and keyboard restore identically. Falls back to page 1 when the id
+  // list has not resolved yet (currentIndex < 0 → pageFromIndex undefined).
+  const buildBackToListUrl = useCallback(
+    () => buildContactListUrl(listContext, pageFromIndex(currentIndex)),
+    [listContext, currentIndex]
   )
 
   // Prefetch adjacent contacts for smooth navigation
@@ -262,15 +272,15 @@ export default function ContactDetailPage() {
           // Discard changes and exit edit mode
           setIsEditing(false)
         } else {
-          // Return to contacts list (preserving context)
-          router.push(buildNavigationUrl())
+          // Return to contacts list (preserving context + page)
+          router.push(buildBackToListUrl())
         }
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isEditing, router, buildNavigationUrl])
+  }, [isEditing, router, buildBackToListUrl])
 
   // Detect if notes content overflows the 4-line clamp. ResizeObserver
   // re-measures whenever the container's box changes — the initial
@@ -437,6 +447,7 @@ export default function ContactDetailPage() {
 
         {/* Navigation Bar (disabled in edit mode) */}
         <ContactNavigationBar
+          onBack={() => router.push(buildBackToListUrl())}
           onPrevious={goBack}
           onNext={goForward}
           canGoBack={canGoBack}
@@ -524,6 +535,7 @@ export default function ContactDetailPage() {
 
       {/* Navigation Bar */}
       <ContactNavigationBar
+        onBack={() => router.push(buildBackToListUrl())}
         onPrevious={goBack}
         onNext={goForward}
         canGoBack={canGoBack}

--- a/frontend/src/app/contacts/page.tsx
+++ b/frontend/src/app/contacts/page.tsx
@@ -28,8 +28,10 @@ import type { Contact } from '@/types/contact'
 import {
   buildContactDetailUrl,
   buildContactListUrl,
+  CONTACTS_PAGE_SIZE,
   defaultOrderFor,
   parseListContext,
+  parseListPage,
   type ContactListContext,
   type SortField,
 } from '@/lib/contact-list-params'
@@ -421,14 +423,16 @@ function ContactsPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  // The URL is the source of truth for the list view: sort, order, and
-  // filters are derived from it every render, and event handlers write the
-  // next view straight back to it (replace, not push — view tweaks
-  // shouldn't grow history). Back-to-list, refresh, bookmarks, and
-  // same-route navigation all restore the view for free. Pagination is
-  // deliberately kept out of the URL.
+  // The URL is the source of truth for the list view: sort, order, filters,
+  // and the current page are derived from it every render, and event handlers
+  // write the next view straight back to it (replace, not push — view tweaks
+  // shouldn't grow history). Back-to-list, refresh, bookmarks, and same-route
+  // navigation all restore the view for free. Page rides the URL directly (not
+  // through ContactListContext, which stays page-free so detail and prev/next
+  // URLs never carry a page) so a deep-linked or refreshed list restores its
+  // page, and "Back to list" can land on the page holding the open contact.
   const urlContext = parseListContext(searchParams)
-  const [page, setPage] = useState(1)
+  const page = parseListPage(searchParams)
 
   // The search input keeps local state so keystrokes render instantly
   // (router.replace is async), overlaying the URL's search value.
@@ -444,7 +448,7 @@ function ContactsPageContent() {
   }
 
   const applyContext = (next: ContactListContext) => {
-    setPage(1)
+    // No page arg → the page param is dropped → the list resets to page 1.
     router.replace(buildContactListUrl(next), { scroll: false })
   }
 
@@ -459,7 +463,7 @@ function ContactsPageContent() {
 
   const { data, isLoading, error } = useContacts({
     page,
-    limit: 20,
+    limit: CONTACTS_PAGE_SIZE,
     sort: listContext.sort,
     order: listContext.order,
     cadence_filter: listContext.cadence_filter,
@@ -476,7 +480,6 @@ function ContactsPageContent() {
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
-    setPage(1)
   }
 
   const handleSort = (field: SortField) => {
@@ -565,7 +568,9 @@ function ContactsPageContent() {
               page={data.page}
               pages={data.pages}
               total={data.total}
-              onPageChange={p => setPage(p)}
+              onPageChange={p =>
+                router.replace(buildContactListUrl(listContext, p), { scroll: false })
+              }
               noun="contacts"
             />
           </div>
@@ -611,7 +616,9 @@ function ContactsPageContent() {
               page={data.page}
               pages={data.pages}
               total={data.total}
-              onPageChange={p => setPage(p)}
+              onPageChange={p =>
+                router.replace(buildContactListUrl(listContext, p), { scroll: false })
+              }
               noun="contacts"
             />
           </div>

--- a/frontend/src/components/contacts/__tests__/contact-navigation-bar.test.tsx
+++ b/frontend/src/components/contacts/__tests__/contact-navigation-bar.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { ContactNavigationBar } from '../contact-navigation-bar'
+
+// Common props with prev/next NOT disabled by their boundary flags, so any
+// disabling that shows up comes from isEditMode/isLoading — not the boundaries.
+const baseProps = {
+  onBack: vi.fn(),
+  onPrevious: vi.fn(),
+  onNext: vi.fn(),
+  canGoBack: true,
+  canGoForward: true,
+  currentIndex: 5,
+  totalCount: 21,
+}
+
+describe('ContactNavigationBar back control', () => {
+  it('keeps Back enabled while the id list loads, even though prev/next are disabled', () => {
+    render(<ContactNavigationBar {...baseProps} isLoading={true} isEditMode={false} />)
+
+    // Back is decoupled from isLoading — it is the return escape hatch and
+    // falls back to page 1 gracefully if clicked before the index resolves.
+    expect(screen.getByRole('button', { name: 'Back to list' })).toBeEnabled()
+    // Prev/next ARE disabled while loading (their predicate includes isLoading),
+    // proving the enabled-Back assertion above is not vacuous.
+    expect(screen.getByRole('button', { name: 'Previous contact' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Next contact' })).toBeDisabled()
+  })
+
+  it('disables Back in edit mode', () => {
+    render(<ContactNavigationBar {...baseProps} isEditMode={true} isLoading={false} />)
+    expect(screen.getByRole('button', { name: 'Back to list' })).toBeDisabled()
+  })
+
+  it('enables Back when not editing and not loading', () => {
+    render(<ContactNavigationBar {...baseProps} isEditMode={false} isLoading={false} />)
+    expect(screen.getByRole('button', { name: 'Back to list' })).toBeEnabled()
+  })
+
+  it('fires onBack when the enabled control is clicked', async () => {
+    const onBack = vi.fn()
+    render(<ContactNavigationBar {...baseProps} onBack={onBack} isEditMode={false} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Back to list' }))
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/contacts/contact-navigation-bar.tsx
+++ b/frontend/src/components/contacts/contact-navigation-bar.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react'
 import { clsx } from 'clsx'
 
 interface ContactNavigationBarProps {
+  /** Return to the contact list at the user's place */
+  onBack: () => void
   /** Navigate to previous contact */
   onPrevious: () => void
   /** Navigate to next contact */
@@ -25,7 +27,11 @@ interface ContactNavigationBarProps {
 /**
  * Compact navigation bar for contact details page
  *
- * Shows: [←] [N of M] [→]
+ * Shows: [Back to list] ... [‹ N of M ›]
+ *
+ * The bar background is full-bleed; its contents are constrained to the same
+ * max-w-4xl column as the detail body so "Back to list" aligns with the
+ * contact name (left) and the pager aligns with the action buttons (right).
  *
  * Visual states:
  * - Enabled: text-gray-500, hover:text-gray-700
@@ -33,6 +39,7 @@ interface ContactNavigationBarProps {
  * - Disabled (edit mode): text-gray-300, cursor-not-allowed
  */
 export function ContactNavigationBar({
+  onBack,
   onPrevious,
   onNext,
   canGoBack,
@@ -44,6 +51,10 @@ export function ContactNavigationBar({
 }: ContactNavigationBarProps) {
   const isPrevDisabled = !canGoBack || isEditMode || isLoading
   const isNextDisabled = !canGoForward || isEditMode || isLoading
+  // Back stays available whenever the user isn't mid-edit — it's the return
+  // escape hatch and works regardless of the id list's load state (it falls
+  // back to page 1 gracefully if clicked before the index resolves).
+  const isBackDisabled = isEditMode
 
   // Determine button styles based on state
   const getButtonStyles = (isDisabled: boolean) => {
@@ -57,50 +68,68 @@ export function ContactNavigationBar({
   }
 
   return (
-    <div className="flex items-center justify-between py-1.5 px-4 bg-gray-100 border-b border-gray-200">
-      <button
-        onClick={onPrevious}
-        disabled={isPrevDisabled}
-        title={
-          isEditMode
-            ? 'Save or discard changes to navigate'
-            : canGoBack
-              ? 'Previous contact (←)'
-              : 'At first contact'
-        }
-        aria-label="Previous contact"
-        className={clsx('p-1 rounded transition-colors', getButtonStyles(isPrevDisabled))}
-      >
-        <ChevronLeft className="w-4 h-4" />
-      </button>
+    <div className="py-1.5 bg-gray-100 border-b border-gray-200">
+      <div className="max-w-4xl mx-auto sm:px-6 lg:px-8 flex items-center justify-between">
+        <button
+          onClick={onBack}
+          disabled={isBackDisabled}
+          title={isEditMode ? 'Save or discard changes to navigate' : 'Back to list'}
+          className={clsx(
+            'inline-flex items-center gap-1.5 leading-none p-1 rounded transition-colors text-sm',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+            getButtonStyles(isBackDisabled)
+          )}
+        >
+          <ArrowLeft className="w-4 h-4 block" aria-hidden="true" />
+          <span className="block">Back to list</span>
+        </button>
 
-      <span className="text-xs text-gray-600">
-        {totalCount > 0 ? (
-          <>
-            <span className="font-medium">{currentIndex + 1}</span>
-            {' of '}
-            <span className="font-medium">{totalCount}</span>
-          </>
-        ) : (
-          <span className="text-gray-400">No contacts</span>
-        )}
-      </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onPrevious}
+            disabled={isPrevDisabled}
+            title={
+              isEditMode
+                ? 'Save or discard changes to navigate'
+                : canGoBack
+                  ? 'Previous contact (←)'
+                  : 'At first contact'
+            }
+            aria-label="Previous contact"
+            className={clsx('p-1 rounded transition-colors', getButtonStyles(isPrevDisabled))}
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
 
-      <button
-        onClick={onNext}
-        disabled={isNextDisabled}
-        title={
-          isEditMode
-            ? 'Save or discard changes to navigate'
-            : canGoForward
-              ? 'Next contact (→)'
-              : 'At last contact'
-        }
-        aria-label="Next contact"
-        className={clsx('p-1 rounded transition-colors', getButtonStyles(isNextDisabled))}
-      >
-        <ChevronRight className="w-4 h-4" />
-      </button>
+          <span className="text-xs text-gray-600">
+            {totalCount > 0 ? (
+              <>
+                <span className="font-medium">{currentIndex + 1}</span>
+                {' of '}
+                <span className="font-medium">{totalCount}</span>
+              </>
+            ) : (
+              <span className="text-gray-400">No contacts</span>
+            )}
+          </span>
+
+          <button
+            onClick={onNext}
+            disabled={isNextDisabled}
+            title={
+              isEditMode
+                ? 'Save or discard changes to navigate'
+                : canGoForward
+                  ? 'Next contact (→)'
+                  : 'At last contact'
+            }
+            aria-label="Next contact"
+            className={clsx('p-1 rounded transition-colors', getButtonStyles(isNextDisabled))}
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/lib/__tests__/contact-list-params.test.ts
+++ b/frontend/src/lib/__tests__/contact-list-params.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  CONTACTS_PAGE_SIZE,
   DEFAULT_SORT_FIELD,
   DEFAULT_SORT_ORDER,
   buildContactDetailUrl,
   buildContactListUrl,
   defaultOrderFor,
   listContextSearchParams,
+  pageFromIndex,
   parseListContext,
+  parseListPage,
   type ContactListContext,
 } from '../contact-list-params'
 
@@ -90,6 +93,64 @@ describe('contact-list-params', () => {
       expect(buildContactListUrl({ sort: 'name', order: 'asc' })).toBe(
         '/contacts?sort=name&order=asc'
       )
+    })
+  })
+
+  describe('buildContactListUrl page arg', () => {
+    const ctx: ContactListContext = { sort: 'name', order: 'asc', search: 'q' }
+
+    it('appends &page=N after the context params when page > 1', () => {
+      expect(buildContactListUrl(ctx, 2)).toBe('/contacts?sort=name&order=asc&search=q&page=2')
+    })
+
+    it('omits page for page 1 (the canonical bare URL)', () => {
+      expect(buildContactListUrl(ctx, 1)).toBe('/contacts?sort=name&order=asc&search=q')
+    })
+
+    it('omits page for undefined / 0 / negative / non-integer values', () => {
+      const bare = '/contacts?sort=name&order=asc&search=q'
+      expect(buildContactListUrl(ctx)).toBe(bare)
+      expect(buildContactListUrl(ctx, 0)).toBe(bare)
+      expect(buildContactListUrl(ctx, -3)).toBe(bare)
+      expect(buildContactListUrl(ctx, 1.5)).toBe(bare)
+      expect(buildContactListUrl(ctx, NaN)).toBe(bare)
+    })
+
+    it('does not leak page back into the parsed context', () => {
+      const parsed = parseListContext(new URL(buildContactListUrl(ctx, 3), 'http://x').searchParams)
+      expect(parsed).toEqual(ctx)
+      expect('page' in parsed).toBe(false)
+    })
+  })
+
+  describe('parseListPage', () => {
+    it('reads a valid 1-based page from the URL', () => {
+      expect(parseListPage(new URLSearchParams('page=3'))).toBe(3)
+    })
+
+    it('falls back to page 1 for missing / malformed / zero / negative / fractional', () => {
+      expect(parseListPage(new URLSearchParams(''))).toBe(1)
+      expect(parseListPage(new URLSearchParams('page=abc'))).toBe(1)
+      expect(parseListPage(new URLSearchParams('page=0'))).toBe(1)
+      expect(parseListPage(new URLSearchParams('page=-1'))).toBe(1)
+      expect(parseListPage(new URLSearchParams('page=1.5'))).toBe(1)
+    })
+  })
+
+  describe('pageFromIndex', () => {
+    it('maps a global index to its 1-based page, and < 0 to undefined', () => {
+      expect(pageFromIndex(-1)).toBeUndefined()
+      expect(pageFromIndex(0)).toBe(1)
+      expect(pageFromIndex(19)).toBe(1)
+      expect(pageFromIndex(20)).toBe(2)
+      expect(pageFromIndex(39)).toBe(2)
+      expect(pageFromIndex(40)).toBe(3)
+    })
+  })
+
+  describe('CONTACTS_PAGE_SIZE', () => {
+    it('is 20 — the list limit and the pageFromIndex divisor must not drift', () => {
+      expect(CONTACTS_PAGE_SIZE).toBe(20)
     })
   })
 

--- a/frontend/src/lib/contact-list-params.ts
+++ b/frontend/src/lib/contact-list-params.ts
@@ -31,6 +31,10 @@ export const SORT_FIELDS: readonly SortField[] = [
 export const DEFAULT_SORT_FIELD: SortField = 'cadence'
 export const DEFAULT_SORT_ORDER: SortOrder = 'desc'
 
+// The list's page size; also the divisor pageFromIndex uses to compute which
+// list page holds the contact in view. One constant so the two can never drift.
+export const CONTACTS_PAGE_SIZE = 20
+
 // Order applied when a column is first selected: most-frequent/most-recent
 // first for cadence and last_response_at, ascending for everything else.
 export function defaultOrderFor(field: SortField): SortOrder {
@@ -96,9 +100,31 @@ export function listContextSearchParams(context: ContactListContext): URLSearchP
 }
 
 // buildContactListUrl builds the list page URL carrying the full context
-// (the detail page's "back to list" target).
-export function buildContactListUrl(context: ContactListContext): string {
-  return `/contacts?${listContextSearchParams(context).toString()}`
+// (the detail page's "back to list" target). The optional page is appended as
+// &page=N only when it is a finite integer > 1 — page 1 is the canonical bare
+// URL, so existing links and the sort/filter reset path stay byte-identical.
+export function buildContactListUrl(context: ContactListContext, page?: number): string {
+  const params = listContextSearchParams(context)
+  if (page !== undefined && Number.isInteger(page) && page > 1) {
+    params.set('page', String(page))
+  }
+  return `/contacts?${params.toString()}`
+}
+
+// parseListPage reads the 1-based list page from URL search params, falling
+// back to page 1 for a missing, malformed, zero, negative, or non-integer
+// value. Page rides the URL directly and is NOT part of ContactListContext.
+export function parseListPage(searchParams: { get(name: string): string | null }): number {
+  const raw = Number(searchParams.get('page'))
+  return Number.isInteger(raw) && raw > 0 ? raw : 1
+}
+
+// pageFromIndex maps a global 0-based list index to the 1-based list page that
+// holds it. undefined when the id list has not resolved (index < 0) → the
+// caller omits page → the list opens on page 1.
+export function pageFromIndex(currentIndex: number): number | undefined {
+  if (currentIndex < 0) return undefined
+  return Math.floor(currentIndex / CONTACTS_PAGE_SIZE) + 1
 }
 
 // buildContactDetailUrl builds a detail page URL carrying the full context

--- a/frontend/tests/e2e/contact-navigation.spec.ts
+++ b/frontend/tests/e2e/contact-navigation.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test'
-import { createTestAPI, TestAPI } from './helpers/test-api'
+import { test, expect, type Page } from '@playwright/test'
+import { createTestAPI, TestAPI, type SeedContactInput } from './helpers/test-api'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
 const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
@@ -43,6 +43,10 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     const nextButton = page.getByRole('button', { name: 'Next contact' })
     await expect(nextButton).toBeEnabled()
 
+    // "Back to list" is enabled on the read view (disabled only in edit mode).
+    const backButton = page.getByRole('button', { name: 'Back to list' })
+    await expect(backButton).toBeEnabled()
+
     // Enter edit mode
     await page.getByRole('button', { name: 'Edit' }).first().click()
     await page.waitForLoadState('domcontentloaded')
@@ -53,6 +57,8 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     // Buttons should have disabled styling (opacity or disabled attribute)
     await expect(prevButton).toHaveAttribute('disabled', '')
     await expect(nextButton).toHaveAttribute('disabled', '')
+    // Back is disabled in edit mode too (you can't leave mid-edit).
+    await expect(backButton).toHaveAttribute('disabled', '')
 
     // Try pressing arrow key - should not navigate. Register the observation
     // window BEFORE the keypress (waitForURL only sees navigations that begin
@@ -459,5 +465,230 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     expect(await navProbe).toBe(false)
     // Final confirmation: still on the original contact's URL.
     await expect(page).toHaveURL(url)
+  })
+})
+
+// A paginated-list request (the useContacts fetch), distinguished from the
+// navigation id list (useContactIDs) by the absent ids_only param.
+function isListRequest(url: string): boolean {
+  const u = new URL(url)
+  return u.pathname === '/api/v1/contacts' && u.searchParams.get('ids_only') === null
+}
+
+test.describe('Contact Back-to-list navigation @area:contact-navigation', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  // 21 prefix-isolated contacts, each with a cadence and no followup, named
+  // Back Nav 01..21 in insertion order so name-asc order == ids[0..20]. Under
+  // has_cadence + no_followup the filtered set is all 21, and ids[20] ("Back
+  // Nav 21") is the first (only) row of page 2 (CONTACTS_PAGE_SIZE=20).
+  async function seedBackNavFixture(): Promise<string[]> {
+    const contacts: SeedContactInput[] = Array.from({ length: 21 }, (_, i) => ({
+      full_name: `Back Nav ${String(i + 1).padStart(2, '0')}`,
+      cadence: 'monthly',
+    }))
+    const { ids } = await testApi.seedContacts(contacts)
+    return ids
+  }
+
+  // Walk the REAL journey — filtered/sorted list → page 2 → open the first
+  // page-2 contact (global index 20) → reload the DETAIL page — leaving the
+  // page on the reloaded detail view ready to return. The reload tears down the
+  // QueryClient so the list's staleTime:2min cache can't serve the return from
+  // cache and hang a return waitForResponse. Also asserts the list→detail URL
+  // is page-free.
+  async function journeyToBackNav21Detail(page: Page, ids: string[]): Promise<void> {
+    const prefix = testApi.prefix
+    await page.goto(`/contacts?search=${encodeURIComponent(prefix)}&followup_filter=no_followup`)
+    await page.waitForLoadState('domcontentloaded')
+
+    // Real sort interaction, then settle on the applied state before the next
+    // interaction (a click mid re-render lands on a replaced node and is lost).
+    const nameHeader = page.getByRole('columnheader').filter({ hasText: /^Name/ })
+    await nameHeader.click()
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending')
+    await expect(page).toHaveURL(/sort=name/)
+    await expect(page).toHaveURL(/order=asc/)
+
+    // Real filter interaction.
+    await page.getByLabel('Filter by cadence').selectOption('has_cadence')
+    await expect(page).toHaveURL(/cadence_filter=has_cadence/)
+
+    // Page to page 2 via the Pagination control; the list writes ?page=2.
+    const pager = page.locator('[data-testid="pagination"]').first()
+    await expect(pager).toBeVisible({ timeout: 10000 })
+    await pager.getByRole('button', { name: '2' }).click()
+    await expect(page).toHaveURL(/page=2/)
+
+    // Open the first page-2 contact (global index 20 → "Back Nav 21").
+    const backNav21 = `${prefix}-Back Nav 21`
+    await page.getByText(backNav21).click()
+    await page.waitForURL(u => u.pathname === `/contacts/${ids[20]}`)
+
+    // The list→detail URL carries the full context but NEVER a page.
+    const detail = new URL(page.url())
+    expect(detail.searchParams.get('sort')).toBe('name')
+    expect(detail.searchParams.get('order')).toBe('asc')
+    expect(detail.searchParams.get('search')).toBe(prefix)
+    expect(detail.searchParams.get('cadence_filter')).toBe('has_cadence')
+    expect(detail.searchParams.get('followup_filter')).toBe('no_followup')
+    expect(detail.searchParams.get('page')).toBeNull()
+
+    // Reload the detail page (clears the QueryClient), then wait for nav to be
+    // ready so Back computes the real page, not the page-1 fallback.
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByRole('heading', { name: backNav21 })).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('21 of 21')).toBeVisible({ timeout: 10000 })
+  }
+
+  // Assert a captured list request and the browser URL both carry the complete
+  // preserved set: sort/order/search/BOTH filters + the given page.
+  async function expectFullContextRestored(
+    page: Page,
+    reqUrl: string,
+    expectedPage: string
+  ): Promise<void> {
+    const prefix = testApi.prefix
+    const params = new URL(reqUrl).searchParams
+    expect(params.get('sort')).toBe('name')
+    expect(params.get('order')).toBe('asc')
+    expect(params.get('search')).toBe(prefix)
+    expect(params.get('cadence_filter')).toBe('has_cadence')
+    expect(params.get('followup_filter')).toBe('no_followup')
+    expect(params.get('page')).toBe(expectedPage)
+
+    await page.waitForURL(
+      u =>
+        u.pathname === '/contacts' &&
+        u.searchParams.get('sort') === 'name' &&
+        u.searchParams.get('order') === 'asc' &&
+        u.searchParams.get('search') === prefix &&
+        u.searchParams.get('cadence_filter') === 'has_cadence' &&
+        u.searchParams.get('followup_filter') === 'no_followup' &&
+        u.searchParams.get('page') === expectedPage
+    )
+  }
+
+  test('the Back to list control restores full context AND page via the real journey', async ({
+    page,
+  }) => {
+    // spec: CON-065[0], CON-065[1]
+    const ids = await seedBackNavFixture()
+    await journeyToBackNav21Detail(page, ids)
+
+    const listReq = page.waitForResponse(
+      r => r.request().method() === 'GET' && isListRequest(r.url())
+    )
+    await page.getByRole('button', { name: 'Back to list' }).click()
+    await expectFullContextRestored(page, (await listReq).url(), '2')
+  })
+
+  test('Escape restores full context AND page identically to the button', async ({ page }) => {
+    // spec: CON-040[3], CON-065[1]
+    const ids = await seedBackNavFixture()
+    await journeyToBackNav21Detail(page, ids)
+
+    const listReq = page.waitForResponse(
+      r => r.request().method() === 'GET' && isListRequest(r.url())
+    )
+    await page.keyboard.press('Escape')
+    await expectFullContextRestored(page, (await listReq).url(), '2')
+  })
+
+  test('changing sort/search/filter from a later page resets to page 1', async ({ page }) => {
+    // spec: CON-066[0]
+    await seedBackNavFixture()
+    const prefix = testApi.prefix
+    const backNav21 = `${prefix}-Back Nav 21`
+    const page2Url =
+      `/contacts?search=${encodeURIComponent(prefix)}` +
+      `&sort=name&order=asc&cadence_filter=has_cadence&followup_filter=no_followup&page=2`
+
+    // (a) sort-FIELD change: name → cadence.
+    await page.goto(page2Url)
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText(backNav21)).toBeVisible({ timeout: 15000 })
+    let reset = page.waitForResponse(r => {
+      if (!isListRequest(r.url())) return false
+      const p = new URL(r.url()).searchParams
+      return p.get('page') === '1' && p.get('sort') === 'cadence'
+    })
+    await page
+      .getByRole('columnheader')
+      .filter({ hasText: /^Cadence/ })
+      .click()
+    await reset
+    await expect(page).not.toHaveURL(/[?&]page=/)
+
+    // (b) search change: append a character.
+    await page.goto(page2Url)
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText(backNav21)).toBeVisible({ timeout: 15000 })
+    const newTerm = `${prefix}x`
+    reset = page.waitForResponse(r => {
+      if (!isListRequest(r.url())) return false
+      const p = new URL(r.url()).searchParams
+      return p.get('page') === '1' && p.get('search') === newTerm
+    })
+    await page.getByPlaceholder('Search contacts...').fill(newTerm)
+    await reset
+    await expect(page).not.toHaveURL(/[?&]page=/)
+
+    // (c) cadence-filter change: has_cadence → no_cadence.
+    await page.goto(page2Url)
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText(backNav21)).toBeVisible({ timeout: 15000 })
+    reset = page.waitForResponse(r => {
+      if (!isListRequest(r.url())) return false
+      const p = new URL(r.url()).searchParams
+      return p.get('page') === '1' && p.get('cadence_filter') === 'no_cadence'
+    })
+    await page.getByLabel('Filter by cadence').selectOption('no_cadence')
+    await reset
+    await expect(page).not.toHaveURL(/[?&]page=/)
+  })
+
+  test('using pagination reflects the page into the URL and survives a reload', async ({
+    page,
+  }) => {
+    // spec: CON-058[2]
+    await seedBackNavFixture()
+    const prefix = testApi.prefix
+    await page.goto(
+      `/contacts?search=${encodeURIComponent(prefix)}` +
+        `&sort=name&order=asc&cadence_filter=has_cadence&followup_filter=no_followup`
+    )
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText(`${prefix}-Back Nav 01`)).toBeVisible({ timeout: 15000 })
+
+    // USE the Pagination control → the URL gains ?page=2. Await the click's
+    // OWN page-2 fetch to settle first, so the reload waiter below cannot
+    // resolve from this still-in-flight response instead of the reload's.
+    const pager = page.locator('[data-testid="pagination"]').first()
+    await expect(pager).toBeVisible({ timeout: 10000 })
+    const clickReq = page.waitForResponse(
+      r => isListRequest(r.url()) && new URL(r.url()).searchParams.get('page') === '2'
+    )
+    await pager.getByRole('button', { name: '2' }).click()
+    await expect(page).toHaveURL(/page=2/)
+    await clickReq
+
+    // Refresh-stability: arm a DISTINCT waiter AFTER the click fetch settled,
+    // then reload. The reloaded list fetches page 2 from the URL (cold, so this
+    // also covers deep-linking), not page 1.
+    const reloadReq = page.waitForResponse(
+      r => isListRequest(r.url()) && new URL(r.url()).searchParams.get('page') === '2'
+    )
+    await page.reload()
+    expect(new URL((await reloadReq).url()).searchParams.get('page')).toBe('2')
   })
 })

--- a/frontend/tests/tours/judge/README.md
+++ b/frontend/tests/tours/judge/README.md
@@ -64,6 +64,10 @@ Captures land in `frontend/tests/tours/.runs/<runId>/captures/{contacts,dashboar
 
 There is no drafter CLI and no `*.labeled.json` round-trip. The judge's own live verdict on each graded item IS the draft — shipped to Langfuse via the label-trace contract (above), self-sufficient for adjudication in the annotation queue, where the maintainer confirms or rejects it. Git holds no labels. See `.ai/spec/2026-07-19-codex-sdk-judge-transport.md` for the deferred fail-precision bar over that labeled set.
 
+## Issue triage — the `ux-qa-agent` label convention
+
+Issues filed from a UXQA judge finding carry the **`ux-qa-agent`** source label plus a type label (`bug` or `enhancement`). The source label is **orthogonal** to type — it marks provenance (this came from a judge trace), not severity — mirroring the existing `improvement-audit` precedent. Filter judge-derived work with `label:ux-qa-agent`. (Convention established alongside #712.)
+
 ## The mechanical-vs-deferred split
 
 **Mergeable now (zero human labels):** the grader + machinery unit tests, the doctoring library (`doctor.ts`) + live trap self-test (`trap-selftest.ts`), the advisory report, the export scrub + label-trace contract. **Backlog:** fail-precision over the labeled set, the error-analysis taxonomy, the scrubber name-bigram pass, the promptfoo spike. (The codex-sdk transport — `QA_JUDGE=codex-sdk`, `adapter/codex-sdk.ts` — is now built: a like-for-like transport swap of codex-exec behind the identical `Judge` interface.) All follow-ups are tracked in `.ai/spec/2026-07-19-codex-sdk-judge-transport.md` — never GitHub issues.

--- a/frontend/tests/tours/judge/intent-catalog.ts
+++ b/frontend/tests/tours/judge/intent-catalog.ts
@@ -65,7 +65,7 @@ export const INTENT_CATALOG: Record<string, IntentSpec> = {
     statement:
       'moving between the contact list and contact detail feels like traversing one consistent, ordered list — sort, search, and filter context carries across navigation in both directions, with keyboard and mouse as equals',
     status: 'current',
-    servedBy: ['CON-038', 'CON-040', 'CON-041', 'CON-057', 'CON-059', 'CON-060'],
+    servedBy: ['CON-038', 'CON-040', 'CON-041', 'CON-057', 'CON-059', 'CON-060', 'CON-065'],
   },
   'CON-052': {
     id: 'CON-052',

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -730,6 +730,7 @@ behaviors:
     then:
       - page-number buttons move between pages, with the current page marked
       - the previous/next controls disable at the list boundaries
+      - the current page is reflected in the list URL, so a deep-linked or refreshed list restores that same page
     provenance: [pagination.tsx, contacts page]
 
   - id: CON-059
@@ -856,6 +857,30 @@ behaviors:
       a client that cannot learn which method its own addition resolved to will
       later fail to edit or remove that method — the response shape is
       load-bearing, not incidental.
+
+  - id: CON-065
+    title: A visible control returns to the list at the user's place
+    type: ux
+    status: current
+    surface: ui
+    given: a contact detail page opened from a filtered, sorted, or searched list
+    when: the user returns to the list via the visible back control or the keyboard
+    then:
+      - a visible return-to-list control returns to the contact list with the sort, order, search, and filter context preserved
+      - returning lands on the list page that contains the contact that was open, rather than page 1
+    serves: [CON-051]
+    provenance: [ContactNavigationBar back control, buildBackToListUrl, 'contacts page ?page URL sync', contact-navigation.spec.ts, '.ai/spec/2026-07-21-contact-list-back-navigation-design.md']
+
+  - id: CON-066
+    title: Changing list context resets pagination to the first page
+    type: ux
+    status: current
+    surface: ui
+    given: the contact list showing a page other than the first
+    when: the sort, order, search, or a filter is changed
+    then:
+      - the list returns to the first page rather than carrying the prior page position into the new view
+    provenance: [contacts page applyContext/handleSearchInput, buildContactListUrl page arg]
 
   # --- Intents (judged experience goals — Track B agentic judge only) ---
 


### PR DESCRIPTION
Closes #712. Serves intent **CON-051** — *"Browsing contacts never loses the user's place."*

## Problem

The contact detail page carried list context (sort/order/search/filters) into prev/next navigation, and keyboard **Escape** returned to the list with that context — but there was **no visible, mouse-reachable route back**. The only clickable path was the top-nav "Contacts" link, which resets sort/search/filter to defaults. That broke CON-051's "keyboard and mouse as equals" clause. Page position was also lost, even via Escape.

## What this does

- Adds a labeled, column-aligned **"Back to list"** control (back arrow) at the leading edge of the contact detail navigation bar, with the prev/next pager as a distinct cluster on the right — matching the design-system convention (Material/Apple/Polaris) of separating "leave this level" from "next sibling."
- Makes list pagination **URL-backed** (`?page=N`): the list reads it on mount and writes it on change, so the page is deep-linkable and refresh-stable (previously a refresh silently snapped back to page 1).
- Both the new button and **Escape** share one page-aware helper, returning to the exact list page holding the contact in view (computed from the contact's index), with full sort/order/search/both-filter context — graceful page-1 fallback while the id list loads.

## Design

Decisions (layout, arrow icon, static "Back to list" label, page-restore scope, scroll/highlight explicitly excluded) were settled via an interactive prototype plus research into leading apps and design systems. The approved design doc is included at `.ai/spec/2026-07-21-contact-list-back-navigation-design.md`.

## Spec & tests

- New behaviors **CON-065** (visible context-preserving return) and **CON-066** (list-context change resets pagination), plus an appended **CON-058[2]** (page URL-backed / deep-linkable / refresh-stable) — each with citing E2E tests (`contacts.yaml` is `e2e_settled`).
- 4 new Back-to-list E2E tests + extended edit-mode test; unit tests for the index/page math (boundaries + fallback) and the URL page reader; a component test for the enabled-while-loading control state.
- `make test`, `make test-e2e-diff` (91 E2E pass), `make spec-lint`, `make spec-coverage` all green.

## Also

Documents the `ux-qa-agent` label convention (source label orthogonal to `bug`/`enhancement`, per the `improvement-audit` precedent) in the QA judge README — this issue was surfaced by the UXQA agent.