### PR TITLE
test(synthetic): broaden linked-task seeding on visible axis (#710 D)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ test: test-unit test-integration test-frontend
 
 test-unit:
 	@echo "Running backend unit tests..."
-	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/synthetic/factory/... ./internal/spec/... ./cmd/spec-lint/... ./cmd/spec-coverage/... $(GOTEST_VERBOSE) -short
+	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/synthetic/factory/... ./internal/synthetic/replay/... ./internal/spec/... ./cmd/spec-lint/... ./cmd/spec-coverage/... $(GOTEST_VERBOSE) -short
 
 # Provisions the per-worktree Postgres instance BEFORE the integration recipes
 # expand $(TEST_DATABASE_URL) (gh #433). As a prerequisite it runs to

--- a/backend/internal/db/contact_task.sql.go
+++ b/backend/internal/db/contact_task.sql.go
@@ -234,6 +234,71 @@ func (q *Queries) CreateContactTask(ctx context.Context, arg CreateContactTaskPa
 	return &i, err
 }
 
+const CreateContactTaskAtTime = `-- name: CreateContactTaskAtTime :one
+INSERT INTO contact_task (
+    contact_id,
+    provider,
+    kind,
+    lifecycle,
+    external_task_id,
+    state,
+    metadata,
+    created_at
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    COALESCE($6, 'managed'),
+    COALESCE($7::jsonb, '{}'::jsonb),
+    $8
+) RETURNING id, contact_id, provider, kind, external_task_id, state, metadata, created_at, updated_at, idempotency_key, lifecycle
+`
+
+type CreateContactTaskAtTimeParams struct {
+	ContactID      pgtype.UUID        `json:"contact_id"`
+	Provider       string             `json:"provider"`
+	Kind           string             `json:"kind"`
+	Lifecycle      string             `json:"lifecycle"`
+	ExternalTaskID string             `json:"external_task_id"`
+	State          interface{}        `json:"state"`
+	Metadata       []byte             `json:"metadata"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+}
+
+// Seed-only variant of CreateContactTask that sets created_at explicitly, so the
+// synthetic seeder can vary a linked task's created_at (its "link age")
+// anchor-relatively without a raw SQL insert. Production creators always let
+// created_at default to NOW(); no request path calls this.
+func (q *Queries) CreateContactTaskAtTime(ctx context.Context, arg CreateContactTaskAtTimeParams) (*ContactTask, error) {
+	row := q.db.QueryRow(ctx, CreateContactTaskAtTime,
+		arg.ContactID,
+		arg.Provider,
+		arg.Kind,
+		arg.Lifecycle,
+		arg.ExternalTaskID,
+		arg.State,
+		arg.Metadata,
+		arg.CreatedAt,
+	)
+	var i ContactTask
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Provider,
+		&i.Kind,
+		&i.ExternalTaskID,
+		&i.State,
+		&i.Metadata,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.IdempotencyKey,
+		&i.Lifecycle,
+	)
+	return &i, err
+}
+
 const CreateContactTaskWithIdempotencyKey = `-- name: CreateContactTaskWithIdempotencyKey :one
 INSERT INTO contact_task (
     contact_id,

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -342,6 +342,11 @@ type Querier interface {
 	CreateContact(ctx context.Context, arg CreateContactParams) (*Contact, error)
 	CreateContactMethod(ctx context.Context, arg CreateContactMethodParams) (*ContactMethod, error)
 	CreateContactTask(ctx context.Context, arg CreateContactTaskParams) (*ContactTask, error)
+	// Seed-only variant of CreateContactTask that sets created_at explicitly, so the
+	// synthetic seeder can vary a linked task's created_at (its "link age")
+	// anchor-relatively without a raw SQL insert. Production creators always let
+	// created_at default to NOW(); no request path calls this.
+	CreateContactTaskAtTime(ctx context.Context, arg CreateContactTaskAtTimeParams) (*ContactTask, error)
 	// Variant of CreateContactTask that accepts an explicit idempotency_key,
 	// used by the cutover FollowUpManager for crash-safe two-step create.
 	// A NULL key is permitted so the generic path can reuse the query shape;

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2218,6 +2218,12 @@ type Querier interface {
 	// contact soft-delete filter scopes to live catalog contacts. Caller passes a BARE
 	// prefix; '%' appended.
 	TestCountCadenceDueByStateAndNamePrefix(ctx context.Context, arg TestCountCadenceDueByStateAndNamePrefixParams) (int64, error)
+	// Exact task accounting (visible-task spread): count EVERY contact_task row on the
+	// namespace's live contacts (all lifecycles + states), so the coverage/determinism
+	// test can assert the total equals ProfileResult.SeededTasks. contact_task has no
+	// deleted_at; the contact soft-delete filter scopes to live contacts. Caller passes
+	// a BARE prefix; '%' appended.
+	TestCountContactTasksByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Coverage gate (F6): count the namespace's LIVE contacts that carry a NON-EMPTY
 	// NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
 	// The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
@@ -2498,6 +2504,21 @@ type Querier interface {
 	// so the catalog guard can assert each is in the wiped list, is schema_migrations,
 	// or matches the river_% allowlist. Read-only catalog access.
 	TestListPublicTables(ctx context.Context) ([]string, error)
+	// Visible-task coverage + determinism fingerprint source: every contact_task row on
+	// the namespace's live contacts, joined to its contact for the stable-identity
+	// full_name. Feeds the kind/lifecycle/state coverage checks, the link-age bucket
+	// spread (from created_at), the non-empty content check, and the run-to-run task
+	// fingerprint (keyed by full_name + kind + lifecycle + state + created_at age bucket
+	// — external_task_id and raw UUIDs excluded). Caller passes a BARE prefix; '%'
+	// appended.
+	TestListTaskRowsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListTaskRowsByNamePrefixRow, error)
+	// Visible-task cohort accounting: for each given contact, the count of its
+	// PRODUCT-VISIBLE tasks — the ones the contact page lists (state='managed' AND
+	// lifecycle IN ('manual','followup_loop')); it never lists cadence_due. A LEFT JOIN
+	// (not a task-side GROUP BY) so a contact with zero visible tasks still appears with
+	// count 0 — the 0-visible majority cannot be produced from task rows alone. Scoped to
+	// the passed catalog id set. Test only.
+	TestListVisibleTaskCountsByContactIds(ctx context.Context, contactIds []pgtype.UUID) ([]*TestListVisibleTaskCountsByContactIdsRow, error)
 	// TEST ONLY. Probe a contact row with FOR UPDATE NOWAIT: fails immediately
 	// (lock_not_available) when another tx holds a conflicting lock on the row.
 	// Used by the recompute lock-ordering regression test to prove (without a

--- a/backend/internal/db/queries/contact_task.sql
+++ b/backend/internal/db/queries/contact_task.sql
@@ -88,6 +88,31 @@ INSERT INTO contact_task (
     COALESCE(@metadata::jsonb, '{}'::jsonb)
 ) RETURNING *;
 
+-- name: CreateContactTaskAtTime :one
+-- Seed-only variant of CreateContactTask that sets created_at explicitly, so the
+-- synthetic seeder can vary a linked task's created_at (its "link age")
+-- anchor-relatively without a raw SQL insert. Production creators always let
+-- created_at default to NOW(); no request path calls this.
+INSERT INTO contact_task (
+    contact_id,
+    provider,
+    kind,
+    lifecycle,
+    external_task_id,
+    state,
+    metadata,
+    created_at
+) VALUES (
+    @contact_id,
+    @provider,
+    @kind,
+    @lifecycle,
+    @external_task_id,
+    COALESCE(@state, 'managed'),
+    COALESCE(@metadata::jsonb, '{}'::jsonb),
+    @created_at
+) RETURNING *;
+
 -- name: CreateContactTaskWithIdempotencyKey :one
 -- Variant of CreateContactTask that accepts an explicit idempotency_key,
 -- used by the cutover FollowUpManager for crash-safe two-step create.

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1446,3 +1446,51 @@ WHERE c.full_name LIKE @name_prefix || '%'
   AND c.deleted_at IS NULL
   AND c.last_outreach_at IS NOT NULL
   AND c.last_contacted IS NULL;
+
+-- name: TestCountContactTasksByNamePrefix :one
+-- Exact task accounting (visible-task spread): count EVERY contact_task row on the
+-- namespace's live contacts (all lifecycles + states), so the coverage/determinism
+-- test can assert the total equals ProfileResult.SeededTasks. contact_task has no
+-- deleted_at; the contact soft-delete filter scopes to live contacts. Caller passes
+-- a BARE prefix; '%' appended.
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL;
+
+-- name: TestListVisibleTaskCountsByContactIds :many
+-- Visible-task cohort accounting: for each given contact, the count of its
+-- PRODUCT-VISIBLE tasks — the ones the contact page lists (state='managed' AND
+-- lifecycle IN ('manual','followup_loop')); it never lists cadence_due. A LEFT JOIN
+-- (not a task-side GROUP BY) so a contact with zero visible tasks still appears with
+-- count 0 — the 0-visible majority cannot be produced from task rows alone. Scoped to
+-- the passed catalog id set. Test only.
+SELECT c.id AS contact_id, COUNT(ct.id) AS visible_count
+FROM contact c
+LEFT JOIN contact_task ct
+  ON ct.contact_id = c.id
+  AND ct.state = 'managed'
+  AND ct.lifecycle IN ('manual', 'followup_loop')
+WHERE c.id = ANY(@contact_ids::uuid[])
+  AND c.deleted_at IS NULL
+GROUP BY c.id;
+
+-- name: TestListTaskRowsByNamePrefix :many
+-- Visible-task coverage + determinism fingerprint source: every contact_task row on
+-- the namespace's live contacts, joined to its contact for the stable-identity
+-- full_name. Feeds the kind/lifecycle/state coverage checks, the link-age bucket
+-- spread (from created_at), the non-empty content check, and the run-to-run task
+-- fingerprint (keyed by full_name + kind + lifecycle + state + created_at age bucket
+-- — external_task_id and raw UUIDs excluded). Caller passes a BARE prefix; '%'
+-- appended.
+SELECT c.full_name,
+       ct.kind,
+       ct.lifecycle,
+       ct.state,
+       ct.created_at,
+       COALESCE(ct.metadata->>'content', '')::text AS content
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL;

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2175,6 +2175,26 @@ func (q *Queries) TestCountCadenceDueByStateAndNamePrefix(ctx context.Context, a
 	return count, err
 }
 
+const TestCountContactTasksByNamePrefix = `-- name: TestCountContactTasksByNamePrefix :one
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+`
+
+// Exact task accounting (visible-task spread): count EVERY contact_task row on the
+// namespace's live contacts (all lifecycles + states), so the coverage/determinism
+// test can assert the total equals ProfileResult.SeededTasks. contact_task has no
+// deleted_at; the contact soft-delete filter scopes to live contacts. Caller passes
+// a BARE prefix; '%' appended.
+func (q *Queries) TestCountContactTasksByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountContactTasksByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const TestCountContactsWithNotepadByNamePrefix = `-- name: TestCountContactsWithNotepadByNamePrefix :one
 SELECT COUNT(DISTINCT c.id)
 FROM contact c
@@ -3092,6 +3112,105 @@ func (q *Queries) TestListPublicTables(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, table_name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const TestListTaskRowsByNamePrefix = `-- name: TestListTaskRowsByNamePrefix :many
+SELECT c.full_name,
+       ct.kind,
+       ct.lifecycle,
+       ct.state,
+       ct.created_at,
+       COALESCE(ct.metadata->>'content', '')::text AS content
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+`
+
+type TestListTaskRowsByNamePrefixRow struct {
+	FullName  string             `json:"full_name"`
+	Kind      string             `json:"kind"`
+	Lifecycle string             `json:"lifecycle"`
+	State     string             `json:"state"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	Content   string             `json:"content"`
+}
+
+// Visible-task coverage + determinism fingerprint source: every contact_task row on
+// the namespace's live contacts, joined to its contact for the stable-identity
+// full_name. Feeds the kind/lifecycle/state coverage checks, the link-age bucket
+// spread (from created_at), the non-empty content check, and the run-to-run task
+// fingerprint (keyed by full_name + kind + lifecycle + state + created_at age bucket
+// — external_task_id and raw UUIDs excluded). Caller passes a BARE prefix; '%'
+// appended.
+func (q *Queries) TestListTaskRowsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListTaskRowsByNamePrefixRow, error) {
+	rows, err := q.db.Query(ctx, TestListTaskRowsByNamePrefix, namePrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TestListTaskRowsByNamePrefixRow{}
+	for rows.Next() {
+		var i TestListTaskRowsByNamePrefixRow
+		if err := rows.Scan(
+			&i.FullName,
+			&i.Kind,
+			&i.Lifecycle,
+			&i.State,
+			&i.CreatedAt,
+			&i.Content,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const TestListVisibleTaskCountsByContactIds = `-- name: TestListVisibleTaskCountsByContactIds :many
+SELECT c.id AS contact_id, COUNT(ct.id) AS visible_count
+FROM contact c
+LEFT JOIN contact_task ct
+  ON ct.contact_id = c.id
+  AND ct.state = 'managed'
+  AND ct.lifecycle IN ('manual', 'followup_loop')
+WHERE c.id = ANY($1::uuid[])
+  AND c.deleted_at IS NULL
+GROUP BY c.id
+`
+
+type TestListVisibleTaskCountsByContactIdsRow struct {
+	ContactID    pgtype.UUID `json:"contact_id"`
+	VisibleCount int64       `json:"visible_count"`
+}
+
+// Visible-task cohort accounting: for each given contact, the count of its
+// PRODUCT-VISIBLE tasks — the ones the contact page lists (state='managed' AND
+// lifecycle IN ('manual','followup_loop')); it never lists cadence_due. A LEFT JOIN
+// (not a task-side GROUP BY) so a contact with zero visible tasks still appears with
+// count 0 — the 0-visible majority cannot be produced from task rows alone. Scoped to
+// the passed catalog id set. Test only.
+func (q *Queries) TestListVisibleTaskCountsByContactIds(ctx context.Context, contactIds []pgtype.UUID) ([]*TestListVisibleTaskCountsByContactIdsRow, error) {
+	rows, err := q.db.Query(ctx, TestListVisibleTaskCountsByContactIds, contactIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TestListVisibleTaskCountsByContactIdsRow{}
+	for rows.Next() {
+		var i TestListVisibleTaskCountsByContactIdsRow
+		if err := rows.Scan(&i.ContactID, &i.VisibleCount); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/backend/internal/repository/contact_task.go
+++ b/backend/internal/repository/contact_task.go
@@ -362,6 +362,43 @@ func (r *ContactTaskRepository) CreateContactTask(ctx context.Context, req Creat
 	return &task, nil
 }
 
+// CreateContactTaskAtTime is a seed-only variant of CreateContactTask that sets
+// created_at explicitly (production always defaults it to NOW()). It lets the
+// synthetic seeder vary a linked task's created_at — its "link age" — relative to
+// the generator anchor. No request path calls this.
+func (r *ContactTaskRepository) CreateContactTaskAtTime(ctx context.Context, req CreateContactTaskRequest, createdAt time.Time) (*ContactTask, error) {
+	state := req.State
+	if state == "" {
+		state = string(ContactTaskStateManaged)
+	}
+
+	var metadataBytes []byte
+	if req.Metadata != nil {
+		var err error
+		metadataBytes, err = json.Marshal(req.Metadata)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	dbTask, err := r.queries.CreateContactTaskAtTime(ctx, db.CreateContactTaskAtTimeParams{
+		ContactID:      uuidToPgUUID(req.ContactID),
+		Provider:       req.Provider,
+		Kind:           req.Kind,
+		Lifecycle:      req.Lifecycle,
+		ExternalTaskID: req.ExternalTaskID,
+		State:          state,
+		Metadata:       metadataBytes,
+		CreatedAt:      timeToPgTimestamptz(&createdAt),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	task := convertDbContactTask(dbTask)
+	return &task, nil
+}
+
 // UpsertContactTask creates or updates a contact task
 func (r *ContactTaskRepository) UpsertContactTask(ctx context.Context, req CreateContactTaskRequest) (*ContactTask, error) {
 	state := req.State

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -292,6 +292,76 @@ func (r *SyntheticSupportRepository) CountCadenceDueByStateByNamePrefix(ctx cont
 	})
 }
 
+// CountContactTasksByNamePrefix counts EVERY contact_task row on the namespace's
+// live contacts (all lifecycles + states), so the coverage/determinism test can
+// assert the total equals ProfileResult.SeededTasks. Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) CountContactTasksByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountContactTasksByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// VisibleTaskCount is a contact's product-visible task count (the tasks the contact
+// page lists: managed manual/follow-up), for the 0/1/>1 cohort assertions.
+type VisibleTaskCount struct {
+	ContactID    uuid.UUID
+	VisibleCount int64
+}
+
+// ListVisibleTaskCountsByContactIds returns, for each given contact, its count of
+// product-visible tasks (managed AND lifecycle IN manual/followup_loop). A LEFT JOIN
+// so zero-visible contacts appear with count 0 — the 0-visible majority the coverage
+// test proves over the catalog id set.
+func (r *SyntheticSupportRepository) ListVisibleTaskCountsByContactIds(ctx context.Context, contactIDs []uuid.UUID) ([]VisibleTaskCount, error) {
+	if len(contactIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := r.queries.TestListVisibleTaskCountsByContactIds(ctx, pgUUIDs(contactIDs))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]VisibleTaskCount, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, VisibleTaskCount{
+			ContactID:    uuid.UUID(row.ContactID.Bytes),
+			VisibleCount: row.VisibleCount,
+		})
+	}
+	return out, nil
+}
+
+// TaskRow is a contact_task row projected with its contact's stable-identity
+// full_name, for the visible-task coverage checks + the run-to-run task fingerprint.
+type TaskRow struct {
+	FullName  string
+	Kind      string
+	Lifecycle string
+	State     string
+	CreatedAt time.Time
+	Content   string
+}
+
+// ListTaskRowsByNamePrefix returns every contact_task row on the namespace's live
+// contacts, joined to its contact for the full_name. Feeds the kind/lifecycle/state
+// coverage, the link-age bucket spread, the non-empty content check, and the
+// name-keyed task fingerprint. Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) ListTaskRowsByNamePrefix(ctx context.Context, namePrefix string) ([]TaskRow, error) {
+	rows, err := r.queries.TestListTaskRowsByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]TaskRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, TaskRow{
+			FullName:  row.FullName,
+			Kind:      row.Kind,
+			Lifecycle: row.Lifecycle,
+			State:     row.State,
+			CreatedAt: row.CreatedAt.Time,
+			Content:   row.Content,
+		})
+	}
+	return out, nil
+}
+
 // StrandedKnowledgeCacheCountByNamePrefix counts the namespace's live contacts
 // holding a current-accepted cutover assertion (lives_in / birthday / how_met)
 // whose derived cache column is NULL — the production-impossible state (the cache

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -68,13 +68,26 @@ type ProfileResult struct {
 	// pages are not near-empty — a judge touring an empty page reads it as a broken
 	// feature. Counts-only / no PII.
 	ContactsWithNotes int
-	// SeededTasks counts the contact_task rows the profile seeded: one `managed`
-	// cadence_due task per cadence-bearing catalog contact (via ReplayTodoist's
-	// reconcile, one of which is then driven to `unmanaged` via the recurring-edit
-	// path — a state change, not a row change) PLUS the one seeded follow-up loop
-	// (SeedPendingFollowUp increments it). It is therefore NOT a pure cadence_due row
-	// count; a future exact-count gate must account for the follow-up too.
+	// SeededTasks counts EVERY contact_task row the profile seeded — the exact total:
+	// one `managed` cadence_due task per cadence-bearing catalog contact (via
+	// ReplayTodoist's reconcile, one of which is then driven to `unmanaged` via the
+	// recurring-edit path — a state change, not a row change), PLUS the visible-task
+	// spread's manual tasks (SeededManualTasks — the product-visible 0/1/multiple
+	// distribution), PLUS the one seeded follow-up loop (SeedPendingFollowUp). A
+	// namespace-scoped `count(contact_task)` equals this exactly.
 	SeededTasks int
+	// SeededManualTasks / SeededContactsWithManualTasks /
+	// SeededContactsWithMultipleManualTasks count the visible-task spread's MANUAL
+	// tasks (SeedVisibleTaskSpread): the total manual rows, the distinct catalog
+	// contacts with ≥1 manual task (the 1-visible + >1-visible cohorts), and the
+	// distinct catalog contacts with >1 manual task (the >1-visible cohort). Scoped
+	// to the catalog manual cohorts ONLY — they deliberately do NOT count the
+	// separately-created follow-up contact, so a namespace-wide product-visible count
+	// equals SeededContactsWithManualTasks + the one follow-up contact. Counts-only /
+	// no PII.
+	SeededManualTasks                     int
+	SeededContactsWithManualTasks         int
+	SeededContactsWithMultipleManualTasks int
 	// SeededPendingFollowUps counts the LIVE followup_loop rows seeded — the "awaiting
 	// reply" state (has_pending_followup). A seeded world cannot reach this state through
 	// the production path (see the seeding site), so it is written directly; without it the
@@ -744,14 +757,26 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededTasks = len(cadenceBearingCatalogIDs)
 
-		// The "awaiting reply" state (has_pending_followup). NOT reachable through the
-		// production path from a seed: the harness runs FollowUpManager in off-mode, and
-		// CAD-012 suppresses follow-ups for backdated automated outbounds anyway — which is
-		// every interaction a historical replay produces. So no seeded world ever contained
-		// a live follow-up; the tours could not capture the state; and the agentic judge,
-		// shown only contact pages with no "Awaiting reply" marker, concluded the FEATURE
-		// DID NOT EXIST and reported a false CAD-036 regression — every run.
-		//
+		// Product-VISIBLE task spread: attach user-style MANUAL tasks to a fixed,
+		// creation-index-selected subset of the cadence-bearing catalog so the
+		// manual/follow-up axis the contact page actually lists (it never lists
+		// cadence_due) forms a realistic 0/1/multiple distribution: a default majority
+		// with zero visible tasks (background cadence_due only), a reserved 1-visible
+		// cohort, and a reserved >1-visible cohort — with varied kind and link age.
+		// SeedVisibleTaskSpread draws NO generator PRNG (repository reads + writes
+		// only), so it is PRNG-neutral in this task block. Record the catalog +
+		// reserved cohort ids on the Harness so the coverage check can assert the
+		// cohorts subject-scoped without putting non-deterministic UUIDs in
+		// ProfileResult.
+		h.SetCatalogContactIDs(catalogContactIDs)
+		spread, err := h.SeedVisibleTaskSpread(ctx, cadenceBearingCatalogIDs)
+		if err != nil {
+			return res, fmt.Errorf("profile %s: seed visible task spread: %w", params.Profile, err)
+		}
+		res.SeededTasks += spread.ManualTasks
+		res.SeededManualTasks = spread.ManualTasks
+		res.SeededContactsWithManualTasks = spread.ContactsWithManualTasks
+		res.SeededContactsWithMultipleManualTasks = spread.ContactsWithMultipleManualTasks
 	}
 
 	// Merge + soft-delete scenarios. Seeded LAST: each draws gen.Contact (name PRNG)

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -188,6 +188,18 @@ type Harness struct {
 	// so it stays off the counts-only, determinism-compared result struct.
 	dateFactContactID uuid.UUID
 
+	// catalogContactIDs / manualCohortIDs record the ids the visible-task spread
+	// (SeedVisibleTaskSpread) touched: every catalog contact (the universe the
+	// 0-visible majority is proven over via a LEFT JOIN) and the reserved subset
+	// that received manual tasks. A profile sets them via SetCatalogContactIDs /
+	// SetManualCohortIDs; the coverage check reads them via CatalogContactIDs /
+	// ManualCohortIDs to assert the 0/1/>1 visible-task cohorts subject-scoped.
+	// Like the ids above they are NOT ProfileResult fields: contact ids come from
+	// uuid_generate_v4() (non-deterministic), so they stay off the counts-only,
+	// determinism-compared result struct.
+	catalogContactIDs []uuid.UUID
+	manualCohortIDs   []uuid.UUID
+
 	created   *created
 	createdMu sync.Mutex
 
@@ -693,6 +705,45 @@ func (h *Harness) DateFactContactID() uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return h.dateFactContactID
+}
+
+// SetCatalogContactIDs records the full catalog contact id set the visible-task
+// spread ran over, so the coverage check can prove the 0-visible majority via a
+// LEFT JOIN of the catalog universe against its visible tasks (grouping task rows
+// alone can't produce the zero-task contacts). Called by the seeding block after
+// the catalog is populated — hence exported. Guarded by the ledger mutex for
+// parity with the other tracked ids.
+func (h *Harness) SetCatalogContactIDs(ids []uuid.UUID) {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	h.catalogContactIDs = append([]uuid.UUID(nil), ids...)
+}
+
+// CatalogContactIDs returns the catalog contact ids the visible-task spread ran
+// over (nil if the spread did not run). Read by the coverage check to scope the
+// 0/1/>1 visible-task cohort assertions to the catalog universe.
+func (h *Harness) CatalogContactIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.catalogContactIDs...)
+}
+
+// SetManualCohortIDs records the reserved catalog contacts the visible-task
+// spread gave manual tasks (the 1-visible + >1-visible cohorts). Called by
+// SeedVisibleTaskSpread — hence exported. Guarded by the ledger mutex.
+func (h *Harness) SetManualCohortIDs(ids []uuid.UUID) {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	h.manualCohortIDs = append([]uuid.UUID(nil), ids...)
+}
+
+// ManualCohortIDs returns the reserved catalog contacts that received manual
+// tasks (nil if the spread did not run). Read by the coverage check to assert
+// the manual cohorts subject-scoped without putting UUIDs in ProfileResult.
+func (h *Harness) ManualCohortIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.manualCohortIDs...)
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -481,7 +481,16 @@ func (h *Harness) SeedVisibleTaskSpread(ctx context.Context, cadenceBearingIDs [
 // base62UUIDWidth and the ordinal to visibleTaskOrdinalWidth makes the split
 // unambiguous, so (contactID, ordinal) → id is one-to-one. The result stays
 // alphanumeric (base62 digits + '0' padding), matching the Todoist-v1 id shape.
+//
+// Precondition: 0 <= ordinal < 62*62 (the values that fit visibleTaskOrdinalWidth
+// base62 digits). Callers use small per-contact ordinals (0, 1). A negative ordinal
+// would emit a non-alphanumeric '-', and an over-wide one would drive strings.Repeat
+// to a negative count — both are seed-time programming errors, so this panics loudly
+// rather than returning a malformed id.
 func paddedBase62UUID(id uuid.UUID, ordinal int) string {
+	if ordinal < 0 || ordinal >= 62*62 {
+		panic(fmt.Sprintf("paddedBase62UUID: ordinal %d out of range [0, %d)", ordinal, 62*62))
+	}
 	raw := base62UUID(id)
 	padded := strings.Repeat("0", base62UUIDWidth-len(raw)) + raw
 	ord := new(big.Int).SetInt64(int64(ordinal)).Text(62)

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
@@ -345,6 +346,147 @@ func (h *Harness) SeedPendingFollowUp(ctx context.Context, contactID uuid.UUID, 
 	}
 	h.track(func(c *created) { c.addContactTask(task.ID) })
 	return task.ID, nil
+}
+
+// Visible-task spread constants. The spread attaches user-style MANUAL tasks to a
+// fixed, creation-index-selected subset of the cadence-bearing catalog so the
+// product-visible task axis (manual/follow-up tasks — the contact page never lists
+// cadence_due) forms a 0/1/multiple distribution.
+const (
+	// visibleSpreadMinCatalog is the minimum cadence-bearing catalog size the
+	// spread requires: it addresses creation indices 1, 2, and 3, so index 3 must
+	// exist. Below this the spread is a documented no-op (protects a custom short
+	// profile that lowers SeededContacts).
+	visibleSpreadMinCatalog = 4
+	// base62UUIDWidth is the maximum number of base62 digits a 128-bit UUID needs
+	// (ceil(128 * ln2 / ln62) = 22). paddedBase62UUID left-pads to this fixed width
+	// so the (uuid, ordinal) external id is injective.
+	base62UUIDWidth = 22
+	// visibleTaskOrdinalWidth is the fixed base62 width of the per-contact task
+	// ordinal appended to the padded UUID.
+	visibleTaskOrdinalWidth = 2
+)
+
+// manualTaskSpec is one MANUAL task the visible-task spread seeds, addressed by
+// creation index into the cadence-bearing catalog slice.
+type manualTaskSpec struct {
+	contactIdx int    // index into the creation-ordered cadence-bearing catalog ids
+	ordinal    int    // this contact's Nth manual task (0-based) — external-id uniqueness
+	kind       string // rotates reach_out/send/reminder so all three kinds appear
+	ageDays    int    // created_at = anchor - ageDays days (varies the link age)
+}
+
+// visibleTaskSpread is the FIXED, creation-index-based manual-task allocation:
+// indices 1 and 2 each get one manual task (the 1-visible cohort); index 3 gets
+// two (the >1-visible cohort). Every other catalog contact gets none (the
+// 0-visible majority — it keeps its background cadence_due row, which the contact
+// page never lists). Selection is by creation index, never by a random contact
+// UUID, so it is byte-stable across reseeds. Kinds cover all three user-pickable
+// values; ageDays spans three link-age buckets (days / weeks / months).
+var visibleTaskSpread = []manualTaskSpec{
+	{contactIdx: 1, ordinal: 0, kind: contacttask.KindReachOut, ageDays: 2},
+	{contactIdx: 2, ordinal: 0, kind: contacttask.KindSend, ageDays: 21},
+	{contactIdx: 3, ordinal: 0, kind: contacttask.KindReminder, ageDays: 90},
+	{contactIdx: 3, ordinal: 1, kind: contacttask.KindReachOut, ageDays: 2},
+}
+
+// SpreadResult is the settled outcome of SeedVisibleTaskSpread.
+type SpreadResult struct {
+	// ManualTasks is the total managed manual contact_task rows created.
+	ManualTasks int
+	// ContactsWithManualTasks is the distinct catalog contacts that received ≥1
+	// manual task (the 1-visible + >1-visible cohorts).
+	ContactsWithManualTasks int
+	// ContactsWithMultipleManualTasks is the distinct catalog contacts that
+	// received >1 manual task (the >1-visible cohort).
+	ContactsWithMultipleManualTasks int
+}
+
+// SeedVisibleTaskSpread attaches user-style MANUAL tasks to a deterministic,
+// creation-index-selected subset of the cadence-bearing catalog contacts, so the
+// product-VISIBLE task axis (the manual/follow-up tasks the contact page lists —
+// it never lists cadence_due) forms a realistic 0/1/multiple distribution.
+//
+// cadenceBearingIDs must be the CREATION-ORDERED cadence-bearing catalog ids: the
+// spread selects cohorts by fixed index into that slice (see visibleTaskSpread),
+// never by a random contact UUID, so the assignment is byte-stable across reseeds.
+// It draws NO generator PRNG (only repository reads + writes), so it is safe to run
+// inside the existing task block without shifting the deterministic id sequence the
+// earlier source replays depend on. Below visibleSpreadMinCatalog contacts it is a
+// documented no-op (the fixed indices would be out of range).
+//
+// Manual tasks are state='managed' (a user-created linked task's steady state;
+// completion happens remotely) with lifecycle='manual' and a rotating kind. Each
+// carries a distinct link age (created_at = anchor - ageDays) via
+// CreateContactTaskAtTime. External ids are fixed-width, injective, alphanumeric
+// (paddedBase62UUID) so a contact's second task never collides on
+// unique_external_task_id. Records the reserved cohort ids on the Harness via
+// SetManualCohortIDs for subject-scoped assertions.
+func (h *Harness) SeedVisibleTaskSpread(ctx context.Context, cadenceBearingIDs []uuid.UUID) (SpreadResult, error) {
+	if len(cadenceBearingIDs) < visibleSpreadMinCatalog {
+		return SpreadResult{}, nil
+	}
+
+	taskRepo := repository.NewContactTaskRepository(h.database.Queries)
+	anchor := h.gen.Anchor()
+
+	perContact := make(map[uuid.UUID]int)
+	cohortOrder := make([]uuid.UUID, 0, len(visibleTaskSpread))
+	for _, spec := range visibleTaskSpread {
+		contactID := cadenceBearingIDs[spec.contactIdx]
+
+		contact, err := h.contactRepo.GetContact(ctx, contactID)
+		if err != nil {
+			return SpreadResult{}, fmt.Errorf("visible task spread: get contact %s: %w", contactID, err)
+		}
+		content := fmt.Sprintf("Task: [%s](%s/contacts/%s)", contact.FullName, syntheticFrontendBase, contactID)
+
+		createdAt := anchor.Add(-time.Duration(spec.ageDays) * 24 * time.Hour)
+		task, err := taskRepo.CreateContactTaskAtTime(ctx, repository.CreateContactTaskRequest{
+			ContactID:      contactID,
+			Provider:       todoist.SourceName,
+			Kind:           spec.kind,
+			Lifecycle:      contacttask.LifecycleManual,
+			ExternalTaskID: paddedBase62UUID(contactID, spec.ordinal),
+			State:          string(repository.ContactTaskStateManaged),
+			Metadata:       map[string]any{"content": content},
+		}, createdAt)
+		if err != nil {
+			return SpreadResult{}, fmt.Errorf("visible task spread: create manual task on contact %s: %w", contactID, err)
+		}
+		h.track(func(c *created) { c.addContactTask(task.ID) })
+
+		if perContact[contactID] == 0 {
+			cohortOrder = append(cohortOrder, contactID)
+		}
+		perContact[contactID]++
+	}
+
+	res := SpreadResult{ManualTasks: len(visibleTaskSpread)}
+	for _, count := range perContact {
+		res.ContactsWithManualTasks++
+		if count > 1 {
+			res.ContactsWithMultipleManualTasks++
+		}
+	}
+	h.SetManualCohortIDs(cohortOrder)
+	return res, nil
+}
+
+// paddedBase62UUID builds a fixed-width, injective, alphanumeric external task id
+// from a contact UUID and a per-contact ordinal. base62UUID's width VARIES with the
+// numeric value (a leading-zero byte shrinks it), so a bare concat of the id and an
+// ordinal would not be injective — a shorter id + a longer ordinal could collide
+// with a longer id + a shorter ordinal. Left-padding the UUID component to
+// base62UUIDWidth and the ordinal to visibleTaskOrdinalWidth makes the split
+// unambiguous, so (contactID, ordinal) → id is one-to-one. The result stays
+// alphanumeric (base62 digits + '0' padding), matching the Todoist-v1 id shape.
+func paddedBase62UUID(id uuid.UUID, ordinal int) string {
+	raw := base62UUID(id)
+	padded := strings.Repeat("0", base62UUIDWidth-len(raw)) + raw
+	ord := new(big.Int).SetInt64(int64(ordinal)).Text(62)
+	ordPadded := strings.Repeat("0", visibleTaskOrdinalWidth-len(ord)) + ord
+	return padded + ordPadded
 }
 
 // externalTaskIDForContact derives a stable, alphanumeric external id from the

--- a/backend/internal/synthetic/replay/todoist_test.go
+++ b/backend/internal/synthetic/replay/todoist_test.go
@@ -1,0 +1,77 @@
+package replay
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestPaddedBase62UUID pins the injective, fixed-width, alphanumeric external-id
+// encoding the visible-task spread relies on to keep a contact's multiple manual
+// tasks distinct on unique_external_task_id.
+func TestPaddedBase62UUID(t *testing.T) {
+	alnum := regexp.MustCompile(`^[A-Za-z0-9]+$`)
+	wantLen := base62UUIDWidth + visibleTaskOrdinalWidth
+
+	// A low-valued UUID (all-zero) exercises the left-padding boundary: base62 of 0
+	// is a single "0", so the UUID component must pad out to base62UUIDWidth. Random
+	// fixtures essentially never hit this, so assert it explicitly.
+	var zero uuid.UUID
+	if got := paddedBase62UUID(zero, 0); got != "000000000000000000000000" {
+		t.Fatalf("all-zero UUID ordinal 0: got %q, want 24 zeros", got)
+	}
+
+	// A max-valued UUID (all 0xFF) is the widest base62 a 128-bit value produces
+	// (base62UUIDWidth chars), so the pad adds nothing and the total width holds.
+	var maxU uuid.UUID
+	for i := range maxU {
+		maxU[i] = 0xFF
+	}
+	if got := paddedBase62UUID(maxU, 0); len(got) != wantLen {
+		t.Fatalf("max UUID: got length %d, want %d", len(got), wantLen)
+	}
+
+	// A representative UUID: fixed 24-char alphanumeric shape, split into a 22-char
+	// padded id and a 2-char padded ordinal.
+	id := uuid.MustParse("12345678-90ab-cdef-1234-567890abcdef")
+	got := paddedBase62UUID(id, 0)
+	if len(got) != wantLen {
+		t.Fatalf("representative UUID: got length %d, want %d", len(got), wantLen)
+	}
+	if !alnum.MatchString(got) {
+		t.Fatalf("representative UUID: %q is not alphanumeric", got)
+	}
+	if suffix := got[base62UUIDWidth:]; suffix != "00" {
+		t.Fatalf("ordinal 0 suffix: got %q, want %q", suffix, "00")
+	}
+	if suffix := paddedBase62UUID(id, 1)[base62UUIDWidth:]; suffix != "01" {
+		t.Fatalf("ordinal 1 suffix: got %q, want %q", suffix, "01")
+	}
+
+	// Distinct ordinals on the SAME contact produce distinct ids (the second-task
+	// uniqueness the spread depends on).
+	if a, b := paddedBase62UUID(id, 0), paddedBase62UUID(id, 1); a == b {
+		t.Fatalf("ordinals 0 and 1 collided: both %q", a)
+	}
+
+	// Injectivity across (contact, ordinal): every combination in a small grid maps
+	// to a distinct id, including the padding-boundary low-valued UUID beside others.
+	ids := []uuid.UUID{zero, id, maxU, uuid.MustParse("00000000-0000-0000-0000-000000000001")}
+	seen := make(map[string]struct{})
+	for _, u := range ids {
+		for ord := 0; ord < 3; ord++ {
+			enc := paddedBase62UUID(u, ord)
+			if len(enc) != wantLen {
+				t.Fatalf("(%s, %d): got length %d, want %d", u, ord, len(enc), wantLen)
+			}
+			if !alnum.MatchString(enc) {
+				t.Fatalf("(%s, %d): %q is not alphanumeric", u, ord, enc)
+			}
+			if _, dup := seen[enc]; dup {
+				t.Fatalf("(%s, %d) collided on %q", u, ord, enc)
+			}
+			seen[enc] = struct{}{}
+		}
+	}
+}

--- a/backend/internal/synthetic/replay/todoist_test.go
+++ b/backend/internal/synthetic/replay/todoist_test.go
@@ -1,10 +1,12 @@
 package replay
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPaddedBase62UUID pins the injective, fixed-width, alphanumeric external-id
@@ -55,6 +57,15 @@ func TestPaddedBase62UUID(t *testing.T) {
 		t.Fatalf("ordinals 0 and 1 collided: both %q", a)
 	}
 
+	// Documented ordinal domain [0, 62*62): the top of the range still yields a
+	// fixed-width alphanumeric id, and out-of-range ordinals panic rather than emit a
+	// malformed ('-' or over-width) id.
+	if top := paddedBase62UUID(id, 62*62-1); len(top) != wantLen || !alnum.MatchString(top) {
+		t.Fatalf("ordinal 62*62-1: got %q (len %d)", top, len(top))
+	}
+	require.Panics(t, func() { paddedBase62UUID(id, -1) }, "negative ordinal must panic")
+	require.Panics(t, func() { paddedBase62UUID(id, 62*62) }, "over-wide ordinal must panic")
+
 	// Injectivity across (contact, ordinal): every combination in a small grid maps
 	// to a distinct id, including the padding-boundary low-valued UUID beside others.
 	ids := []uuid.UUID{zero, id, maxU, uuid.MustParse("00000000-0000-0000-0000-000000000001")}
@@ -73,5 +84,25 @@ func TestPaddedBase62UUID(t *testing.T) {
 			}
 			seen[enc] = struct{}{}
 		}
+	}
+}
+
+// TestSeedVisibleTaskSpread_NoOpBelowMinCatalog is the regression guard for the
+// visibleSpreadMinCatalog precondition: below the threshold the spread must be a
+// documented no-op (protecting a custom short profile from the fixed-index access).
+// The guard returns before touching the harness's DB/generator, so a bare Harness
+// suffices; removing the guard makes these calls dereference a nil database and
+// panic, failing the test loudly.
+func TestSeedVisibleTaskSpread_NoOpBelowMinCatalog(t *testing.T) {
+	h := &Harness{}
+	for k := 0; k < visibleSpreadMinCatalog; k++ {
+		ids := make([]uuid.UUID, k)
+		for i := range ids {
+			ids[i] = uuid.New()
+		}
+		res, err := h.SeedVisibleTaskSpread(context.Background(), ids)
+		require.NoError(t, err, "no-op for %d ids", k)
+		require.Equal(t, SpreadResult{}, res, "spread is a no-op below %d ids (got %d)", visibleSpreadMinCatalog, k)
+		require.Nil(t, h.ManualCohortIDs(), "no manual cohort recorded for %d ids", k)
 	}
 }

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -45,6 +46,132 @@ func trailingSeq(s string) (int, bool) {
 // fixedAccelBaseUnix is a deterministic TIME_BASE (a fixed Unix second) for the
 // high-acceleration settle-budget test, so the fixture makes no wall-clock call.
 const fixedAccelBaseUnix int64 = 1735689600 // 2025-01-01T00:00:00Z
+
+// taskAgeBucket coarsely buckets a contact_task's created_at relative to a fixed
+// reference (the generator anchor), so the visible-task assertions + fingerprint
+// key on link-age CLASS, not an exact timestamp — the cadence/follow-up rows are
+// created at ~NOW (a hair after the anchor, differing per run) yet must land in a
+// stable bucket. The manual spread's ages (2d / 21d / 90d) split across all three.
+func taskAgeBucket(ref, createdAt time.Time) string {
+	days := ref.Sub(createdAt).Hours() / 24
+	switch {
+	case days < 7:
+		return "recent"
+	case days < 60:
+		return "weeks"
+	default:
+		return "months"
+	}
+}
+
+// taskFingerprint is the run-to-run determinism witness for the visible-task
+// spread: the sorted (full_name, kind, lifecycle, state, age-bucket) tuples over
+// every seeded contact_task. Keyed by STABLE identity (full_name) + attributes,
+// excluding external_task_id + raw UUIDs, so it is byte-stable iff the spread maps
+// shape→named-contact by a stable creation index and DIFFERS if a random UUID keyed
+// the bucket assignment. ref is the (pinned) generator anchor.
+func taskFingerprint(rows []repository.TaskRow, ref time.Time) []string {
+	fp := make([]string, 0, len(rows))
+	for _, r := range rows {
+		fp = append(fp, strings.Join([]string{r.FullName, r.Kind, r.Lifecycle, r.State, taskAgeBucket(ref, r.CreatedAt)}, "|"))
+	}
+	sort.Strings(fp)
+	return fp
+}
+
+// assertVisibleTaskSpread verifies the product-visible task spread: the exact task
+// total, the manual-scoped ProfileResult counters, the 0/1/>1 visible-task cohorts
+// (subject-scoped to the catalog id set, with the follow-up contact accounted
+// separately), and the kind / lifecycle / link-age / content coverage over the
+// seeded task rows. Shared by the dev + prod-shaped coverage tests (the fixed
+// creation-index allocation is identical at any catalog size ≥ 4).
+func assertVisibleTaskSpread(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, res synthetic.ProfileResult, prefix string) {
+	t.Helper()
+
+	// Exact task total: every seeded contact_task row on the namespace == SeededTasks
+	// (cadence + manual + follow-up), so the accounting is closed.
+	totalTasks, err := support.CountContactTasksByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, int64(res.SeededTasks), totalTasks, "scoped contact_task count == res.SeededTasks (cadence + manual + follow-up)")
+
+	// Manual-scoped counters are EXACT for the fixed creation-index allocation
+	// (indices 1,2 → one manual each; index 3 → two), independent of catalog size.
+	require.Equal(t, 4, res.SeededManualTasks, "visible spread seeds 4 manual tasks")
+	require.Equal(t, 3, res.SeededContactsWithManualTasks, "3 catalog contacts get manual tasks")
+	require.Equal(t, 1, res.SeededContactsWithMultipleManualTasks, "1 catalog contact gets >1 manual task")
+	require.Len(t, h.ManualCohortIDs(), 3, "3 reserved manual-cohort contact ids recorded")
+
+	// Visible-task cohorts over the CATALOG universe. A LEFT JOIN so a 0-visible
+	// contact appears with count 0 — it still holds a background cadence_due row the
+	// contact page never lists, so 0-visible is asserted through the UI filters, NOT
+	// count(*)==0. The follow-up contact is NON-catalog and asserted separately below.
+	catalogIDs := h.CatalogContactIDs()
+	require.NotEmpty(t, catalogIDs, "catalog ids recorded for the spread")
+	counts, err := support.ListVisibleTaskCountsByContactIds(ctx, catalogIDs)
+	require.NoError(t, err)
+	require.Len(t, counts, len(catalogIDs), "every catalog contact appears (LEFT JOIN produces the 0-visible rows)")
+	var zeroVisible, oneVisible, multiVisible int
+	for _, c := range counts {
+		switch {
+		case c.VisibleCount == 0:
+			zeroVisible++
+		case c.VisibleCount == 1:
+			oneVisible++
+		default:
+			multiVisible++
+		}
+	}
+	require.Equal(t, 2, oneVisible, "exactly 2 catalog contacts have 1 visible task (indices 1,2)")
+	require.Equal(t, 1, multiVisible, "exactly 1 catalog contact has >1 visible task (index 3)")
+	require.Equal(t, len(catalogIDs)-3, zeroVisible, "the remaining catalog contacts are the 0-visible majority (background cadence_due only)")
+
+	// Row-level coverage over every seeded task (joined to its stable-identity
+	// full_name): the product-visible picture, kinds, lifecycles, link-age spread,
+	// and non-empty manual content.
+	taskRows, err := support.ListTaskRowsByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Len(t, taskRows, res.SeededTasks, "task row list covers every seeded task")
+
+	visibleByContact := map[string]int{}
+	visibleRows := 0
+	kinds := map[string]int{}
+	lifecycles := map[string]int{}
+	ageBuckets := map[string]struct{}{}
+	anchor := h.Generator().Anchor()
+	for _, r := range taskRows {
+		lifecycles[r.Lifecycle]++
+		if r.State == string(repository.ContactTaskStateManaged) &&
+			(r.Lifecycle == contacttask.LifecycleManual || r.Lifecycle == contacttask.LifecycleFollowUpLoop) {
+			visibleRows++
+			visibleByContact[r.FullName]++
+		}
+		if r.Lifecycle == contacttask.LifecycleManual {
+			kinds[r.Kind]++
+			require.NotEmpty(t, r.Content, "manual task carries non-empty content")
+			ageBuckets[taskAgeBucket(anchor, r.CreatedAt)] = struct{}{}
+		}
+	}
+
+	// Product-visible picture (the UI filters: managed + manual/followup_loop) ==
+	// the manual cohorts + the 1 follow-up contact — accounted, not double-counted.
+	require.Equal(t, res.SeededManualTasks+res.SeededPendingFollowUps, visibleRows,
+		"product-visible task rows == manual tasks + the follow-up")
+	require.Len(t, visibleByContact, res.SeededContactsWithManualTasks+res.SeededPendingFollowUps,
+		"product-visible contacts == manual-cohort catalog contacts + the 1 follow-up contact")
+
+	// Varied kind: all three user-pickable kinds present among manual tasks.
+	require.GreaterOrEqual(t, kinds[contacttask.KindReachOut], 1, "≥1 reach_out manual task")
+	require.GreaterOrEqual(t, kinds[contacttask.KindSend], 1, "≥1 send manual task")
+	require.GreaterOrEqual(t, kinds[contacttask.KindReminder], 1, "≥1 reminder manual task")
+
+	// Varied lifecycle across the seeded tasks.
+	require.GreaterOrEqual(t, lifecycles[contacttask.LifecycleCadenceDue], 1, "≥1 cadence_due task")
+	require.GreaterOrEqual(t, lifecycles[contacttask.LifecycleManual], 1, "≥1 manual task")
+	require.GreaterOrEqual(t, lifecycles[contacttask.LifecycleFollowUpLoop], 1, "≥1 followup_loop task")
+
+	// Varied link age: ≥2 distinct created_at buckets among manual tasks.
+	require.GreaterOrEqual(t, len(ageBuckets), 2, "≥2 distinct link-age buckets among manual tasks")
+}
 
 // These profile-orchestration integration tests are SLOW-gated
 // (testsupport.RequireLongTests) and routed to the nightly slow suite via the
@@ -362,6 +489,9 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 		incoherentCadence, err := cadenceSupport.IncoherentCadenceDueCountByNamePrefix(ctx, devPrefix)
 		require.NoError(t, err)
 		require.Equal(t, int64(0), incoherentCadence, "no cadence_due task may be completed/dismissed or carry a non-finalized external id")
+		// Product-visible task spread (dev catalog is 18 ≥ 4, so the spread runs): the
+		// same fixed 0/1/multiple manual-task allocation + exact accounting.
+		assertVisibleTaskSpread(t, ctx, cadenceSupport, h, res, devPrefix)
 	}
 	// Value-type + edge graph rows: the dev catalog (18) far exceeds the small
 	// dev knob counts, so the seeded counts are exact (no catalog-size bounding),
@@ -733,6 +863,10 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, liveFollowUps, int64(1),
 		"≥1 COHERENT live followup_loop task (on a contact with an outbound) — the has_pending_followup state the contact page renders")
 
+	// Product-visible task spread: 0/1/multiple manual tasks across catalog cohorts,
+	// varied kind/lifecycle/link-age, exact accounting (cadence + manual + follow-up).
+	assertVisibleTaskSpread(t, ctx, support, h, res, prefix)
+
 	// Interaction volume: each dedicated source contact carries MessagesPerContact
 	// settled interactions, so SettledInteractions == (settled contacts) ×
 	// MessagesPerContact — PLUS the single GCal event the awaiting-reply scenario
@@ -935,7 +1069,7 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// teardown swept every entity node (pool + place) — a leaked entity node would
 	// FK-block or duplicate-violate the next run, and a surviving place node from a
 	// `within` edge would FK-block the sweep — and every import-candidate row.
-	run := func() (synthetic.ProfileResult, []repository.AssertionSummary, []repository.EntityNameSummary, []repository.ExternalContactSummary) {
+	run := func() (synthetic.ProfileResult, []repository.AssertionSummary, []repository.EntityNameSummary, []repository.ExternalContactSummary, []string) {
 		h, teardown, err := synthetic.NewHarnessWithDBForNamespaceAt(ctx, database, params.Namespace, params.Seed, anchor)
 		require.NoError(t, err)
 		res, err := synthetic.RunProfile(ctx, h, params)
@@ -952,6 +1086,13 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		// peer band + the run-to-run ProfileResult count equality.
 		extFP, err := support.ListExternalContactSourceIDsByPrefix(ctx, prefix)
 		require.NoError(t, err)
+		// Visible-task fingerprint: keyed by stable identity (full_name) + attributes +
+		// link-age bucket over every seeded task, so a random-UUID-keyed cohort reshuffle
+		// (which the name stays stable through) is caught. Computed off the pinned outer
+		// anchor before teardown drops the rows.
+		taskRows, err := support.ListTaskRowsByNamePrefix(ctx, prefix)
+		require.NoError(t, err)
+		taskFP := taskFingerprint(taskRows, anchor)
 		require.NoError(t, teardown(context.Background()))
 		// Teardown correctness: the entity nodes (org/topic/tag pool + place nodes)
 		// are swept, so the namespace is clean for the next run.
@@ -982,11 +1123,11 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		contactsRemaining, err := h.ContactsRemaining(ctx)
 		require.NoError(t, err)
 		require.Zero(t, contactsRemaining, "all seeded contacts (incl. merge/soft-delete) swept by teardown")
-		return res, fp, entFP, extFP
+		return res, fp, entFP, extFP, taskFP
 	}
 
-	res1, fp1, ent1, ext1 := run()
-	res2, fp2, ent2, ext2 := run()
+	res1, fp1, ent1, ext1, task1 := run()
+	res2, fp2, ent2, ext2, task2 := run()
 
 	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
 	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")
@@ -995,6 +1136,8 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	require.Equal(t, ent1, ent2, "entity (subtype, normalized_name) fingerprint must be deterministic across runs")
 	require.NotEmpty(t, ext1, "the seed must produce import-candidate external_contact rows to fingerprint")
 	require.Equal(t, ext1, ext2, "import-candidate (source, source_id) fingerprint must be deterministic across runs")
+	require.NotEmpty(t, task1, "the seed must produce contact_task rows to fingerprint")
+	require.Equal(t, task1, task2, "visible-task (full_name, kind, lifecycle, state, age-bucket) fingerprint must be deterministic across runs")
 
 	// Ordering guard for the "seed gen.X() LAST" rule. The run-to-run
 	// comparison above catches NON-deterministic drift but NOT a DETERMINISTIC

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -125,6 +125,27 @@ func assertVisibleTaskSpread(t *testing.T, ctx context.Context, support *reposit
 	require.Equal(t, 1, multiVisible, "exactly 1 catalog contact has >1 visible task (index 3)")
 	require.Equal(t, len(catalogIDs)-3, zeroVisible, "the remaining catalog contacts are the 0-visible majority (background cadence_due only)")
 
+	// Enforce the EXACT creation-index allocation, not just the aggregate histogram: a
+	// deterministic reallocation to other indices (e.g. 0,1,4) would pass the histogram
+	// + the name-keyed fingerprint but must fail HERE. Every catalog slot is
+	// cadence-bearing (catalogOptionsFor), so CatalogContactIDs is the same
+	// creation-ordered slice SeedVisibleTaskSpread indexed into.
+	countByID := make(map[uuid.UUID]int64, len(counts))
+	for _, c := range counts {
+		countByID[c.ContactID] = c.VisibleCount
+	}
+	for i, id := range catalogIDs {
+		want := int64(0)
+		switch i {
+		case 1, 2:
+			want = 1
+		case 3:
+			want = 2
+		}
+		require.Equal(t, want, countByID[id], "catalog creation index %d visible-task count", i)
+	}
+	require.Equal(t, catalogIDs[1:4], h.ManualCohortIDs(), "manual cohorts are exactly creation indices 1, 2, 3")
+
 	// Row-level coverage over every seeded task (joined to its stable-identity
 	// full_name): the product-visible picture, kinds, lifecycles, link-age spread,
 	// and non-empty manual content.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -112,10 +112,10 @@ func assertVisibleTaskSpread(t *testing.T, ctx context.Context, support *reposit
 	require.Len(t, counts, len(catalogIDs), "every catalog contact appears (LEFT JOIN produces the 0-visible rows)")
 	var zeroVisible, oneVisible, multiVisible int
 	for _, c := range counts {
-		switch {
-		case c.VisibleCount == 0:
+		switch c.VisibleCount {
+		case 0:
 			zeroVisible++
-		case c.VisibleCount == 1:
+		case 1:
 			oneVisible++
 		default:
 			multiVisible++


### PR DESCRIPTION
Closes part of #710 (Part D). Seed-only — the sole production files are a test/seed-only sqlc query + repository wrapper called only by the synthetic seeder; no product handler/service/frontend change.

## What & why
The prod-shaped profile seeded a thin, uniform linked-task spread (one background `cadence_due` per cadence-bearing contact). This broadens it to a realistic **product-visible** distribution so populated task states are reachable for tours and future task work, and gives staging a prod-shaped spread rather than one-per-contact monotony.

## Design (product-visible axis)
The contact page never lists `cadence_due` tasks — it shows `managed` tasks of lifecycle `manual`/`followup_loop`. So "0 / 1 / multiple linked tasks" is defined on the **visible** axis, not raw DB rows:
- **0-visible** (default majority): background `cadence_due` only.
- **1-visible / >1-visible**: reserved, **creation-index-based** cohorts (catalog indices 1, 2 → one manual task; index 3 → two) given manual tasks via a new seed-only `CreateContactTaskAtTime` (needed for varied `created_at` link-age — no created-at setter existed), with varied kind/state/lifecycle.
- Attaches only to **existing** catalog contacts by stable creation index — never mints contacts, never adds follow-ups (the catalog is interaction-free; `SeedPendingFollowUp` requires cadence + outbound history).

## Determinism
`SeedVisibleTaskSpread` draws **no** generator PRNG (not even `sourceIDSeq`) — PRNG-neutral. Cohort selection keys off stable creation index, never random UUIDs. New `ProfileResult` counter + matching integration invariants + a **name-keyed task fingerprint** (`full_name, kind, lifecycle, state, created_at age-bucket`) asserted `fp1==fp2` in the run-to-run determinism test. Reserved-cohort IDs live on the **Harness** (not `ProfileResult`, whose UUIDs would break result determinism). Manual external IDs use an injective padded base62 `(contactID, ordinal)` encoding (24 chars, can't collide with ≤22-char UUID-derived cadence/follow-up IDs).

## Tests
- Integration: exact per-index visible-task allocation (indices 1,2→1, 3→2, all others→0) + `ManualCohortIDs == catalogIDs[1:4]`, kind/state/lifecycle coverage, `created_at` age buckets, scoped DB-count equality with the counter, and the name-keyed fingerprint.
- Replay unit tests: `paddedBase62UUID` (top-of-range + both panic cases) and a `<4`-catalog no-op regression test. Added `./internal/synthetic/replay/...` to the Makefile `test-unit` target (that package was in no test target before).

## Verification
`make test-unit`, replay unit tests, `make spec-lint` + `make spec-coverage` (no drift), `make api-types-check` + `make api-docs-check` (in sync), synthetic profile integration suite (~88s). Local Codex review: PASS (2 rounds; P0=P1=P2=P3=0).

PR2 of a 3-PR arc (#710). PR3 (#711 birthdays) is authored next against this merged tree.
