### PR TITLE
chore(ci): git-ancestry-aware GHCR tag retention

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -8,9 +8,9 @@ name: GHCR retention
 # un-promoted develop SHA are kept regardless of age — so a long promote gap is
 # safe. See scripts/ci/ghcr-retention.sh for the full policy.
 #
-# GHCR packages here are USER-owned (spengrah/*), and the built-in GITHUB_TOKEN
-# cannot delete user-owned package versions, so this uses a PAT secret
-# (GHCR_CLEANUP_TOKEN, classic, scopes: read:packages + delete:packages).
+# GHCR packages here are USER-owned (spengrah/*). GITHUB_TOKEN can delete versions
+# of ORG-owned, repo-scoped packages, but not USER-owned ones, so this uses a PAT
+# secret (GHCR_CLEANUP_TOKEN, classic, scopes: read:packages + delete:packages).
 #
 # Manual runs default to a DRY RUN (log only); the weekly schedule deletes for real.
 

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,57 @@
+name: GHCR retention
+
+# Bounds GHCR tag growth on personalcrm-{backend,frontend} (one :<sha> per develop
+# push, otherwise unbounded) WITHOUT deleting any image prod runs or could roll
+# back to. The delete rule is git-ancestry-aware, not date/count-based: a version
+# is removed only when its SHA is an ancestor of the current `main` tip AND more
+# than BUFFER commits behind it. The current prod image (main tip) and every
+# un-promoted develop SHA are kept regardless of age — so a long promote gap is
+# safe. See scripts/ci/ghcr-retention.sh for the full policy.
+#
+# GHCR packages here are USER-owned (spengrah/*), and the built-in GITHUB_TOKEN
+# cannot delete user-owned package versions, so this uses a PAT secret
+# (GHCR_CLEANUP_TOKEN, classic, scopes: read:packages + delete:packages).
+#
+# Manual runs default to a DRY RUN (log only); the weekly schedule deletes for real.
+
+on:
+  schedule:
+    - cron: '17 4 * * 1'   # Mondays 04:17 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log intended deletions without deleting"
+        type: boolean
+        default: true
+      buffer:
+        description: "Rollback-window commits to keep behind the main tip"
+        type: string
+        default: "30"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ghcr-retention
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so main-ancestry is resolvable
+
+      - name: Fetch main (prod tip for the ancestry test)
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+
+      - name: Prune promoted-and-superseded GHCR tags
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_CLEANUP_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          BUFFER: ${{ github.event.inputs.buffer || '30' }}
+          # schedule -> real delete; workflow_dispatch -> honor the dry_run input
+          # (defaults true, so a manual run is safe to inspect before enabling).
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') && '1' || '0' }}
+        run: scripts/ci/ghcr-retention.sh

--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ test-api:
 # inside <string> values, so it parses fine); plutil is macOS-only and not used here.
 test-deploy-scripts:
 	@echo "Running deploy-script shell tests (parallel)..."
-	@tests="scripts/deploy-artifact.test.sh scripts/backup-db.test.sh scripts/restore-db.test.sh scripts/deploy-staging.test.sh scripts/staging-reset.test.sh scripts/ci/staging-reseed-decision.test.sh scripts/ci/qa-round-cadence-gate.test.sh scripts/ci/qa-nightly-round.test.sh scripts/ci/qa-fn-backfill-guard.test.sh scripts/staging-deployed-sha.test.sh scripts/staging-reseed.test.sh scripts/admin/setup-staging-reseed-host.sh.test.sh scripts/run-tours.test.sh scripts/reconcile-mac-daemon.test.sh scripts/setup-mac-deploy.test.sh scripts/trigger-mac-deploy.test.sh scripts/test/test-promote-preflight.sh"; \
+	@tests="scripts/deploy-artifact.test.sh scripts/backup-db.test.sh scripts/restore-db.test.sh scripts/deploy-staging.test.sh scripts/staging-reset.test.sh scripts/ci/staging-reseed-decision.test.sh scripts/ci/ghcr-retention.test.sh scripts/ci/qa-round-cadence-gate.test.sh scripts/ci/qa-nightly-round.test.sh scripts/ci/qa-fn-backfill-guard.test.sh scripts/staging-deployed-sha.test.sh scripts/staging-reseed.test.sh scripts/admin/setup-staging-reseed-host.sh.test.sh scripts/run-tours.test.sh scripts/reconcile-mac-daemon.test.sh scripts/setup-mac-deploy.test.sh scripts/trigger-mac-deploy.test.sh scripts/test/test-promote-preflight.sh"; \
 	tmp="$$(mktemp -d)"; \
 	for t in $$tests; do \
 	  ( bash "$$t" >"$$tmp/$$(echo "$$t" | tr / _).out" 2>&1; echo "$$?" >"$$tmp/$$(echo "$$t" | tr / _).rc" ) & \

--- a/scripts/ci/ghcr-retention.sh
+++ b/scripts/ci/ghcr-retention.sh
@@ -15,10 +15,15 @@
 # promoted to main or superseded by a more recent one"):
 #   - the current prod image (main tip), REGARDLESS of age -> a long promote gap
 #     (e.g. no promote for 2 weeks) never deletes what prod runs / rolls back to;
-#   - the last BUFFER promoted commits (rollback window);
+#   - the tip PLUS the BUFFER most recent promoted ancestors (the rollback window);
 #   - every UN-promoted develop SHA (ahead of main) — un-promoted work is kept;
 #   - :latest, and any untagged version (untagged versions may back a manifest, so
 #     they are never touched here).
+#
+# SCOPE: this bounds TAG count, not total storage. Deleting a tagged buildx
+# manifest-index can leave its child/attestation manifests as UNTAGGED orphans,
+# which this script intentionally never touches (safety). An untagged-orphan sweep
+# is a separate follow-up.
 #
 # main is a strict linear prefix of develop (fast-forward promote model), so every
 # SHA is either an ancestor of main (promoted) or ahead of it (un-promoted); the
@@ -32,8 +37,10 @@
 # Env:
 #   OWNER      GHCR owner            (default: spengrah)
 #   PACKAGES   space-separated pkgs  (default: personalcrm-backend personalcrm-frontend)
-#   BUFFER     rollback-window commits kept behind main tip (default: 30)
-#   MAIN_REF   ref for the prod tip  (default: origin/main; falls back to main)
+#   BUFFER     rollback-window commits kept behind main tip (default: 30; must be a
+#              non-negative integer — anything else fails closed and deletes nothing)
+#   MAIN_REF   ref for the prod tip  (default: origin/main; NO fallback — a ref that
+#              does not resolve deletes nothing, so a stale local `main` can't drive it)
 #   DRY_RUN    "1" -> log intended deletes, delete nothing (default: 0)
 #   GH_TOKEN   PAT with read:packages + delete:packages (required for a real run)
 #   GHCR_LIST_VERSIONS_CMD / GHCR_DELETE_VERSION_CMD  test-injection hooks (see below)
@@ -51,18 +58,33 @@ DRY_RUN="${DRY_RUN:-0}"
 
 log() { printf '%s\n' "$*" >&2; }
 
+# BUFFER feeds `$((BUFFER + 1))` arithmetic below; a non-numeric value there would
+# resolve to 1 (bash treats an unset name as 0) and collapse the rollback window to
+# the tip alone. Reject anything that is not a non-negative integer -> delete nothing.
+case "$BUFFER" in
+  ''|*[!0-9]*)
+    log "ghcr-retention: BUFFER='${BUFFER}' is not a non-negative integer; deleting nothing"
+    exit 0 ;;
+esac
+
 DELSET="$(mktemp)"
-cleanup() { rm -f "$DELSET"; }
+LISTFILE="$(mktemp)"
+cleanup() { rm -f "$DELSET" "$LISTFILE"; }
 trap cleanup EXIT
 
-# Resolve the prod (main) tip; fail-closed if neither ref resolves.
+# Resolve the prod (main) tip; fail-closed if the ref does not resolve. There is NO
+# fallback to a bare local `main`: a stale or divergent local main must never drive
+# deletions. The caller passes a fetched remote ref (origin/main) and the workflow
+# fails the job if that fetch fails, so an unresolved ref here means "delete nothing".
 main_tip="$(git rev-parse --verify "${MAIN_REF}^{commit}" 2>/dev/null)" \
-  || main_tip="$(git rev-parse --verify "main^{commit}" 2>/dev/null)" \
-  || { log "ghcr-retention: cannot resolve main tip (${MAIN_REF} / main); deleting nothing"; exit 0; }
+  || { log "ghcr-retention: cannot resolve main tip (${MAIN_REF}); deleting nothing"; exit 0; }
 
-# The delete floor is BUFFER commits behind the tip. If main has <= BUFFER commits
-# of history, nothing is old enough to delete -> keep everything.
-floor="$(git rev-parse --verify "${main_tip}~${BUFFER}^{commit}" 2>/dev/null)" || {
+# Keep the tip plus the BUFFER most recent promoted ancestors (the rollback window);
+# delete only ancestors STRICTLY MORE THAN BUFFER commits behind the tip. The floor
+# is the first deletable commit (BUFFER+1 behind); rev-list from it covers it and
+# every older ancestor. If main has <= BUFFER commits of history behind its tip,
+# nothing is old enough -> keep everything.
+floor="$(git rev-parse --verify "${main_tip}~$((BUFFER + 1))^{commit}" 2>/dev/null)" || {
   log "ghcr-retention: main has <= ${BUFFER} commits behind its tip; nothing eligible, deleting nothing"
   exit 0
 }
@@ -73,15 +95,18 @@ git rev-list "$floor" > "$DELSET" 2>/dev/null || {
   log "ghcr-retention: git rev-list failed; deleting nothing"; exit 0
 }
 
-# SAFETY: the current prod image must NEVER be in the delete set. If it is, abort
-# loudly rather than risk deleting what prod is running.
+# SAFETY (defense-in-depth): the current prod image must NEVER be in the delete set.
+# The floor math (tip~(BUFFER+1)) makes this unreachable — the floor is always a
+# strict ancestor of the tip — but assert it anyway so any future refactor of the
+# floor/rev-list logic that reintroduces the tip fails LOUD instead of deleting prod.
 if grep -Fxq "$main_tip" "$DELSET"; then
   log "ghcr-retention: SAFETY ABORT — main tip ${main_tip} is in the delete set; deleting nothing"
   exit 1
 fi
 
-count="$(grep -c . "$DELSET" 2>/dev/null || echo 0)"
-if [ "${count:-0}" -eq 0 ]; then
+count="$(grep -c . "$DELSET" 2>/dev/null)"
+count="${count:-0}"
+if [ "$count" -eq 0 ]; then
   log "ghcr-retention: empty delete set; nothing to do"
   exit 0
 fi
@@ -117,8 +142,18 @@ delete_version() {  # <pkg> <id>
 }
 
 total=0
+list_failed=0
 for pkg in $PACKAGES; do
   log "== package: ${pkg}"
+  # Capture the listing to a file and CHECK its exit status. A process-substitution
+  # `while ... < <(list_versions)` would swallow a list/API/auth/pagination failure
+  # and silently report "0 deleted"; capturing surfaces it (and we exit non-zero at
+  # the end so a scheduled run goes red instead of looking like a clean no-op).
+  if ! list_versions "$pkg" > "$LISTFILE" 2>/dev/null; then
+    log "  ERROR: could not list versions for ${pkg} (API/auth/pagination failure); skipping this package"
+    list_failed=1
+    continue
+  fi
   while IFS=$'\t' read -r id tags; do
     [ -n "$id" ] || continue
     # Untagged version -> never touch (may back a manifest list / :latest digest).
@@ -140,11 +175,18 @@ for pkg in $PACKAGES; do
       delete_version "$pkg" "$id" || log "  WARN: delete failed for ${pkg} version ${id}"
     fi
     total=$((total + 1))
-  done < <(list_versions "$pkg")
+  done < "$LISTFILE"
 done
 
 if [ "$DRY_RUN" = "1" ]; then
   log "ghcr-retention: ${total} version(s) would be deleted (dry run)"
 else
   log "ghcr-retention: ${total} version(s) deleted"
+fi
+
+# Surface any listing failure as a non-zero exit so a scheduled run goes red rather
+# than masquerading as a clean no-op (deletions that DID run above still stand).
+if [ "$list_failed" -eq 1 ]; then
+  log "ghcr-retention: one or more package listings failed; exiting non-zero to surface it"
+  exit 1
 fi

--- a/scripts/ci/ghcr-retention.sh
+++ b/scripts/ci/ghcr-retention.sh
@@ -58,14 +58,23 @@ DRY_RUN="${DRY_RUN:-0}"
 
 log() { printf '%s\n' "$*" >&2; }
 
-# BUFFER feeds `$((BUFFER + 1))` arithmetic below; a non-numeric value there would
-# resolve to 1 (bash treats an unset name as 0) and collapse the rollback window to
-# the tip alone. Reject anything that is not a non-negative integer -> delete nothing.
+# BUFFER feeds `$((10#$BUFFER + 1))` arithmetic below; a non-numeric value there
+# would resolve to 1 (bash treats an unset name as 0) and collapse the rollback
+# window to the tip alone. Reject anything that is not a run of digits -> delete
+# nothing. The `10#` prefix at the use site forces base 10 so a leading-zero value
+# like "010" is decimal 10, not octal 8 (which would silently narrow the window).
 case "$BUFFER" in
   ''|*[!0-9]*)
     log "ghcr-retention: BUFFER='${BUFFER}' is not a non-negative integer; deleting nothing"
     exit 0 ;;
 esac
+# Bound the digit count so `10#$BUFFER` can never overflow bash's 64-bit signed
+# arithmetic (a 19+ digit value wraps to a small/negative result and would collapse
+# the rollback window). <=9 digits (max 999,999,999) dwarfs any real commit count.
+if [ "${#BUFFER}" -gt 9 ]; then
+  log "ghcr-retention: BUFFER='${BUFFER}' has too many digits (max 9); deleting nothing"
+  exit 0
+fi
 
 DELSET="$(mktemp)"
 LISTFILE="$(mktemp)"
@@ -84,7 +93,7 @@ main_tip="$(git rev-parse --verify "${MAIN_REF}^{commit}" 2>/dev/null)" \
 # is the first deletable commit (BUFFER+1 behind); rev-list from it covers it and
 # every older ancestor. If main has <= BUFFER commits of history behind its tip,
 # nothing is old enough -> keep everything.
-floor="$(git rev-parse --verify "${main_tip}~$((BUFFER + 1))^{commit}" 2>/dev/null)" || {
+floor="$(git rev-parse --verify "${main_tip}~$((10#$BUFFER + 1))^{commit}" 2>/dev/null)" || {
   log "ghcr-retention: main has <= ${BUFFER} commits behind its tip; nothing eligible, deleting nothing"
   exit 0
 }

--- a/scripts/ci/ghcr-retention.sh
+++ b/scripts/ci/ghcr-retention.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# ghcr-retention.sh — prune promoted-and-superseded GHCR image tags, safely.
+#
+# Bounds the growth of the personalcrm-{backend,frontend} GHCR packages (one
+# :<sha> tag per develop push, otherwise unbounded) WITHOUT ever deleting an image
+# prod is running or could roll back to.
+#
+# A :<sha> image version is deleted ONLY when ALL hold:
+#   1. its SHA is an ANCESTOR of the current `main` tip — i.e. it was promoted AND
+#      main has since advanced past it ("superseded by a more recent promotion"),
+#   2. it is more than BUFFER commits behind main's tip (prod rollback window), and
+#   3. it is neither :latest nor untagged.
+#
+# NEVER deleted (matches the operator rule "never clear a tag that hasn't been
+# promoted to main or superseded by a more recent one"):
+#   - the current prod image (main tip), REGARDLESS of age -> a long promote gap
+#     (e.g. no promote for 2 weeks) never deletes what prod runs / rolls back to;
+#   - the last BUFFER promoted commits (rollback window);
+#   - every UN-promoted develop SHA (ahead of main) — un-promoted work is kept;
+#   - :latest, and any untagged version (untagged versions may back a manifest, so
+#     they are never touched here).
+#
+# main is a strict linear prefix of develop (fast-forward promote model), so every
+# SHA is either an ancestor of main (promoted) or ahead of it (un-promoted); the
+# ancestry test cleanly separates the two. The build tags images with the FULL
+# 40-hex github.sha, matching `git rev-list` output verbatim.
+#
+# FAIL-CLOSED: any inability to resolve main / compute the delete set deletes
+# NOTHING and exits 0 (a real run also refuses without a token). Deletion is
+# irreversible; uncertainty must never widen it.
+#
+# Env:
+#   OWNER      GHCR owner            (default: spengrah)
+#   PACKAGES   space-separated pkgs  (default: personalcrm-backend personalcrm-frontend)
+#   BUFFER     rollback-window commits kept behind main tip (default: 30)
+#   MAIN_REF   ref for the prod tip  (default: origin/main; falls back to main)
+#   DRY_RUN    "1" -> log intended deletes, delete nothing (default: 0)
+#   GH_TOKEN   PAT with read:packages + delete:packages (required for a real run)
+#   GHCR_LIST_VERSIONS_CMD / GHCR_DELETE_VERSION_CMD  test-injection hooks (see below)
+#
+# Bash 3.2-safe (no associative arrays): the delete set is a temp file matched with
+# `grep -Fxq`, so it runs on the macOS system bash the deploy-script tests use.
+
+set -uo pipefail
+
+OWNER="${OWNER:-spengrah}"
+PACKAGES="${PACKAGES:-personalcrm-backend personalcrm-frontend}"
+BUFFER="${BUFFER:-30}"
+MAIN_REF="${MAIN_REF:-origin/main}"
+DRY_RUN="${DRY_RUN:-0}"
+
+log() { printf '%s\n' "$*" >&2; }
+
+DELSET="$(mktemp)"
+cleanup() { rm -f "$DELSET"; }
+trap cleanup EXIT
+
+# Resolve the prod (main) tip; fail-closed if neither ref resolves.
+main_tip="$(git rev-parse --verify "${MAIN_REF}^{commit}" 2>/dev/null)" \
+  || main_tip="$(git rev-parse --verify "main^{commit}" 2>/dev/null)" \
+  || { log "ghcr-retention: cannot resolve main tip (${MAIN_REF} / main); deleting nothing"; exit 0; }
+
+# The delete floor is BUFFER commits behind the tip. If main has <= BUFFER commits
+# of history, nothing is old enough to delete -> keep everything.
+floor="$(git rev-parse --verify "${main_tip}~${BUFFER}^{commit}" 2>/dev/null)" || {
+  log "ghcr-retention: main has <= ${BUFFER} commits behind its tip; nothing eligible, deleting nothing"
+  exit 0
+}
+
+# Deletable SHAs = the floor commit and all its ancestors (promoted AND strictly
+# more than BUFFER commits behind the tip). Full 40-hex, one per line.
+git rev-list "$floor" > "$DELSET" 2>/dev/null || {
+  log "ghcr-retention: git rev-list failed; deleting nothing"; exit 0
+}
+
+# SAFETY: the current prod image must NEVER be in the delete set. If it is, abort
+# loudly rather than risk deleting what prod is running.
+if grep -Fxq "$main_tip" "$DELSET"; then
+  log "ghcr-retention: SAFETY ABORT — main tip ${main_tip} is in the delete set; deleting nothing"
+  exit 1
+fi
+
+count="$(grep -c . "$DELSET" 2>/dev/null || echo 0)"
+if [ "${count:-0}" -eq 0 ]; then
+  log "ghcr-retention: empty delete set; nothing to do"
+  exit 0
+fi
+
+if [ "$DRY_RUN" != "1" ] && [ -z "${GH_TOKEN:-}" ]; then
+  # Not-yet-configured secret -> green no-op (deletes nothing), not a weekly red.
+  # Set the GHCR_CLEANUP_TOKEN PAT secret (read:packages + delete:packages) to enable.
+  log "ghcr-retention: GH_TOKEN/GHCR_CLEANUP_TOKEN not set; skipping (configure the PAT secret to enable). Deleting nothing."
+  exit 0
+fi
+
+log "ghcr-retention: owner=${OWNER} main_tip=${main_tip} buffer=${BUFFER} deletable-ancestor-SHAs=${count} dry_run=${DRY_RUN}"
+
+is_deletable() { grep -Fxq "$1" "$DELSET"; }
+
+list_versions() {  # <pkg> -> lines: "<id>\t<tag,tag,...>"  (untagged -> empty tag field)
+  local pkg="$1"
+  if [ -n "${GHCR_LIST_VERSIONS_CMD:-}" ]; then
+    PKG="$pkg" bash -c "$GHCR_LIST_VERSIONS_CMD"
+    return
+  fi
+  gh api --paginate "/users/${OWNER}/packages/container/${pkg}/versions" \
+    --jq '.[] | [(.id|tostring), (.metadata.container.tags | join(","))] | @tsv'
+}
+
+delete_version() {  # <pkg> <id>
+  local pkg="$1" id="$2"
+  if [ -n "${GHCR_DELETE_VERSION_CMD:-}" ]; then
+    PKG="$pkg" VERSION_ID="$id" bash -c "$GHCR_DELETE_VERSION_CMD"
+    return
+  fi
+  gh api -X DELETE "/users/${OWNER}/packages/container/${pkg}/versions/${id}"
+}
+
+total=0
+for pkg in $PACKAGES; do
+  log "== package: ${pkg}"
+  while IFS=$'\t' read -r id tags; do
+    [ -n "$id" ] || continue
+    # Untagged version -> never touch (may back a manifest list / :latest digest).
+    [ -n "$tags" ] || continue
+    # Delete only if EVERY tag on the version is a deletable SHA. A version that
+    # also carries :latest, or any tag not in the delete set, is kept.
+    keep=0
+    old_ifs="$IFS"; IFS=','
+    for t in $tags; do
+      if ! is_deletable "$t"; then keep=1; break; fi
+    done
+    IFS="$old_ifs"
+    [ "$keep" -eq 0 ] || continue
+
+    if [ "$DRY_RUN" = "1" ]; then
+      log "  DRY-RUN would delete ${pkg} version ${id} (tags: ${tags})"
+    else
+      log "  deleting ${pkg} version ${id} (tags: ${tags})"
+      delete_version "$pkg" "$id" || log "  WARN: delete failed for ${pkg} version ${id}"
+    fi
+    total=$((total + 1))
+  done < <(list_versions "$pkg")
+done
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "ghcr-retention: ${total} version(s) would be deleted (dry run)"
+else
+  log "ghcr-retention: ${total} version(s) deleted"
+fi

--- a/scripts/ci/ghcr-retention.test.sh
+++ b/scripts/ci/ghcr-retention.test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Tests for ghcr-retention.sh — the git-ancestry-aware GHCR tag delete decision.
+#
+# Builds a throwaway linear git fixture (main a strict prefix of develop), points
+# MAIN_REF at a chosen commit, feeds a MOCKED package-version list through the
+# GHCR_LIST_VERSIONS_CMD injection hook, and asserts which versions the script
+# marks for deletion (DRY_RUN=1, so nothing hits the network). Also covers the
+# fail-closed paths (unresolvable main, too-short history, real-run-without-token).
+#
+# Portable: no network, no BSD-only flags. Sets a LOCAL git identity (CI may lack a
+# global one) and unsets the hook-inherited git env so the fixture is isolated.
+
+set -uo pipefail
+
+# Git pre-push hooks export GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE; without unsetting
+# them the fixture's git commands (and the script's rev-parse/rev-list in the
+# fixture CWD) would hit the real repo. Unset restores cwd-based discovery.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/ci/ghcr-retention.sh"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+# ---- Build a 12-commit linear fixture; capture each commit SHA into C1..C12. ----
+FIXTURE="$(mktemp -d)"
+declare -a C
+(
+  cd "$FIXTURE" || exit 1
+  git init -q
+  git config user.email "ci@example.com"
+  git config user.name "CI"
+  git config commit.gpgsign false
+  # Name the branch `develop` so neither `main` nor `master` exists — the
+  # unresolvable-main test relies on the script's `main` fallback also failing.
+  git checkout -q -b develop 2>/dev/null || git branch -q -m develop
+) || { echo "fixture init failed" >&2; exit 1; }
+
+for i in $(seq 1 12); do
+  ( cd "$FIXTURE" && echo "c$i" > file.txt && git add file.txt && git commit -q -m "c$i" )
+  C[i]="$( cd "$FIXTURE" && git rev-parse HEAD )"
+done
+
+# main tip = C9 (so C1..C9 are promoted ancestors; C10..C12 are ahead/un-promoted).
+MAIN=${C[9]}
+
+# Mock version list: "<id>\t<tags>". Tab-separated, one per line.
+MOCK="$FIXTURE/versions.tsv"
+{
+  printf '100\t%s\n'    "${C[3]}"            # deletable: promoted, >3 behind tip
+  printf '101\t%s\n'    "${C[6]}"            # deletable: exactly the floor (C9~3)
+  printf '102\t%s\n'    "${C[7]}"            # KEEP: within rollback buffer
+  printf '103\t%s\n'    "${C[9]}"            # KEEP: current prod image (main tip)
+  printf '104\t%s\n'    "${C[11]}"           # KEEP: un-promoted (ahead of main)
+  printf '105\t%s,latest\n' "${C[2]}"        # KEEP: carries :latest despite old sha
+  printf '106\t\n'                            # KEEP: untagged
+  printf '107\t%s\n'    "${C[1]}"            # deletable: oldest promoted
+} > "$MOCK"
+
+run() {  # run <main_ref> <buffer> <dry_run> <token>  -> stderr captured to $OUT, rc in $RC
+  OUT="$FIXTURE/out.$$"
+  ( cd "$FIXTURE" \
+    && MAIN_REF="$1" BUFFER="$2" DRY_RUN="$3" GH_TOKEN="$4" \
+       OWNER="testowner" PACKAGES="pkg" \
+       GHCR_LIST_VERSIONS_CMD="cat '$MOCK'" \
+       bash "$SCRIPT" ) >/dev/null 2>"$OUT"
+  RC=$?
+}
+
+# ---- Test 1: the core delete decision (dry run). ----
+run "$MAIN" 3 1 ""
+[ "$RC" -eq 0 ] || fail "core: expected rc 0, got $RC"
+for id in 100 101 107; do
+  if grep -q "would delete pkg version ${id} " "$OUT"; then ok; else fail "core: version ${id} should be deleted"; fi
+done
+for id in 102 103 104 105 106; do
+  if grep -q "version ${id} " "$OUT"; then fail "core: version ${id} must be kept"; else ok; fi
+done
+# exactly 3 deletions reported
+if grep -q "3 version(s) would be deleted" "$OUT"; then ok; else fail "core: expected 3 deletions, got: $(grep 'would be deleted' "$OUT")"; fi
+
+# ---- Test 2: unresolvable main -> fail-closed, delete nothing. ----
+run "refs/heads/nope" 3 1 ""
+[ "$RC" -eq 0 ] || fail "unresolvable-main: expected rc 0, got $RC"
+if grep -q "cannot resolve main tip" "$OUT"; then ok; else fail "unresolvable-main: expected resolve failure message"; fi
+if grep -q "would delete" "$OUT"; then fail "unresolvable-main: must delete nothing"; else ok; fi
+
+# ---- Test 3: history <= BUFFER behind tip -> nothing eligible. ----
+run "$MAIN" 50 1 ""
+[ "$RC" -eq 0 ] || fail "short-history: expected rc 0, got $RC"
+if grep -q "nothing eligible" "$OUT"; then ok; else fail "short-history: expected 'nothing eligible'"; fi
+if grep -q "would delete" "$OUT"; then fail "short-history: must delete nothing"; else ok; fi
+
+# ---- Test 4: real run (DRY_RUN=0) with no token -> green no-op skip. ----
+run "$MAIN" 3 0 ""
+[ "$RC" -eq 0 ] || fail "no-token: expected rc 0 (green skip), got $RC"
+if grep -q "not set; skipping" "$OUT"; then ok; else fail "no-token: expected skip message"; fi
+if grep -q "would delete\|deleting" "$OUT"; then fail "no-token: must delete nothing"; else ok; fi
+
+# ---- Test 5: real run actually invokes delete for the right ids only. ----
+DELLOG="$FIXTURE/deleted.log"
+: > "$DELLOG"
+( cd "$FIXTURE" \
+  && MAIN_REF="$MAIN" BUFFER=3 DRY_RUN=0 GH_TOKEN="fake" \
+     OWNER="testowner" PACKAGES="pkg" \
+     GHCR_LIST_VERSIONS_CMD="cat '$MOCK'" \
+     GHCR_DELETE_VERSION_CMD="printf '%s\n' \"\$VERSION_ID\" >> '$DELLOG'" \
+     bash "$SCRIPT" ) >/dev/null 2>"$FIXTURE/out.real"
+rc=$?
+[ "$rc" -eq 0 ] || fail "real-run: expected rc 0, got $rc"
+deleted="$(sort "$DELLOG" | tr '\n' ' ')"
+if [ "$deleted" = "100 101 107 " ]; then ok; else fail "real-run: expected deleted ids '100 101 107', got '${deleted}'"; fi
+
+rm -rf "$FIXTURE"
+
+echo "ghcr-retention.test.sh: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/ci/ghcr-retention.test.sh
+++ b/scripts/ci/ghcr-retention.test.sh
@@ -112,11 +112,22 @@ run "$MAIN" 3 0 ""
 if grep -q "not set; skipping" "$OUT"; then ok; else fail "no-token: expected skip message"; fi
 if grep -q "would delete\|deleting" "$OUT"; then fail "no-token: must delete nothing"; else ok; fi
 
-# ---- Test 5: invalid BUFFER -> fail-closed (guards the $((BUFFER+1)) arithmetic). ----
+# ---- Test 5: invalid BUFFER -> fail-closed (guards the $((10#$BUFFER + 1)) math). ----
+# 5a: non-numeric.
 run "$MAIN" "abc" 1 ""
-[ "$RC" -eq 0 ] || fail "bad-buffer: expected rc 0, got $RC"
-if grep -q "not a non-negative integer" "$OUT"; then ok; else fail "bad-buffer: expected validation message"; fi
-if grep -q "would delete" "$OUT"; then fail "bad-buffer: must delete nothing"; else ok; fi
+[ "$RC" -eq 0 ] || fail "bad-buffer(abc): expected rc 0, got $RC"
+if grep -q "not a non-negative integer" "$OUT"; then ok; else fail "bad-buffer(abc): expected validation message"; fi
+if grep -q "would delete" "$OUT"; then fail "bad-buffer(abc): must delete nothing"; else ok; fi
+# 5b: negative (the '-' is a non-digit -> rejected).
+run "$MAIN" "-5" 1 ""
+[ "$RC" -eq 0 ] || fail "bad-buffer(-5): expected rc 0, got $RC"
+if grep -q "not a non-negative integer" "$OUT"; then ok; else fail "bad-buffer(-5): expected validation message"; fi
+if grep -q "would delete" "$OUT"; then fail "bad-buffer(-5): must delete nothing"; else ok; fi
+# 5c: overflow-sized value (> 9 digits) -> rejected before it can wrap the arithmetic.
+run "$MAIN" "10000000000" 1 ""
+[ "$RC" -eq 0 ] || fail "bad-buffer(huge): expected rc 0, got $RC"
+if grep -q "too many digits" "$OUT"; then ok; else fail "bad-buffer(huge): expected digit-count message"; fi
+if grep -q "would delete" "$OUT"; then fail "bad-buffer(huge): must delete nothing"; else ok; fi
 
 # ---- Test 6: real run deletes exactly the right ids. ----
 DELLOG="$FIXTURE/deleted.log"
@@ -171,6 +182,40 @@ rc=$?
 [ "$rc" -eq 1 ] || fail "list-failure: expected rc 1, got $rc"
 if grep -q "could not list versions" "$FIXTURE/out.listfail"; then ok; else fail "list-failure: expected error message"; fi
 if [ -s "$DELLOG" ]; then fail "list-failure: must delete nothing, deleted: $(tr '\n' ' ' < "$DELLOG")"; else ok; fi
+
+# ---- Test 9b: multi-package where the SECOND package's listing fails -> the first
+#      package's deletions still stand, the run exits 1, and the shared $LISTFILE
+#      does not bleed the good package's entries into the failed one. ----
+: > "$DELLOG"
+( cd "$FIXTURE" \
+  && MAIN_REF="$MAIN" BUFFER=3 DRY_RUN=0 GH_TOKEN="fake" \
+     OWNER="testowner" PACKAGES="pkggood pkgbad" \
+     GHCR_LIST_VERSIONS_CMD="[ \"\$PKG\" = pkgbad ] && exit 3; cat '$MOCK'" \
+     GHCR_DELETE_VERSION_CMD="printf '%s\n' \"\$VERSION_ID\" >> '$DELLOG'" \
+     bash "$SCRIPT" ) >/dev/null 2>"$FIXTURE/out.mixfail"
+rc=$?
+[ "$rc" -eq 1 ] || fail "mixed-list-failure: expected rc 1, got $rc"
+if grep -q "could not list versions for pkgbad" "$FIXTURE/out.mixfail"; then ok; else fail "mixed-list-failure: expected pkgbad error"; fi
+mixdeleted="$(sort "$DELLOG" | tr '\n' ' ')"
+if [ "$mixdeleted" = "100 107 108 " ]; then ok; else fail "mixed-list-failure: expected only pkggood's '100 107 108', got '${mixdeleted}'"; fi
+
+# ---- Test 10: leading-zero BUFFER is treated as DECIMAL, not octal (10#$BUFFER).
+#              With MAIN=C12, "010" as decimal 10 -> floor C12~11 = C1 -> only C1
+#              deletable; the octal-8 bug would floor at C12~9 = C3 and also delete
+#              C2/C3, narrowing the rollback window (the dangerous direction). ----
+MAIN12=${C[12]}
+MOCK2="$FIXTURE/versions2.tsv"
+{
+  printf '200\t%s\n' "${C[1]}"
+  printf '201\t%s\n' "${C[2]}"
+  printf '202\t%s\n' "${C[3]}"
+} > "$MOCK2"
+run "$MAIN12" "010" 1 "" "cat '$MOCK2'"
+[ "$RC" -eq 0 ] || fail "octal-buffer: expected rc 0, got $RC"
+if grep -q "would delete pkg version 200 " "$OUT"; then ok; else fail "octal-buffer: 200 (C1) should be deleted at BUFFER=010 (=decimal 10)"; fi
+for id in 201 202; do
+  if grep -q "version ${id} " "$OUT"; then fail "octal-buffer: version ${id} must be kept (010 must be decimal 10, not octal 8)"; else ok; fi
+done
 
 rm -rf "$FIXTURE"
 

--- a/scripts/ci/ghcr-retention.test.sh
+++ b/scripts/ci/ghcr-retention.test.sh
@@ -5,7 +5,9 @@
 # MAIN_REF at a chosen commit, feeds a MOCKED package-version list through the
 # GHCR_LIST_VERSIONS_CMD injection hook, and asserts which versions the script
 # marks for deletion (DRY_RUN=1, so nothing hits the network). Also covers the
-# fail-closed paths (unresolvable main, too-short history, real-run-without-token).
+# fail-closed paths (unresolvable main with NO fallback, too-short history, invalid
+# BUFFER, real-run-without-token, list-command failure), the buffer boundary, the
+# tip/un-promoted safety property across BUFFER values, and multi-package handling.
 #
 # Portable: no network, no BSD-only flags. Sets a LOCAL git identity (CI may lack a
 # global one) and unsets the hook-inherited git env so the fixture is isolated.
@@ -34,8 +36,6 @@ declare -a C
   git config user.email "ci@example.com"
   git config user.name "CI"
   git config commit.gpgsign false
-  # Name the branch `develop` so neither `main` nor `master` exists — the
-  # unresolvable-main test relies on the script's `main` fallback also failing.
   git checkout -q -b develop 2>/dev/null || git branch -q -m develop
 ) || { echo "fixture init failed" >&2; exit 1; }
 
@@ -44,49 +44,61 @@ for i in $(seq 1 12); do
   C[i]="$( cd "$FIXTURE" && git rev-parse HEAD )"
 done
 
+# A local `main` at C12 (divergent from the C9 we treat as prod). Its presence is
+# what makes the no-fallback test meaningful: a stale/divergent local main must NOT
+# be used when the configured ref is unresolvable.
+( cd "$FIXTURE" && git branch main develop )
+
 # main tip = C9 (so C1..C9 are promoted ancestors; C10..C12 are ahead/un-promoted).
 MAIN=${C[9]}
 
-# Mock version list: "<id>\t<tags>". Tab-separated, one per line.
+# Mock version list: "<id>\t<tags>". With MAIN=C9, BUFFER=3 the delete floor is
+# C9~4 = C5, so deletable = {C1..C5} (strictly MORE than 3 commits behind the tip).
 MOCK="$FIXTURE/versions.tsv"
 {
-  printf '100\t%s\n'    "${C[3]}"            # deletable: promoted, >3 behind tip
-  printf '101\t%s\n'    "${C[6]}"            # deletable: exactly the floor (C9~3)
-  printf '102\t%s\n'    "${C[7]}"            # KEEP: within rollback buffer
-  printf '103\t%s\n'    "${C[9]}"            # KEEP: current prod image (main tip)
-  printf '104\t%s\n'    "${C[11]}"           # KEEP: un-promoted (ahead of main)
-  printf '105\t%s,latest\n' "${C[2]}"        # KEEP: carries :latest despite old sha
-  printf '106\t\n'                            # KEEP: untagged
-  printf '107\t%s\n'    "${C[1]}"            # deletable: oldest promoted
+  printf '100\t%s\n'         "${C[3]}"          # DELETE: promoted, 6 behind
+  printf '101\t%s\n'         "${C[6]}"          # KEEP: exactly BUFFER (3) behind — boundary
+  printf '102\t%s\n'         "${C[7]}"          # KEEP: within rollback buffer
+  printf '103\t%s\n'         "${C[9]}"          # KEEP: current prod image (main tip)
+  printf '104\t%s\n'         "${C[11]}"         # KEEP: un-promoted (ahead of main)
+  printf '105\t%s,latest\n'  "${C[2]}"          # KEEP: carries :latest despite old sha
+  printf '106\t\n'                               # KEEP: untagged
+  printf '107\t%s\n'         "${C[1]}"          # DELETE: oldest promoted
+  printf '108\t%s\n'         "${C[5]}"          # DELETE: exactly BUFFER+1 (4) behind — boundary
+  printf '109\t%s,%s\n'      "${C[4]}" "${C[11]}" # KEEP: one deletable sha + one un-promoted sha
 } > "$MOCK"
 
-run() {  # run <main_ref> <buffer> <dry_run> <token>  -> stderr captured to $OUT, rc in $RC
+run() {  # run <main_ref> <buffer> <dry_run> <token> [list_cmd]  -> stderr in $OUT, rc in $RC
   OUT="$FIXTURE/out.$$"
+  # $MOCK expands (outer double quotes); the inner single quotes are literal so the
+  # injected command is `cat '<path>'`. shellcheck SC2016 misreads the nesting.
+  # shellcheck disable=SC2016
+  local list_cmd="${5:-cat '$MOCK'}"
   ( cd "$FIXTURE" \
     && MAIN_REF="$1" BUFFER="$2" DRY_RUN="$3" GH_TOKEN="$4" \
        OWNER="testowner" PACKAGES="pkg" \
-       GHCR_LIST_VERSIONS_CMD="cat '$MOCK'" \
+       GHCR_LIST_VERSIONS_CMD="$list_cmd" \
        bash "$SCRIPT" ) >/dev/null 2>"$OUT"
   RC=$?
 }
 
-# ---- Test 1: the core delete decision (dry run). ----
+# ---- Test 1: the core delete decision (dry run) under the new floor semantics. ----
 run "$MAIN" 3 1 ""
 [ "$RC" -eq 0 ] || fail "core: expected rc 0, got $RC"
-for id in 100 101 107; do
+for id in 100 107 108; do
   if grep -q "would delete pkg version ${id} " "$OUT"; then ok; else fail "core: version ${id} should be deleted"; fi
 done
-for id in 102 103 104 105 106; do
+for id in 101 102 103 104 105 106 109; do
   if grep -q "version ${id} " "$OUT"; then fail "core: version ${id} must be kept"; else ok; fi
 done
-# exactly 3 deletions reported
 if grep -q "3 version(s) would be deleted" "$OUT"; then ok; else fail "core: expected 3 deletions, got: $(grep 'would be deleted' "$OUT")"; fi
 
-# ---- Test 2: unresolvable main -> fail-closed, delete nothing. ----
-run "refs/heads/nope" 3 1 ""
-[ "$RC" -eq 0 ] || fail "unresolvable-main: expected rc 0, got $RC"
-if grep -q "cannot resolve main tip" "$OUT"; then ok; else fail "unresolvable-main: expected resolve failure message"; fi
-if grep -q "would delete" "$OUT"; then fail "unresolvable-main: must delete nothing"; else ok; fi
+# ---- Test 2: unresolvable main + NO fallback -> delete nothing (stale local main
+#              at C12 must NOT be used). ----
+run "refs/remotes/origin/does-not-exist" 3 1 ""
+[ "$RC" -eq 0 ] || fail "no-fallback: expected rc 0, got $RC"
+if grep -q "cannot resolve main tip" "$OUT"; then ok; else fail "no-fallback: expected resolve failure message"; fi
+if grep -q "would delete" "$OUT"; then fail "no-fallback: must delete nothing (no local-main fallback)"; else ok; fi
 
 # ---- Test 3: history <= BUFFER behind tip -> nothing eligible. ----
 run "$MAIN" 50 1 ""
@@ -100,7 +112,13 @@ run "$MAIN" 3 0 ""
 if grep -q "not set; skipping" "$OUT"; then ok; else fail "no-token: expected skip message"; fi
 if grep -q "would delete\|deleting" "$OUT"; then fail "no-token: must delete nothing"; else ok; fi
 
-# ---- Test 5: real run actually invokes delete for the right ids only. ----
+# ---- Test 5: invalid BUFFER -> fail-closed (guards the $((BUFFER+1)) arithmetic). ----
+run "$MAIN" "abc" 1 ""
+[ "$RC" -eq 0 ] || fail "bad-buffer: expected rc 0, got $RC"
+if grep -q "not a non-negative integer" "$OUT"; then ok; else fail "bad-buffer: expected validation message"; fi
+if grep -q "would delete" "$OUT"; then fail "bad-buffer: must delete nothing"; else ok; fi
+
+# ---- Test 6: real run deletes exactly the right ids. ----
 DELLOG="$FIXTURE/deleted.log"
 : > "$DELLOG"
 ( cd "$FIXTURE" \
@@ -112,7 +130,47 @@ DELLOG="$FIXTURE/deleted.log"
 rc=$?
 [ "$rc" -eq 0 ] || fail "real-run: expected rc 0, got $rc"
 deleted="$(sort "$DELLOG" | tr '\n' ' ')"
-if [ "$deleted" = "100 101 107 " ]; then ok; else fail "real-run: expected deleted ids '100 101 107', got '${deleted}'"; fi
+if [ "$deleted" = "100 107 108 " ]; then ok; else fail "real-run: expected deleted ids '100 107 108', got '${deleted}'"; fi
+
+# ---- Test 7: SAFETY PROPERTY — across BUFFER values, the tip (103/C9) and an
+#              un-promoted sha (104/C11) are NEVER deleted. ----
+for b in 0 1 3 5; do
+  : > "$DELLOG"
+  ( cd "$FIXTURE" \
+    && MAIN_REF="$MAIN" BUFFER="$b" DRY_RUN=0 GH_TOKEN="fake" \
+       OWNER="testowner" PACKAGES="pkg" \
+       GHCR_LIST_VERSIONS_CMD="cat '$MOCK'" \
+       GHCR_DELETE_VERSION_CMD="printf '%s\n' \"\$VERSION_ID\" >> '$DELLOG'" \
+       bash "$SCRIPT" ) >/dev/null 2>"$FIXTURE/out.prop"
+  if grep -qx "103" "$DELLOG"; then fail "safety-property (BUFFER=$b): prod tip (103) was deleted"; else ok; fi
+  if grep -qx "104" "$DELLOG"; then fail "safety-property (BUFFER=$b): un-promoted (104) was deleted"; else ok; fi
+done
+
+# ---- Test 8: multi-package — same mock for two packages -> 6 deletions. ----
+: > "$DELLOG"
+( cd "$FIXTURE" \
+  && MAIN_REF="$MAIN" BUFFER=3 DRY_RUN=0 GH_TOKEN="fake" \
+     OWNER="testowner" PACKAGES="pkg1 pkg2" \
+     GHCR_LIST_VERSIONS_CMD="cat '$MOCK'" \
+     GHCR_DELETE_VERSION_CMD="printf '%s\n' \"\$VERSION_ID\" >> '$DELLOG'" \
+     bash "$SCRIPT" ) >/dev/null 2>"$FIXTURE/out.multi"
+rc=$?
+[ "$rc" -eq 0 ] || fail "multi-package: expected rc 0, got $rc"
+n="$(grep -c . "$DELLOG")"
+if [ "$n" -eq 6 ]; then ok; else fail "multi-package: expected 6 deletions (3 per package), got $n"; fi
+
+# ---- Test 9: list-command failure on a real run -> surface it (rc 1), delete nothing. ----
+: > "$DELLOG"
+( cd "$FIXTURE" \
+  && MAIN_REF="$MAIN" BUFFER=3 DRY_RUN=0 GH_TOKEN="fake" \
+     OWNER="testowner" PACKAGES="pkg" \
+     GHCR_LIST_VERSIONS_CMD="exit 3" \
+     GHCR_DELETE_VERSION_CMD="printf '%s\n' \"\$VERSION_ID\" >> '$DELLOG'" \
+     bash "$SCRIPT" ) >/dev/null 2>"$FIXTURE/out.listfail"
+rc=$?
+[ "$rc" -eq 1 ] || fail "list-failure: expected rc 1, got $rc"
+if grep -q "could not list versions" "$FIXTURE/out.listfail"; then ok; else fail "list-failure: expected error message"; fi
+if [ -s "$DELLOG" ]; then fail "list-failure: must delete nothing, deleted: $(tr '\n' ' ' < "$DELLOG")"; else ok; fi
 
 rm -rf "$FIXTURE"
 


### PR DESCRIPTION
## Summary

Bounds unbounded GHCR tag growth on the `personalcrm-{backend,frontend}` packages (one `:<sha>` tag per develop push, otherwise unbounded — currently ~169 tags each and climbing ~6/day) **without ever deleting an image prod runs or could roll back to**.

## Policy

A `:<sha>` image version is deleted only when **all** hold:
1. its SHA is an **ancestor of the current `main` tip** (promoted, and main has since advanced past it), **and**
2. it is more than `BUFFER` (default 30) commits behind main's tip (rollback window), **and**
3. it is neither `:latest` nor untagged.

Never deleted: the current prod image (main tip) **regardless of age** — so a long promote gap (e.g. no promote for 2 weeks) never touches what prod runs/rolls back to; the last 30 promoted commits; **every un-promoted develop SHA** (ahead of main); `:latest`; untagged versions. `main` is a strict linear prefix of `develop` (fast-forward promote model), so ancestry cleanly separates promoted from un-promoted SHAs. Fail-closed: any inability to resolve main deletes nothing.

Validated against real data (169 real backend tags × real `origin/main`, dry-run): 130 old promoted-and-superseded images reclaimed; main tip and develop-ahead SHAs correctly excluded from the delete set.

## Mechanics

- `scripts/ci/ghcr-retention.sh` — the decision + delete logic. Bash 3.2-safe (temp-file delete set, no associative arrays), dry-run capable, with test-injection hooks for the GHCR API.
- `.github/workflows/ghcr-cleanup.yml` — weekly schedule (real delete) + manual dispatch (defaults to **dry-run**). Concurrency-serialized, never cancels.
- `scripts/ci/ghcr-retention.test.sh` — 16 assertions over a linear git fixture with mocked GHCR responses; wired into `make test-deploy-scripts`.

## Operator note

The packages are user-owned, so the built-in `GITHUB_TOKEN` cannot delete their versions — deletion needs a classic PAT (`read:packages` + `delete:packages`) stored as repo secret `GHCR_CLEANUP_TOKEN`. Until it is set, the scheduled run is a **green no-op** (logs "not set; skipping"). First real cleanup: a manual dispatch with `dry_run: false` clears the backlog in one run.

Note: this PR deliberately does **not** add a `cancel-in-progress` concurrency block to `build-images.yml` — that would break the "every develop SHA is promotable" invariant (gate-enforced in `promote-preflight.sh`) for negligible CI-minute savings.