### PR TITLE
test(spec): close contacts api coverage gaps and settle the domain

### DIFF
--- a/backend/internal/api/handlers/contact_methods_test.go
+++ b/backend/internal/api/handlers/contact_methods_test.go
@@ -83,3 +83,27 @@ func TestValidateContactMethods_WhatsAppLength(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+// spec: CON-015[3]
+func TestValidateContactMethods_GChatValidation(t *testing.T) {
+	validate := validator.New()
+	err := validateContactMethods(validate, []ContactMethodRequest{
+		{Type: "gchat", Value: "not-an-email"},
+	})
+	assert.Error(t, err)
+}
+
+// spec: CON-015[4]
+func TestValidateContactMethods_SignalLength(t *testing.T) {
+	validate := validator.New()
+
+	err := validateContactMethods(validate, []ContactMethodRequest{
+		{Type: "signal", Value: strings.Repeat("1", 50)},
+	})
+	assert.NoError(t, err)
+
+	err = validateContactMethods(validate, []ContactMethodRequest{
+		{Type: "signal", Value: strings.Repeat("1", 51)},
+	})
+	assert.Error(t, err)
+}

--- a/backend/tests/api/contact_ids_test.go
+++ b/backend/tests/api/contact_ids_test.go
@@ -173,6 +173,7 @@ func TestContactAPI_ListContactIDs(t *testing.T) {
 	})
 
 	t.Run("returns sorted IDs when sort parameter provided", func(t *testing.T) {
+		// spec: CON-018[0]
 		// spec: CON-018[1]
 		// Create contacts with different names for sorting
 		id1 := createContact("IDs Sort Zebra " + ns)
@@ -273,6 +274,7 @@ func TestContactAPI_ListContactIDs(t *testing.T) {
 	})
 
 	t.Run("sorts by cadence frequency descending (most frequent first)", func(t *testing.T) {
+		// spec: CON-018[0]
 		// Create contacts with different cadences
 		// We need to use the full API to set cadence, so use raw request
 		createContactWithCadence := func(name, cadence string) string {

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -911,3 +911,128 @@ func TestContactMergePreviewAPI_Errors(t *testing.T) {
 		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
 	})
 }
+
+// TestContactMergePreviewAPI_SuccessCounts proves the success path of the
+// merge-preview route over HTTP: the JSON response must carry all five
+// counters the spec names, with values matching seeded data — a service-level
+// preview test cannot catch an omitted or misnamed response field.
+func TestContactMergePreviewAPI_SuccessCounts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, rcleanup := setupContactMergePreviewTestRouter()
+	defer rcleanup()
+
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	ns := uuid.New().String()[:8]
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	noteRepo := repository.NewNoteRepository(database.Queries)
+	calendarEventRepo := repository.NewCalendarEventRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(t, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
+
+	t.Run("GetMergePreview_AllFiveCountersInResponse", func(t *testing.T) {
+		// spec: CON-037[0]
+		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "Preview Counts Target " + ns,
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
+
+		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "Preview Counts Source " + ns,
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, source.ID) }()
+
+		// Target owns the shared method so exactly one of the source's four
+		// methods is a duplicate: methods_to_transfer=3, duplicate_methods=1.
+		// The counts are chosen pairwise-distinct where the fixture model
+		// allows (a contact has at most one notepad note, so notes_to_transfer
+		// and duplicate_methods are both 1).
+		dupValue := "dup-" + ns + "@example.com"
+		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: target.ID, Type: "email", Value: dupValue,
+		})
+		require.NoError(t, err)
+		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: source.ID, Type: "email", Value: dupValue,
+		})
+		require.NoError(t, err)
+		for _, v := range []string{"a-" + ns + "@example.com", "b-" + ns + "@example.com", "c-" + ns + "@example.com"} {
+			_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+				ContactID: source.ID, Type: "email", Value: v,
+			})
+			require.NoError(t, err)
+		}
+
+		_, err = noteRepo.CreateNotepad(ctx, source.ID, "Preview counts notepad "+ns)
+		require.NoError(t, err)
+
+		now := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+		for i := 0; i < 4; i++ {
+			_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+				ContactID:  source.ID,
+				Source:     repository.InteractionSourceManual,
+				OccurredAt: now.Add(-time.Duration(i) * time.Hour),
+				Direction:  repository.InteractionDirectionOutbound,
+			})
+			require.NoError(t, err)
+		}
+
+		title := "Preview Counts Event"
+		for _, suffix := range []string{"1", "2"} {
+			event, err := calendarEventRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+				GcalEventID:       "preview-counts-" + ns + "-" + suffix,
+				GcalCalendarID:    "preview-counts-" + ns + "-cal",
+				GoogleAccountID:   "preview-counts-" + ns + "-acct",
+				Title:             &title,
+				StartTime:         now,
+				EndTime:           now.Add(time.Hour),
+				Status:            "confirmed",
+				Attendees:         []repository.Attendee{},
+				MatchedContactIDs: []uuid.UUID{source.ID},
+				SyncedAt:          now,
+			})
+			require.NoError(t, err)
+			eventID := event.ID
+			defer func() { _ = calendarEventRepo.TestHardDeleteByID(ctx, eventID) }()
+		}
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+target.ID.String()+"/merge/preview?source_id="+source.ID.String(), nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.True(t, response.Success)
+
+		data, err := json.Marshal(response.Data)
+		require.NoError(t, err)
+		var preview handlers.MergePreviewResponse
+		require.NoError(t, json.Unmarshal(data, &preview))
+
+		assert.Equal(t, source.ID.String(), preview.SourceContact.ID)
+		assert.Equal(t, target.ID.String(), preview.TargetContact.ID)
+		assert.Equal(t, int64(3), preview.MethodsToTransfer)
+		assert.Equal(t, int64(1), preview.DuplicateMethods)
+		assert.Equal(t, int64(1), preview.NotesToTransfer)
+		assert.Equal(t, int64(4), preview.InteractionsToTransfer)
+		assert.Equal(t, int64(2), preview.CalendarEventsToUpdate)
+	})
+}

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -1022,17 +1022,31 @@ func TestContactMergePreviewAPI_SuccessCounts(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 		require.True(t, response.Success)
 
-		data, err := json.Marshal(response.Data)
-		require.NoError(t, err)
-		var preview handlers.MergePreviewResponse
-		require.NoError(t, json.Unmarshal(data, &preview))
+		// Assert the literal wire keys rather than decoding into the
+		// production MergePreviewResponse struct: decoding with the same tags
+		// that serialized the payload would round-trip a renamed or swapped
+		// key and leave every assertion green.
+		preview, ok := response.Data.(map[string]interface{})
+		require.True(t, ok, "preview payload must be a JSON object")
 
-		assert.Equal(t, source.ID.String(), preview.SourceContact.ID)
-		assert.Equal(t, target.ID.String(), preview.TargetContact.ID)
-		assert.Equal(t, int64(3), preview.MethodsToTransfer)
-		assert.Equal(t, int64(1), preview.DuplicateMethods)
-		assert.Equal(t, int64(1), preview.NotesToTransfer)
-		assert.Equal(t, int64(4), preview.InteractionsToTransfer)
-		assert.Equal(t, int64(2), preview.CalendarEventsToUpdate)
+		sourceObj, ok := preview["source_contact"].(map[string]interface{})
+		require.True(t, ok, "response must carry a source_contact object")
+		assert.Equal(t, source.ID.String(), sourceObj["id"])
+		targetObj, ok := preview["target_contact"].(map[string]interface{})
+		require.True(t, ok, "response must carry a target_contact object")
+		assert.Equal(t, target.ID.String(), targetObj["id"])
+
+		counters := map[string]float64{
+			"methods_to_transfer":       3,
+			"duplicate_methods":         1,
+			"notes_to_transfer":         1,
+			"interactions_to_transfer":  4,
+			"calendar_events_to_update": 2,
+		}
+		for key, want := range counters {
+			got, present := preview[key]
+			require.True(t, present, "response must carry the %q key", key)
+			assert.Equal(t, want, got, "counter %q", key)
+		}
 	})
 }

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -959,20 +959,22 @@ func TestContactMergePreviewAPI_SuccessCounts(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = contactRepo.HardDeleteContact(ctx, source.ID) }()
 
-		// Target owns the shared method so exactly one of the source's four
-		// methods is a duplicate: methods_to_transfer=3, duplicate_methods=1.
-		// The counts are chosen pairwise-distinct where the fixture model
-		// allows (a contact has at most one notepad note, so notes_to_transfer
-		// and duplicate_methods are both 1).
-		dupValue := "dup-" + ns + "@example.com"
-		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
-			ContactID: target.ID, Type: "email", Value: dupValue,
-		})
-		require.NoError(t, err)
-		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
-			ContactID: source.ID, Type: "email", Value: dupValue,
-		})
-		require.NoError(t, err)
+		// All five counters are pairwise-distinct (3/2/1/4/5) so swapping any
+		// two DTO JSON tags produces a detectably different payload. A contact
+		// has at most one notepad note, so notes_to_transfer anchors the value
+		// 1 and every other counter avoids it. Target owns two shared methods,
+		// making two of the source's five methods duplicates:
+		// methods_to_transfer=3, duplicate_methods=2.
+		for _, dupValue := range []string{"dup1-" + ns + "@example.com", "dup2-" + ns + "@example.com"} {
+			_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+				ContactID: target.ID, Type: "email", Value: dupValue,
+			})
+			require.NoError(t, err)
+			_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+				ContactID: source.ID, Type: "email", Value: dupValue,
+			})
+			require.NoError(t, err)
+		}
 		for _, v := range []string{"a-" + ns + "@example.com", "b-" + ns + "@example.com", "c-" + ns + "@example.com"} {
 			_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 				ContactID: source.ID, Type: "email", Value: v,
@@ -995,7 +997,7 @@ func TestContactMergePreviewAPI_SuccessCounts(t *testing.T) {
 		}
 
 		title := "Preview Counts Event"
-		for _, suffix := range []string{"1", "2"} {
+		for _, suffix := range []string{"1", "2", "3", "4", "5"} {
 			event, err := calendarEventRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
 				GcalEventID:       "preview-counts-" + ns + "-" + suffix,
 				GcalCalendarID:    "preview-counts-" + ns + "-cal",
@@ -1038,10 +1040,10 @@ func TestContactMergePreviewAPI_SuccessCounts(t *testing.T) {
 
 		counters := map[string]float64{
 			"methods_to_transfer":       3,
-			"duplicate_methods":         1,
+			"duplicate_methods":         2,
 			"notes_to_transfer":         1,
 			"interactions_to_transfer":  4,
-			"calendar_events_to_update": 2,
+			"calendar_events_to_update": 5,
 		}
 		for key, want := range counters {
 			got, present := preview[key]

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -1,16 +1,24 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,6 +70,7 @@ func TestContactMerge_Integration(t *testing.T) {
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	noteRepo := repository.NewNoteRepository(database.Queries)
+	calendarEventRepo := repository.NewCalendarEventRepository(database.Queries)
 
 	// Create service
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
@@ -155,6 +164,91 @@ func TestContactMerge_Integration(t *testing.T) {
 
 		assert.Equal(t, int64(1), preview.MethodsToTransfer) // unique@example.com
 		assert.Equal(t, int64(1), preview.DuplicateMethods)  // shared@example.com
+	})
+
+	t.Run("GetMergePreview_InteractionsAndCalendarEvents", func(t *testing.T) {
+		// spec: CON-037[0]
+		// Create target contact
+		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "Merge Target Events " + ns,
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
+
+		// Create source contact
+		source, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
+			FullName: "Merge Source Events " + ns,
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, source.ID) }()
+
+		// Seed three interactions on the source contact. A count that differs
+		// from the calendar-event count below (2) also catches a field-swap
+		// defect, not just a dropped-to-zero one.
+		now := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+		_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+			ContactID:  source.ID,
+			Source:     repository.InteractionSourceManual,
+			OccurredAt: now,
+			Direction:  repository.InteractionDirectionOutbound,
+		})
+		require.NoError(t, err)
+		_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+			ContactID:  source.ID,
+			Source:     repository.InteractionSourceManual,
+			OccurredAt: now.Add(-time.Hour),
+			Direction:  repository.InteractionDirectionInbound,
+		})
+		require.NoError(t, err)
+		_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+			ContactID:  source.ID,
+			Source:     repository.InteractionSourceManual,
+			OccurredAt: now.Add(-2 * time.Hour),
+			Direction:  repository.InteractionDirectionOutbound,
+		})
+		require.NoError(t, err)
+
+		// Seed two calendar events that match the source contact. Calendar
+		// events are not FK-linked to contact (matched_contact_ids is a plain
+		// uuid[] column, no ON DELETE CASCADE), so they must be hard-deleted
+		// explicitly rather than relying on the source contact's cleanup.
+		title := "Merge Preview Event"
+		event1, err := calendarEventRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+			GcalEventID:       "merge-preview-" + ns + "-1",
+			GcalCalendarID:    "merge-preview-" + ns + "-cal",
+			GoogleAccountID:   "merge-preview-" + ns + "-acct",
+			Title:             &title,
+			StartTime:         now,
+			EndTime:           now.Add(time.Hour),
+			Status:            "confirmed",
+			Attendees:         []repository.Attendee{},
+			MatchedContactIDs: []uuid.UUID{source.ID},
+			SyncedAt:          now,
+		})
+		require.NoError(t, err)
+		defer func() { _ = calendarEventRepo.TestHardDeleteByID(ctx, event1.ID) }()
+
+		event2, err := calendarEventRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+			GcalEventID:       "merge-preview-" + ns + "-2",
+			GcalCalendarID:    "merge-preview-" + ns + "-cal",
+			GoogleAccountID:   "merge-preview-" + ns + "-acct",
+			Title:             &title,
+			StartTime:         now.Add(24 * time.Hour),
+			EndTime:           now.Add(25 * time.Hour),
+			Status:            "confirmed",
+			Attendees:         []repository.Attendee{},
+			MatchedContactIDs: []uuid.UUID{source.ID},
+			SyncedAt:          now,
+		})
+		require.NoError(t, err)
+		defer func() { _ = calendarEventRepo.TestHardDeleteByID(ctx, event2.ID) }()
+
+		// Get merge preview
+		preview, err := contactService.GetMergePreview(ctx, source.ID, target.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(3), preview.InteractionsToTransfer)
+		assert.Equal(t, int64(2), preview.CalendarEventsToUpdate)
 	})
 
 	t.Run("MergeContacts_TransfersAllData", func(t *testing.T) {
@@ -658,5 +752,162 @@ func TestContactMerge_Integration(t *testing.T) {
 		// value, confirming BulkApply ran and the refetch picked it up.
 		assert.Equal(t, sourceLastContacted.UTC(), merged.LastContacted.UTC(),
 			"BulkApply should forward-max last_contacted to the source value")
+	})
+}
+
+// setupContactMergePreviewTestRouter mirrors setupContactValidationTestRouter's
+// wiring, but only registers the merge-preview route (GET /:id/merge/preview,
+// where :id is the TARGET and source_id is a query param) plus a bare CreateContact
+// route needed to seed fixtures through the HTTP layer's own DB handle.
+func setupContactMergePreviewTestRouter() (*gin.Engine, func()) {
+	ctx := context.Background()
+	databaseURL := os.Getenv("DATABASE_URL")
+
+	dbConfig := config.DatabaseConfig{
+		URL:               databaseURL,
+		MaxConns:          8,
+		MinConns:          1,
+		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
+		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
+		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
+	}
+	database, err := db.NewDatabase(ctx, dbConfig)
+	if err != nil {
+		panic("Failed to connect to test database: " + err.Error())
+	}
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(nil, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(nil, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
+	contactHandler := handlers.NewContactHandler(contactService)
+
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	corsConfig := config.CORSConfig{AllowAll: true}
+	router.Use(api.CORSMiddleware(corsConfig))
+
+	v1 := router.Group("/api/v1")
+	contacts := v1.Group("/contacts")
+	{
+		contacts.POST("", contactHandler.CreateContact)
+		contacts.GET("/:id/merge/preview", contactHandler.GetMergePreview)
+	}
+
+	cleanup := func() {
+		database.Close()
+	}
+
+	return router, cleanup
+}
+
+func TestContactMergePreviewAPI_Errors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, cleanup := setupContactMergePreviewTestRouter()
+	defer cleanup()
+
+	ns := uuid.New().String()[:8]
+
+	// createContactViaAPI seeds a fixture contact through the router's own
+	// CreateContact route, matching the DB handle the merge-preview route
+	// reads from.
+	createContactViaAPI := func(t *testing.T, name string) uuid.UUID {
+		t.Helper()
+		body, err := json.Marshal(handlers.CreateContactRequest{FullName: name})
+		require.NoError(t, err)
+		req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		data, err := json.Marshal(response.Data)
+		require.NoError(t, err)
+		var created handlers.ContactResponse
+		require.NoError(t, json.Unmarshal(data, &created))
+		id, err := uuid.Parse(created.ID)
+		require.NoError(t, err)
+		return id
+	}
+
+	t.Run("GetMergePreview_UnknownSourceID_NotFound", func(t *testing.T) {
+		// spec: CON-037[1]
+		target := createContactViaAPI(t, "Preview Errors Target A "+ns)
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+target.String()+"/merge/preview?source_id="+uuid.New().String(), nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.False(t, response.Success)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("GetMergePreview_UnknownTargetID_NotFound", func(t *testing.T) {
+		// spec: CON-037[1]
+		source := createContactViaAPI(t, "Preview Errors Source B "+ns)
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+uuid.New().String()+"/merge/preview?source_id="+source.String(), nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.False(t, response.Success)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("GetMergePreview_MissingSourceID_ValidationError", func(t *testing.T) {
+		// spec: CON-037[2]
+		target := createContactViaAPI(t, "Preview Errors Target C "+ns)
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+target.String()+"/merge/preview", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.False(t, response.Success)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("GetMergePreview_MalformedSourceID_ValidationError", func(t *testing.T) {
+		// spec: CON-037[2]
+		target := createContactViaAPI(t, "Preview Errors Target D "+ns)
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+target.String()+"/merge/preview?source_id=not-a-uuid", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.False(t, response.Success)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
 	})
 }

--- a/backend/tests/api/contact_method_operations_test.go
+++ b/backend/tests/api/contact_method_operations_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -452,6 +453,108 @@ func TestMethodOps_TwoAddsOrderIndependent(t *testing.T) {
 		reverse = collect(t, addOp("email", second), addOp("email", first))
 	})
 	assert.ElementsMatch(t, forward, reverse)
+}
+
+// TestMethodOps_MixedOperationOrderYieldsIdenticalCompleteState is
+// CON-062[2]'s citing test. The permutation test above proves the SHAPE of the
+// outcome is order-independent; this one proves the COMPLETE outcome is —
+// specifically that an updated row's persisted VALUE survives reordering, which
+// no shape comparison can see: a fold that silently dropped the update's value
+// under one ordering would still produce the right cardinality, identity and
+// primary designation.
+//
+// Two contacts are prepared in identical starting states and receive the SAME
+// mixed add+update+remove set, one forward and one reversed. The complete
+// final state — types, values, trigger-owned normalized values, primary
+// designation, cardinality — must be identical across the two, comparing both
+// the method set as read back over HTTP and the persisted rows. Contact-owned
+// ids and timestamps are the only fields excluded: they differ per contact by
+// construction and carry no outcome semantics.
+// spec: CON-062[2]
+func TestMethodOps_MixedOperationOrderYieldsIdenticalCompleteState(t *testing.T) {
+	t.Parallel()
+
+	// One set of values shared by both contacts, so the two outcomes are
+	// comparable value-for-value. Per-contact uniqueness makes the sharing safe.
+	var (
+		startEmail   = uniqueEmail()
+		updatedEmail = uniqueEmail()
+		phone        = "+15550118902"
+		handle       = "h" + uuid.NewString()[:8]
+	)
+
+	type finalRow struct {
+		Type            string
+		Value           string
+		ValueNormalized string
+		IsPrimary       bool
+	}
+	sortRows := func(rows []finalRow) {
+		sort.Slice(rows, func(i, j int) bool {
+			if rows[i].Type != rows[j].Type {
+				return rows[i].Type < rows[j].Type
+			}
+			return rows[i].Value < rows[j].Value
+		})
+	}
+
+	// applyIn seeds a fresh contact into the shared starting state, applies the
+	// operation set in the given order, and returns the complete outcome two
+	// ways: the method set as read back over HTTP, and the persisted rows
+	// carrying the trigger-owned value_normalized the wire shape omits.
+	applyIn := func(t *testing.T, reversed bool) (httpRows, storedRows []finalRow) {
+		f := newMethodOpsFx(t)
+		toUpdate := f.seed("email", startEmail, true)
+		toRemove := f.seed("phone", phone, false)
+
+		ops := []map[string]any{
+			updateOp(toUpdate.ID, "email", updatedEmail),
+			idOp("remove", toRemove.ID),
+			addOp("discord", handle),
+		}
+		if reversed {
+			for l, r := 0, len(ops)-1; l < r; l, r = l+1, r-1 {
+				ops[l], ops[r] = ops[r], ops[l]
+			}
+		}
+
+		w, body := f.post(ops...)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		for _, m := range body.Methods {
+			httpRows = append(httpRows, finalRow{Type: m.Type, Value: m.Value, IsPrimary: m.IsPrimary})
+		}
+		for _, m := range f.stored() {
+			storedRows = append(storedRows, finalRow{
+				Type: m.Type, Value: m.Value, ValueNormalized: m.ValueNormalized, IsPrimary: m.IsPrimary,
+			})
+		}
+		sortRows(httpRows)
+		sortRows(storedRows)
+		return httpRows, storedRows
+	}
+
+	forwardHTTP, forwardStored := applyIn(t, false)
+	reverseHTTP, reverseStored := applyIn(t, true)
+
+	// The structural claim: the complete outcome is identical across orderings.
+	assert.Equal(t, forwardHTTP, reverseHTTP,
+		"the method set read back over HTTP depends on the order operations appeared in the request")
+	assert.Equal(t, forwardStored, reverseStored,
+		"the persisted final state depends on the order operations appeared in the request")
+
+	// The vacuity guard: equality alone would also pass if BOTH orderings
+	// discarded the update identically, so each ordering is additionally held
+	// to the one deterministic expected outcome — the update's NEW value
+	// persisted on the still-primary email row, the add present, the removed
+	// phone gone, and nothing else. Both value strings are already in
+	// normalized form, so the trigger's output must equal them byte-for-byte.
+	expected := []finalRow{
+		{Type: "discord", Value: handle, ValueNormalized: handle, IsPrimary: false},
+		{Type: "email", Value: updatedEmail, ValueNormalized: updatedEmail, IsPrimary: true},
+	}
+	assert.Equal(t, expected, forwardStored, "forward ordering did not produce the expected complete state")
+	assert.Equal(t, expected, reverseStored, "reversed ordering did not produce the expected complete state")
 }
 
 // --- CON-062[3][4]: idempotency --------------------------------------------
@@ -964,6 +1067,66 @@ func TestMethodOps_ResultsResolveAddToExistingRow(t *testing.T) {
 		"the snapshot echoed the submitted value instead of the resolved row's stored value")
 	assert.True(t, body.Results[0].Method.IsPrimary,
 		"the snapshot did not report the resolved row's primary flag")
+}
+
+// TestMethodOps_MixedOperationsResultsIdentifyAndReflectStoredState is
+// CON-062[13]'s citing test. A mixed add+update+remove request is the case
+// where identification actually matters: with three results in flight, a
+// result that merely counts or orders correctly could still point at the
+// wrong row, or echo the submitted payload instead of what landed. Each
+// result is checked against a follow-up read of the contact's stored
+// methods, not against the request that produced it.
+//
+// spec: CON-062[13]
+func TestMethodOps_MixedOperationsResultsIdentifyAndReflectStoredState(t *testing.T) {
+	t.Parallel()
+	f := newMethodOpsFx(t)
+	toUpdate := f.seed("email", uniqueEmail(), false)
+	toRemove := f.seed("phone", "+15550116789", false)
+	updatedValue := uniqueEmail()
+
+	w, body := f.post(
+		addPrimaryOp("email", uniqueEmail()),
+		updateOp(toUpdate.ID, "email", updatedValue),
+		idOp("remove", toRemove.ID),
+	)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Len(t, body.Results, 3)
+
+	// The add result identifies the newly created method: its id must name a
+	// row that actually exists post-apply, and the reported type/value/primary
+	// must equal that row as read back from storage, not the submitted op.
+	addResult := body.Results[0]
+	assert.Equal(t, "created", addResult.Outcome)
+	addedID, err := uuid.Parse(addResult.MethodID)
+	require.NoError(t, err, "add result did not identify a method id")
+	addedStored := f.storedByID(addedID)
+	require.NotNil(t, addedStored, "the add result's id does not name a persisted method")
+	require.NotNil(t, addResult.Method, "the add result did not report a stored state")
+	assert.Equal(t, addedStored.Type, addResult.Method.Type)
+	assert.Equal(t, addedStored.Value, addResult.Method.Value)
+	assert.Equal(t, addedStored.IsPrimary, addResult.Method.IsPrimary)
+
+	// The update result identifies the method its operation targeted, and its
+	// reported state matches that same row read back after the request.
+	updateResult := body.Results[1]
+	assert.Equal(t, toUpdate.ID.String(), updateResult.MethodID,
+		"the update result did not identify the method its operation addressed")
+	updatedStored := f.storedByID(toUpdate.ID)
+	require.NotNil(t, updatedStored)
+	require.NotNil(t, updateResult.Method, "the update result did not report a stored state")
+	assert.Equal(t, updatedStored.Type, updateResult.Method.Type)
+	assert.Equal(t, updatedStored.Value, updateResult.Method.Value, "the update result did not reflect the persisted value")
+	assert.Equal(t, updatedValue, updateResult.Method.Value)
+	assert.Equal(t, updatedStored.IsPrimary, updateResult.Method.IsPrimary)
+
+	// The remove result identifies the removed method by the id the request
+	// submitted, and reports no stored state: the operation left none.
+	removeResult := body.Results[2]
+	assert.Equal(t, toRemove.ID.String(), removeResult.MethodID,
+		"the remove result did not identify the method its operation addressed")
+	assert.Nil(t, removeResult.Method, "the remove result reported a stored method that no longer exists")
+	assert.Nil(t, f.storedByID(toRemove.ID), "the removed method is still persisted")
 }
 
 // --- Validation -------------------------------------------------------------

--- a/backend/tests/api/contact_sort_test.go
+++ b/backend/tests/api/contact_sort_test.go
@@ -18,6 +18,7 @@ import (
 	_ "personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -380,6 +381,7 @@ func TestContactSort_ContactBy(t *testing.T) {
 	})
 
 	t.Run("contact_by sort is accepted by API validation", func(t *testing.T) {
+		// spec: CON-018[0]
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=contact_by&order=asc", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -532,6 +534,7 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 	})
 
 	t.Run("last_response_at sort is accepted by API validation", func(t *testing.T) {
+		// spec: CON-018[0]
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=last_response_at&order=desc", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -539,6 +542,7 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 	})
 
 	t.Run("legacy last_contacted sort still accepted", func(t *testing.T) {
+		// spec: CON-018[0]
 		// last_contacted remains a valid sort value on the API even though no UI
 		// surface emits it; regression-guard for any external caller still using
 		// the legacy field.
@@ -610,7 +614,7 @@ func TestContactSort_Location(t *testing.T) {
 
 	t.Run("location sort is accepted by API validation and returned in the response body", func(t *testing.T) {
 		// spec: CON-018[0]
-		prefix := "SortLocShape"
+		prefix := "SortLocShape" + uuid.New().String()[:8]
 		id := h.createContactWithLocation(prefix+" Shape Test", "Shapeburg")
 		defer h.deleteContact(id)
 
@@ -688,7 +692,7 @@ func TestContactSort_Birthday(t *testing.T) {
 
 	t.Run("birthday sort is accepted by API validation and returned in the response body", func(t *testing.T) {
 		// spec: CON-018[0]
-		prefix := "SortBdayShape"
+		prefix := "SortBdayShape" + uuid.New().String()[:8]
 		id := h.createContactWithBirthday(prefix+" Shape Test", "1990-01-15")
 		defer h.deleteContact(id)
 

--- a/backend/tests/api/contact_sort_test.go
+++ b/backend/tests/api/contact_sort_test.go
@@ -93,6 +93,36 @@ func (h *sortTestHelper) createContact(name string) string {
 	return contactData["id"].(string)
 }
 
+func (h *sortTestHelper) createContactWithLocation(name, location string) string {
+	body := fmt.Sprintf(`{"full_name": "%s", "location": "%s"}`, name, location)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, req)
+	require.Equal(h.t, http.StatusCreated, w.Code)
+
+	var resp api.APIResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(h.t, err)
+	contactData := resp.Data.(map[string]interface{})
+	return contactData["id"].(string)
+}
+
+func (h *sortTestHelper) createContactWithBirthday(name, birthday string) string {
+	body := fmt.Sprintf(`{"full_name": "%s", "birthday": "%s"}`, name, birthday)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, req)
+	require.Equal(h.t, http.StatusCreated, w.Code)
+
+	var resp api.APIResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(h.t, err)
+	contactData := resp.Data.(map[string]interface{})
+	return contactData["id"].(string)
+}
+
 func (h *sortTestHelper) createContactWithCadence(name, cadence string) string {
 	body := fmt.Sprintf(`{"full_name": "%s", "cadence": "%s"}`, name, cadence)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/contacts", bytes.NewBufferString(body))
@@ -523,5 +553,161 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestContactSort_Location(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, cleanup := setupContactSortTestRouter(t)
+	defer cleanup()
+
+	h := &sortTestHelper{router: router, t: t}
+
+	t.Run("location ascending sorts alphabetically", func(t *testing.T) {
+		// spec: CON-018[0]
+		prefix := "SortLocAsc"
+		idA := h.createContactWithLocation(prefix+" Alpha Test", "Alphaville")
+		idZ := h.createContactWithLocation(prefix+" Zulu Test", "Zurich Town")
+		defer h.deleteContact(idA)
+		defer h.deleteContact(idZ)
+
+		resp := h.getIDsResponse("/api/v1/contacts?ids_only=true&search=" + prefix + "&sort=location&order=asc")
+
+		posA := h.findPosition(resp.IDs, idA)
+		posZ := h.findPosition(resp.IDs, idZ)
+
+		assert.NotEqual(t, -1, posA, "Alphaville contact should be in results")
+		assert.NotEqual(t, -1, posZ, "Zurich contact should be in results")
+		assert.Less(t, posA, posZ, "Alphaville should come before Zurich Town in asc order")
+	})
+
+	t.Run("location descending sorts reverse alphabetically", func(t *testing.T) {
+		// spec: CON-018[0]
+		prefix := "SortLocDesc"
+		idA := h.createContactWithLocation(prefix+" Alpha Test", "Alphaville")
+		idZ := h.createContactWithLocation(prefix+" Zulu Test", "Zurich Town")
+		defer h.deleteContact(idA)
+		defer h.deleteContact(idZ)
+
+		resp := h.getIDsResponse("/api/v1/contacts?ids_only=true&search=" + prefix + "&sort=location&order=desc")
+
+		posA := h.findPosition(resp.IDs, idA)
+		posZ := h.findPosition(resp.IDs, idZ)
+
+		assert.NotEqual(t, -1, posA, "Alphaville contact should be in results")
+		assert.NotEqual(t, -1, posZ, "Zurich contact should be in results")
+		assert.Less(t, posZ, posA, "Zurich Town should come before Alphaville in desc order")
+	})
+
+	t.Run("location sort is accepted by API validation and returned in the response body", func(t *testing.T) {
+		// spec: CON-018[0]
+		prefix := "SortLocShape"
+		id := h.createContactWithLocation(prefix+" Shape Test", "Shapeburg")
+		defer h.deleteContact(id)
+
+		ids := h.getListResponseIDs("/api/v1/contacts?search=" + prefix + "&sort=location&order=asc")
+		require.NotEqual(t, -1, h.findPosition(ids, id), "seeded contact should be in the full list response")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?search="+prefix+"&sort=location&order=asc", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var apiResp api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &apiResp))
+		require.True(t, apiResp.Success)
+
+		dataIface, ok := apiResp.Data.([]interface{})
+		require.True(t, ok, "expected list response data to be an array")
+		require.Len(t, dataIface, 1)
+		row := dataIface[0].(map[string]interface{})
+		assert.Equal(t, "Shapeburg", row["location"], "response body should carry the seeded location value")
+	})
+}
+
+func TestContactSort_Birthday(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, cleanup := setupContactSortTestRouter(t)
+	defer cleanup()
+
+	h := &sortTestHelper{router: router, t: t}
+
+	t.Run("birthday ascending sorts earliest first", func(t *testing.T) {
+		// spec: CON-018[0]
+		prefix := "SortBdayAsc"
+		idOld := h.createContactWithBirthday(prefix+" Old Test", "1980-01-01")
+		idYoung := h.createContactWithBirthday(prefix+" Young Test", "2000-06-01")
+		defer h.deleteContact(idOld)
+		defer h.deleteContact(idYoung)
+
+		resp := h.getIDsResponse("/api/v1/contacts?ids_only=true&search=" + prefix + "&sort=birthday&order=asc")
+
+		posOld := h.findPosition(resp.IDs, idOld)
+		posYoung := h.findPosition(resp.IDs, idYoung)
+
+		assert.NotEqual(t, -1, posOld, "Old birthday contact should be in results")
+		assert.NotEqual(t, -1, posYoung, "Young birthday contact should be in results")
+		assert.Less(t, posOld, posYoung, "Earlier birthday should come before later birthday in asc order")
+	})
+
+	t.Run("birthday descending sorts latest first", func(t *testing.T) {
+		// spec: CON-018[0]
+		prefix := "SortBdayDesc"
+		idOld := h.createContactWithBirthday(prefix+" Old Test", "1980-01-01")
+		idYoung := h.createContactWithBirthday(prefix+" Young Test", "2000-06-01")
+		defer h.deleteContact(idOld)
+		defer h.deleteContact(idYoung)
+
+		resp := h.getIDsResponse("/api/v1/contacts?ids_only=true&search=" + prefix + "&sort=birthday&order=desc")
+
+		posOld := h.findPosition(resp.IDs, idOld)
+		posYoung := h.findPosition(resp.IDs, idYoung)
+
+		assert.NotEqual(t, -1, posOld, "Old birthday contact should be in results")
+		assert.NotEqual(t, -1, posYoung, "Young birthday contact should be in results")
+		assert.Less(t, posYoung, posOld, "Later birthday should come before earlier birthday in desc order")
+	})
+
+	t.Run("birthday sort is accepted by API validation and returned in the response body", func(t *testing.T) {
+		// spec: CON-018[0]
+		prefix := "SortBdayShape"
+		id := h.createContactWithBirthday(prefix+" Shape Test", "1990-01-15")
+		defer h.deleteContact(id)
+
+		ids := h.getListResponseIDs("/api/v1/contacts?search=" + prefix + "&sort=birthday&order=asc")
+		require.NotEqual(t, -1, h.findPosition(ids, id), "seeded contact should be in the full list response")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?search="+prefix+"&sort=birthday&order=asc", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var apiResp api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &apiResp))
+		require.True(t, apiResp.Success)
+
+		dataIface, ok := apiResp.Data.([]interface{})
+		require.True(t, ok, "expected list response data to be an array")
+		require.Len(t, dataIface, 1)
+		row := dataIface[0].(map[string]interface{})
+		assert.Equal(t, "1990-01-15T00:00:00Z", row["birthday"], "response body should carry the seeded birthday value")
 	})
 }

--- a/backend/tests/api/contact_validation_test.go
+++ b/backend/tests/api/contact_validation_test.go
@@ -348,9 +348,32 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 
 	t.Run("CreateContact_ProfilePhotoTooLong", func(t *testing.T) {
 		// spec: CON-002[2]
-		// Syntactically valid URL, but its total length exceeds the 500 cap.
-		longURL := "https://example.com/" + strings.Repeat("a", 490) + ".jpg"
-		require.Greater(t, len(longURL), 500)
+		// Pin the 500-character cap exactly: a syntactically valid URL of
+		// exactly 500 characters is accepted, and one of exactly 501 is
+		// rejected, so a validator capped anywhere else fails one side.
+		okURL := "https://example.com/" + strings.Repeat("a", 476) + ".jpg"
+		require.Len(t, okURL, 500)
+
+		okBody, _ := json.Marshal(handlers.CreateContactRequest{
+			FullName:     "Test User PhotoCap",
+			ProfilePhoto: stringPtr(okURL),
+		})
+		okReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(okBody))
+		okReq.Header.Set("Content-Type", "application/json")
+		okW := httptest.NewRecorder()
+		router.ServeHTTP(okW, okReq)
+		require.Equal(t, http.StatusCreated, okW.Code, "a 500-char profile_photo URL must be accepted: %s", okW.Body.String())
+
+		var okResp api.APIResponse
+		require.NoError(t, json.Unmarshal(okW.Body.Bytes(), &okResp))
+		createdID := okResp.Data.(map[string]interface{})["id"].(string)
+		defer func() {
+			delReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+createdID, nil)
+			router.ServeHTTP(httptest.NewRecorder(), delReq)
+		}()
+
+		longURL := "https://example.com/" + strings.Repeat("a", 477) + ".jpg"
+		require.Len(t, longURL, 501)
 
 		requestBody := handlers.CreateContactRequest{
 			FullName:     "Test User",
@@ -671,6 +694,7 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	})
 
 	t.Run("UpdateContact_InvalidCadenceRejected", func(t *testing.T) {
+		// spec: CON-047[0]
 		// spec: CON-047[1]
 		updateReq := handlers.UpdateContactRequest{
 			FullName: "Update Test User " + ns,
@@ -916,9 +940,12 @@ func TestContactAPI_DeleteValidation(t *testing.T) {
 
 	t.Run("DeleteContact_NoHardDeleteRouteExposed", func(t *testing.T) {
 		// spec: CON-048[3]
-		// Registers the whole contact route surface through the production
-		// registrar (not a hand-picked subset) so this is an assertion about the
-		// routes the binary actually serves.
+		// Registers the contact-resource registrar (RegisterContactRoutes) and
+		// enumerates every DELETE route it serves under /contacts. Other
+		// registrars mount subresources under /contacts/:id/..., but the
+		// contact row's own lifecycle routes are registered here, so a
+		// hard-delete variant on the contact resource would surface in this
+		// enumeration.
 		routesRouter := gin.New()
 		routesV1 := routesRouter.Group("/api/v1")
 		handlers.RegisterContactRoutes(routesV1, handlers.ContactRouteDeps{

--- a/backend/tests/api/contact_validation_test.go
+++ b/backend/tests/api/contact_validation_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -259,6 +261,182 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 		assert.NotNil(t, response.Error)
 	})
 
+	t.Run("CreateContact_FullNameSingleCharAccepted", func(t *testing.T) {
+		// spec: CON-002[0]
+		ns := uuid.New().String()[:8]
+		requestBody := handlers.CreateContactRequest{
+			FullName: "A", // Lower bound of the 1-255 range
+			Methods: []handlers.ContactMethodRequest{
+				{
+					Type:  "email",
+					Value: "single-char+" + ns + "@example.com",
+				},
+			},
+		}
+
+		jsonBody, _ := json.Marshal(requestBody)
+		req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.True(t, response.Success)
+		contactData := response.Data.(map[string]interface{})
+		assert.Equal(t, "A", contactData["full_name"])
+
+		deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactData["id"].(string), nil)
+		deleteW := httptest.NewRecorder()
+		router.ServeHTTP(deleteW, deleteReq)
+	})
+
+	t.Run("CreateContact_LocationTooLong", func(t *testing.T) {
+		// spec: CON-002[1]
+		requestBody := handlers.CreateContactRequest{
+			FullName: "Test User",
+			Location: stringPtr(strings.Repeat("a", 256)), // Exceeds max 255
+		}
+
+		jsonBody, _ := json.Marshal(requestBody)
+		req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("CreateContact_HowMetTooLong", func(t *testing.T) {
+		// spec: CON-002[1]
+		requestBody := handlers.CreateContactRequest{
+			FullName: "Test User",
+			HowMet:   stringPtr(strings.Repeat("a", 501)), // Exceeds max 500
+		}
+
+		jsonBody, _ := json.Marshal(requestBody)
+		req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("CreateContact_ProfilePhotoTooLong", func(t *testing.T) {
+		// spec: CON-002[2]
+		// Syntactically valid URL, but its total length exceeds the 500 cap.
+		longURL := "https://example.com/" + strings.Repeat("a", 490) + ".jpg"
+		require.Greater(t, len(longURL), 500)
+
+		requestBody := handlers.CreateContactRequest{
+			FullName:     "Test User",
+			ProfilePhoto: stringPtr(longURL),
+		}
+
+		jsonBody, _ := json.Marshal(requestBody)
+		req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("CreateContact_MalformedBirthday", func(t *testing.T) {
+		// spec: CON-002[3]
+		requestBody := map[string]interface{}{
+			"full_name": "Test User",
+			"birthday":  "not-a-date",
+		}
+
+		jsonBody, _ := json.Marshal(requestBody)
+		req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("CreateContact_AllCadenceValuesAccepted", func(t *testing.T) {
+		// spec: CON-002[4]
+		validCadences := []string{"weekly", "biweekly", "monthly", "quarterly", "biannual", "annual"}
+
+		for _, cadence := range validCadences {
+			cadence := cadence
+			t.Run(cadence, func(t *testing.T) {
+				ns := uuid.New().String()[:8]
+				requestBody := handlers.CreateContactRequest{
+					FullName: "Cadence Test " + ns,
+					Cadence:  stringPtr(cadence),
+				}
+
+				jsonBody, _ := json.Marshal(requestBody)
+				req, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+				req.Header.Set("Content-Type", "application/json")
+
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+				var response api.APIResponse
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				require.NoError(t, err)
+
+				assert.True(t, response.Success)
+				contactData := response.Data.(map[string]interface{})
+				assert.Equal(t, cadence, contactData["cadence"])
+
+				deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactData["id"].(string), nil)
+				deleteW := httptest.NewRecorder()
+				router.ServeHTTP(deleteW, deleteReq)
+			})
+		}
+	})
+
 	t.Run("CreateContact_AllFieldsMaxLength", func(t *testing.T) {
 		// spec: CON-002[6]
 		// Use unique email to avoid conflicts in CI
@@ -445,6 +623,325 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("UpdateContact_BlankFullNameRejected", func(t *testing.T) {
+		// spec: CON-047[0]
+		updateReq := handlers.UpdateContactRequest{
+			FullName: "",
+		}
+
+		jsonBody, _ := json.Marshal(updateReq)
+		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+contactID, bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("UpdateContact_FullNameTooLongRejected", func(t *testing.T) {
+		// spec: CON-047[0]
+		updateReq := handlers.UpdateContactRequest{
+			FullName: strings.Repeat("a", 256), // Exceeds max 255
+		}
+
+		jsonBody, _ := json.Marshal(updateReq)
+		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+contactID, bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("UpdateContact_InvalidCadenceRejected", func(t *testing.T) {
+		// spec: CON-047[1]
+		updateReq := handlers.UpdateContactRequest{
+			FullName: "Update Test User " + ns,
+			Cadence:  stringPtr("daily"), // Not in the closed set
+		}
+
+		jsonBody, _ := json.Marshal(updateReq)
+		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+contactID, bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("UpdateContact_UnknownContactNotFound", func(t *testing.T) {
+		// spec: CON-047[2]
+		unknownID := uuid.New().String()
+		updateReq := handlers.UpdateContactRequest{
+			FullName: "Updated Name",
+		}
+
+		jsonBody, _ := json.Marshal(updateReq)
+		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+unknownID, bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("UpdateContact_SoftDeletedContactNotFound", func(t *testing.T) {
+		// spec: CON-047[2]
+		createReq := handlers.CreateContactRequest{
+			FullName: "Update SoftDeleted " + ns,
+		}
+		jsonBody, _ := json.Marshal(createReq)
+		createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		createHTTPReq.Header.Set("Content-Type", "application/json")
+		createW := httptest.NewRecorder()
+		router.ServeHTTP(createW, createHTTPReq)
+		require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+		var createResp api.APIResponse
+		require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &createResp))
+		softDeletedID := createResp.Data.(map[string]interface{})["id"].(string)
+
+		deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+softDeletedID, nil)
+		deleteW := httptest.NewRecorder()
+		router.ServeHTTP(deleteW, deleteReq)
+		require.Equal(t, http.StatusNoContent, deleteW.Code)
+
+		updateReq := handlers.UpdateContactRequest{
+			FullName: "Should Not Apply",
+		}
+		updateBody, _ := json.Marshal(updateReq)
+		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+softDeletedID, bytes.NewBuffer(updateBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("UpdateContact_ValidRequestReturnsUpdatedContact", func(t *testing.T) {
+		// spec: CON-047[3]
+		updatedName := "Updated Name " + ns
+		updateReq := handlers.UpdateContactRequest{
+			FullName: updatedName,
+			Cadence:  stringPtr("quarterly"),
+		}
+
+		jsonBody, _ := json.Marshal(updateReq)
+		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+contactID, bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.True(t, response.Success)
+		updated := response.Data.(map[string]interface{})
+		assert.Equal(t, updatedName, updated["full_name"])
+		assert.Equal(t, "quarterly", updated["cadence"])
+		assert.Equal(t, contactID, updated["id"])
+
+		// Persisted, not just echoed back on the update response.
+		getReq, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID, nil)
+		getW := httptest.NewRecorder()
+		router.ServeHTTP(getW, getReq)
+		require.Equal(t, http.StatusOK, getW.Code)
+
+		var getResponse api.APIResponse
+		require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &getResponse))
+		current := getResponse.Data.(map[string]interface{})
+		assert.Equal(t, updatedName, current["full_name"])
+		assert.Equal(t, "quarterly", current["cadence"])
+	})
+}
+
+// TestContactAPI_DeleteValidation covers CON-048: malformed-id rejection,
+// not-found for unknown/already-deleted contacts, the no-content shape of a
+// successful delete, and the absence of any hard-delete route.
+func TestContactAPI_DeleteValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, cleanup := setupContactValidationTestRouter()
+	defer cleanup()
+
+	ns := uuid.New().String()[:8]
+
+	t.Run("DeleteContact_MalformedIDRejected", func(t *testing.T) {
+		// spec: CON-048[0]
+		req, _ := http.NewRequest("DELETE", "/api/v1/contacts/not-a-uuid", nil)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("DeleteContact_UnknownContactNotFound", func(t *testing.T) {
+		// spec: CON-048[1]
+		unknownID := uuid.New().String()
+		req, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+unknownID, nil)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("DeleteContact_AlreadyDeletedContactNotFound", func(t *testing.T) {
+		// spec: CON-048[1]
+		createReq := handlers.CreateContactRequest{
+			FullName: "Delete Twice " + ns,
+		}
+		jsonBody, _ := json.Marshal(createReq)
+		createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		createHTTPReq.Header.Set("Content-Type", "application/json")
+		createW := httptest.NewRecorder()
+		router.ServeHTTP(createW, createHTTPReq)
+		require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+		var createResp api.APIResponse
+		require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &createResp))
+		contactID := createResp.Data.(map[string]interface{})["id"].(string)
+
+		firstDeleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		firstDeleteW := httptest.NewRecorder()
+		router.ServeHTTP(firstDeleteW, firstDeleteReq)
+		require.Equal(t, http.StatusNoContent, firstDeleteW.Code)
+
+		secondDeleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, secondDeleteReq)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("DeleteContact_SuccessfulDeleteReturnsEmptyNoContent", func(t *testing.T) {
+		// spec: CON-048[2]
+		createReq := handlers.CreateContactRequest{
+			FullName: "Delete Success " + ns,
+		}
+		jsonBody, _ := json.Marshal(createReq)
+		createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		createHTTPReq.Header.Set("Content-Type", "application/json")
+		createW := httptest.NewRecorder()
+		router.ServeHTTP(createW, createHTTPReq)
+		require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+		var createResp api.APIResponse
+		require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &createResp))
+		contactID := createResp.Data.(map[string]interface{})["id"].(string)
+
+		req, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Empty(t, w.Body.Bytes(), "a 204 response must have an empty body")
+	})
+
+	t.Run("DeleteContact_NoHardDeleteRouteExposed", func(t *testing.T) {
+		// spec: CON-048[3]
+		// Registers the whole contact route surface through the production
+		// registrar (not a hand-picked subset) so this is an assertion about the
+		// routes the binary actually serves.
+		routesRouter := gin.New()
+		routesV1 := routesRouter.Group("/api/v1")
+		handlers.RegisterContactRoutes(routesV1, handlers.ContactRouteDeps{
+			Contact:       &handlers.ContactHandler{},
+			Interaction:   &handlers.InteractionHandler{},
+			Note:          &handlers.NoteHandler{},
+			ContactMethod: handlers.NewContactMethodHandler(stubApplier{err: errors.New("unused")}),
+		})
+
+		var contactDeleteRoutes []string
+		for _, route := range routesRouter.Routes() {
+			if route.Method != http.MethodDelete {
+				continue
+			}
+			if !strings.HasPrefix(route.Path, "/api/v1/contacts") {
+				continue
+			}
+			contactDeleteRoutes = append(contactDeleteRoutes, route.Path)
+		}
+
+		assert.Equal(t, []string{"/api/v1/contacts/:id"}, contactDeleteRoutes,
+			"the only DELETE route under /contacts must be the soft-delete by id; no hard/purge/force variant may be registered")
+	})
 }
 
 // The create path still accepts methods, and must: creation is not a
@@ -599,6 +1096,224 @@ func TestContactAPI_QueryValidation(t *testing.T) {
 
 		assert.True(t, response.Success)
 	})
+
+	t.Run("ListContacts_DefaultPagination", func(t *testing.T) {
+		// spec: CON-017[0]
+		// Seed more than the default page size so the un-paginated request is
+		// guaranteed to have a 20-row page to return regardless of what other
+		// tests have left in the shared DB.
+		ns := uuid.New().String()[:8]
+		var ids []string
+		for i := 0; i < 25; i++ {
+			createReq := handlers.CreateContactRequest{
+				FullName: fmt.Sprintf("DefaultPage %s %02d", ns, i),
+			}
+			jsonBody, _ := json.Marshal(createReq)
+			createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+			createHTTPReq.Header.Set("Content-Type", "application/json")
+			createW := httptest.NewRecorder()
+			router.ServeHTTP(createW, createHTTPReq)
+			require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+			var created api.APIResponse
+			require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &created))
+			ids = append(ids, created.Data.(map[string]interface{})["id"].(string))
+		}
+		defer func() {
+			for _, id := range ids {
+				delReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+id, nil)
+				router.ServeHTTP(httptest.NewRecorder(), delReq)
+			}
+		}()
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.True(t, response.Success)
+		require.NotNil(t, response.Meta)
+		require.NotNil(t, response.Meta.Pagination)
+		assert.Equal(t, 1, response.Meta.Pagination.Page)
+		assert.Equal(t, 20, response.Meta.Pagination.Limit)
+
+		rows, ok := response.Data.([]interface{})
+		require.True(t, ok)
+		assert.Len(t, rows, 20)
+	})
+
+	t.Run("ListContacts_LimitCapAccepted", func(t *testing.T) {
+		// spec: CON-017[1]
+		req, _ := http.NewRequest("GET", "/api/v1/contacts?limit=1000", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.True(t, response.Success)
+		require.NotNil(t, response.Meta)
+		require.NotNil(t, response.Meta.Pagination)
+		assert.Equal(t, 1000, response.Meta.Pagination.Limit)
+	})
+
+	t.Run("ListContacts_PaginationMetaAccurate", func(t *testing.T) {
+		// spec: CON-017[2]
+		ns := uuid.New().String()[:8]
+		const seeded = 7
+		var ids []string
+		for i := 0; i < seeded; i++ {
+			createReq := handlers.CreateContactRequest{
+				FullName: fmt.Sprintf("MetaCount %s %02d", ns, i),
+			}
+			jsonBody, _ := json.Marshal(createReq)
+			createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+			createHTTPReq.Header.Set("Content-Type", "application/json")
+			createW := httptest.NewRecorder()
+			router.ServeHTTP(createW, createHTTPReq)
+			require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+			var created api.APIResponse
+			require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &created))
+			ids = append(ids, created.Data.(map[string]interface{})["id"].(string))
+		}
+		defer func() {
+			for _, id := range ids {
+				delReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+id, nil)
+				router.ServeHTTP(httptest.NewRecorder(), delReq)
+			}
+		}()
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts?search=MetaCount+"+ns+"&limit=3", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var response api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.True(t, response.Success)
+		require.NotNil(t, response.Meta)
+		require.NotNil(t, response.Meta.Pagination)
+		assert.EqualValues(t, seeded, response.Meta.Pagination.Total)
+		assert.Equal(t, 3, response.Meta.Pagination.Pages, "ceil(7/3) = 3")
+		assert.Equal(t, 1, response.Meta.Pagination.Page)
+		assert.Equal(t, 3, response.Meta.Pagination.Limit)
+
+		rows, ok := response.Data.([]interface{})
+		require.True(t, ok)
+		assert.Len(t, rows, 3)
+	})
+
+	t.Run("ListContacts_CadenceFilter", func(t *testing.T) {
+		// spec: CON-018[2]
+		ns := uuid.New().String()[:8]
+		var withCadenceIDs, withoutCadenceIDs []string
+
+		for i := 0; i < 3; i++ {
+			createReq := handlers.CreateContactRequest{
+				FullName: fmt.Sprintf("CadenceFilter %s WithCadence %02d", ns, i),
+				Cadence:  stringPtr("monthly"),
+			}
+			jsonBody, _ := json.Marshal(createReq)
+			createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+			createHTTPReq.Header.Set("Content-Type", "application/json")
+			createW := httptest.NewRecorder()
+			router.ServeHTTP(createW, createHTTPReq)
+			require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+			var created api.APIResponse
+			require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &created))
+			withCadenceIDs = append(withCadenceIDs, created.Data.(map[string]interface{})["id"].(string))
+		}
+		for i := 0; i < 3; i++ {
+			createReq := handlers.CreateContactRequest{
+				FullName: fmt.Sprintf("CadenceFilter %s NoCadence %02d", ns, i),
+			}
+			jsonBody, _ := json.Marshal(createReq)
+			createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+			createHTTPReq.Header.Set("Content-Type", "application/json")
+			createW := httptest.NewRecorder()
+			router.ServeHTTP(createW, createHTTPReq)
+			require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+			var created api.APIResponse
+			require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &created))
+			withoutCadenceIDs = append(withoutCadenceIDs, created.Data.(map[string]interface{})["id"].(string))
+		}
+		defer func() {
+			for _, id := range append(withCadenceIDs, withoutCadenceIDs...) {
+				delReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+id, nil)
+				router.ServeHTTP(httptest.NewRecorder(), delReq)
+			}
+		}()
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts?search=CadenceFilter+"+ns+"&cadence_filter=has_cadence&limit=100", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var hasResp api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &hasResp))
+		hasRows, ok := hasResp.Data.([]interface{})
+		require.True(t, ok)
+		require.Len(t, hasRows, 3)
+		for _, row := range hasRows {
+			r := row.(map[string]interface{})
+			assert.Equal(t, "monthly", r["cadence"])
+		}
+
+		req, _ = http.NewRequest("GET", "/api/v1/contacts?search=CadenceFilter+"+ns+"&cadence_filter=no_cadence&limit=100", nil)
+		w = httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var noResp api.APIResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &noResp))
+		noRows, ok := noResp.Data.([]interface{})
+		require.True(t, ok)
+		require.Len(t, noRows, 3)
+		for _, row := range noRows {
+			r := row.(map[string]interface{})
+			_, hasCadenceKey := r["cadence"]
+			assert.False(t, hasCadenceKey, "no_cadence rows must not carry a cadence value")
+		}
+	})
+
+	t.Run("ListContacts_InvalidCadenceFilter", func(t *testing.T) {
+		// spec: CON-018[4]
+		req, _ := http.NewRequest("GET", "/api/v1/contacts?cadence_filter=bogus", nil)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
+
+	t.Run("ListContacts_InvalidFollowupFilter", func(t *testing.T) {
+		// spec: CON-018[4]
+		req, _ := http.NewRequest("GET", "/api/v1/contacts?followup_filter=bogus", nil)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+	})
 }
 
 func TestContactAPI_GetContactValidation(t *testing.T) {
@@ -636,6 +1351,42 @@ func TestContactAPI_GetContactValidation(t *testing.T) {
 		nonExistentID := uuid.New().String()
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+nonExistentID, nil)
 
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("GetContact_SoftDeleted_NotFound", func(t *testing.T) {
+		// spec: CON-005[1]
+		ns := uuid.New().String()[:8]
+		createReq := handlers.CreateContactRequest{
+			FullName: "SoftDeleted Test " + ns,
+		}
+		jsonBody, _ := json.Marshal(createReq)
+		createHTTPReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(jsonBody))
+		createHTTPReq.Header.Set("Content-Type", "application/json")
+		createW := httptest.NewRecorder()
+		router.ServeHTTP(createW, createHTTPReq)
+		require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+		var createResponse api.APIResponse
+		require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &createResponse))
+		contactID := createResponse.Data.(map[string]interface{})["id"].(string)
+
+		deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		deleteW := httptest.NewRecorder()
+		router.ServeHTTP(deleteW, deleteReq)
+		require.Equal(t, http.StatusNoContent, deleteW.Code)
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID, nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -622,11 +622,15 @@ behaviors:
     given: a PUT for an existing contact
     when: the request is handled
     then:
-      - field validation follows the same rules as create (name required and bounded, cadence from the closed set, methods validated)
+      - field validation follows the same rules as create (name required and bounded, cadence from the closed set)
       - an invalid request is rejected with a validation error (400)
       - an unknown or soft-deleted contact returns not-found (404)
       - a valid request returns the updated contact (200)
     provenance: [ContactHandler.UpdateContact, UpdateContactRequest]
+    notes: >
+      Methods are not validated on this path: a methods key on the update body
+      is rejected outright rather than validated per create rules — that
+      rejection is CON-064's behavior.
 
   - id: CON-048
     title: Contact delete returns no content and admits no hard delete

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -1,7 +1,7 @@
 domain: contacts
 prefix: CON
 maturity: reviewed
-settled: [ui]
+settled: [ui, api]
 behaviors:
   # --- CRUD ---
 


### PR DESCRIPTION
## Summary

Gap phase PR 1 of the api-citation arc (follow-on to #730): closes all 27 remaining `api`-surface coverage orphans in the **contacts** domain with new tests, then flips the domain to `settled: [ui, api]` so contacts api orphans become push/CI-blocking from here on.

Every new test carries a `// spec: <ID>[<n>]` citation and was authored under a self-certifying contract: compile + scoped run green, plus an **injected-defect red/green proof** — a minimal behavioral defect (widened cap, dropped check, removed enum member) was temporarily applied to the production code to confirm the test goes red, then reverted and re-run green. No test in this PR passes vacuously.

## Items closed (27)

- **CON-002[0..4]** create validation: 1-char name lower-bound acceptance; location/how_met over-cap 400s; profile_photo >500-char 400; malformed birthday 400; all six cadence enum members accepted (biweekly/quarterly/biannual were previously unproven).
- **CON-005[1]** GET of a soft-deleted contact 404s (only the unknown-id branch was tested).
- **CON-017[0..2]** pagination: default page 1/20; limit=1000 acceptance (cap boundary); HTTP response meta carries correct total/page count.
- **CON-018[0,2,4]** list vocabulary: sort=location and sort=birthday via HTTP; cadence_filter=has_cadence/no_cadence as HTTP query params; invalid cadence_filter/followup_filter 400.
- **CON-037[0..2]** merge preview: interactions + calendar-event counts asserted; first handler-level coverage of the preview route (404 unknown source/target, 400 malformed id).
- **CON-047[0..3]** update: create-rule field validation via PUT; 400 shape; unknown/soft-deleted 404; valid PUT returns the updated contact.
- **CON-048[0..3]** delete: malformed-id 400; unknown/already-deleted 404; 204 empty body; route-table proof that no hard-delete route is exposed.
- **CON-015[3,4]** method validation: malformed gchat rejected as invalid email (email-family member previously uncovered); signal 50-char boundary pair (50 accepted / 51 rejected).
- **CON-062[2,13]** method operations: order-independence now compares the complete persisted outcome (including an updated row's value) across two operation orderings; per-operation results verified to identify their method and report stored state matching a read-back.

## Test plan

- `make spec-coverage`: contacts `api: 0 orphaned` (was 27); corpus total 107 → 80.
- Full backend suites + E2E-diff via pre-push hook; CI runs the full matrix.
