### PR TITLE
test(synthetic): seed clock-anchored imminent-birthday fixtures (#711)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ test: test-unit test-integration test-frontend
 
 test-unit:
 	@echo "Running backend unit tests..."
-	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/synthetic/factory/... ./internal/synthetic/replay/... ./internal/spec/... ./cmd/spec-lint/... ./cmd/spec-coverage/... $(GOTEST_VERBOSE) -short
+	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/synthetic ./internal/synthetic/factory/... ./internal/synthetic/replay/... ./internal/spec/... ./cmd/spec-lint/... ./cmd/spec-coverage/... $(GOTEST_VERBOSE) -short
 
 # Provisions the per-worktree Postgres instance BEFORE the integration recipes
 # expand $(TEST_DATABASE_URL) (gh #433). As a prerequisite it runs to

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2473,6 +2473,11 @@ type Querier interface {
 	// has_pending mirrors FindPendingFollowUp's live followup_loop predicate. Caller
 	// passes a BARE prefix.
 	TestListCadenceActivityFlagsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListCadenceActivityFlagsByNamePrefixRow, error)
+	// CON-052 birthday-fixture proof: (id, full_name, birthday) for the reserved
+	// clock-anchored birthday fixture contacts, so the coverage/determinism tests can
+	// classify each subject-scoped (id-list bounded) and fingerprint by stable identity
+	// (GetContactCacheColumns is per-id and lacks full_name). Test only.
+	TestListContactBirthdayFixturesByIds(ctx context.Context, ids []pgtype.UUID) ([]*TestListContactBirthdayFixturesByIdsRow, error)
 	// Profile coverage test only: list the namespace's contacts (by full_name
 	// prefix) with the bucket-defining columns + a method count, so the test can
 	// assert the catalog produced ≥1 overdue (cadence + last_contacted in the past),

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1308,6 +1308,15 @@ WHERE c.full_name LIKE @name_prefix || '%'
 -- coherent, not just that SOME cutover cache is populated).
 SELECT location, birthday, how_met FROM contact WHERE id = @id AND deleted_at IS NULL;
 
+-- name: TestListContactBirthdayFixturesByIds :many
+-- CON-052 birthday-fixture proof: (id, full_name, birthday) for the reserved
+-- clock-anchored birthday fixture contacts, so the coverage/determinism tests can
+-- classify each subject-scoped (id-list bounded) and fingerprint by stable identity
+-- (GetContactCacheColumns is per-id and lacks full_name). Test only.
+SELECT id, full_name, birthday
+FROM contact
+WHERE id = ANY(@ids::uuid[]) AND deleted_at IS NULL;
+
 -- name: TestGetLiveFollowUpByNamePrefix :one
 -- Coherence gate (F3, Go-side): return the namespace's live managed follow-up loop
 -- task's contact_id, external_task_id, and metadata so the test can decode the

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2910,6 +2910,42 @@ func (q *Queries) TestListCadenceActivityFlagsByNamePrefix(ctx context.Context, 
 	return items, nil
 }
 
+const TestListContactBirthdayFixturesByIds = `-- name: TestListContactBirthdayFixturesByIds :many
+SELECT id, full_name, birthday
+FROM contact
+WHERE id = ANY($1::uuid[]) AND deleted_at IS NULL
+`
+
+type TestListContactBirthdayFixturesByIdsRow struct {
+	ID       pgtype.UUID `json:"id"`
+	FullName string      `json:"full_name"`
+	Birthday pgtype.Date `json:"birthday"`
+}
+
+// CON-052 birthday-fixture proof: (id, full_name, birthday) for the reserved
+// clock-anchored birthday fixture contacts, so the coverage/determinism tests can
+// classify each subject-scoped (id-list bounded) and fingerprint by stable identity
+// (GetContactCacheColumns is per-id and lacks full_name). Test only.
+func (q *Queries) TestListContactBirthdayFixturesByIds(ctx context.Context, ids []pgtype.UUID) ([]*TestListContactBirthdayFixturesByIdsRow, error) {
+	rows, err := q.db.Query(ctx, TestListContactBirthdayFixturesByIds, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TestListContactBirthdayFixturesByIdsRow{}
+	for rows.Next() {
+		var i TestListContactBirthdayFixturesByIdsRow
+		if err := rows.Scan(&i.ID, &i.FullName, &i.Birthday); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const TestListContactBucketsByNamePrefix = `-- name: TestListContactBucketsByNamePrefix :many
 SELECT
     c.id,

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -398,6 +398,38 @@ func (r *SyntheticSupportRepository) GetContactCacheColumns(ctx context.Context,
 	}, nil
 }
 
+// BirthdayFixtureRow is a contact projected with its stable-identity full_name and
+// derived birthday cache, for the clock-anchored birthday-fixture coverage +
+// determinism checks (subject-scoped to the reserved fixture ids).
+type BirthdayFixtureRow struct {
+	ContactID uuid.UUID
+	FullName  string
+	Birthday  *time.Time
+}
+
+// ListContactBirthdayFixturesByIds returns (id, full_name, birthday) for the given
+// contact ids (the reserved clock-anchored birthday fixtures), so the coverage +
+// determinism tests can classify each subject-scoped and fingerprint by stable
+// identity. Nil-safe on an empty id set.
+func (r *SyntheticSupportRepository) ListContactBirthdayFixturesByIds(ctx context.Context, ids []uuid.UUID) ([]BirthdayFixtureRow, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	rows, err := r.queries.TestListContactBirthdayFixturesByIds(ctx, pgUUIDs(ids))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]BirthdayFixtureRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, BirthdayFixtureRow{
+			ContactID: uuid.UUID(row.ID.Bytes),
+			FullName:  row.FullName,
+			Birthday:  pgDateToTimePtr(row.Birthday),
+		})
+	}
+	return out, nil
+}
+
 // DeleteContactMethodsByContactIds removes contact_method rows by contact
 // (cleanup step 11).
 func (r *SyntheticSupportRepository) DeleteContactMethodsByContactIds(ctx context.Context, contactIDs []uuid.UUID) (int64, error) {

--- a/backend/internal/synthetic/birthday_fixtures.go
+++ b/backend/internal/synthetic/birthday_fixtures.go
@@ -1,0 +1,142 @@
+package synthetic
+
+import "time"
+
+// BirthdayFixture is one clock-anchored birthday fixture: an offset in days from
+// the (UTC) anchor day and the birthdays-page section it is meant to demonstrate.
+// The offset is applied to the reseed clock so "imminent birthdays visibly stand
+// apart" is demonstrable on a real-clock staging run rather than on an arbitrary
+// fixed date that only lands in the highlight window a few days a year.
+type BirthdayFixture struct {
+	OffsetDays int
+	Role       string
+}
+
+const (
+	// BirthdayRoleToday / Imminent / Distant are the STRICT triple, always seeded
+	// when the catalog has ≥3 birthdayless slots: a {today, +1} redundancy pair so
+	// at least one lands in the ≤7-day highlight window under any residual ±1-day
+	// skew, plus one distant fixture that recedes out of it.
+	BirthdayRoleToday    = "today"
+	BirthdayRoleImminent = "imminent"
+	BirthdayRoleDistant  = "distant"
+	// BirthdayRoleThisWeek / Distant2 / Celebrated are the best-effort extras that
+	// fill out the spread at larger catalog sizes. Celebrated is date-gated (see
+	// BirthdayFixturePlan).
+	BirthdayRoleThisWeek   = "this_week"
+	BirthdayRoleDistant2   = "distant2"
+	BirthdayRoleCelebrated = "celebrated"
+)
+
+// BirthdayFixturePlan is the ordered, degrading list of fixtures to seed for a
+// reseed anchor: the strict {today, +1, distant} triple first (always applicable),
+// then the best-effort extras. celebrated (a "few days ago" birthday) is appended
+// only when it still falls in the anchor's calendar year — in the first days of
+// January a 3-days-ago birthday belongs to the previous year, so its next annual
+// occurrence is ~362 days out and the page classifies it distant, not
+// past-this-year. That single date-dependence is why the strict triple, which is
+// date-independent, is always the first three entries. All math is UTC.
+func BirthdayFixturePlan(anchor time.Time) []BirthdayFixture {
+	day := anchor.UTC()
+	plan := []BirthdayFixture{
+		{OffsetDays: 0, Role: BirthdayRoleToday},
+		{OffsetDays: 1, Role: BirthdayRoleImminent},
+		{OffsetDays: 90, Role: BirthdayRoleDistant},
+		{OffsetDays: 5, Role: BirthdayRoleThisWeek},
+		{OffsetDays: 150, Role: BirthdayRoleDistant2},
+	}
+	if day.AddDate(0, 0, -3).Year() == day.Year() {
+		plan = append(plan, BirthdayFixture{OffsetDays: -3, Role: BirthdayRoleCelebrated})
+	}
+	return plan
+}
+
+// BirthdayFixtureDate is the stored birthday date-only value for a fixture: the
+// anchor's day shifted by offsetDays, taken as month/day, on a historical LEAP
+// birth year (the largest leap year ≤ anchor.Year()-30). The leap birth year keeps
+// the rendered age plausible (~30-33) AND preserves a Feb-29 target as Feb 29 — a
+// Feb-28 clamp would turn the today fixture on a Feb-29 anchor into an
+// already-celebrated one, since the page compares month/day in the current year. No
+// clamping/normalization; UTC throughout.
+func BirthdayFixtureDate(anchor time.Time, offsetDays int) time.Time {
+	target := anchor.UTC().AddDate(0, 0, offsetDays)
+	birthYear := largestLeapYearOnOrBefore(anchor.UTC().Year() - 30)
+	return time.Date(birthYear, target.Month(), target.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// BirthdaylessCatalogCount mirrors catalogOptionsFor's birthday rule: a catalog
+// slot carries a contact-path birthday iff i==0 (the 1900 sentinel) or i%5==2 (a
+// real-year birthday). The complement is the birthdayless set the clock-anchored
+// date-fact fixtures occupy.
+func BirthdaylessCatalogCount(n int) int {
+	count := 0
+	for i := 0; i < n; i++ {
+		if i == 0 || i%5 == 2 {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// BirthdayDaysUntil mirrors birthdays/page.tsx (getNextBirthday +
+// calculateDaysUntilBirthday): days from today to the birthday's next annual
+// occurrence, 0 when the birthday is today. today is the pinned UTC anchor day.
+func BirthdayDaysUntil(bday, today time.Time) int {
+	cur := startOfUTCDay(today)
+	next := birthdayInYear(bday, cur.Year())
+	if next.Before(cur) {
+		next = birthdayInYear(bday, cur.Year()+1)
+	}
+	// Both operands are midnight UTC and UTC has no DST, so the gap is an exact
+	// whole number of days — integer division matches the page's Math.ceil.
+	return int(next.Sub(cur) / (24 * time.Hour))
+}
+
+// BirthdayIsPastThisYear mirrors birthdays/page.tsx (isBirthdayPastThisYear): the
+// birthday's occurrence in the current year is strictly before today.
+func BirthdayIsPastThisYear(bday, today time.Time) bool {
+	cur := startOfUTCDay(today)
+	return birthdayInYear(bday, cur.Year()).Before(cur)
+}
+
+// BirthdayBucket mirrors the birthdays-page section split: celebrated (past this
+// year) → today (daysUntil==0) → week (≤7) → distant. Returns one of "celebrated",
+// "today", "week", "distant".
+func BirthdayBucket(bday, today time.Time) string {
+	if BirthdayIsPastThisYear(bday, today) {
+		return "celebrated"
+	}
+	switch d := BirthdayDaysUntil(bday, today); {
+	case d == 0:
+		return "today"
+	case d <= 7:
+		return "week"
+	default:
+		return "distant"
+	}
+}
+
+func startOfUTCDay(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// birthdayInYear projects a stored birthday onto a given year, matching the page's
+// new Date(year, month, day): a Feb-29 birthday in a non-leap year rolls to Mar 1
+// exactly as JS does, so the mirror stays faithful.
+func birthdayInYear(bday time.Time, year int) time.Time {
+	b := bday.UTC()
+	return time.Date(year, b.Month(), b.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func largestLeapYearOnOrBefore(y int) int {
+	for !isLeapYear(y) {
+		y--
+	}
+	return y
+}
+
+func isLeapYear(y int) bool {
+	return y%4 == 0 && (y%100 != 0 || y%400 == 0)
+}

--- a/backend/internal/synthetic/birthday_fixtures_test.go
+++ b/backend/internal/synthetic/birthday_fixtures_test.go
@@ -103,40 +103,37 @@ func TestBirthdayBucket_BoundaryOffsets(t *testing.T) {
 }
 
 func TestBirthdayFixtureDate_PlanRolesLandAsIntended(t *testing.T) {
-	// The seeding + coverage split verified year-round: the STRICT date-independent
-	// fixtures classify into an exact bucket regardless of anchor, while the
-	// best-effort distant/celebrated fixtures are only guaranteed to RECEDE out of
-	// the ≤7-day highlight window (daysUntil > 7). The distant fixtures are NOT
-	// pinned to the "distant" bucket: a +90/+150 birthday seeded when the anchor is
-	// in ~Oct-Dec wraps into next-year Jan-Mar, so its occurrence THIS calendar year
-	// is already past and the page files it under "Already Celebrated This Year"
-	// (isPastThisYear) even though it is genuinely ~90 days out. Either way it has
-	// receded from the highlight window, which is the CON-052 quality.
-	strictBucket := map[string]string{
-		BirthdayRoleToday:    "today",
-		BirthdayRoleImminent: "week",
-		BirthdayRoleThisWeek: "week",
-	}
+	// Every fixture's next-occurrence distance is DATE-INDEPENDENT: a fixture at
+	// offset o (0<=o<365) is always exactly o days out, regardless of where in the
+	// year the anchor sits. The PAGE SECTION is NOT date-independent — a +5 fixture
+	// seeded on Dec 27 wraps to Jan 1, whose occurrence THIS year is already past, so
+	// the page files it under "Already Celebrated This Year" though it is 5 days out.
+	// So we pin the robust daysUntil==offset for the forward fixtures (not a fragile
+	// section bucket), and past-this-year for the celebrated fixture (which its
+	// date-gating keeps same-year). The section→offset mapping is verified against the
+	// real page by the frontend parity test. Anchors deliberately include the
+	// year-end boundary (Dec 27–31, Jan 1) where the wrap bites.
 	for _, anchor := range []time.Time{
+		time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC),
 		time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC),
 		time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC),
 		time.Date(2024, time.February, 29, 12, 0, 0, 0, time.UTC),
 		time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC),
 		time.Date(2026, time.December, 20, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.December, 27, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.December, 31, 12, 0, 0, 0, time.UTC),
+		time.Date(2023, time.December, 1, 12, 0, 0, 0, time.UTC), // +90 lands Feb 29 2024
 	} {
 		for _, f := range BirthdayFixturePlan(anchor) {
 			bday := BirthdayFixtureDate(anchor, f.OffsetDays)
-			if want, ok := strictBucket[f.Role]; ok {
-				if got := BirthdayBucket(bday, anchor); got != want {
-					t.Errorf("%s role %q (offset %d): bucket = %q, want %q",
-						anchor.Format("2006-01-02"), f.Role, f.OffsetDays, got, want)
+			if f.OffsetDays >= 0 {
+				if got := BirthdayDaysUntil(bday, anchor); got != f.OffsetDays {
+					t.Errorf("%s role %q: daysUntil = %d, want %d (offset)",
+						anchor.Format("2006-01-02"), f.Role, got, f.OffsetDays)
 				}
-				continue
-			}
-			// best-effort distant/celebrated: must recede past the highlight window.
-			if got := BirthdayDaysUntil(bday, anchor); got <= 7 {
-				t.Errorf("%s role %q (offset %d): daysUntil = %d, want > 7 (receded)",
-					anchor.Format("2006-01-02"), f.Role, f.OffsetDays, got)
+			} else if !BirthdayIsPastThisYear(bday, anchor) {
+				t.Errorf("%s role %q (offset %d): want past-this-year (celebrated)",
+					anchor.Format("2006-01-02"), f.Role, f.OffsetDays)
 			}
 		}
 	}

--- a/backend/internal/synthetic/birthday_fixtures_test.go
+++ b/backend/internal/synthetic/birthday_fixtures_test.go
@@ -1,0 +1,143 @@
+package synthetic
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBirthdayFixturePlan_Ordering(t *testing.T) {
+	anchor := time.Date(2026, time.June, 15, 9, 0, 0, 0, time.UTC)
+	plan := BirthdayFixturePlan(anchor)
+
+	// The strict {today, +1, distant} triple is always the first three, in order.
+	if len(plan) < 3 {
+		t.Fatalf("plan must carry the strict triple, got %d fixtures", len(plan))
+	}
+	want := []struct {
+		offset int
+		role   string
+	}{
+		{0, BirthdayRoleToday},
+		{1, BirthdayRoleImminent},
+		{90, BirthdayRoleDistant},
+		{5, BirthdayRoleThisWeek},
+		{150, BirthdayRoleDistant2},
+		{-3, BirthdayRoleCelebrated},
+	}
+	for i, w := range want {
+		if plan[i].OffsetDays != w.offset || plan[i].Role != w.role {
+			t.Errorf("plan[%d] = {%d, %q}, want {%d, %q}", i, plan[i].OffsetDays, plan[i].Role, w.offset, w.role)
+		}
+	}
+}
+
+func TestBirthdayFixturePlan_CelebratedDateGating(t *testing.T) {
+	// In the first three days of January a 3-days-ago birthday falls in the
+	// previous calendar year, so celebrated is dropped and the plan is length 5.
+	for _, day := range []int{1, 2, 3} {
+		anchor := time.Date(2026, time.January, day, 12, 0, 0, 0, time.UTC)
+		if got := len(BirthdayFixturePlan(anchor)); got != 5 {
+			t.Errorf("Jan %d: plan length = %d, want 5 (celebrated gated out)", day, got)
+		}
+	}
+	// From January 4 onward (and every other day of the year) celebrated applies.
+	for _, anchor := range []time.Time{
+		time.Date(2026, time.January, 4, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.June, 15, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.December, 31, 12, 0, 0, 0, time.UTC),
+	} {
+		if got := len(BirthdayFixturePlan(anchor)); got != 6 {
+			t.Errorf("%s: plan length = %d, want 6 (celebrated applies)", anchor.Format("2006-01-02"), got)
+		}
+	}
+}
+
+func TestBirthdayFixtureDate_LeapSafe(t *testing.T) {
+	// A Feb-29 anchor: the today fixture must store Feb 29 (not roll to Mar 1 nor
+	// clamp to Feb 28) so the page still classifies it as today, not celebrated.
+	anchor := time.Date(2024, time.February, 29, 8, 0, 0, 0, time.UTC)
+	bday := BirthdayFixtureDate(anchor, 0)
+	if bday.Month() != time.February || bday.Day() != 29 {
+		t.Fatalf("today fixture on a Feb-29 anchor stored %s, want Feb 29", bday.Format("01-02"))
+	}
+	if !isLeapYear(bday.Year()) {
+		t.Errorf("birth year %d is not a leap year (Feb 29 would roll)", bday.Year())
+	}
+	if bday.Year() > anchor.Year()-30 {
+		t.Errorf("birth year %d is younger than anchor.Year()-30 = %d", bday.Year(), anchor.Year()-30)
+	}
+	if got := BirthdayBucket(bday, anchor); got != "today" {
+		t.Errorf("Feb-29 today fixture bucket = %q, want today", got)
+	}
+}
+
+func TestBirthdaylessCatalogCount(t *testing.T) {
+	cases := map[int]int{5: 3, 18: 13, 150: 119}
+	for n, want := range cases {
+		if got := BirthdaylessCatalogCount(n); got != want {
+			t.Errorf("BirthdaylessCatalogCount(%d) = %d, want %d", n, got, want)
+		}
+	}
+}
+
+func TestBirthdayBucket_BoundaryOffsets(t *testing.T) {
+	// Mid-year anchor so no annual-wrap or year-boundary interaction.
+	anchor := time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		offset int
+		want   string
+	}{
+		{0, "today"},
+		{1, "week"},
+		{7, "week"},
+		{8, "distant"},
+		{90, "distant"},
+		{-3, "celebrated"},
+	}
+	for _, c := range cases {
+		bday := BirthdayFixtureDate(anchor, c.offset)
+		if got := BirthdayBucket(bday, anchor); got != c.want {
+			t.Errorf("offset %d: bucket = %q, want %q (stored %s)", c.offset, got, c.want, bday.Format("01-02"))
+		}
+	}
+}
+
+func TestBirthdayFixtureDate_PlanRolesLandAsIntended(t *testing.T) {
+	// The seeding + coverage split verified year-round: the STRICT date-independent
+	// fixtures classify into an exact bucket regardless of anchor, while the
+	// best-effort distant/celebrated fixtures are only guaranteed to RECEDE out of
+	// the ≤7-day highlight window (daysUntil > 7). The distant fixtures are NOT
+	// pinned to the "distant" bucket: a +90/+150 birthday seeded when the anchor is
+	// in ~Oct-Dec wraps into next-year Jan-Mar, so its occurrence THIS calendar year
+	// is already past and the page files it under "Already Celebrated This Year"
+	// (isPastThisYear) even though it is genuinely ~90 days out. Either way it has
+	// receded from the highlight window, which is the CON-052 quality.
+	strictBucket := map[string]string{
+		BirthdayRoleToday:    "today",
+		BirthdayRoleImminent: "week",
+		BirthdayRoleThisWeek: "week",
+	}
+	for _, anchor := range []time.Time{
+		time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC),
+		time.Date(2024, time.February, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.December, 20, 12, 0, 0, 0, time.UTC),
+	} {
+		for _, f := range BirthdayFixturePlan(anchor) {
+			bday := BirthdayFixtureDate(anchor, f.OffsetDays)
+			if want, ok := strictBucket[f.Role]; ok {
+				if got := BirthdayBucket(bday, anchor); got != want {
+					t.Errorf("%s role %q (offset %d): bucket = %q, want %q",
+						anchor.Format("2006-01-02"), f.Role, f.OffsetDays, got, want)
+				}
+				continue
+			}
+			// best-effort distant/celebrated: must recede past the highlight window.
+			if got := BirthdayDaysUntil(bday, anchor); got <= 7 {
+				t.Errorf("%s role %q (offset %d): daysUntil = %d, want > 7 (receded)",
+					anchor.Format("2006-01-02"), f.Role, f.OffsetDays, got)
+			}
+		}
+	}
+}

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -97,8 +97,11 @@ type ProfileResult struct {
 	// SeededBoolFacts / SeededRelationships / SeededDateFacts count the graph rows
 	// the value-type + edge plumbing seeded: bool facts (job_seeking etc.) on
 	// catalog person nodes, person→person edge assertions among catalog person
-	// nodes, and the single toolkit-authored date fact (a birthday asserted
-	// directly through the assert path). Counts-only / no PII.
+	// nodes, and the clock-anchored birthday date-facts asserted directly through
+	// the assert path (a small, ordered, degrading set — today / +1 / distant plus
+	// best-effort extras — so imminent birthdays visibly stand apart on a real-clock
+	// staging run). SeededDateFacts is the total actually seeded =
+	// min(birthdayless catalog slots, plan size for the anchor). Counts-only / no PII.
 	SeededBoolFacts     int
 	SeededRelationships int
 	SeededDateFacts     int
@@ -586,14 +589,17 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededBoolFacts++
 	}
 
-	// One toolkit-authored date fact (a `birthday`) asserted DIRECTLY through the
-	// assert path (distinct from the contact-create authority-flip birthday path),
-	// to exercise the new ValueDate plumbing end-to-end. Seeded on a catalog
-	// contact that carries no contact-path birthday so it occupies a fresh
-	// single-cardinality slot. Gated with the bool facts (both demonstrate the new
-	// value-type routing). Anchor-relative so no time.Now().
-	if boolFacts > 0 && len(catalogContactsWithoutBirthday) > 0 {
-		bday := time.Date(gen.Anchor().Year()-40, time.April, 12, 0, 0, 0, 0, time.UTC)
+	// The FIRST clock-anchored birthday date-fact (the "today" fixture) asserted
+	// DIRECTLY through the assert path (distinct from the contact-create
+	// authority-flip birthday path). Kept AT this position — the additional fixtures
+	// are appended at the very end of runCatalogProfile — so this single
+	// sourceIDSeq draw stays where it always was and shifts no downstream source id.
+	// Seeded on a catalog contact that carries no contact-path birthday so it
+	// occupies a fresh single-cardinality slot. Anchor-relative (UTC) so no
+	// time.Now() and the fixture tracks the reseed clock.
+	if len(catalogContactsWithoutBirthday) > 0 {
+		plan := BirthdayFixturePlan(gen.Anchor())
+		bday := BirthdayFixtureDate(gen.Anchor(), plan[0].OffsetDays)
 		if _, err := h.ReplayAssertion(ctx, catalogContactsWithoutBirthday[0], gen.DateFact("birthday", bday)); err != nil {
 			return res, fmt.Errorf("profile %s: replay date fact: %w", params.Profile, err)
 		}
@@ -993,6 +999,30 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	}
 	h.SetMutualMessageContactID(mutualContact.ID)
 	res.MutualMessageContacts++
+
+	// --- Additional clock-anchored birthday fixtures (seeded LAST) --------------
+	//
+	// The "today" fixture was seeded above at its historical position. The rest of
+	// the ordered plan (+1 imminent, distant, and the best-effort extras) is
+	// appended HERE, after every other generator/sourceID consumer: gen.DateFact
+	// draws the shared sourceIDSeq, so placing these draws last shifts no downstream
+	// source id. Together with the today fixture they give CON-052 a small set where
+	// imminent birthdays visibly stand apart from those that recede.
+	//
+	// Allocation degrades with the birthdayless catalog slots (a birthday is an
+	// assertion, so even the no-method slot qualifies): plan[i] lands on
+	// catalogContactsWithoutBirthday[i], reserving the full ordered set (today first)
+	// so the coverage/determinism tests can classify each subject-scoped.
+	plan := BirthdayFixturePlan(gen.Anchor())
+	seededCount := min(len(catalogContactsWithoutBirthday), len(plan))
+	for i := 1; i < seededCount; i++ {
+		bday := BirthdayFixtureDate(gen.Anchor(), plan[i].OffsetDays)
+		if _, err := h.ReplayAssertion(ctx, catalogContactsWithoutBirthday[i], gen.DateFact("birthday", bday)); err != nil {
+			return res, fmt.Errorf("profile %s: replay birthday fixture %d: %w", params.Profile, i, err)
+		}
+		res.SeededDateFacts++
+	}
+	h.SetBirthdayFixtureIDs(catalogContactsWithoutBirthday[:seededCount])
 
 	return res, nil
 }

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -179,7 +179,8 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				SeededAssertions:  2,
 				// Bool facts + person→person edges (small, fast) so the dev graph
 				// surfaces have content. Both exercise the value-type/edge assert
-				// plumbing; the bool-fact gate also seeds one toolkit date fact.
+				// plumbing. (Birthday date-facts are seeded independently, gated only on
+				// birthdayless catalog slots — see runCatalogProfile.)
 				SeededBoolFacts:     2,
 				SeededRelationships: 2,
 				// Enable cadence-task seeding (>0 gate). The dev catalog is all

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -200,6 +200,16 @@ type Harness struct {
 	catalogContactIDs []uuid.UUID
 	manualCohortIDs   []uuid.UUID
 
+	// birthdayFixtureIDs is the ORDERED reserved set of catalog contacts the profile
+	// seeded a clock-anchored birthday date-fact on (position i ⇄
+	// BirthdayFixturePlan[i]: [0]=today, [1]=+1, [2]=distant, …). The coverage +
+	// determinism tests read it via BirthdayFixtureIDs to assert the fixtures
+	// subject-scoped and to fingerprint them by stable identity. Like the ids above
+	// it is NOT a ProfileResult field: contact ids come from uuid_generate_v4()
+	// (non-deterministic), so it stays off the counts-only, determinism-compared
+	// result struct.
+	birthdayFixtureIDs []uuid.UUID
+
 	created   *created
 	createdMu sync.Mutex
 
@@ -744,6 +754,28 @@ func (h *Harness) ManualCohortIDs() []uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return append([]uuid.UUID(nil), h.manualCohortIDs...)
+}
+
+// SetBirthdayFixtureIDs records the ORDERED reserved catalog contacts the profile
+// seeded clock-anchored birthday date-facts on (position i ⇄
+// BirthdayFixturePlan[i]). Called by the seeding block after the birthday fixtures
+// are seeded — hence exported. Guarded by the ledger mutex for parity with the
+// other tracked ids.
+func (h *Harness) SetBirthdayFixtureIDs(ids []uuid.UUID) {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	h.birthdayFixtureIDs = append([]uuid.UUID(nil), ids...)
+}
+
+// BirthdayFixtureIDs returns the ORDERED reserved catalog contacts the profile
+// seeded clock-anchored birthday date-facts on (nil if the block did not run).
+// Read by the coverage + determinism checks to scope the fixture assertions and
+// fingerprint to just those subjects (the catalog seeds its own birthdays in the
+// same namespace).
+func (h *Harness) BirthdayFixtureIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.birthdayFixtureIDs...)
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -194,6 +194,104 @@ func assertVisibleTaskSpread(t *testing.T, ctx context.Context, support *reposit
 	require.GreaterOrEqual(t, len(ageBuckets), 2, "≥2 distinct link-age buckets among manual tasks")
 }
 
+// birthdayFingerprint is the run-to-run determinism witness for the clock-anchored
+// birthday fixtures: the sorted (full_name, daysUntil-bucket, age-decade) tuples
+// over the reserved fixture subjects. Keyed by STABLE identity (full_name) +
+// classification, excluding raw UUIDs, so it is byte-stable iff the fixtures map
+// shape→named-contact by a stable creation index and DIFFERS if a random UUID keyed
+// the allocation or the year-math drifts. anchor is the (pinned) generator anchor.
+func birthdayFingerprint(rows []repository.BirthdayFixtureRow, anchor time.Time) []string {
+	fp := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if r.Birthday == nil {
+			continue
+		}
+		ageDecade := (anchor.Year() - r.Birthday.Year()) / 10
+		fp = append(fp, strings.Join([]string{
+			r.FullName,
+			synthetic.BirthdayBucket(*r.Birthday, anchor),
+			strconv.Itoa(ageDecade),
+		}, "|"))
+	}
+	sort.Strings(fp)
+	return fp
+}
+
+// assertBirthdayFixtures verifies the clock-anchored birthday fixtures (CON-052):
+// the SeededDateFacts total via the shared scale helper, the strict guarantee (≥1 of
+// the {today,+1} redundancy pair lands imminent, ≥1 fixture recedes past the ≤7-day
+// highlight window), per-fixture seed integrity (each reserved[i] stored the date the
+// plan computed for its offset), the exact section of the date-independent strict
+// fixtures, and a populated birthday cache on every reserved subject. Subject-scoped
+// to the reserved ids only — the catalog seeds its own birthdays in the same
+// namespace. anchor is the generator anchor; n is the catalog size.
+func assertBirthdayFixtures(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, res synthetic.ProfileResult, anchor time.Time, n int) {
+	t.Helper()
+
+	reserved := h.BirthdayFixtureIDs()
+	plan := synthetic.BirthdayFixturePlan(anchor)
+	wantSeeded := min(synthetic.BirthdaylessCatalogCount(n), len(plan))
+	require.Equal(t, wantSeeded, res.SeededDateFacts, "SeededDateFacts == min(birthdayless catalog slots, plan size)")
+	require.Len(t, reserved, wantSeeded, "reserved fixture id count == SeededDateFacts")
+	require.GreaterOrEqual(t, len(reserved), 3, "at least the strict {today,+1,distant} triple is seeded")
+
+	rows, err := support.ListContactBirthdayFixturesByIds(ctx, reserved)
+	require.NoError(t, err)
+	byID := make(map[uuid.UUID]repository.BirthdayFixtureRow, len(rows))
+	for _, r := range rows {
+		byID[r.ContactID] = r
+	}
+	require.Len(t, byID, len(reserved), "every reserved fixture contact resolves")
+
+	// Strict imminent guarantee — over the {today,+1} redundancy PAIR ONLY: ≥1 lands
+	// in the ≤7-day highlight window, so a regression of BOTH pair fixtures fails even
+	// if the independent +5 this-week fixture still classifies imminent.
+	imminentInPair := 0
+	for _, id := range reserved[:min(2, len(reserved))] {
+		row := byID[id]
+		require.NotNil(t, row.Birthday, "reserved pair fixture has a populated birthday cache")
+		if synthetic.BirthdayDaysUntil(*row.Birthday, anchor) <= 7 {
+			imminentInPair++
+		}
+	}
+	require.GreaterOrEqual(t, imminentInPair, 1, "≥1 of the {today,+1} pair classifies imminent (≤7 days)")
+
+	// Strict recedes guarantee — ≥1 reserved fixture is OUTSIDE the highlight window
+	// (daysUntil > 7). Deliberately NOT `&& !past`: a +90/+150 fixture seeded when the
+	// anchor is in ~Oct-Dec wraps into next-year Jan-Mar, so its occurrence THIS
+	// calendar year is already past (the page files it under "Already Celebrated This
+	// Year") though its next occurrence is genuinely ~90 days out — it has still
+	// receded from the imminent window, which is the CON-052 quality.
+	receded := 0
+	for _, id := range reserved {
+		if row := byID[id]; row.Birthday != nil && synthetic.BirthdayDaysUntil(*row.Birthday, anchor) > 7 {
+			receded++
+		}
+	}
+	require.GreaterOrEqual(t, receded, 1, "≥1 reserved fixture recedes past the ≤7-day highlight window")
+
+	// Per-fixture seed integrity + section: each reserved[i] stored the date the plan
+	// computed for its offset (reserved[i] ⇄ plan[i]), and the date-INDEPENDENT strict
+	// fixtures classify into their exact section. The distant/celebrated fixtures'
+	// section is date-dependent near year boundaries, so only their stored date is
+	// pinned here; the frontend parity test closes the offset→section loop.
+	strictBucket := map[string]string{
+		synthetic.BirthdayRoleToday:    "today",
+		synthetic.BirthdayRoleImminent: "week",
+		synthetic.BirthdayRoleThisWeek: "week",
+	}
+	for i, id := range reserved {
+		row := byID[id]
+		require.NotNil(t, row.Birthday, "reserved fixture %d birthday cache populated", i)
+		want := synthetic.BirthdayFixtureDate(anchor, plan[i].OffsetDays)
+		require.Equal(t, want.Month(), row.Birthday.Month(), "fixture %d (%s) stored month", i, plan[i].Role)
+		require.Equal(t, want.Day(), row.Birthday.Day(), "fixture %d (%s) stored day", i, plan[i].Role)
+		if bucket, ok := strictBucket[plan[i].Role]; ok {
+			require.Equal(t, bucket, synthetic.BirthdayBucket(*row.Birthday, anchor), "fixture %d (%s) classifies %q", i, plan[i].Role, bucket)
+		}
+	}
+}
+
 // These profile-orchestration integration tests are SLOW-gated
 // (testsupport.RequireLongTests) and routed to the nightly slow suite via the
 // TestSynthetic name prefix. Each sub-test uses a UNIQUE namespace so
@@ -515,11 +613,11 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 		assertVisibleTaskSpread(t, ctx, cadenceSupport, h, res, devPrefix)
 	}
 	// Value-type + edge graph rows: the dev catalog (18) far exceeds the small
-	// dev knob counts, so the seeded counts are exact (no catalog-size bounding),
-	// and the bool-fact gate produces exactly one toolkit date fact.
+	// dev knob counts, so the seeded counts are exact (no catalog-size bounding).
+	// The clock-anchored birthday date-facts are asserted subject-scoped below via
+	// assertBirthdayFixtures.
 	require.Equal(t, params.Counts.SeededBoolFacts, res.SeededBoolFacts, "dev profile seeds bool facts")
 	require.Equal(t, params.Counts.SeededRelationships, res.SeededRelationships, "dev profile seeds person→person edges")
-	require.Equal(t, 1, res.SeededDateFacts, "dev profile seeds one toolkit date fact")
 	// Entity pool + person→entity edges: the dev catalog (18) far exceeds the small
 	// dev knob counts, so the seeded counts are exact (no catalog-size bounding).
 	require.Equal(t, params.Counts.SeededEntities, res.SeededEntities, "dev profile seeds the entity pool")
@@ -558,6 +656,8 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
 	support := repository.NewSyntheticSupportRepository(database.Queries)
 	assertSeedCoherence(t, ctx, support, h.Generator().Prefix(), h.DateFactContactID())
+	// Clock-anchored birthday fixtures (CON-052), subject-scoped to the reserved ids.
+	assertBirthdayFixtures(t, ctx, support, h, res, h.Generator().Anchor(), params.Counts.SeededContacts)
 	// Two-sided message-direction coverage (F4).
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
 	// Notes coverage (F6).
@@ -726,6 +826,8 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 
 	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
 	assertSeedCoherence(t, ctx, support, h.Generator().Prefix(), h.DateFactContactID())
+	// Clock-anchored birthday fixtures (CON-052), subject-scoped to the reserved ids.
+	assertBirthdayFixtures(t, ctx, support, h, res, h.Generator().Anchor(), params.Counts.SeededContacts)
 	// Two-sided message-direction coverage (F4).
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
 	// Notes coverage (F6).
@@ -1090,7 +1192,7 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// teardown swept every entity node (pool + place) — a leaked entity node would
 	// FK-block or duplicate-violate the next run, and a surviving place node from a
 	// `within` edge would FK-block the sweep — and every import-candidate row.
-	run := func() (synthetic.ProfileResult, []repository.AssertionSummary, []repository.EntityNameSummary, []repository.ExternalContactSummary, []string) {
+	run := func() (synthetic.ProfileResult, []repository.AssertionSummary, []repository.EntityNameSummary, []repository.ExternalContactSummary, []string, []string) {
 		h, teardown, err := synthetic.NewHarnessWithDBForNamespaceAt(ctx, database, params.Namespace, params.Seed, anchor)
 		require.NoError(t, err)
 		res, err := synthetic.RunProfile(ctx, h, params)
@@ -1114,6 +1216,21 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		taskRows, err := support.ListTaskRowsByNamePrefix(ctx, prefix)
 		require.NoError(t, err)
 		taskFP := taskFingerprint(taskRows, anchor)
+		// Birthday-fixture fingerprint: keyed by stable identity (full_name) +
+		// daysUntil-bucket + age-decade over the reserved fixture subjects, so a
+		// random-UUID-keyed allocation or a year-math drift is caught. Computed off the
+		// pinned outer anchor before teardown drops the rows.
+		bdayRows, err := support.ListContactBirthdayFixturesByIds(ctx, h.BirthdayFixtureIDs())
+		require.NoError(t, err)
+		bdayFP := birthdayFingerprint(bdayRows, anchor)
+		// n=5 degrading allocation is exact + deterministic: the strict {today,+1,distant}
+		// triple on the birthdayless catalog creation indices {1,3,4} (index 3 is the
+		// no-method slot — a birthday is an assertion, not a contact_method).
+		require.Equal(t, 3, res.SeededDateFacts, "n=5 seeds exactly the {today,+1,distant} triple")
+		catalog := h.CatalogContactIDs()
+		require.GreaterOrEqual(t, len(catalog), 5, "n=5 catalog populated for the allocation check")
+		require.Equal(t, []uuid.UUID{catalog[1], catalog[3], catalog[4]}, h.BirthdayFixtureIDs(),
+			"birthday fixtures land on catalog creation indices 1,3,4 (today,+1,distant)")
 		require.NoError(t, teardown(context.Background()))
 		// Teardown correctness: the entity nodes (org/topic/tag pool + place nodes)
 		// are swept, so the namespace is clean for the next run.
@@ -1144,11 +1261,11 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		contactsRemaining, err := h.ContactsRemaining(ctx)
 		require.NoError(t, err)
 		require.Zero(t, contactsRemaining, "all seeded contacts (incl. merge/soft-delete) swept by teardown")
-		return res, fp, entFP, extFP, taskFP
+		return res, fp, entFP, extFP, taskFP, bdayFP
 	}
 
-	res1, fp1, ent1, ext1, task1 := run()
-	res2, fp2, ent2, ext2, task2 := run()
+	res1, fp1, ent1, ext1, task1, bday1 := run()
+	res2, fp2, ent2, ext2, task2, bday2 := run()
 
 	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
 	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")
@@ -1159,6 +1276,8 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	require.Equal(t, ext1, ext2, "import-candidate (source, source_id) fingerprint must be deterministic across runs")
 	require.NotEmpty(t, task1, "the seed must produce contact_task rows to fingerprint")
 	require.Equal(t, task1, task2, "visible-task (full_name, kind, lifecycle, state, age-bucket) fingerprint must be deterministic across runs")
+	require.NotEmpty(t, bday1, "the seed must produce birthday fixtures to fingerprint")
+	require.Equal(t, bday1, bday2, "birthday (full_name, daysUntil-bucket, age-decade) fingerprint must be deterministic across runs")
 
 	// Ordering guard for the "seed gen.X() LAST" rule. The run-to-run
 	// comparison above catches NON-deterministic drift but NOT a DETERMINISTIC

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -206,7 +206,10 @@ func birthdayFingerprint(rows []repository.BirthdayFixtureRow, anchor time.Time)
 		if r.Birthday == nil {
 			continue
 		}
-		ageDecade := (anchor.Year() - r.Birthday.Year()) / 10
+		// Use the UTC year to match BirthdayFixtureDate's UTC-pinned birth year, so the
+		// age decade agrees with the UTC-pinned browser's rendered age around the year
+		// boundary (anchor.Year() could differ from anchor.UTC().Year() there).
+		ageDecade := (anchor.UTC().Year() - r.Birthday.Year()) / 10
 		fp = append(fp, strings.Join([]string{
 			r.FullName,
 			synthetic.BirthdayBucket(*r.Birthday, anchor),
@@ -221,10 +224,11 @@ func birthdayFingerprint(rows []repository.BirthdayFixtureRow, anchor time.Time)
 // the SeededDateFacts total via the shared scale helper, the strict guarantee (≥1 of
 // the {today,+1} redundancy pair lands imminent, ≥1 fixture recedes past the ≤7-day
 // highlight window), per-fixture seed integrity (each reserved[i] stored the date the
-// plan computed for its offset), the exact section of the date-independent strict
-// fixtures, and a populated birthday cache on every reserved subject. Subject-scoped
-// to the reserved ids only — the catalog seeds its own birthdays in the same
-// namespace. anchor is the generator anchor; n is the catalog size.
+// plan computed for its offset), the date-INDEPENDENT classification (forward
+// fixtures are exactly their offset days out via daysUntil==offset; the celebrated
+// fixture is past this year), and a populated birthday cache on every reserved
+// subject. Subject-scoped to the reserved ids only — the catalog seeds its own
+// birthdays in the same namespace. anchor is the generator anchor; n is the catalog size.
 func assertBirthdayFixtures(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, res synthetic.ProfileResult, anchor time.Time, n int) {
 	t.Helper()
 
@@ -270,24 +274,26 @@ func assertBirthdayFixtures(t *testing.T, ctx context.Context, support *reposito
 	}
 	require.GreaterOrEqual(t, receded, 1, "≥1 reserved fixture recedes past the ≤7-day highlight window")
 
-	// Per-fixture seed integrity + section: each reserved[i] stored the date the plan
-	// computed for its offset (reserved[i] ⇄ plan[i]), and the date-INDEPENDENT strict
-	// fixtures classify into their exact section. The distant/celebrated fixtures'
-	// section is date-dependent near year boundaries, so only their stored date is
-	// pinned here; the frontend parity test closes the offset→section loop.
-	strictBucket := map[string]string{
-		synthetic.BirthdayRoleToday:    "today",
-		synthetic.BirthdayRoleImminent: "week",
-		synthetic.BirthdayRoleThisWeek: "week",
-	}
+	// Per-fixture seed integrity + classification: each reserved[i] stored the date the
+	// plan computed for its offset (reserved[i] ⇄ plan[i]), and its next-occurrence
+	// distance is exactly that offset. daysUntil==offset is DATE-INDEPENDENT (a +5
+	// fixture is 5 days out whether or not its wrapped January occurrence lands the
+	// page's "celebrated" section near year-end), so it — not a fragile section bucket
+	// — is what we pin. The celebrated fixture (offset<0) is always past-this-year when
+	// present (its date-gating keeps it same-year). The section→offset mapping is
+	// verified against the real page by the frontend parity test.
 	for i, id := range reserved {
 		row := byID[id]
 		require.NotNil(t, row.Birthday, "reserved fixture %d birthday cache populated", i)
 		want := synthetic.BirthdayFixtureDate(anchor, plan[i].OffsetDays)
 		require.Equal(t, want.Month(), row.Birthday.Month(), "fixture %d (%s) stored month", i, plan[i].Role)
 		require.Equal(t, want.Day(), row.Birthday.Day(), "fixture %d (%s) stored day", i, plan[i].Role)
-		if bucket, ok := strictBucket[plan[i].Role]; ok {
-			require.Equal(t, bucket, synthetic.BirthdayBucket(*row.Birthday, anchor), "fixture %d (%s) classifies %q", i, plan[i].Role, bucket)
+		if plan[i].OffsetDays >= 0 {
+			require.Equal(t, plan[i].OffsetDays, synthetic.BirthdayDaysUntil(*row.Birthday, anchor),
+				"fixture %d (%s) is exactly %d days out", i, plan[i].Role, plan[i].OffsetDays)
+		} else {
+			require.True(t, synthetic.BirthdayIsPastThisYear(*row.Birthday, anchor),
+				"fixture %d (%s) is past this year (celebrated)", i, plan[i].Role)
 		}
 	}
 }
@@ -708,8 +714,8 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// One full bool-fact cycle (job_seeking/on_sabbatical/traveling) + one full
 	// edge cycle (knows/introduced_by/sibling_of) so every new predicate — incl.
 	// the always-confirm sibling_of (→ proposed) and the auto-if-confident rest
-	// (→ accepted) — is exercised. The bool-fact gate also seeds one toolkit date
-	// fact.
+	// (→ accepted) — is exercised. (Birthday date-facts are seeded independently,
+	// gated only on birthdayless catalog slots.)
 	params.Counts.SeededBoolFacts = 3
 	params.Counts.SeededRelationships = 3
 	// Enable cadence-task seeding (>0 gate). The 9-contact catalog is all

--- a/frontend/playwright.tours.config.ts
+++ b/frontend/playwright.tours.config.ts
@@ -31,6 +31,13 @@ export default defineConfig({
     baseURL: process.env.TOURS_BASE_URL,
     trace: 'on',
     screenshot: 'only-on-failure',
+    // Pin the browser's calendar zone + locale to UTC so "today" resolves in the
+    // same zone the reseed computes the clock-anchored birthday fixtures in
+    // (staging-reset.sh pins the reseed container to TZ=UTC). Without this the
+    // judge host's local zone could shift the browser's day off the seed's, so an
+    // imminent fixture might not land in the birthdays page's highlight window.
+    timezoneId: 'UTC',
+    locale: 'en-US',
   },
   // NO webServer — tours target a remote, already-running staging app.
 })

--- a/frontend/tests/tours/support/tours-config.test.ts
+++ b/frontend/tests/tours/support/tours-config.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import toursConfig from '../../../playwright.tours.config'
+
+// The clock-anchored birthday fixtures (CON-052) only land in the birthdays page's
+// highlight window if the tour browser resolves "today" in the SAME zone the reseed
+// computes the fixtures in (UTC). This guard fails loudly if that pin is dropped —
+// the pin is load-bearing, so it must be provably removable-detectable.
+describe('playwright.tours.config UTC pin', () => {
+  it('pins the browser calendar zone to UTC', () => {
+    expect(toursConfig.use?.timezoneId).toBe('UTC')
+  })
+
+  it('pins a fixed locale', () => {
+    expect(toursConfig.use?.locale).toBe('en-US')
+  })
+})

--- a/frontend/tests/unit/birthdays-page.test.tsx
+++ b/frontend/tests/unit/birthdays-page.test.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+// The backend seeds clock-anchored birthday fixtures by offset-in-days from the
+// reseed clock (synthetic/birthday_fixtures.go). Its Go classifier mirror agreeing
+// with itself is circular — this test closes the loop against the REAL page: it
+// renders the production birthdays page (reads frontend/src, does not modify it) and
+// asserts the offset→section contract at the imminent/celebrated boundary as the
+// page classifies it. If the page's classification drifts from the seed's offsets,
+// this fails.
+
+vi.mock('@/hooks/use-contacts', () => ({
+  useContacts: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-accelerated-time', () => ({
+  useAcceleratedTime: vi.fn(),
+}))
+
+vi.mock('@/components/layout/navigation', () => ({
+  Navigation: () => <div>Navigation</div>,
+}))
+
+import BirthdaysPage from '@/app/birthdays/page'
+import { useContacts } from '@/hooks/use-contacts'
+import { useAcceleratedTime } from '@/hooks/use-accelerated-time'
+import type { Contact } from '@/types/contact'
+
+// A mid-year anchor so celebrated applies and there is no Nov/Dec gift-planning
+// wrinkle. Matches the backend's parity-friendly window.
+const CURRENT_TIME = new Date(2026, 5, 15) // 2026-06-15, local
+
+function isLeapYear(y: number): boolean {
+  return y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0)
+}
+
+function largestLeapYearOnOrBefore(y: number): number {
+  while (!isLeapYear(y)) y--
+  return y
+}
+
+// TS mirror of the Go BirthdayFixtureDate: the anchor's day shifted by offsetDays,
+// taken as month/day, on a historical leap birth year → 'YYYY-MM-DD'. parseDateOnly
+// interprets that as a local date, matching the page's local day math.
+function fixtureBirthday(anchor: Date, offsetDays: number): string {
+  const target = new Date(anchor.getFullYear(), anchor.getMonth(), anchor.getDate() + offsetDays)
+  const birthYear = largestLeapYearOnOrBefore(anchor.getFullYear() - 30)
+  const mm = String(target.getMonth() + 1).padStart(2, '0')
+  const dd = String(target.getDate()).padStart(2, '0')
+  return `${birthYear}-${mm}-${dd}`
+}
+
+function contact(name: string, offsetDays: number): Contact {
+  return {
+    id: `id-${name}`,
+    full_name: name,
+    birthday: fixtureBirthday(CURRENT_TIME, offsetDays),
+  } as unknown as Contact
+}
+
+function sectionByHeading(pattern: RegExp): HTMLElement {
+  const heading = screen.getByText(pattern)
+  const section = heading.closest('section')
+  if (!section) throw new Error(`no <section> for heading ${pattern}`)
+  return section
+}
+
+describe('birthdays page offset→section parity', () => {
+  beforeEach(() => {
+    ;(useAcceleratedTime as any).mockReturnValue({
+      currentTime: CURRENT_TIME,
+      isAccelerated: false,
+    })
+    ;(useContacts as any).mockReturnValue({
+      data: {
+        contacts: [
+          contact('Fixture Today', 0),
+          contact('Fixture Imminent', 1),
+          contact('Fixture Distant', 90),
+          contact('Fixture Celebrated', -3),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('places each fixture in the section its offset implies', () => {
+    render(<BirthdaysPage />)
+
+    const todaySection = sectionByHeading(/Today's Birthdays/)
+    expect(within(todaySection).getByText('Fixture Today')).toBeInTheDocument()
+    expect(within(todaySection).getByText('🎉 Today!')).toBeInTheDocument()
+
+    const upcomingSection = sectionByHeading(/Upcoming Birthdays/)
+    expect(within(upcomingSection).getByText('Fixture Imminent')).toBeInTheDocument()
+    expect(within(upcomingSection).getByText('Fixture Distant')).toBeInTheDocument()
+
+    // The distant fixture must NOT be highlighted as today.
+    expect(within(todaySection).queryByText('Fixture Distant')).not.toBeInTheDocument()
+
+    const celebratedSection = sectionByHeading(/Already Celebrated This Year/)
+    expect(within(celebratedSection).getByText('Fixture Celebrated')).toBeInTheDocument()
+    expect(within(celebratedSection).getByText(/Turned/)).toBeInTheDocument()
+  })
+})

--- a/scripts/staging-reset.sh
+++ b/scripts/staging-reset.sh
@@ -261,13 +261,17 @@ staging_ctl stop personalcrm-backend.service
 # 6. Reset + reseed from the ephemeral container off the deployed image. The
 #    --env-file carries CRM_ENV=staging (-> SeedAllowed passes), DATABASE_URL
 #    (host crm-postgres), and TIME_BASE/TIME_ACCELERATION (so seeded cadence /
-#    overdue semantics track the app clock). The image ENTRYPOINT is crm-api, so
-#    --entrypoint is required to run crm-admin.
+#    overdue semantics track the app clock). TZ=UTC pins the container's local
+#    zone so the clock-anchored birthday fixtures compute their calendar day in
+#    UTC — the same zone the tour browser is pinned to — so imminent fixtures land
+#    in the birthdays page's highlight window regardless of the host zone. The
+#    image ENTRYPOINT is crm-api, so --entrypoint is required to run crm-admin.
 echo "staging-reset: reset + reseed ('$PROFILE') from $IMAGE_REF..." >&2
 staging_podman run --rm \
     --network "$PODMAN_NETWORK" \
     --env-file "$ENV_FILE" \
     -e "MIGRATIONS_PATH=$MIGRATIONS_PATH" \
+    -e "TZ=UTC" \
     --entrypoint "$CRM_ADMIN" \
     "$IMAGE_REF" \
     --reset-and-seed --profile "$PROFILE" --yes

--- a/scripts/staging-reset.test.sh
+++ b/scripts/staging-reset.test.sh
@@ -226,6 +226,7 @@ assert_reset_run_line() {
     if [ -z "$run" ]; then fail "no 'podman run ... --reset-and-seed' recorded"; return; fi
     local needle
     for needle in "--rm" "--network crm" "--env-file" "-e MIGRATIONS_PATH=/migrations" \
+                  "-e TZ=UTC" \
                   "--entrypoint /usr/local/bin/crm-admin" "$want_ref" \
                   "--reset-and-seed" "--profile prod-shaped" "--yes"; do
         if [[ "$run" == *"$needle"* ]]; then ok; else fail "reset run line missing '$needle': $run"; fi


### PR DESCRIPTION
Closes #711. Seed-only + QA-harness config; no product/frontend-src change.

## What & why
CON-052 ("the birthdays page is a planning surface — imminent birthdays visibly stand apart") returned a nightly **false fail**: seeded birthdays were fixed-date (`April 12`) while "imminent" is clock-relative, and staging runs a real clock — so on an arbitrary night nothing landed in the ≤7-day highlight window. This seeds a small deterministic set of **clock-anchored** birthday fixtures so the imminence quality is reliably demonstrable. CON-052 **stays enrolled** with the judge (seed-only fix, no de-enrollment).

## Design
- **Canonical UTC frame.** The tour browser and the reseed container had no timezone pin, so a backend-computed bucket couldn't be assumed to match what the judge's browser renders. This pins `timezoneId: 'UTC'` + a fixed locale in `playwright.tours.config.ts`, `TZ=UTC` on the reseed container in `staging-reset.sh`, and computes seed dates in UTC. Both pins have **removal-sensitive guard tests** (a `staging-reset.test.sh` `-e TZ=UTC` needle + a vitest assertion on the tours config) that go red if a pin is dropped.
- **Date-aware fixtures.** Each fixture's target month/day is computed from the reseed clock in UTC using the same classification the birthdays page uses, with a **leap-safe historical birth year** (largest leap year ≤ anchor−30, preserving Feb 29). Strict always-satisfiable guarantee: a `{today, +1}` redundancy pair (≥1 lands imminent under any ±1-day skew) + ≥1 fixture that recedes past the ≤7-day window. Best-effort extras (+5, distant, celebrated) are date-computed with dynamic expected counts.
- **Determinism.** The existing single date-fact draw stays at its current position (only its date changes); all additional draws are appended after every later generator/sourceID consumer, preserving byte-stability. Assertions + a birthday fingerprint are **subject-scoped** to the reserved date-fact ids (the catalog seeds its own birthdays in the same namespace). Forward fixtures are asserted by date-INDEPENDENT `daysUntil==offset` (not fragile section buckets, which wrap near year-end); the celebrated fixture by `IsPastThisYear`.
- A **test-only sqlc batch query** (`full_name`+`birthday` over ids — the existing cache accessor lacks `full_name`) via a repo wrapper; no raw SQL in Go.
- **One direct-page parity test** in `frontend/tests/unit/` importing the real birthdays page via the `@` alias — reads `frontend/src`, does not modify it.

## Verification
`make lint` (0 issues), `make test` (unit incl. the newly-wired `./internal/synthetic` package + integration + 917 frontend tests, exit 0), `make test-integration` (dev/prod-shaped coverage + determinism, subject-scoped), `make test-frontend` (parity test), `make spec-lint` + `make spec-coverage` (no drift — CON-052/CON-045 unchanged), `make test-e2e-diff`, `make test-deploy-scripts` (TZ=UTC pin guard). Unit anchor matrix covers year-round incl. Dec 27/31, Jan 1, and a Feb-29-2024 leap case. Local Codex review: PASS (2 rounds; P0=P1=P2=0). Both pins proven to fail-on-removal.

PR3 (final) of a 3-PR arc (#710 + #711).
