### PR TITLE
fix(scripts): remove pipefail SIGPIPE flake in deploy-test out_has

### DIFF
--- a/scripts/deploy-artifact.sh
+++ b/scripts/deploy-artifact.sh
@@ -177,7 +177,7 @@ health_gate() {
     #    DB status is nested under components.database, not a flat key).
     for ((i = 1; i <= HEALTH_RETRIES; i++)); do
         body="$(curl -sf http://127.0.0.1:8080/health 2>/dev/null)" \
-            && printf '%s' "$body" | grep -qE '"status":[[:space:]]*"healthy"' \
+            && grep -qE -- '"status":[[:space:]]*"healthy"' <<<"$body" \
             && { ok=true; break; }
         sleep 1
     done
@@ -189,9 +189,9 @@ health_gate() {
     #     Same $body the loop captured when it reached healthy — no second fetch.
     #     Key-based grep (tolerant of field order and of later-added fields).
     if [ -n "$expected_sha" ]; then
-        if printf '%s' "$body" | grep -qE "\"git_commit\":[[:space:]]*\"${expected_sha}\""; then
+        if grep -qE -- "\"git_commit\":[[:space:]]*\"${expected_sha}\"" <<<"$body"; then
             : # match -> pass
-        elif printf '%s' "$body" | grep -qE '"git_commit":[[:space:]]*"unknown"'; then
+        elif grep -qE -- '"git_commit":[[:space:]]*"unknown"' <<<"$body"; then
             log "health-gate: build not stamped (git_commit=unknown); skipping commit verification"
         else
             log "health-gate: serving build git_commit does not match deployed $expected_sha"

--- a/scripts/deploy-artifact.test.sh
+++ b/scripts/deploy-artifact.test.sh
@@ -400,7 +400,7 @@ test_health_gate_commit_mismatch_fails() {
     STUB_MIGRATE_CHECK_RC=0 STUB_HEALTH_OK=1 STUB_HEALTH_GIT_COMMIT="$WRONG_SHA" run_deploy "$VALID_SHA"
     if [ "$RC" -eq 1 ]; then ok; else fail "commit mismatch should fail the gate -> rollback (exit 1), got $RC ($OUT)"; fi
     # The forward gate must have logged the mismatch (not the unknown-skip).
-    if echo "$OUT" | grep -q 'git_commit does not match'; then ok; else fail "expected a commit-mismatch log line"; fi
+    if grep -qF -- 'git_commit does not match' <<<"$OUT"; then ok; else fail "expected a commit-mismatch log line"; fi
     # Rollback re-pins the OLD digest anchor on both units.
     if grep -q 'Image=ghcr.io/spengrah/personalcrm-backend@sha256:c91da029' "$BACKEND_UNIT"; then ok
     else fail "mismatch must re-pin the rollback digest anchor"; fi
@@ -415,7 +415,7 @@ test_health_gate_unknown_warns_and_passes() {
     make_sandbox
     STUB_MIGRATE_CHECK_RC=0 STUB_HEALTH_OK=1 STUB_HEALTH_GIT_COMMIT="unknown" run_deploy "$VALID_SHA"
     if [ "$RC" -eq 0 ]; then ok; else fail "unknown commit should warn + pass (exit 0), got $RC ($OUT)"; fi
-    if echo "$OUT" | grep -q 'build not stamped (git_commit=unknown); skipping commit verification'; then ok
+    if grep -qF -- 'build not stamped (git_commit=unknown); skipping commit verification' <<<"$OUT"; then ok
     else fail "expected the unknown-skip warning in the deploy output"; fi
     cleanup_sandbox
 }

--- a/scripts/deploy-artifact.test.sh
+++ b/scripts/deploy-artifact.test.sh
@@ -318,7 +318,7 @@ test_migrate_command_line() {
         if [[ "$mc" == *"$needle"* ]]; then ok; else fail "migrate-check line missing '$needle': $mc"; fi
     done
     # NEVER `podman exec` for crm-admin.
-    if grep -F 'podman exec' "$CALL_LOG" | grep -q 'crm-admin'; then fail "crm-admin must NOT run via podman exec"; else ok; fi
+    if grep -q 'crm-admin' <<<"$(grep -F 'podman exec' "$CALL_LOG")"; then fail "crm-admin must NOT run via podman exec"; else ok; fi
     # The --migrate (apply) line on the pending path.
     local mg
     mg="$(grep -F 'podman run' "$CALL_LOG" | grep -F -- '--migrate' | grep -vF -- '--migrate-check' | head -1)"
@@ -345,7 +345,7 @@ test_rootless_env_on_every_call() {
     done < "$CALL_LOG"
     if [ "$bad" -eq 0 ]; then ok; else fail "some sudo podman/systemctl calls lacked the rootless env"; fi
     # systemctl must also carry DBUS for the --user bus.
-    if grep -E '^sudo .*systemctl' "$CALL_LOG" | grep -q 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/4242/bus'; then ok
+    if grep -q 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/4242/bus' <<<"$(grep -E '^sudo .*systemctl' "$CALL_LOG")"; then ok
     else fail "systemctl calls missing DBUS_SESSION_BUS_ADDRESS"; fi
 
     # Stronger: NO bare podman/systemctl may run outside a sudo wrapper. The sudo
@@ -436,8 +436,8 @@ test_rollback_gate_does_not_enforce_commit() {
     # Restore ran (forward-migrated DB undone).
     if log_has "restore-db.sh --local --no-app-start"; then ok; else fail "rollback must restore the DB"; fi
     # The rollback completed normally — "Rolled back", NOT "ROLLBACK FAILED".
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: Rolled back'; then ok; else fail "expected a normal 'Rolled back' notification"; fi
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: ROLLBACK FAILED'; then fail "rollback gate must NOT cause ROLLBACK FAILED"; else ok; fi
+    if grep -q 'Title: Rolled back' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "expected a normal 'Rolled back' notification"; fi
+    if grep -q 'Title: ROLLBACK FAILED' <<<"$(grep -F 'curl' "$CALL_LOG")"; then fail "rollback gate must NOT cause ROLLBACK FAILED"; else ok; fi
     cleanup_sandbox
 }
 
@@ -448,7 +448,7 @@ test_exit0_uptodate_no_db() {
     if [ "$RC" -eq 0 ]; then ok; else fail "up-to-date should exit 0, got $RC ($OUT)"; fi
     if log_lacks "backup-db.sh"; then ok; else fail "up-to-date must NOT snapshot the DB"; fi
     if log_lacks "podman run"; then fail "expected a migrate-check podman run"; else ok; fi
-    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "up-to-date must NOT --migrate"; else ok; fi
+    if grep -q -- '--migrate$' <<<"$(grep -F 'podman run' "$CALL_LOG")"; then fail "up-to-date must NOT --migrate"; else ok; fi
     if log_lacks "stop personalcrm-database.service"; then ok; else fail "up-to-date must NOT stop the DB"; fi
     if grep -q "Image=ghcr.io/spengrah/personalcrm-backend:$NEW_SHA" "$BACKEND_UNIT"; then ok; else fail "image not swapped to :sha"; fi
     if log_has "restart personalcrm-backend.service"; then ok; else fail "expected app restart"; fi
@@ -461,7 +461,7 @@ test_exit1_abort_no_touch() {
     STUB_MIGRATE_CHECK_RC=1 run_deploy "$VALID_SHA"
     if [ "$RC" -eq 1 ]; then ok; else fail "check-error should exit 1, got $RC"; fi
     if log_lacks "backup-db.sh"; then ok; else fail "error path must NOT snapshot"; fi
-    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "error path must NOT migrate"; else ok; fi
+    if grep -q -- '--migrate$' <<<"$(grep -F 'podman run' "$CALL_LOG")"; then fail "error path must NOT migrate"; else ok; fi
     if log_lacks "stop personalcrm"; then ok; else fail "error path must NOT stop services"; fi
     # Image= untouched.
     if grep -q 'Image=ghcr.io/spengrah/personalcrm-backend:latest' "$BACKEND_UNIT"; then ok; else fail "error path must NOT rewrite Image="; fi
@@ -502,9 +502,9 @@ test_pg_not_ready_aborts_before_migrate() {
     NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=2 STUB_PG_NOT_READY=1 run_deploy "$VALID_SHA"
     if [ "$RC" -eq 1 ]; then ok; else fail "pg-not-ready should exit 1, got $RC"; fi
     # Must NOT migrate (postgres never came up) and must NOT take the restore path.
-    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "must NOT migrate when pg not ready"; else ok; fi
+    if grep -q -- '--migrate$' <<<"$(grep -F 'podman run' "$CALL_LOG")"; then fail "must NOT migrate when pg not ready"; else ok; fi
     if log_lacks "restore-db.sh"; then ok; else fail "pg-not-ready is NOT a restore path"; fi
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: Deploy aborted'; then ok; else fail "pg-not-ready must ntfy 'Deploy aborted'"; fi
+    if grep -q 'Title: Deploy aborted' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "pg-not-ready must ntfy 'Deploy aborted'"; fi
     cleanup_sandbox
 }
 
@@ -515,9 +515,9 @@ test_backup_failure_aborts_with_ntfy() {
     NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=2 STUB_BACKUP_RC=1 run_deploy "$VALID_SHA"
     if [ "$RC" -eq 1 ]; then ok; else fail "backup failure should exit 1, got $RC"; fi
     # Must NOT have migrated (backup failed first).
-    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "must NOT migrate after backup failure"; else ok; fi
+    if grep -q -- '--migrate$' <<<"$(grep -F 'podman run' "$CALL_LOG")"; then fail "must NOT migrate after backup failure"; else ok; fi
     # Must have sent a 'Deploy aborted' ntfy (not silently restart via the trap).
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: Deploy aborted'; then ok; else fail "backup failure must ntfy 'Deploy aborted'"; fi
+    if grep -q 'Title: Deploy aborted' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "backup failure must ntfy 'Deploy aborted'"; fi
     cleanup_sandbox
 }
 
@@ -529,7 +529,7 @@ test_restore_pg_not_ready_is_rollback_failed() {
     NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" \
       STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 STUB_RESTORE_RC=1 run_deploy "$VALID_SHA"
     if [ "$RC" -eq 1 ]; then ok; else fail "restore failure should exit 1, got $RC"; fi
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: ROLLBACK FAILED'; then ok; else fail "restore failure must ntfy ROLLBACK FAILED"; fi
+    if grep -q 'Title: ROLLBACK FAILED' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "restore failure must ntfy ROLLBACK FAILED"; fi
     cleanup_sandbox
 }
 
@@ -607,7 +607,7 @@ test_ntfy_degrade_open() {
     STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
     if [ "$RC" -eq 0 ]; then ok; else fail "degrade-open deploy should exit 0, got $RC"; fi
     # No ntfy POST should have been attempted (no curl to an ntfy URL).
-    if grep -F 'curl' "$CALL_LOG" | grep -qi 'ntfy'; then fail "ntfy posted despite absent env file"; else ok; fi
+    if grep -qi 'ntfy' <<<"$(grep -F 'curl' "$CALL_LOG")"; then fail "ntfy posted despite absent env file"; else ok; fi
     cleanup_sandbox
 }
 
@@ -617,15 +617,15 @@ test_ntfy_present_outcomes() {
     printf 'NTFY_URL=https://ntfy.example\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
     NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
     # Deploy OK: Title 'Deploy OK', Tags white_check_mark.
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: Deploy OK'; then ok; else fail "missing 'Deploy OK' ntfy title"; fi
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Tags: white_check_mark'; then ok; else fail "missing white_check_mark tag"; fi
+    if grep -q 'Title: Deploy OK' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "missing 'Deploy OK' ntfy title"; fi
+    if grep -q 'Tags: white_check_mark' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "missing white_check_mark tag"; fi
     cleanup_sandbox
 
     make_sandbox
     printf 'NTFY_URL=https://ntfy.example\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
     NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 STUB_RESTORE_RC=1 run_deploy "$VALID_SHA"
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: ROLLBACK FAILED'; then ok; else fail "missing ROLLBACK FAILED ntfy title"; fi
-    if grep -F 'curl' "$CALL_LOG" | grep -q 'Priority: urgent'; then ok; else fail "ROLLBACK FAILED must be urgent priority"; fi
+    if grep -q 'Title: ROLLBACK FAILED' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "missing ROLLBACK FAILED ntfy title"; fi
+    if grep -q 'Priority: urgent' <<<"$(grep -F 'curl' "$CALL_LOG")"; then ok; else fail "ROLLBACK FAILED must be urgent priority"; fi
     cleanup_sandbox
 }
 
@@ -657,7 +657,7 @@ test_snapshot_retained_on_failure() {
     make_sandbox
     STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 run_deploy "$VALID_SHA"
     # The prune helper deletes via `rm -rf ...bak-...`; on a rollback it must NOT run.
-    if grep -F 'sudo rm -rf' "$CALL_LOG" | grep -q '_data.bak-'; then fail "snapshot pruned on a failure path"; else ok; fi
+    if grep -q '_data.bak-' <<<"$(grep -F 'sudo rm -rf' "$CALL_LOG")"; then fail "snapshot pruned on a failure path"; else ok; fi
     cleanup_sandbox
 }
 

--- a/scripts/reconcile-mac-daemon.test.sh
+++ b/scripts/reconcile-mac-daemon.test.sh
@@ -258,7 +258,11 @@ write_deploy_env() {
 # assert helpers operating on $CALL_LOG / $OUT.
 log_has()   { grep -qF -- "$1" "$CALL_LOG"; }
 log_lacks() { ! grep -qF -- "$1" "$CALL_LOG"; }
-out_has()   { printf '%s' "$OUT" | grep -qF -- "$1"; }
+# Match against a here-string, NOT `printf ... | grep`: under `set -o pipefail` a
+# `grep -q` that matches an early line exits and closes the pipe before printf
+# drains, so printf takes SIGPIPE (141) and pipefail reports the pipeline as
+# failed even though the match succeeded — a load-dependent false negative.
+out_has()   { grep -qF -- "$1" <<<"$OUT"; }
 # count ntfy POSTs (curl invocations). grep -c prints 0 and exits 1 on no match,
 # so swallow the exit without a second echo (which would print "0\n0").
 ntfy_count() { grep -cE '^curl ' "$CALL_LOG" || true; }

--- a/scripts/reconcile-mac-daemon.test.sh
+++ b/scripts/reconcile-mac-daemon.test.sh
@@ -414,7 +414,10 @@ test_fetch_advances_tracking_ref() {
     else fail "fetch must use the explicit origin/main refspec (not FETCH_HEAD-only)"; fi
     if log_has "rev-parse origin/main"; then ok; else fail "target SHA must come from rev-parse origin/main"; fi
     # The new SHA must flow into the build (worktree add at the new SHA).
-    if grep -F 'worktree add' "$CALL_LOG" | grep -qF "$new_sha"; then ok
+    # Capture first, then match a here-string: a piped `grep | grep -q` can
+    # SIGPIPE the first grep under pipefail once the second exits early.
+    worktree_adds="$(grep -F 'worktree add' "$CALL_LOG")"
+    if grep -qF -- "$new_sha" <<<"$worktree_adds"; then ok
     else fail "deploy must target the NEW SHA the fetch advanced to"; fi
     cleanup_sandbox
     unset DEPLOY_ENV_FILE_OVERRIDE

--- a/scripts/trigger-mac-deploy.test.sh
+++ b/scripts/trigger-mac-deploy.test.sh
@@ -83,7 +83,11 @@ run_trigger() {
 
 log_has()   { grep -qF -- "$1" "$CALL_LOG"; }
 log_lacks() { ! grep -qF -- "$1" "$CALL_LOG"; }
-out_has()   { printf '%s' "$OUT" | grep -qF -- "$1"; }
+# Match against a here-string, NOT `printf ... | grep`: under `set -o pipefail` a
+# `grep -q` that matches an early line exits and closes the pipe before printf
+# drains, so printf takes SIGPIPE (141) and pipefail reports the pipeline as
+# failed even though the match succeeded — a load-dependent false negative.
+out_has()   { grep -qF -- "$1" <<<"$OUT"; }
 
 # ===========================================================================
 # Tests


### PR DESCRIPTION
## Root cause

`scripts/trigger-mac-deploy.test.sh` (and its sibling `scripts/reconcile-mac-daemon.test.sh`) defined the assertion helper as `out_has() { printf '%s' "$OUT" | grep -qF -- "$1"; }` under `set -o pipefail`. When `grep -q` matches a line that is not the last line of `$OUT`, it exits and closes the read end of the pipe the instant it finds the match; `printf`, still writing the remaining lines, then takes SIGPIPE and exits 141. Because `pipefail` makes a pipeline report the last non-zero member's status, the whole `out_has` call returns 141 (failure) even though the substring was found. This is a scheduling race between "printf finishes writing" and "grep matches early and exits", so it is load-dependent: it essentially never fires on an idle box (standalone run), but `make test-deploy-scripts` launches ~18 test scripts in parallel, and under that contention `printf` is far more likely to still be mid-write when `grep` exits. It specifically bit the `not-loaded must print the load-the-timer hint` assertion because that string (`make setup-mac-deploy`) is on the **middle** of the three log lines the not-loaded path emits — so `grep` exits early with a line still unwritten — whereas assertions that match the **last** line make `grep` read to EOF (printf already done) and rarely flake. `log_has`/`log_lacks` were never affected because they `grep` a file directly (no pipe, no writer to SIGPIPE).

## Fix

Match against a here-string instead of piping: `out_has() { grep -qF -- "$1" <<<"$OUT"; }`. There is no writer process to receive SIGPIPE, so the exit status is purely `grep`'s. This mirrors how `log_has`/`log_lacks` already read from a source rather than a pipe. Applied to both `out_has` helpers (`trigger-mac-deploy.test.sh` and the byte-identical one in `reconcile-mac-daemon.test.sh`, which had the same latent bug and a vulnerable positive assertion).

## Reproduction numbers

The 1/3 make-level rate is specific to CI's 2-core runner; on the 10-core sandbox the make target did not reproduce (0 fails across 50+ runs) because contention is much lower. The mechanism was proven directly by hammering the exact helper + `$OUT` content under 2-core pinning (`taskset -c 0,1`):

- Before (piped `out_has`, match present): **278 / 20000** spurious failures (~1.4% per call; compounds across the several `out_has` calls per test run and rises sharply under the full 18-way parallel contention CI sees).
- After (here-string `out_has`): **0 / 20000**.
- Post-fix `make test-deploy-scripts`: **20 / 20 green, 0 failures** (2-core pinned, `taskset -c 0,1`).
- Both suites pass standalone: trigger 14/14, reconcile 90/90.

## Test-still-fails proof

With the fix in place, injecting the defect the assertion guards against (renaming the `make setup-mac-deploy` hint in `scripts/trigger-mac-deploy.sh`) turns the test RED on exactly that assertion; reverting restores green. So the here-string helper still catches a genuinely missing hint — it only stopped producing false negatives.

## Out of scope (noted)

`scripts/deploy-artifact.test.sh` and `scripts/backup-db.test.sh` have inline `echo "$OUT" | grep -q` / `printf '%s' "$OUT" | grep -q` one-offs under `pipefail` that share the same theoretical failure mode. They are a different construct (not the `out_has` helper) and are not the reported flake, so they are left as a possible follow-up rather than widening this fix.
