### PR TITLE
test(qa): retire CAD-037 → deterministic unlink coverage (#710 A-C)

### DIFF
--- a/backend/tests/contact_task_service_test.go
+++ b/backend/tests/contact_task_service_test.go
@@ -63,9 +63,10 @@ func (m *mockTodoistClient) Sync(ctx context.Context, syncToken string, resource
 	return &todoist.SyncResponse{SyncToken: "new-sync-token"}, nil
 }
 
-// setupServiceTest creates the service with necessary database setup
-// Returns the service, contact, and cleanup function
-func setupServiceTest(t *testing.T) (*service.ContactTaskService, *repository.Contact, func()) {
+// setupServiceTest creates the service with necessary database setup.
+// Returns the service, contact, the contact and contact-task repositories
+// (for direct-DB seeding and re-fetch assertions), and a cleanup function.
+func setupServiceTest(t *testing.T) (*service.ContactTaskService, *repository.Contact, *repository.ContactRepository, *repository.ContactTaskRepository, func()) {
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
@@ -133,7 +134,7 @@ func setupServiceTest(t *testing.T) (*service.ContactTaskService, *repository.Co
 		database.Close()
 	}
 
-	return svc, contact, cleanup
+	return svc, contact, contactRepo, contactTaskRepo, cleanup
 }
 
 func TestContactTaskService_CreateManualTask_Integration(t *testing.T) {
@@ -142,7 +143,7 @@ func TestContactTaskService_CreateManualTask_Integration(t *testing.T) {
 	}
 
 	t.Parallel()
-	svc, contact, cleanup := setupServiceTest(t)
+	svc, contact, _, _, cleanup := setupServiceTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -430,7 +431,7 @@ func TestContactTaskService_CRMMarkerFormat(t *testing.T) {
 	}
 
 	t.Parallel()
-	svc, contact, cleanup := setupServiceTest(t)
+	svc, contact, _, _, cleanup := setupServiceTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -473,6 +474,78 @@ func TestContactTaskService_CRMMarkerFormat(t *testing.T) {
 		assert.Equal(t, "manual", marker["lifecycle"])
 		assert.Equal(t, "instance-789", marker["instance"])
 	})
+}
+
+// TestDeleteTaskLink_IssuesNoOutboundTodoistCall proves the unlink path is a
+// pure local delete: the contact_task row IS the link (there is no separate
+// "underlying task" table), so a pure local unlink leaves the remote task
+// untouched precisely because no outbound call fires. The spy recording zero
+// calls is a regression guard — it fails loudly if anyone later adds an
+// outbound call to the unlink path.
+func TestDeleteTaskLink_IssuesNoOutboundTodoistCall(t *testing.T) {
+	// spec: CAD-039[0], CAD-039[1]
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	t.Parallel()
+	svc, contact, contactRepo, taskRepo, cleanup := setupServiceTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// A spy in place of a real Todoist client: DeleteTaskLink must never reach
+	// it, so any recorded call is a regression.
+	spy := &mockTodoistClient{}
+	svc.SetTodoistClientFactory(func(string) todoist.Client { return spy })
+
+	// Seed two managed, linked tasks on the same contact directly via the repo
+	// (no Todoist): a target to unlink and a sibling that must survive. Distinct
+	// namespaced external ids avoid unique_external_task_id collisions across
+	// parallel runs; reach_out + manual satisfies contact_task_kind_lifecycle_check.
+	suffix := uuid.New().String()[:8]
+	target, err := taskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       todoist.SourceName,
+		Kind:           contacttask.KindReachOut,
+		Lifecycle:      contacttask.LifecycleManual,
+		ExternalTaskID: "ext-" + suffix + "-t",
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{"content": "Target task"},
+	})
+	require.NoError(t, err)
+	sibling, err := taskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       todoist.SourceName,
+		Kind:           contacttask.KindReachOut,
+		Lifecycle:      contacttask.LifecycleManual,
+		ExternalTaskID: "ext-" + suffix + "-s",
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{"content": "Sibling task"},
+	})
+	require.NoError(t, err)
+
+	// Act: unlink the target.
+	require.NoError(t, svc.DeleteTaskLink(ctx, contact.ID, target.ID))
+
+	// The target link row is gone from PostgreSQL (real persistence).
+	_, err = taskRepo.GetContactTask(ctx, target.ID)
+	require.ErrorIs(t, err, db.ErrNotFound)
+
+	// The delete hit only the selected row: the sibling task on the same
+	// contact survives.
+	_, err = taskRepo.GetContactTask(ctx, sibling.ID)
+	require.NoError(t, err)
+
+	// The contact itself is intact (fresh DB read, not the stale pre-delete
+	// struct).
+	_, err = contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+
+	// Zero outbound: the unlink issued no call to the remote provider, so the
+	// remote task is untouched.
+	require.Empty(t, spy.quickAddCalls)
+	require.Empty(t, spy.syncCalls)
 }
 
 func strPtr(s string) *string {

--- a/frontend/tests/e2e/contact-tasks.spec.ts
+++ b/frontend/tests/e2e/contact-tasks.spec.ts
@@ -426,6 +426,13 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     })
   })
 
+  // These are the UI-affordance tests for unlink (CAD-033): the row offers
+  // unlink behind a confirmation, confirming removes the row, dismissing keeps
+  // it, and no in-CRM complete/dismiss control exists. Real persistence — the
+  // link row actually deleted from PostgreSQL and zero outbound calls to the
+  // remote provider (CAD-039) — is owned by the backend integration test
+  // TestDeleteTaskLink_IssuesNoOutboundTodoistCall; the /tasks routes are
+  // OAuth-gated, so a provider-less E2E env mocks the read + DELETE here.
   test.describe('Linked Task Row (mocked)', () => {
     const UNLINK_TITLE = 'Remove from CRM (keeps in Todoist)'
 
@@ -525,12 +532,11 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
 
     test('exposes no in-CRM complete or dismiss control on a linked task', async ({ page }) => {
       // spec: CAD-033[1], TDS-035[1]
-      // The CRM-side half of the clause: a linked task row offers ONLY
-      // unlink (plus "Open in Todoist") — completing and dismissing happen
-      // in the remote task app. The remote-survival half ("keeps the task
-      // alive in Todoist") is a backend guarantee covered by backend
-      // integration tests; the retired verifier abstained on it, so no
-      // proven coverage is lost.
+      // The CRM-side affordance: a linked task row offers ONLY unlink (plus
+      // "Open in Todoist") — completing and dismissing happen in the remote
+      // task app. The remote-survival guarantee (unlinking does not touch the
+      // remote task) is CAD-039, proven deterministically by the backend
+      // integration test TestDeleteTaskLink_IssuesNoOutboundTodoistCall.
       const { ids } = await testApi.seedContacts([{ full_name: 'No Complete Contact' }])
       const contactId = ids[0]
       const linked = makeTask(contactId, { id: 'task-linked-3', content: 'Mock linked task' })

--- a/frontend/tests/tours/judge/intent-catalog.test.ts
+++ b/frontend/tests/tours/judge/intent-catalog.test.ts
@@ -2,6 +2,10 @@
 // YAML and asserts the transcription matches — intent ids/titles/statements/
 // status verbatim, and servedBy equal to the corpus-wide inversion of the
 // `serves:` edges. Catalog drift fails HERE (offline), never in a live run.
+//
+// The catalog transcribes the NON-RETIRED intent set: a retired intent is an
+// SSOT tombstone (its row stays for the ID to never be reused) but is absent
+// from the judged catalog, so it must never re-enroll.
 
 import * as fs from 'fs'
 import * as path from 'path'
@@ -38,7 +42,7 @@ function loadBehaviors(): YamlBehavior[] {
 
 describe('intent-catalog ↔ spec YAML sync', () => {
   const behaviors = loadBehaviors()
-  const yamlIntents = behaviors.filter(b => b.type === 'intent')
+  const yamlIntents = behaviors.filter(b => b.type === 'intent' && b.status !== 'retired')
 
   it('transcribes exactly the intent set of the whole corpus', () => {
     expect(Object.keys(INTENT_CATALOG).sort()).toEqual(yamlIntents.map(b => b.id).sort())

--- a/frontend/tests/tours/judge/intent-catalog.ts
+++ b/frontend/tests/tours/judge/intent-catalog.ts
@@ -84,14 +84,6 @@ export const INTENT_CATALOG: Record<string, IntentSpec> = {
     status: 'current',
     servedBy: ['CAD-029', 'CAD-030', 'CAD-031'],
   },
-  'CAD-037': {
-    id: 'CAD-037',
-    title: 'CRM task actions are safe for remote task state',
-    statement:
-      "managing a linked task from the CRM never silently mutates or destroys the user's task in the remote app — remote state changes only where the user expects them to happen",
-    status: 'current',
-    servedBy: ['CAD-033'],
-  },
   // The core value loop, judged as ONE journey. Evidence comes from
   // relationship-loop.tour.ts, whose captures are tagged CAD-038 directly.
   //

--- a/spec/cadence-followup.yaml
+++ b/spec/cadence-followup.yaml
@@ -428,9 +428,8 @@ behaviors:
     given: a task linked to a contact
     when: the user manages it from the CRM
     then:
-      - the CRM offers unlink (with confirmation), which keeps the task alive in the remote app
-      - completing and dismissing happen in the remote task app, not the CRM
-    serves: [CAD-037]
+      - the CRM offers unlink behind a confirmation prompt; confirming removes the task from the CRM
+      - the linked task row offers no in-CRM complete or dismiss control — those happen in the remote task app
     provenance: [tasks-section.tsx TaskRow, useDeleteTaskLink]
 
   - id: CAD-034
@@ -459,6 +458,19 @@ behaviors:
     provenance: [todoist provider deadline-edit handling, CadenceUpdater.ApplyContactByOverride, MetadataKeySyncedDeadline]
     notes: The last-pushed watermark mechanics live in the todoist domain; this pins the cadence-side outcome.
 
+  - id: CAD-039
+    title: Unlinking a task issues no outbound call to the remote provider
+    type: business-logic
+    status: current
+    surface: none
+    given: a task linked to a contact
+    when: the user unlinks it from the CRM
+    then:
+      - the CRM deletes only its own tracking row for the task
+      - no outbound call is made to the remote task provider — the remote task is untouched
+    provenance: [service/contact_task.go DeleteTaskLink]
+    notes: The safe-remote-state guarantee formerly expressed as the judged intent CAD-037; moved to deterministic coverage (a backend integration test asserts zero outbound calls) per the QA-program rule that deterministic guarantees belong in tests, not the judge.
+
   # --- Intents (judged experience goals — Track B agentic judge only) ---
 
   - id: CAD-036
@@ -471,9 +483,10 @@ behaviors:
   - id: CAD-037
     title: CRM task actions are safe for remote task state
     type: intent
-    status: current
+    status: retired
     statement: managing a linked task from the CRM never silently mutates or destroys the user's task in the remote app — remote state changes only where the user expects them to happen
     provenance: ['.ai/spec/2026-07-10-ssot-intent-layer-and-judged-ux-goals-design.md']
+    notes: Superseded by CAD-039 (the backend invariant that unlinking issues no outbound call) and the CAD-033 UI affordance; retired from the judged intent set because the guarantee is deterministic and belongs in tests, not the agentic judge.
 
   - id: CAD-038
     title: The relationship loop closes — notice, act, and the app remembers


### PR DESCRIPTION
Closes part of #710 (Parts A + B + C). Test/spec-only — **no production code change**.

## What & why
The **CAD-037** intent ("CRM task actions are safe for remote task state") is a *deterministic* guarantee the UX judge structurally cannot observe on staging (unlink is provider-free; the tour skip-lists populated-task captures), so it returned an honest `unsure` every night. This moves the guarantee off the judge onto deterministic tests, per the QA-program rule (deterministic → tests, never the judge).

## Changes
- **A — spec re-home.** Retire intent `CAD-037` (tombstone per `spec/README`, not deleted); mint **`CAD-039`** (`type: business-logic`, `surface: none`, `status: current`) to own the provider-free/zero-outbound unlink invariant; reword `CAD-033`. `intent-catalog.ts` now filters retired intents (first retired *intent* in the corpus) and the catalog-sync test excludes them via an exact-set assertion so CAD-037 can't be re-enrolled.
- **B — backend integration test** (`contact_task_service_test.go`, the mandatory real-persistence owner): seeds a contact + linked task + a **sibling** task, injects a spy Todoist client, calls `DeleteTaskLink`, and asserts target-row deletion + **sibling survival** + contact intact (re-fetched, real PostgreSQL) for `CAD-039[0]`, and **zero** calls across the full `todoist.Client` boundary (QuickAdd + Sync) for `CAD-039[1]`.
- **C — mocked UI-affordance E2E** (`contact-tasks.spec.ts`): kept as the affordance check (only-unlink, confirm, row-removal), citing `CAD-033`. Per the user's **Option B** decision, Part B (not this E2E) owns real persistence — no testing-mode route wiring / production change.

## Verification
`make test` (unit+integration+frontend, 0 fail), `make spec-lint`, `make spec-coverage`, `make test-e2e-diff` (all 11 in-path contact-tasks tests green incl. unlink; one out-of-path expandable-notes flake passed on isolated retry). Local Codex review: P0=P1=P2=P3=0.

First PR of a 3-PR arc (#710 seeding + #711 birthdays follow).
