### PR TITLE
fix(contacts): clamp out-of-range ?page to the last valid page

### DIFF
--- a/frontend/src/app/contacts/page.tsx
+++ b/frontend/src/app/contacts/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useState, useEffect, useRef, useCallback } from 'react'
+import { Suspense, useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -439,13 +439,25 @@ function ContactsPageContent() {
   const [searchTerm, setSearchTerm] = useState(urlContext.search ?? '')
   const searchInputRef = useRef<HTMLInputElement>(null)
 
-  const listContext: ContactListContext = {
-    sort: urlContext.sort,
-    order: urlContext.order,
-    ...(searchTerm ? { search: searchTerm } : {}),
-    ...(urlContext.cadence_filter ? { cadence_filter: urlContext.cadence_filter } : {}),
-    ...(urlContext.followup_filter ? { followup_filter: urlContext.followup_filter } : {}),
-  }
+  // Memoized so its identity is stable across renders: it feeds the clamp
+  // effect's dependency array, where an object rebuilt every render would
+  // re-run the effect on every render.
+  const listContext: ContactListContext = useMemo(
+    () => ({
+      sort: urlContext.sort,
+      order: urlContext.order,
+      ...(searchTerm ? { search: searchTerm } : {}),
+      ...(urlContext.cadence_filter ? { cadence_filter: urlContext.cadence_filter } : {}),
+      ...(urlContext.followup_filter ? { followup_filter: urlContext.followup_filter } : {}),
+    }),
+    [
+      urlContext.sort,
+      urlContext.order,
+      searchTerm,
+      urlContext.cadence_filter,
+      urlContext.followup_filter,
+    ]
+  )
 
   const applyContext = (next: ContactListContext) => {
     // No page arg → the page param is dropped → the list resets to page 1.
@@ -470,6 +482,20 @@ function ContactsPageContent() {
     followup_filter: listContext.followup_filter,
     ...(searchTerm && { search: searchTerm }),
   })
+
+  // Clamp an out-of-range ?page once the response reveals the real page count.
+  // A stale bookmark/deep-link (?page=9999) or a page whose filtered set later
+  // shrank asks for a page past the end: the API returns an empty page and both
+  // Pagination blocks hide (they require pages > 1), stranding the user on an
+  // empty table with a nonzero header count and no control to recover. Rewrite
+  // the URL to the last valid page so the list re-fetches and lands on real
+  // rows. buildContactListUrl drops page=1 to the bare URL, so a single-page
+  // result recovers to page 1.
+  useEffect(() => {
+    if (data && data.total > 0 && page > data.pages) {
+      router.replace(buildContactListUrl(listContext, data.pages), { scroll: false })
+    }
+  }, [data, page, listContext, router])
 
   const handleSearchInput = (value: string) => {
     setSearchTerm(value)

--- a/frontend/tests/e2e/contact-navigation.spec.ts
+++ b/frontend/tests/e2e/contact-navigation.spec.ts
@@ -604,6 +604,62 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
     await expectFullContextRestored(page, (await listReq).url(), '2')
   })
 
+  test('an out-of-range ?page deep-link clamps to the last valid page', async ({ page }) => {
+    // spec: CON-058[3]
+    // A stale bookmark / hand-edited URL asking for a page past the end must
+    // land on the last valid page with real rows, not an empty table with the
+    // pagination controls hidden. The fixture is 21 has_cadence contacts → 2
+    // pages, so ?page=9999 must clamp to page 2 (holding "Back Nav 21").
+    await seedBackNavFixture()
+    const prefix = testApi.prefix
+    const backNav21 = `${prefix}-Back Nav 21`
+
+    // The clamp fires after the first response reveals the real page count, so
+    // a page-2 list request follows the out-of-range page-9999 request.
+    const clampReq = page.waitForResponse(
+      r => isListRequest(r.url()) && new URL(r.url()).searchParams.get('page') === '2'
+    )
+    await page.goto(
+      `/contacts?search=${encodeURIComponent(prefix)}` +
+        `&sort=name&order=asc&cadence_filter=has_cadence&followup_filter=no_followup&page=9999`
+    )
+    await page.waitForLoadState('domcontentloaded')
+    await clampReq
+
+    // URL is rewritten to page 2 and the real page-2 row is on screen — not an
+    // empty table.
+    await expect(page).toHaveURL(/[?&]page=2\b/)
+    await expect(page.getByText(backNav21)).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('tbody tr')).toHaveCount(1)
+    // Pagination controls are back (they hide entirely on an empty page).
+    await expect(page.locator('[data-testid="pagination"]').first()).toBeVisible()
+  })
+
+  test('an out-of-range ?page on a single-page list clamps to the bare page-1 URL', async ({
+    page,
+  }) => {
+    // spec: CON-058[3]
+    // When the whole filtered set fits on one page, the clamp target is page 1,
+    // which buildContactListUrl renders as the bare (page-less) URL — the
+    // distinct recovery branch from the multi-page clamp above.
+    await testApi.seedContacts([{ full_name: 'Solo Page A' }, { full_name: 'Solo Page B' }])
+    const prefix = testApi.prefix
+
+    // The clamp re-fetches page 1 (the request carries page=1 even though the
+    // browser URL becomes page-less).
+    const clampReq = page.waitForResponse(
+      r => isListRequest(r.url()) && new URL(r.url()).searchParams.get('page') === '1'
+    )
+    await page.goto(`/contacts?search=${encodeURIComponent(prefix)}&page=2`)
+    await page.waitForLoadState('domcontentloaded')
+    await clampReq
+
+    // URL is rewritten to the bare page-1 form (no page param at all) and the
+    // rows are on screen — not an empty table.
+    await expect(page).not.toHaveURL(/[?&]page=/)
+    await expect(page.getByText(`${prefix}-Solo Page A`)).toBeVisible({ timeout: 15000 })
+  })
+
   test('changing sort/search/filter from a later page resets to page 1', async ({ page }) => {
     // spec: CON-066[0]
     await seedBackNavFixture()
@@ -653,6 +709,21 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
       return p.get('page') === '1' && p.get('cadence_filter') === 'no_cadence'
     })
     await page.getByLabel('Filter by cadence').selectOption('no_cadence')
+    await reset
+    await expect(page).not.toHaveURL(/[?&]page=/)
+
+    // (d) order-TOGGLE change: re-click the active sort header (name asc → desc).
+    // Same handleSort → applyContext path as (a), but the toggle branch, which
+    // keeps the field and flips only the direction.
+    await page.goto(page2Url)
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByText(backNav21)).toBeVisible({ timeout: 15000 })
+    reset = page.waitForResponse(r => {
+      if (!isListRequest(r.url())) return false
+      const p = new URL(r.url()).searchParams
+      return p.get('page') === '1' && p.get('sort') === 'name' && p.get('order') === 'desc'
+    })
+    await page.getByRole('columnheader').filter({ hasText: /^Name/ }).click()
     await reset
     await expect(page).not.toHaveURL(/[?&]page=/)
   })

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -731,6 +731,7 @@ behaviors:
       - page-number buttons move between pages, with the current page marked
       - the previous/next controls disable at the list boundaries
       - the current page is reflected in the list URL, so a deep-linked or refreshed list restores that same page
+      - a URL asking for a page past the end of a non-empty list (stale deep-link or a shrunk result set) clamps to the last valid page rather than stranding the user on an empty list
     provenance: [pagination.tsx, contacts page]
 
   - id: CON-059


### PR DESCRIPTION
Closes #714. Follow-up from the review gate on #713 (CON-051 "Back to list").

## Problem

#713 made the contact list's page URL-backed (`?page=N`), which introduced a failure mode the old `useState(1)` could not reach: a stale bookmark/deep-link (`?page=9999`) — or a page whose filtered set later shrank to ≤ one page — asks for a page past the end. The API returns an empty page with `pages = 1`, so **both** `{data && data.pages > 1 && …}` Pagination blocks hide, stranding the user on an empty table while the header still reports a nonzero contact count and offering no control to recover.

This is only reachable via manual URL persistence (bookmark / hand-edit / deep-link) plus a subsequent data shrink — the in-app prev/next/back flow bounds its target page by the contact's index — hence P2.

## Fix

Once the response reveals the real page count, a mount/data effect clamps the URL to the last valid page (`router.replace(buildContactListUrl(listContext, data.pages))`) so the list re-fetches and lands on real rows. `buildContactListUrl` drops `page=1` to the bare URL, so a single-page result recovers to page 1. Guarded by `data.total > 0 && page > data.pages`, so it is a no-op on every normal render (no loop: after the clamp, `page === data.pages`).

`listContext` is now memoized so the effect's dependency array is stable across renders (an object rebuilt every render would re-run the effect each render); this also stabilizes the prop handed to `ContactsTable`.

## Tests

- New E2E regression: `?page=9999` on a 2-page filtered set clamps to page 2, shows the real row, and re-reveals the pagination controls — **verified to fail without the fix** (times out waiting for the clamp's page-2 request).
- Fourth sub-case added to the CON-066 reset test (the P3 review-head noted): re-clicking the active sort header from page 2 toggles `order` and resets to `page=1` — proving the `handleSort` toggle branch, not just the field-change branch.
- Documents the clamp as a new then-item **CON-058[3]** in `spec/contacts.yaml`; `make spec-lint` + `make spec-coverage` green (contacts: 53 covered, 0 orphaned).

All pre-push checks (lint, Go, frontend, filter, E2E) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)