### PR TITLE
test(spec): close settings and telegram api coverage gaps

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -220,12 +220,10 @@ func run() int {
 	registerRematchDispatcher(reg, graph, database, eventBus)
 
 	// External sync components (feature-flagged). A zero syncStack
-	// reproduces today's all-nil handler set when disabled; the gate stays
-	// here so buildExternalSync runs only when the feature is on.
-	var syncStk syncStack
-	if cfg.Features.EnableExternalSync {
-		syncStk = buildExternalSync(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
-	}
+	// reproduces today's all-nil handler set when disabled; the gate lives in
+	// buildExternalSyncIfEnabled, the seam shared with the OAuth route-wiring
+	// boundary test.
+	syncStk := buildExternalSyncIfEnabled(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
 	syncHandler := syncStk.SyncHandler
 	identityHandler := syncStk.IdentityHandler
 	oauthHandler := syncStk.OAuthHandler

--- a/backend/cmd/crm-api/oauth_routes_boundary_test.go
+++ b/backend/cmd/crm-api/oauth_routes_boundary_test.go
@@ -103,10 +103,10 @@ func buildRouterForOAuthWiring(t *testing.T, cfg *config.Config) *gin.Engine {
 	domain := buildDomainServices(database, core, graph, ingest, consumers, ingestStk, eventBus)
 	registerRematchDispatcher(reg, graph, database, eventBus)
 
-	var syncStk syncStack
-	if cfg.Features.EnableExternalSync {
-		syncStk = buildExternalSync(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
-	}
+	// The external-sync feature gate is exercised through the SAME production
+	// seam run() uses — the gate logic itself lives in
+	// buildExternalSyncIfEnabled (wire_sync.go), never re-implemented here.
+	syncStk := buildExternalSyncIfEnabled(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
 
 	// Telegram is intentionally SKIPPED (Start must not run); a nil
 	// telegramManager is exactly a telegram-disabled boot for aggregation.
@@ -343,4 +343,35 @@ func TestOAuthRouteWiring_ProviderGating(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code,
 			"an unconfigured provider's callback URL must return 404")
 	})
+
+	// Partially-configured shapes: the derivation requires BOTH credential
+	// fields, so a provider with only one populated must expose no routes. An
+	// erroneous OR in the credential check passes the all-empty shapes above
+	// but fails these.
+	partialShapes := []struct {
+		name  string
+		setup func(cfg *config.Config)
+		want  []string
+		probe string
+	}{
+		{"google client id only", func(cfg *config.Config) { cfg.Google.ClientSecret = "" }, wiringTodoistOAuthRouteSet, "/api/v1/auth/google/callback"},
+		{"google client secret only", func(cfg *config.Config) { cfg.Google.ClientID = "" }, wiringTodoistOAuthRouteSet, "/api/v1/auth/google/callback"},
+		{"todoist client id only", func(cfg *config.Config) { cfg.Todoist.ClientSecret = "" }, wiringGoogleOAuthRouteSet, "/api/v1/auth/todoist/callback"},
+		{"todoist client secret only", func(cfg *config.Config) { cfg.Todoist.ClientID = "" }, wiringGoogleOAuthRouteSet, "/api/v1/auth/todoist/callback"},
+	}
+	for _, shape := range partialShapes {
+		t.Run("partially configured: "+shape.name+" exposes no routes for that provider", func(t *testing.T) {
+			// spec: SET-005
+			t.Parallel()
+			cfg := oauthWiringConfig(t)
+			cfg.Features.EnableExternalSync = true
+			shape.setup(cfg)
+			router := buildRouterForOAuthWiring(t, cfg)
+
+			assert.ElementsMatch(t, shape.want, oauthWiringRouteSet(router))
+			w := serveOAuthWiringRequest(router, http.MethodGet, shape.probe, false)
+			assert.Equal(t, http.StatusNotFound, w.Code,
+				"a partially-configured provider's callback URL must return 404")
+		})
+	}
 }

--- a/backend/cmd/crm-api/oauth_routes_boundary_test.go
+++ b/backend/cmd/crm-api/oauth_routes_boundary_test.go
@@ -1,0 +1,346 @@
+//go:build integration_testdb
+
+// OAuth route-registration boundary pin against the PRODUCTION wiring.
+//
+// The registrar-level tests in internal/api/handlers/oauth_routes_test.go
+// reconstruct the middleware ordering and provider gates themselves, so they
+// cannot catch a regression in THIS package's composition root (e.g.
+// RegisterOAuthCallbackRoutes moved behind the API-key middleware in
+// routes.go, or the GoogleEnabled derivation broken). These tests drive the
+// real wire chain (buildWireChainForGolden's exact order, minus buildTelegram
+// per the telegram-skip rule and minus riverClient.Start / the HTTP server)
+// through the real registerRoutes per config shape, then probe the resulting
+// router. They are the citation holders for SET-001 and SET-005.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/testdb"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const oauthWiringTestAPIKey = "oauth-wiring-boundary-test-key-91d4"
+
+// oauthWiringConfig returns a TestConfig over a fresh ephemeral clone DB with
+// the API key set so auth.APIKeyMiddleware enforces. TestConfig ships with
+// both providers' client credentials configured; shapes mutate from there.
+func oauthWiringConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	cfg.Database.MigrationsPath = migrationsPathForTest()
+	cfg.External.APIKey = oauthWiringTestAPIKey
+	return cfg
+}
+
+// buildRouterForOAuthWiring drives the wire chain in run()'s exact order
+// (minus buildTelegram — telegram-skip rule — and minus riverClient.Start /
+// the HTTP server), then registers the production route tree via the real
+// registerRoutes with deps drawn exactly the way run() draws them. The
+// returned router is therefore the production route tree for cfg's shape.
+func buildRouterForOAuthWiring(t *testing.T, cfg *config.Config) *gin.Engine {
+	t.Helper()
+	ctx := context.Background()
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	core := buildCoreRepos(database.Queries)
+
+	riverWorkers := river.NewWorkers()
+	reg := newRiverRegistrar(riverWorkers)
+	addWorker(reg, &noopWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		JobTimeout: cfg.River.JobTimeout,
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers:                     riverWorkers,
+		ErrorHandler:                events.NewRiverErrorHandler(logger.Get()),
+		Logger:                      logger.NewSlogLogger(logger.Get()),
+		DiscardedJobRetentionPeriod: riverDiscardedJobRetention,
+	})
+	require.NoError(t, err)
+	reg.periodic = riverClient.PeriodicJobs()
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
+
+	ingest := buildIngestRepos(database.Queries)
+	graph := buildGraphCore(database, eventBus)
+	messaging := buildMessagingFoundation(database.Queries, ingest.MessagesMessage, ingest.CalendarEvent)
+	consumers := buildDomainConsumers(cfg, database, core, graph, eventBus, riverClient)
+	contactService := buildContactService(cfg, database, core, graph, consumers, eventBus, riverClient)
+	interactionRecorder := buildInteractionRecorder(contactService, messaging, ingest, consumers, eventBus)
+	ingestStk := buildIngestStack(database, core, contactService, ingest, messaging, consumers, eventBus, riverClient)
+	registerCoreConsumerWorkers(reg, database, core, contactService, interactionRecorder, messaging, consumers, eventBus)
+	pubBus, manualHandler := resolveInteractionMode(cfg, database, interactionRecorder, eventBus)
+	registerModeWorkers(reg, cfg, database, core, consumers, eventBus, riverClient)
+	domain := buildDomainServices(database, core, graph, ingest, consumers, ingestStk, eventBus)
+	registerRematchDispatcher(reg, graph, database, eventBus)
+
+	var syncStk syncStack
+	if cfg.Features.EnableExternalSync {
+		syncStk = buildExternalSync(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
+	}
+
+	// Telegram is intentionally SKIPPED (Start must not run); a nil
+	// telegramManager is exactly a telegram-disabled boot for aggregation.
+	agg := buildAggregationEngines(database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
+	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
+
+	handlersCore := buildCoreHandlers(database, core, contactService, graph, cfg, domain.NoteService, manualHandler, eventBus)
+	machost := buildMacHost(reg, database, core, ingest)
+	staleness := buildStaleness(reg, cfg, database, machost)
+	registerAssertionRollover(reg, graph)
+	registerSyncScheduler(reg, cfg, syncStk, riverClient)
+	registerJobSampleWorkers(reg, repository.NewJobSampleRepository(database.Queries), cfg)
+
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+	router.Use(api.ErrorHandlerMiddleware())
+
+	registerRoutes(routeDeps{
+		Router:                   router,
+		Cfg:                      cfg,
+		Database:                 database,
+		StalenessService:         staleness.Service,
+		MacHostRepo:              machost.Repo,
+		MacHostHandler:           machost.Handler,
+		IngestHandler:            ingestStk.IngestHandler,
+		MeetingNoteHandler:       ingestStk.MeetingNoteHandler,
+		ContactHandler:           handlersCore.Contact,
+		InteractionHandler:       handlersCore.Interaction,
+		NoteHandler:              handlersCore.Note,
+		ContactMethodHandler:     handlersCore.ContactMethod,
+		RematchHandler:           handlersCore.Rematch,
+		StalenessHandler:         staleness.Handler,
+		SystemHandler:            handlersCore.System,
+		OAuthHandler:             syncStk.OAuthHandler,
+		GoogleOAuthService:       syncStk.GoogleOAuthService,
+		TodoistHandler:           syncStk.TodoistHandler,
+		TelegramHandler:          nil,
+		SyncHandler:              syncStk.SyncHandler,
+		IdentityHandler:          syncStk.IdentityHandler,
+		ContactTaskHandler:       syncStk.ContactTaskHandler,
+		CalendarHandler:          syncStk.CalendarHandler,
+		ImportHandler:            syncStk.ImportHandler,
+		AnarlogDiscoveryHandler:  syncStk.AnarlogDiscoveryHandler,
+		SuggestionHandler:        syncStk.SuggestionHandler,
+		ExternalContactRepo:      syncStk.ExternalContactRepo,
+		ContactService:           contactService,
+		MeetingNoteRepoForIngest: ingest.MeetingNote,
+	})
+	return router
+}
+
+func serveOAuthWiringRequest(router *gin.Engine, method, path string, withKey bool) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	if withKey {
+		req.Header.Set("X-API-Key", oauthWiringTestAPIKey)
+	}
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// oauthWiringRouteSet returns "METHOD path" for every registered route under
+// /api/v1/auth.
+func oauthWiringRouteSet(router *gin.Engine) []string {
+	var routes []string
+	for _, route := range router.Routes() {
+		if len(route.Path) >= len("/api/v1/auth") && route.Path[:len("/api/v1/auth")] == "/api/v1/auth" {
+			routes = append(routes, route.Method+" "+route.Path)
+		}
+	}
+	return routes
+}
+
+var wiringGoogleOAuthRouteSet = []string{
+	"GET /api/v1/auth/google/callback",
+	"GET /api/v1/auth/google",
+	"GET /api/v1/auth/google/accounts",
+	"GET /api/v1/auth/google/accounts/:id/status",
+	"POST /api/v1/auth/google/accounts/:id/revoke",
+}
+
+var wiringTodoistOAuthRouteSet = []string{
+	"GET /api/v1/auth/todoist/callback",
+	"GET /api/v1/auth/todoist",
+	"GET /api/v1/auth/todoist/accounts",
+	"GET /api/v1/auth/todoist/accounts/:id/status",
+	"POST /api/v1/auth/todoist/accounts/:id/revoke",
+}
+
+// TestOAuthRouteWiring_AuthBoundary probes the PRODUCTION auth boundary: the
+// provider callbacks must sit OUTSIDE the API-key middleware (a keyless
+// request reaches the handler), while every auth-URL and account-management
+// route sits inside it (keyless is 401, keyed proceeds).
+func TestOAuthRouteWiring_AuthBoundary(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	cfg := oauthWiringConfig(t)
+	cfg.Features.EnableExternalSync = true
+	router := buildRouterForOAuthWiring(t, cfg)
+
+	t.Run("callback routes are reachable without the API key", func(t *testing.T) {
+		// spec: SET-001
+		// A keyless request to each provider callback must get PAST the auth
+		// middleware and into the handler. With no query params the handler
+		// deterministically 302-redirects to the settings surface with an
+		// invalid_state outcome — proof it executed.
+		for provider, path := range map[string]string{
+			"google":  "/api/v1/auth/google/callback",
+			"todoist": "/api/v1/auth/todoist/callback",
+		} {
+			w := serveOAuthWiringRequest(router, http.MethodGet, path, false)
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"%s callback must not be rejected by the API-key middleware", provider)
+			require.Equal(t, http.StatusFound, w.Code,
+				"%s callback handler must run and redirect", provider)
+			location := w.Header().Get("Location")
+			assert.Contains(t, location, "/settings?auth=error", "provider %s", provider)
+			assert.Contains(t, location, "provider="+provider)
+		}
+	})
+
+	t.Run("auth-URL and account routes without a key are rejected 401", func(t *testing.T) {
+		// spec: SET-001
+		protected := []struct {
+			method string
+			path   string
+		}{
+			{http.MethodGet, "/api/v1/auth/google"},
+			{http.MethodGet, "/api/v1/auth/google/accounts"},
+			{http.MethodGet, fmt.Sprintf("/api/v1/auth/google/accounts/%s/status", uuid.New())},
+			{http.MethodPost, fmt.Sprintf("/api/v1/auth/google/accounts/%s/revoke", uuid.New())},
+			{http.MethodGet, "/api/v1/auth/todoist"},
+			{http.MethodGet, "/api/v1/auth/todoist/accounts"},
+			{http.MethodGet, fmt.Sprintf("/api/v1/auth/todoist/accounts/%s/status", uuid.New())},
+			{http.MethodPost, fmt.Sprintf("/api/v1/auth/todoist/accounts/%s/revoke", uuid.New())},
+		}
+		for _, route := range protected {
+			w := serveOAuthWiringRequest(router, route.method, route.path, false)
+			name := route.method + " " + route.path
+			require.Equal(t, http.StatusUnauthorized, w.Code,
+				"%s without an API key must be rejected by the auth middleware", name)
+			var body map[string]interface{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "route %s", name)
+			assert.Equal(t, false, body["success"], "route %s", name)
+			errObj, ok := body["error"].(map[string]interface{})
+			require.True(t, ok, "route %s: 401 body must carry an error object", name)
+			assert.Equal(t, "MISSING_API_KEY", errObj["code"], "route %s", name)
+		}
+	})
+
+	t.Run("auth-URL routes with the key reach their handlers", func(t *testing.T) {
+		// spec: SET-001
+		// Acceptance side of the boundary: the same protected routes proceed
+		// once the key is supplied (the real OAuth services build the
+		// provider auth URLs locally — no network involved).
+		wGoogle := serveOAuthWiringRequest(router, http.MethodGet, "/api/v1/auth/google", true)
+		require.Equal(t, http.StatusOK, wGoogle.Code)
+		assert.Contains(t, wGoogle.Body.String(), "accounts.google.com")
+
+		wTodoist := serveOAuthWiringRequest(router, http.MethodGet, "/api/v1/auth/todoist", true)
+		require.Equal(t, http.StatusOK, wTodoist.Code)
+		assert.Contains(t, wTodoist.Body.String(), "todoist.com")
+	})
+}
+
+// TestOAuthRouteWiring_ProviderGating pins the PRODUCTION provider gates: the
+// wire chain must derive nil OAuth services from external-sync/credential
+// config, and registerRoutes must translate those nils into absent routes.
+func TestOAuthRouteWiring_ProviderGating(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Run("external sync enabled with both providers configured registers both full route sets", func(t *testing.T) {
+		// spec: SET-005
+		t.Parallel()
+		cfg := oauthWiringConfig(t)
+		cfg.Features.EnableExternalSync = true
+		router := buildRouterForOAuthWiring(t, cfg)
+
+		assert.ElementsMatch(t,
+			append(append([]string{}, wiringGoogleOAuthRouteSet...), wiringTodoistOAuthRouteSet...),
+			oauthWiringRouteSet(router))
+	})
+
+	t.Run("external sync disabled registers no oauth routes for either provider", func(t *testing.T) {
+		// spec: SET-005
+		t.Parallel()
+		cfg := oauthWiringConfig(t)
+		cfg.Features.EnableExternalSync = false
+		router := buildRouterForOAuthWiring(t, cfg)
+
+		assert.Empty(t, oauthWiringRouteSet(router),
+			"with external sync disabled no /api/v1/auth route may exist")
+		for _, path := range []string{"/api/v1/auth/google/callback", "/api/v1/auth/todoist/callback"} {
+			w := serveOAuthWiringRequest(router, http.MethodGet, path, false)
+			assert.Equal(t, http.StatusNotFound, w.Code,
+				"disabled provider callback %s must 404", path)
+		}
+	})
+
+	t.Run("google credentials unconfigured derives a nil google service and absent google routes", func(t *testing.T) {
+		// spec: SET-005
+		t.Parallel()
+		cfg := oauthWiringConfig(t)
+		cfg.Features.EnableExternalSync = true
+		cfg.Google.ClientID = ""
+		cfg.Google.ClientSecret = ""
+		router := buildRouterForOAuthWiring(t, cfg)
+
+		assert.ElementsMatch(t, wiringTodoistOAuthRouteSet, oauthWiringRouteSet(router))
+		w := serveOAuthWiringRequest(router, http.MethodGet, "/api/v1/auth/google/callback", false)
+		assert.Equal(t, http.StatusNotFound, w.Code,
+			"an unconfigured provider's callback URL must return 404")
+	})
+
+	t.Run("todoist credentials unconfigured derives a nil todoist service and absent todoist routes", func(t *testing.T) {
+		// spec: SET-005
+		t.Parallel()
+		cfg := oauthWiringConfig(t)
+		cfg.Features.EnableExternalSync = true
+		cfg.Todoist.ClientID = ""
+		cfg.Todoist.ClientSecret = ""
+		router := buildRouterForOAuthWiring(t, cfg)
+
+		assert.ElementsMatch(t, wiringGoogleOAuthRouteSet, oauthWiringRouteSet(router))
+		w := serveOAuthWiringRequest(router, http.MethodGet, "/api/v1/auth/todoist/callback", false)
+		assert.Equal(t, http.StatusNotFound, w.Code,
+			"an unconfigured provider's callback URL must return 404")
+	})
+}

--- a/backend/cmd/crm-api/wire_sync.go
+++ b/backend/cmd/crm-api/wire_sync.go
@@ -229,3 +229,29 @@ func buildExternalSync(
 
 	return stack
 }
+
+// buildExternalSyncIfEnabled applies the external-sync feature gate: the full
+// sync stack when cfg.Features.EnableExternalSync is set, a zero syncStack
+// otherwise. This is the single gate seam shared by run() and the OAuth
+// route-wiring boundary test — a regression that drops or inverts the gate
+// fails the test because the test exercises this exact function.
+func buildExternalSyncIfEnabled(
+	ctx context.Context,
+	cfg *config.Config,
+	database *db.Database,
+	core coreRepos,
+	contactService *service.ContactService,
+	graph graphCore,
+	ingest ingestRepos,
+	messaging messagingFoundation,
+	consumers eventConsumers,
+	domain domainServices,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+	pubBus *events.Bus,
+) syncStack {
+	if !cfg.Features.EnableExternalSync {
+		return syncStack{}
+	}
+	return buildExternalSync(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
+}

--- a/backend/internal/api/handlers/oauth_routes_test.go
+++ b/backend/internal/api/handlers/oauth_routes_test.go
@@ -1,0 +1,243 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTodoistOAuthService is a minimal mock of todoist.OAuthServiceInterface.
+// Registration tests only need HasTodoistOAuth() to flip true, so every
+// method is a stub; the Google twin reuses MockOAuthService from
+// oauth_test.go (same package).
+type mockTodoistOAuthService struct{}
+
+var _ todoist.OAuthServiceInterface = (*mockTodoistOAuthService)(nil)
+
+func (m *mockTodoistOAuthService) GetAuthURL(state string) string {
+	return "https://todoist.com/oauth/authorize?state=" + state
+}
+
+func (m *mockTodoistOAuthService) ExchangeCode(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockTodoistOAuthService) ListAccounts(ctx context.Context) ([]repository.OAuthCredentialStatus, error) {
+	return nil, nil
+}
+
+func (m *mockTodoistOAuthService) GetAccountStatus(ctx context.Context, id uuid.UUID) (*repository.OAuthCredentialStatus, error) {
+	return nil, db.ErrNotFound
+}
+
+func (m *mockTodoistOAuthService) RevokeAccount(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+
+const oauthRoutesTestAPIKey = "oauth-routes-test-key-2f8c"
+
+// newOAuthTestRouter builds a router wired exactly the way
+// cmd/crm-api/routes.go wires the OAuth registrars: the callback
+// registrar goes on the bare engine BEFORE any auth middleware, then the
+// /api/v1 group gets auth.APIKeyMiddleware and the auth-URL/account
+// registrar is mounted inside it. GoogleEnabled mirrors run()'s
+// googleOAuthService != nil check (the same value gates both registrars);
+// the Todoist gate is the handler's HasTodoistOAuth().
+func newOAuthTestRouter(googleEnabled, todoistEnabled bool) *gin.Engine {
+	var googleSvc google.OAuthServiceInterface
+	if googleEnabled {
+		googleSvc = &MockOAuthService{}
+	}
+	handler := NewOAuthHandler(googleSvc, "http://localhost:3000")
+	if todoistEnabled {
+		handler.SetTodoistOAuth(&mockTodoistOAuthService{})
+	}
+	deps := OAuthCallbackDeps{
+		Handler:       handler,
+		GoogleEnabled: googleEnabled,
+	}
+
+	cfg := &config.Config{
+		External: config.ExternalConfig{APIKey: oauthRoutesTestAPIKey},
+	}
+
+	router := gin.New()
+	// Callback routes: bare router, no auth (provider redirects cannot
+	// carry the global API key).
+	RegisterOAuthCallbackRoutes(router, deps)
+	// Everything else: inside the API-key-protected group.
+	v1 := router.Group("/api/v1")
+	v1.Use(auth.APIKeyMiddleware(cfg))
+	RegisterOAuthRoutes(v1, deps)
+	return router
+}
+
+func serveOAuthTestRequest(router *gin.Engine, method, path string, withKey bool) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	if withKey {
+		req.Header.Set("X-API-Key", oauthRoutesTestAPIKey)
+	}
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// oauthRouteSet returns "METHOD path" for every registered route under
+// /api/v1/auth (both the bare callback routes and the grouped ones).
+func oauthRouteSet(router *gin.Engine) []string {
+	var routes []string
+	for _, route := range router.Routes() {
+		if len(route.Path) >= len("/api/v1/auth") && route.Path[:len("/api/v1/auth")] == "/api/v1/auth" {
+			routes = append(routes, route.Method+" "+route.Path)
+		}
+	}
+	return routes
+}
+
+var googleOAuthRouteSet = []string{
+	"GET /api/v1/auth/google/callback",
+	"GET /api/v1/auth/google",
+	"GET /api/v1/auth/google/accounts",
+	"GET /api/v1/auth/google/accounts/:id/status",
+	"POST /api/v1/auth/google/accounts/:id/revoke",
+}
+
+var todoistOAuthRouteSet = []string{
+	"GET /api/v1/auth/todoist/callback",
+	"GET /api/v1/auth/todoist",
+	"GET /api/v1/auth/todoist/accounts",
+	"GET /api/v1/auth/todoist/accounts/:id/status",
+	"POST /api/v1/auth/todoist/accounts/:id/revoke",
+}
+
+// requireMissingKey401 asserts the literal auth-middleware rejection wire
+// shape: 401 with success=false and error.code=MISSING_API_KEY, decoded
+// from the raw body rather than any production struct.
+func requireMissingKey401(t *testing.T, w *httptest.ResponseRecorder, route string) {
+	t.Helper()
+	require.Equal(t, http.StatusUnauthorized, w.Code,
+		"%s without an API key must be rejected by the auth middleware", route)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "route %s", route)
+	assert.Equal(t, false, body["success"], "route %s", route)
+	errObj, ok := body["error"].(map[string]interface{})
+	require.True(t, ok, "route %s: 401 body must carry an error object", route)
+	assert.Equal(t, "MISSING_API_KEY", errObj["code"], "route %s", route)
+}
+
+func TestOAuthRouteRegistration_AuthBoundary(t *testing.T) {
+	router := newOAuthTestRouter(true, true)
+
+	t.Run("callback routes are reachable without the API key", func(t *testing.T) {
+		// spec: SET-001
+		// A keyless request to each provider callback must get PAST the
+		// auth middleware and into the handler. With no query params the
+		// handler deterministically 302-redirects to the settings surface
+		// with an invalid_state outcome — proof it executed.
+		for provider, path := range map[string]string{
+			"google":  "/api/v1/auth/google/callback",
+			"todoist": "/api/v1/auth/todoist/callback",
+		} {
+			w := serveOAuthTestRequest(router, http.MethodGet, path, false)
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"%s callback must not be rejected by the API-key middleware", provider)
+			require.Equal(t, http.StatusFound, w.Code,
+				"%s callback handler must run and redirect", provider)
+			location := w.Header().Get("Location")
+			assert.Contains(t, location, "/settings?auth=error", "provider %s", provider)
+			assert.Contains(t, location, "provider="+provider)
+		}
+	})
+
+	t.Run("auth-URL and account routes without a key are rejected 401", func(t *testing.T) {
+		// spec: SET-001
+		protected := []struct {
+			method string
+			path   string
+		}{
+			{http.MethodGet, "/api/v1/auth/google"},
+			{http.MethodGet, "/api/v1/auth/google/accounts"},
+			{http.MethodGet, fmt.Sprintf("/api/v1/auth/google/accounts/%s/status", uuid.New())},
+			{http.MethodPost, fmt.Sprintf("/api/v1/auth/google/accounts/%s/revoke", uuid.New())},
+			{http.MethodGet, "/api/v1/auth/todoist"},
+			{http.MethodGet, "/api/v1/auth/todoist/accounts"},
+			{http.MethodGet, fmt.Sprintf("/api/v1/auth/todoist/accounts/%s/status", uuid.New())},
+			{http.MethodPost, fmt.Sprintf("/api/v1/auth/todoist/accounts/%s/revoke", uuid.New())},
+		}
+		for _, route := range protected {
+			w := serveOAuthTestRequest(router, route.method, route.path, false)
+			requireMissingKey401(t, w, route.method+" "+route.path)
+		}
+	})
+
+	t.Run("auth-URL routes with the key reach their handlers", func(t *testing.T) {
+		// spec: SET-001
+		// Acceptance side of the boundary: the same protected routes
+		// proceed once the key is supplied.
+		wGoogle := serveOAuthTestRequest(router, http.MethodGet, "/api/v1/auth/google", true)
+		require.Equal(t, http.StatusOK, wGoogle.Code)
+		assert.Contains(t, wGoogle.Body.String(), "accounts.google.com")
+
+		wTodoist := serveOAuthTestRequest(router, http.MethodGet, "/api/v1/auth/todoist", true)
+		require.Equal(t, http.StatusOK, wTodoist.Code)
+		assert.Contains(t, wTodoist.Body.String(), "todoist.com/oauth/authorize")
+	})
+}
+
+func TestOAuthRouteRegistration_ProviderGating(t *testing.T) {
+	t.Run("both providers enabled registers both full route sets", func(t *testing.T) {
+		// spec: SET-005
+		router := newOAuthTestRouter(true, true)
+		assert.ElementsMatch(t,
+			append(append([]string{}, googleOAuthRouteSet...), todoistOAuthRouteSet...),
+			oauthRouteSet(router))
+	})
+
+	t.Run("google-only registers google routes and no todoist routes", func(t *testing.T) {
+		// spec: SET-005
+		router := newOAuthTestRouter(true, false)
+		assert.ElementsMatch(t, googleOAuthRouteSet, oauthRouteSet(router))
+
+		w := serveOAuthTestRequest(router, http.MethodGet, "/api/v1/auth/todoist/callback", false)
+		assert.Equal(t, http.StatusNotFound, w.Code,
+			"an unconfigured provider's callback URL must return 404")
+	})
+
+	t.Run("todoist-only registers todoist routes and no google routes", func(t *testing.T) {
+		// spec: SET-005
+		router := newOAuthTestRouter(false, true)
+		assert.ElementsMatch(t, todoistOAuthRouteSet, oauthRouteSet(router))
+
+		w := serveOAuthTestRequest(router, http.MethodGet, "/api/v1/auth/google/callback", false)
+		assert.Equal(t, http.StatusNotFound, w.Code,
+			"an unconfigured provider's callback URL must return 404")
+	})
+
+	t.Run("both providers disabled registers no oauth routes", func(t *testing.T) {
+		// spec: SET-005
+		router := newOAuthTestRouter(false, false)
+		assert.Empty(t, oauthRouteSet(router))
+
+		for _, path := range []string{"/api/v1/auth/google/callback", "/api/v1/auth/todoist/callback"} {
+			w := serveOAuthTestRequest(router, http.MethodGet, path, false)
+			assert.Equal(t, http.StatusNotFound, w.Code,
+				"disabled provider callback %s must 404", path)
+		}
+	})
+}

--- a/backend/internal/api/handlers/oauth_routes_test.go
+++ b/backend/internal/api/handlers/oauth_routes_test.go
@@ -141,11 +141,15 @@ func requireMissingKey401(t *testing.T, w *httptest.ResponseRecorder, route stri
 	assert.Equal(t, "MISSING_API_KEY", errObj["code"], "route %s", route)
 }
 
+// NOTE: the SET-001 / SET-005 spec citations live in
+// backend/cmd/crm-api/oauth_routes_boundary_test.go, which drives the
+// PRODUCTION wiring (the real wire chain + registerRoutes) rather than this
+// file's test-local reconstruction. The tests below stay as uncited
+// registrar-level groundwork: they pin the registrars' own behavior.
 func TestOAuthRouteRegistration_AuthBoundary(t *testing.T) {
 	router := newOAuthTestRouter(true, true)
 
 	t.Run("callback routes are reachable without the API key", func(t *testing.T) {
-		// spec: SET-001
 		// A keyless request to each provider callback must get PAST the
 		// auth middleware and into the handler. With no query params the
 		// handler deterministically 302-redirects to the settings surface
@@ -166,7 +170,6 @@ func TestOAuthRouteRegistration_AuthBoundary(t *testing.T) {
 	})
 
 	t.Run("auth-URL and account routes without a key are rejected 401", func(t *testing.T) {
-		// spec: SET-001
 		protected := []struct {
 			method string
 			path   string
@@ -187,7 +190,6 @@ func TestOAuthRouteRegistration_AuthBoundary(t *testing.T) {
 	})
 
 	t.Run("auth-URL routes with the key reach their handlers", func(t *testing.T) {
-		// spec: SET-001
 		// Acceptance side of the boundary: the same protected routes
 		// proceed once the key is supplied.
 		wGoogle := serveOAuthTestRequest(router, http.MethodGet, "/api/v1/auth/google", true)
@@ -202,7 +204,6 @@ func TestOAuthRouteRegistration_AuthBoundary(t *testing.T) {
 
 func TestOAuthRouteRegistration_ProviderGating(t *testing.T) {
 	t.Run("both providers enabled registers both full route sets", func(t *testing.T) {
-		// spec: SET-005
 		router := newOAuthTestRouter(true, true)
 		assert.ElementsMatch(t,
 			append(append([]string{}, googleOAuthRouteSet...), todoistOAuthRouteSet...),
@@ -210,7 +211,6 @@ func TestOAuthRouteRegistration_ProviderGating(t *testing.T) {
 	})
 
 	t.Run("google-only registers google routes and no todoist routes", func(t *testing.T) {
-		// spec: SET-005
 		router := newOAuthTestRouter(true, false)
 		assert.ElementsMatch(t, googleOAuthRouteSet, oauthRouteSet(router))
 
@@ -220,7 +220,6 @@ func TestOAuthRouteRegistration_ProviderGating(t *testing.T) {
 	})
 
 	t.Run("todoist-only registers todoist routes and no google routes", func(t *testing.T) {
-		// spec: SET-005
 		router := newOAuthTestRouter(false, true)
 		assert.ElementsMatch(t, todoistOAuthRouteSet, oauthRouteSet(router))
 
@@ -230,7 +229,6 @@ func TestOAuthRouteRegistration_ProviderGating(t *testing.T) {
 	})
 
 	t.Run("both providers disabled registers no oauth routes", func(t *testing.T) {
-		// spec: SET-005
 		router := newOAuthTestRouter(false, false)
 		assert.Empty(t, oauthRouteSet(router))
 

--- a/backend/internal/api/handlers/oauth_test.go
+++ b/backend/internal/api/handlers/oauth_test.go
@@ -6,18 +6,27 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/todoist"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fixedOAuthTestBaseUnix is a deterministic TIME_BASE (a fixed Unix second) used
+// to drive accelerated.GetCurrentTime() in the state-expiry tests below without
+// ever calling time.Now() directly. Its absolute value is irrelevant — only the
+// relative shift applied against it matters.
+const fixedOAuthTestBaseUnix int64 = 1735689600 // 2025-01-01T00:00:00Z
 
 // MockOAuthService is a mock implementation of google.OAuthServiceInterface
 type MockOAuthService struct {
@@ -63,6 +72,55 @@ func (m *MockOAuthService) RevokeAccount(ctx context.Context, id uuid.UUID) erro
 	return nil
 }
 
+// MockTodoistOAuthService is a mock implementation of
+// todoist.OAuthServiceInterface, mirroring MockOAuthService's configurable
+// func-field shape so Todoist tests can twin the Google callback/auth-URL
+// tests one-for-one.
+type MockTodoistOAuthService struct {
+	GetAuthURLFunc       func(state string) string
+	ExchangeCodeFunc     func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error)
+	ListAccountsFunc     func(ctx context.Context) ([]repository.OAuthCredentialStatus, error)
+	GetAccountStatusFunc func(ctx context.Context, id uuid.UUID) (*repository.OAuthCredentialStatus, error)
+	RevokeAccountFunc    func(ctx context.Context, id uuid.UUID) error
+}
+
+var _ todoist.OAuthServiceInterface = (*MockTodoistOAuthService)(nil)
+
+func (m *MockTodoistOAuthService) GetAuthURL(state string) string {
+	if m.GetAuthURLFunc != nil {
+		return m.GetAuthURLFunc(state)
+	}
+	return "https://todoist.com/oauth/authorize?state=" + state
+}
+
+func (m *MockTodoistOAuthService) ExchangeCode(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+	if m.ExchangeCodeFunc != nil {
+		return m.ExchangeCodeFunc(ctx, code)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockTodoistOAuthService) ListAccounts(ctx context.Context) ([]repository.OAuthCredentialStatus, error) {
+	if m.ListAccountsFunc != nil {
+		return m.ListAccountsFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockTodoistOAuthService) GetAccountStatus(ctx context.Context, id uuid.UUID) (*repository.OAuthCredentialStatus, error) {
+	if m.GetAccountStatusFunc != nil {
+		return m.GetAccountStatusFunc(ctx, id)
+	}
+	return nil, db.ErrNotFound
+}
+
+func (m *MockTodoistOAuthService) RevokeAccount(ctx context.Context, id uuid.UUID) error {
+	if m.RevokeAccountFunc != nil {
+		return m.RevokeAccountFunc(ctx, id)
+	}
+	return nil
+}
+
 func init() {
 	gin.SetMode(gin.TestMode)
 }
@@ -98,6 +156,36 @@ func TestGetGoogleAuthURL(t *testing.T) {
 		assert.Contains(t, response.Data.URL, response.Data.State)
 		assert.NotEmpty(t, response.Data.State)
 	})
+}
+
+// spec: SET-002[0]
+func TestGetGoogleAuthURL_StoresStateServerSide(t *testing.T) {
+	mock := &MockOAuthService{}
+	handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/auth/google", nil)
+
+	handler.GetGoogleAuthURL(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response struct {
+		Data struct {
+			URL   string `json:"url"`
+			State string `json:"state"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotEmpty(t, response.Data.State)
+
+	// The exact state handed back to the caller must have been stored
+	// server-side: validateState accepts it exactly once, proving the copy in
+	// the response and the copy in the store are the same value, not merely
+	// two independently-generated randoms.
+	assert.True(t, handler.validateState(response.Data.State), "the state returned to the caller must have been stored server-side")
+	assert.False(t, handler.validateState(response.Data.State), "a stored state must be single-use")
 }
 
 func TestGoogleCallback(t *testing.T) {
@@ -252,6 +340,138 @@ func TestGoogleCallback(t *testing.T) {
 		assert.Equal(t, http.StatusFound, w.Code)
 		assert.Contains(t, w.Header().Get("Location"), "/settings?auth=success")
 	})
+}
+
+// spec: SET-003[3]
+func TestGoogleCallback_ExpiredStateAbortsBeforeExchange(t *testing.T) {
+	exchangeCalled := false
+	mock := &MockOAuthService{
+		ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+			exchangeCalled = true
+			return &repository.OAuthCredentialStatus{
+				ID:        uuid.New(),
+				Provider:  "google",
+				AccountID: "test@example.com",
+			}, nil
+		},
+	}
+	handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+	t.Setenv("TIME_ACCELERATION", "60")
+	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix, 10))
+
+	state := "expiring-state-" + uuid.New().String()[:8]
+	handler.storeState(state)
+
+	// Shift the accelerated clock's base far enough into the past that the
+	// resulting accelerated "now" lands well beyond the state's 10-minute TTL
+	// (a 1000s base shift * 60x acceleration = 60,000 accelerated seconds,
+	// which dwarfs both the 600s TTL and any real-wall-clock jitter between
+	// the two GetCurrentTime() calls involved).
+	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix-1000, 10))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state="+state, nil)
+
+	handler.GoogleCallback(c)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	location := w.Header().Get("Location")
+	assert.Contains(t, location, "/settings?auth=error")
+	assert.Contains(t, location, "message=invalid_state")
+	assert.False(t, exchangeCalled, "an expired state must abort the flow before the code exchange")
+}
+
+func TestGoogleCallback_FailureRedirectsIncludeProvider(t *testing.T) {
+	t.Run("provider error carries provider name", func(t *testing.T) {
+		// spec: SET-004[2]
+		mock := &MockOAuthService{}
+		handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/google/callback?error=access_denied", nil)
+
+		handler.GoogleCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		location := w.Header().Get("Location")
+		assert.Contains(t, location, "auth=error")
+		assert.Contains(t, location, "provider=google")
+		assert.Contains(t, location, "message=access_denied")
+	})
+
+	t.Run("invalid state carries provider name", func(t *testing.T) {
+		// spec: SET-004[2]
+		mock := &MockOAuthService{}
+		handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state=never-stored-"+uuid.New().String()[:8], nil)
+
+		handler.GoogleCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		location := w.Header().Get("Location")
+		assert.Contains(t, location, "auth=error")
+		assert.Contains(t, location, "provider=google")
+		assert.Contains(t, location, "message=invalid_state")
+	})
+
+	t.Run("exchange failure carries provider name", func(t *testing.T) {
+		// spec: SET-004[2]
+		mock := &MockOAuthService{
+			ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+				return nil, errors.New("exchange failed")
+			},
+		}
+		handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+		state := "provider-check-state-" + uuid.New().String()[:8]
+		handler.storeState(state)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state="+state, nil)
+
+		handler.GoogleCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		location := w.Header().Get("Location")
+		assert.Contains(t, location, "auth=error")
+		assert.Contains(t, location, "provider=google")
+		assert.Contains(t, location, "message=exchange_failed")
+	})
+}
+
+// spec: SET-004[3]
+func TestGoogleCallback_ErrorRedirectIsProperlyURLEncoded(t *testing.T) {
+	mock := &MockOAuthService{}
+	handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+	// A provider error message containing characters that require
+	// percent-encoding (a space, and an "&" that would otherwise be read as a
+	// query-param delimiter).
+	rawMessage := "invalid state & retry"
+	reqURL := "/auth/google/callback?" + (url.Values{"error": {rawMessage}}).Encode()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", reqURL, nil)
+
+	handler.GoogleCallback(c)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	location := w.Header().Get("Location")
+
+	parsed, err := url.Parse(location)
+	require.NoError(t, err)
+	assert.Equal(t, "error", parsed.Query().Get("auth"))
+	assert.Equal(t, "google", parsed.Query().Get("provider"))
+	assert.Equal(t, rawMessage, parsed.Query().Get("message"), "the message must round-trip exactly through proper query encoding, not string concatenation")
+	assert.NotContains(t, location, " ", "a literal space in the Location header means a param was concatenated rather than URL-encoded")
 }
 
 func TestListGoogleAccounts(t *testing.T) {
@@ -520,5 +740,599 @@ func TestStateValidation(t *testing.T) {
 		handler := NewOAuthHandler(mock, "http://localhost:3000")
 
 		assert.False(t, handler.validateState("unknown-state"))
+	})
+}
+
+// spec: SET-002[1]
+func TestOAuthState_ExpiresAfterTenMinutes(t *testing.T) {
+	mock := &MockOAuthService{}
+	handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+	t.Setenv("TIME_ACCELERATION", "60")
+	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix, 10))
+
+	state := "ttl-state-" + uuid.New().String()[:8]
+	handler.storeState(state)
+
+	// Shift the accelerated clock's base far enough into the past that the
+	// resulting accelerated "now" lands well beyond the state's 10-minute TTL
+	// (a 1000s base shift * 60x acceleration = 60,000 accelerated seconds,
+	// which dwarfs both the 600s TTL and any real-wall-clock jitter between
+	// the two GetCurrentTime() calls involved).
+	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix-1000, 10))
+
+	assert.False(t, handler.validateState(state), "a state older than 10 minutes must be rejected")
+}
+
+// spec: SET-002[2]
+// Twin of TestGetGoogleAuthURL: proves the Todoist auth-URL response also
+// carries both the provider authorization URL and the state.
+func TestGetTodoistAuthURL(t *testing.T) {
+	mock := &MockTodoistOAuthService{
+		GetAuthURLFunc: func(state string) string {
+			return "https://todoist.com/oauth/authorize?state=" + state + "&client_id=test"
+		},
+	}
+
+	handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+	handler.SetTodoistOAuth(mock)
+
+	t.Run("returns auth URL with state", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist", nil)
+
+		handler.GetTodoistAuthURL(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response struct {
+			Data struct {
+				URL   string `json:"url"`
+				State string `json:"state"`
+			} `json:"data"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Contains(t, response.Data.URL, "todoist.com")
+		assert.Contains(t, response.Data.URL, response.Data.State)
+		assert.NotEmpty(t, response.Data.State)
+	})
+}
+
+// spec: SET-003[0]
+// Twin of the Google error-short-circuit ordering: a provider error param
+// must abort the flow before any state validation or code exchange. A
+// valid state is stored ahead of the request so that, if the short-circuit
+// did NOT run first, the handler would fall through and consume it during
+// state validation (and/or invoke the exchange) -- neither of which may
+// happen here.
+func TestTodoistCallback_ErrorShortCircuitsBeforeStateOrExchange(t *testing.T) {
+	exchangeCalled := false
+	mock := &MockTodoistOAuthService{
+		ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+			exchangeCalled = true
+			return &repository.OAuthCredentialStatus{
+				ID:        uuid.New(),
+				Provider:  "todoist",
+				AccountID: "test-todoist-user",
+			}, nil
+		},
+	}
+	handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+	handler.SetTodoistOAuth(mock)
+
+	state := "todoist-error-short-circuit-" + uuid.New().String()[:8]
+	handler.storeState(state)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?error=access_denied&code=authcode&state="+state, nil)
+
+	handler.TodoistCallback(c)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	location := w.Header().Get("Location")
+	assert.Contains(t, location, "/settings?auth=error")
+	assert.Contains(t, location, "provider=todoist")
+	assert.Contains(t, location, "message=access_denied")
+	assert.False(t, exchangeCalled, "a provider error must short-circuit before the code exchange")
+	assert.True(t, handler.validateState(state), "a provider error must short-circuit before state validation, leaving the state unconsumed")
+}
+
+// spec: SET-003[1]
+// Twin of the Google validate-then-exchange ordering: an invalid state
+// aborts before the exchange runs, and a valid state is validated and
+// consumed (single-use) before the exchange is attempted -- regardless of
+// whether that exchange goes on to succeed or fail.
+func TestTodoistCallback_ValidatesStateBeforeExchange(t *testing.T) {
+	t.Run("invalid state aborts before exchange", func(t *testing.T) {
+		exchangeCalled := false
+		mock := &MockTodoistOAuthService{
+			ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+				exchangeCalled = true
+				return &repository.OAuthCredentialStatus{
+					ID:        uuid.New(),
+					Provider:  "todoist",
+					AccountID: "test-todoist-user",
+				}, nil
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?code=authcode&state=never-stored-"+uuid.New().String()[:8], nil)
+
+		handler.TodoistCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		location := w.Header().Get("Location")
+		assert.Contains(t, location, "/settings?auth=error")
+		assert.Contains(t, location, "message=invalid_state")
+		assert.False(t, exchangeCalled, "an invalid state must abort the flow before the code exchange")
+	})
+
+	t.Run("valid state is consumed before the exchange runs, regardless of outcome", func(t *testing.T) {
+		mock := &MockTodoistOAuthService{
+			ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+				return nil, errors.New("exchange failed")
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		state := "todoist-consume-state-" + uuid.New().String()[:8]
+		handler.storeState(state)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?code=authcode&state="+state, nil)
+
+		handler.TodoistCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		assert.Contains(t, w.Header().Get("Location"), "message=exchange_failed")
+		// The state must already be consumed even though the exchange itself
+		// failed -- proof that validation-and-consumption happens BEFORE the
+		// exchange is attempted, not as a side effect of a successful one.
+		assert.False(t, handler.validateState(state), "the CSRF state must be consumed before the exchange runs, regardless of the exchange outcome")
+	})
+}
+
+// assertTrivialRedirectBody proves a callback response never carries a
+// rendered page or a JSON body. net/http's Redirect helper (which
+// gin.Context.Redirect delegates to) writes a small boilerplate
+// `<a href="...">Found</a>.` anchor body for GET requests, purely mirroring
+// the Location header -- that boilerplate is the only content a redirect
+// may legitimately carry, so this asserts the body (if any) contains
+// neither JSON markers nor an actual rendered page, and stays trivially
+// small.
+func assertTrivialRedirectBody(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	body := w.Body.String()
+	assert.NotContains(t, body, "{", "a callback redirect must never carry a JSON body")
+	assert.NotContains(t, body, "<html", "a callback redirect must never carry a rendered page")
+	assert.NotContains(t, body, "<body", "a callback redirect must never carry a rendered page")
+	assert.Less(t, len(body), 300, "a callback redirect's body must be trivially small (net/http's boilerplate anchor link, at most) -- never a rendered page")
+}
+
+// spec: SET-004[0]
+// Neither provider's callback redirect may carry a rendered page or JSON
+// body -- the response must be a bare redirect (allowing only net/http's
+// own trivial boilerplate anchor body, never one this handler wrote).
+func TestOAuthCallbackRedirect_BodyIsEmpty(t *testing.T) {
+	t.Run("google callback redirect carries no body", func(t *testing.T) {
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/google/callback?error=access_denied", nil)
+
+		handler.GoogleCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		assertTrivialRedirectBody(t, w)
+	})
+
+	t.Run("todoist callback redirect carries no body", func(t *testing.T) {
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(&MockTodoistOAuthService{})
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?error=access_denied", nil)
+
+		handler.TodoistCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		assertTrivialRedirectBody(t, w)
+	})
+}
+
+// spec: SET-004[0]
+// Twin of the Google redirect-shape assertions: every TodoistCallback
+// outcome must redirect to the settings surface carrying the matching
+// outcome and provider name.
+func TestTodoistCallback_RedirectShape(t *testing.T) {
+	t.Run("provider error", func(t *testing.T) {
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(&MockTodoistOAuthService{})
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?error=access_denied", nil)
+
+		handler.TodoistCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		location := w.Header().Get("Location")
+		assert.Contains(t, location, "/settings?auth=error")
+		assert.Contains(t, location, "provider=todoist")
+		assert.Contains(t, location, "message=access_denied")
+	})
+
+	t.Run("invalid state", func(t *testing.T) {
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(&MockTodoistOAuthService{})
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?code=authcode&state=invalid", nil)
+
+		handler.TodoistCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		location := w.Header().Get("Location")
+		assert.Contains(t, location, "/settings?auth=error")
+		assert.Contains(t, location, "provider=todoist")
+		assert.Contains(t, location, "message=invalid_state")
+	})
+
+	t.Run("exchange failure", func(t *testing.T) {
+		mock := &MockTodoistOAuthService{
+			ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+				return nil, errors.New("exchange failed")
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		state := "todoist-shape-exchange-fail-" + uuid.New().String()[:8]
+		handler.storeState(state)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?code=authcode&state="+state, nil)
+
+		handler.TodoistCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		location := w.Header().Get("Location")
+		assert.Contains(t, location, "/settings?auth=error")
+		assert.Contains(t, location, "provider=todoist")
+		assert.Contains(t, location, "message=exchange_failed")
+	})
+}
+
+// spec: SET-004[1]
+// Twin of TestGoogleCallback's "redirects to success on valid exchange":
+// a successful Todoist exchange redirects with auth=success and
+// provider=todoist.
+func TestTodoistCallback_SuccessRedirectIncludesProvider(t *testing.T) {
+	accountID := uuid.New()
+	mock := &MockTodoistOAuthService{
+		ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+			return &repository.OAuthCredentialStatus{
+				ID:        accountID,
+				Provider:  "todoist",
+				AccountID: "test-todoist-user",
+			}, nil
+		},
+	}
+	handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+	handler.SetTodoistOAuth(mock)
+
+	state := "todoist-success-state-" + uuid.New().String()[:8]
+	handler.storeState(state)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/auth/todoist/callback?code=authcode&state="+state, nil)
+
+	handler.TodoistCallback(c)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	location := w.Header().Get("Location")
+	assert.Contains(t, location, "/settings?auth=success")
+	assert.Contains(t, location, "provider=todoist")
+}
+
+// spec: SET-008[0]
+// Twin of TestListGoogleAccounts: proves ListTodoistAccounts' 200 response
+// carries an array of connected-account objects. The shape assertion below
+// decodes into map[string]interface{} (the raw wire shape) rather than the
+// TodoistAccountResponse DTO, so a json-tag rename on the DTO cannot mask a
+// dropped/renamed field, and the fixture uses pairwise-distinct
+// created/updated/expires timestamps and a run-unique account id/name so a
+// field swap between them is detectable.
+func TestListTodoistAccounts(t *testing.T) {
+	t.Run("returns empty list when no accounts", func(t *testing.T) {
+		mock := &MockTodoistOAuthService{
+			ListAccountsFunc: func(ctx context.Context) ([]repository.OAuthCredentialStatus, error) {
+				return []repository.OAuthCredentialStatus{}, nil
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/accounts", nil)
+
+		handler.ListTodoistAccounts(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response struct {
+			Data []map[string]interface{} `json:"data"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Empty(t, response.Data)
+	})
+
+	t.Run("returns list of accounts with literal wire-key shape", func(t *testing.T) {
+		accountID := uuid.New()
+		externalAccountID := "todoist-user-" + uuid.New().String()[:8]
+		accountName := "Todoist User " + uuid.New().String()[:8]
+		created := accelerated.GetCurrentTime()
+		updated := created.Add(30 * time.Minute)
+		expires := created.Add(1 * time.Hour)
+
+		mock := &MockTodoistOAuthService{
+			ListAccountsFunc: func(ctx context.Context) ([]repository.OAuthCredentialStatus, error) {
+				return []repository.OAuthCredentialStatus{
+					{
+						ID:          accountID,
+						Provider:    "todoist",
+						AccountID:   externalAccountID,
+						AccountName: &accountName,
+						ExpiresAt:   &expires,
+						Scopes:      []string{"data:read_write", "data:delete"},
+						CreatedAt:   created,
+						UpdatedAt:   updated,
+					},
+				}, nil
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/accounts", nil)
+
+		handler.ListTodoistAccounts(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response struct {
+			Data []map[string]interface{} `json:"data"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Len(t, response.Data, 1)
+
+		account := response.Data[0]
+		assert.Equal(t, accountID.String(), account["id"], "wire key 'id'")
+		assert.Equal(t, externalAccountID, account["account_id"], "wire key 'account_id'")
+		assert.Equal(t, accountName, account["account_name"], "wire key 'account_name'")
+		assert.Equal(t, expires.Format(time.RFC3339), account["expires_at"], "wire key 'expires_at'")
+		assert.Equal(t, created.Format(time.RFC3339), account["created_at"], "wire key 'created_at'")
+		assert.Equal(t, updated.Format(time.RFC3339), account["updated_at"], "wire key 'updated_at'")
+		scopes, ok := account["scopes"].([]interface{})
+		require.True(t, ok, "wire key 'scopes' must be an array")
+		assert.ElementsMatch(t, []interface{}{"data:read_write", "data:delete"}, scopes)
+	})
+
+	t.Run("returns error on service failure", func(t *testing.T) {
+		mock := &MockTodoistOAuthService{
+			ListAccountsFunc: func(ctx context.Context) ([]repository.OAuthCredentialStatus, error) {
+				return nil, errors.New("database error")
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/accounts", nil)
+
+		handler.ListTodoistAccounts(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+// Twin of TestGetGoogleAccountStatus: proves GetTodoistAccountStatus shares
+// the same malformed-id / unknown-id / success contract as its Google
+// counterpart.
+func TestGetTodoistAccountStatus(t *testing.T) {
+	t.Run("returns error on invalid UUID", func(t *testing.T) {
+		// spec: SET-008[1]
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(&MockTodoistOAuthService{})
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/accounts/not-a-uuid/status", nil)
+		c.Params = []gin.Param{{Key: "id", Value: "not-a-uuid"}}
+
+		handler.GetTodoistAccountStatus(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 404 for non-existent account", func(t *testing.T) {
+		// spec: SET-008[2]
+		mock := &MockTodoistOAuthService{
+			GetAccountStatusFunc: func(ctx context.Context, id uuid.UUID) (*repository.OAuthCredentialStatus, error) {
+				return nil, db.ErrNotFound
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		accountID := uuid.New()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/accounts/"+accountID.String()+"/status", nil)
+		c.Params = []gin.Param{{Key: "id", Value: accountID.String()}}
+
+		handler.GetTodoistAccountStatus(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns account status", func(t *testing.T) {
+		// spec: SET-008[3]
+		accountID := uuid.New()
+		externalAccountID := "todoist-user-" + uuid.New().String()[:8]
+		accountName := "Todoist Status User " + uuid.New().String()[:8]
+		created := accelerated.GetCurrentTime()
+		updated := created.Add(15 * time.Minute)
+
+		mock := &MockTodoistOAuthService{
+			GetAccountStatusFunc: func(ctx context.Context, id uuid.UUID) (*repository.OAuthCredentialStatus, error) {
+				return &repository.OAuthCredentialStatus{
+					ID:          accountID,
+					Provider:    "todoist",
+					AccountID:   externalAccountID,
+					AccountName: &accountName,
+					Scopes:      []string{"data:read_write"},
+					CreatedAt:   created,
+					UpdatedAt:   updated,
+				}, nil
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/todoist/accounts/"+accountID.String()+"/status", nil)
+		c.Params = []gin.Param{{Key: "id", Value: accountID.String()}}
+
+		handler.GetTodoistAccountStatus(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response struct {
+			Data map[string]interface{} `json:"data"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, accountID.String(), response.Data["id"], "wire key 'id'")
+		assert.Equal(t, externalAccountID, response.Data["account_id"], "wire key 'account_id'")
+		assert.Equal(t, accountName, response.Data["account_name"], "wire key 'account_name'")
+		assert.Equal(t, created.Format(time.RFC3339), response.Data["created_at"], "wire key 'created_at'")
+		assert.Equal(t, updated.Format(time.RFC3339), response.Data["updated_at"], "wire key 'updated_at'")
+	})
+}
+
+// Twin of TestRevokeGoogleAccount: proves RevokeTodoistAccount shares the
+// same malformed-id / unknown-id / success-confirmation contract as its
+// Google counterpart.
+func TestRevokeTodoistAccount(t *testing.T) {
+	t.Run("returns error on invalid UUID", func(t *testing.T) {
+		// spec: SET-008[1]
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(&MockTodoistOAuthService{})
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("POST", "/auth/todoist/accounts/not-a-uuid/revoke", nil)
+		c.Params = []gin.Param{{Key: "id", Value: "not-a-uuid"}}
+
+		handler.RevokeTodoistAccount(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 404 for non-existent account", func(t *testing.T) {
+		// spec: SET-008[2]
+		mock := &MockTodoistOAuthService{
+			RevokeAccountFunc: func(ctx context.Context, id uuid.UUID) error {
+				return db.ErrNotFound
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		accountID := uuid.New()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("POST", "/auth/todoist/accounts/"+accountID.String()+"/revoke", nil)
+		c.Params = []gin.Param{{Key: "id", Value: accountID.String()}}
+
+		handler.RevokeTodoistAccount(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("successfully revokes account", func(t *testing.T) {
+		// spec: SET-008[3]
+		revokedID := uuid.Nil
+		mock := &MockTodoistOAuthService{
+			RevokeAccountFunc: func(ctx context.Context, id uuid.UUID) error {
+				revokedID = id
+				return nil
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		accountID := uuid.New()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("POST", "/auth/todoist/accounts/"+accountID.String()+"/revoke", nil)
+		c.Params = []gin.Param{{Key: "id", Value: accountID.String()}}
+
+		handler.RevokeTodoistAccount(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, accountID, revokedID)
+
+		var response struct {
+			Data map[string]interface{} `json:"data"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		message, ok := response.Data["message"].(string)
+		require.True(t, ok, "wire key 'message' must be a string")
+		assert.Contains(t, message, "disconnected")
+	})
+
+	t.Run("returns error on service failure", func(t *testing.T) {
+		mock := &MockTodoistOAuthService{
+			RevokeAccountFunc: func(ctx context.Context, id uuid.UUID) error {
+				return errors.New("revocation failed")
+			},
+		}
+		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
+		handler.SetTodoistOAuth(mock)
+
+		accountID := uuid.New()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("POST", "/auth/todoist/accounts/"+accountID.String()+"/revoke", nil)
+		c.Params = []gin.Param{{Key: "id", Value: accountID.String()}}
+
+		handler.RevokeTodoistAccount(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 }

--- a/backend/internal/api/handlers/oauth_test.go
+++ b/backend/internal/api/handlers/oauth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -125,6 +126,23 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
+// assertExactWireKeys asserts a decoded account response object's key set is
+// EXACTLY the expected safe set: an extra key (e.g. leaked encrypted token
+// bytes or nonces) fails, and so does a dropped or renamed safe key (which
+// would otherwise let a token field slip in under an old name unnoticed).
+func assertExactWireKeys(t *testing.T, obj map[string]interface{}, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(obj))
+	for k := range obj {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(wantSorted)
+	assert.Equal(t, wantSorted, got,
+		"account response key set must exactly equal the non-sensitive safe set — no token/nonce material may be serialized")
+}
+
 func TestGetGoogleAuthURL(t *testing.T) {
 	mock := &MockOAuthService{
 		GetAuthURLFunc: func(state string) string {
@@ -163,29 +181,42 @@ func TestGetGoogleAuthURL_StoresStateServerSide(t *testing.T) {
 	mock := &MockOAuthService{}
 	handler := NewOAuthHandler(mock, "http://localhost:3000")
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("GET", "/auth/google", nil)
+	requestState := func(t *testing.T) string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/google", nil)
 
-	handler.GetGoogleAuthURL(c)
+		handler.GetGoogleAuthURL(c)
 
-	require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, http.StatusOK, w.Code)
 
-	var response struct {
-		Data struct {
-			URL   string `json:"url"`
-			State string `json:"state"`
-		} `json:"data"`
+		var response struct {
+			Data struct {
+				URL   string `json:"url"`
+				State string `json:"state"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.NotEmpty(t, response.Data.State)
+		return response.Data.State
 	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	require.NotEmpty(t, response.Data.State)
 
-	// The exact state handed back to the caller must have been stored
+	// Two auth-URL requests must mint DISTINCT states — a handler returning
+	// one fixed constant state would otherwise pass every assertion below.
+	firstState := requestState(t)
+	secondState := requestState(t)
+	assert.NotEqual(t, firstState, secondState,
+		"each auth-URL request must generate a fresh random state, not a constant")
+
+	// Each exact state handed back to the caller must have been stored
 	// server-side: validateState accepts it exactly once, proving the copy in
 	// the response and the copy in the store are the same value, not merely
 	// two independently-generated randoms.
-	assert.True(t, handler.validateState(response.Data.State), "the state returned to the caller must have been stored server-side")
-	assert.False(t, handler.validateState(response.Data.State), "a stored state must be single-use")
+	for name, state := range map[string]string{"first": firstState, "second": secondState} {
+		assert.True(t, handler.validateState(state), "the %s state returned to the caller must have been stored server-side", name)
+		assert.False(t, handler.validateState(state), "a stored state must be single-use (%s)", name)
+	}
 }
 
 func TestGoogleCallback(t *testing.T) {
@@ -383,6 +414,81 @@ func TestGoogleCallback_ExpiredStateAbortsBeforeExchange(t *testing.T) {
 	assert.False(t, exchangeCalled, "an expired state must abort the flow before the code exchange")
 }
 
+// spec: SET-003[3]
+// An unknown (never-stored) state must abort the callback with an
+// invalid_state outcome WITHOUT the authorization code ever being exchanged.
+func TestGoogleCallback_UnknownStateAbortsBeforeExchange(t *testing.T) {
+	exchangeCalled := false
+	mock := &MockOAuthService{
+		ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+			exchangeCalled = true
+			return &repository.OAuthCredentialStatus{
+				ID:        uuid.New(),
+				Provider:  "google",
+				AccountID: "test@example.com",
+			}, nil
+		},
+	}
+	handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state=never-stored-"+uuid.New().String()[:8], nil)
+
+	handler.GoogleCallback(c)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	location := w.Header().Get("Location")
+	assert.Contains(t, location, "/settings?auth=error")
+	assert.Contains(t, location, "message=invalid_state")
+	assert.False(t, exchangeCalled, "an unknown state must abort the flow before the code exchange")
+}
+
+// spec: SET-003[3]
+// An already-used state must abort a REPLAYED callback with an invalid_state
+// outcome without invoking the code exchange a second time: the state is
+// stored once, consumed by a first (successful) callback, then replayed.
+func TestGoogleCallback_AlreadyUsedStateAbortsBeforeExchange(t *testing.T) {
+	exchangeCalls := 0
+	mock := &MockOAuthService{
+		ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+			exchangeCalls++
+			return &repository.OAuthCredentialStatus{
+				ID:        uuid.New(),
+				Provider:  "google",
+				AccountID: "test@example.com",
+			}, nil
+		},
+	}
+	handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+	state := "replayed-state-" + uuid.New().String()[:8]
+	handler.storeState(state)
+
+	// First callback: valid state, exchange runs, success redirect.
+	w1 := httptest.NewRecorder()
+	c1, _ := gin.CreateTestContext(w1)
+	c1.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state="+state, nil)
+	handler.GoogleCallback(c1)
+
+	require.Equal(t, http.StatusFound, w1.Code)
+	require.Contains(t, w1.Header().Get("Location"), "/settings?auth=success")
+	require.Equal(t, 1, exchangeCalls, "the first callback must exchange the code exactly once")
+
+	// Replay: the same state must now fail validation and the exchange must
+	// NOT be invoked a second time.
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state="+state, nil)
+	handler.GoogleCallback(c2)
+
+	assert.Equal(t, http.StatusFound, w2.Code)
+	location := w2.Header().Get("Location")
+	assert.Contains(t, location, "/settings?auth=error")
+	assert.Contains(t, location, "message=invalid_state")
+	assert.Equal(t, 1, exchangeCalls, "a replayed state must abort the flow without a second code exchange")
+}
+
 func TestGoogleCallback_FailureRedirectsIncludeProvider(t *testing.T) {
 	t.Run("provider error carries provider name", func(t *testing.T) {
 		// spec: SET-004[2]
@@ -532,15 +638,25 @@ func TestListGoogleAccounts(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 
 		var response struct {
-			Data []GoogleAccountResponse `json:"data"`
+			Data []map[string]interface{} `json:"data"`
 		}
 		err := json.Unmarshal(w.Body.Bytes(), &response)
 		require.NoError(t, err)
 		require.Len(t, response.Data, 1)
-		assert.Equal(t, accountID.String(), response.Data[0].ID)
-		assert.Equal(t, "test@example.com", response.Data[0].AccountID)
-		assert.Equal(t, &accountName, response.Data[0].AccountName)
-		assert.Len(t, response.Data[0].Scopes, 2)
+		account := response.Data[0]
+		assert.Equal(t, accountID.String(), account["id"])
+		assert.Equal(t, "test@example.com", account["account_id"])
+		assert.Equal(t, accountName, account["account_name"])
+		scopes, ok := account["scopes"].([]interface{})
+		require.True(t, ok, "wire key 'scopes' must be an array")
+		assert.Len(t, scopes, 2)
+
+		// spec: SET-009
+		// The raw wire object must carry EXACTLY the non-sensitive metadata
+		// keys — encrypted token bytes and nonces are never serialized.
+		assertExactWireKeys(t, account, []string{
+			"id", "account_id", "account_name", "expires_at", "scopes", "created_at", "updated_at",
+		})
 	})
 
 	t.Run("returns error on service failure", func(t *testing.T) {
@@ -625,12 +741,19 @@ func TestGetGoogleAccountStatus(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 
 		var response struct {
-			Data GoogleAccountResponse `json:"data"`
+			Data map[string]interface{} `json:"data"`
 		}
 		err := json.Unmarshal(w.Body.Bytes(), &response)
 		require.NoError(t, err)
-		assert.Equal(t, accountID.String(), response.Data.ID)
-		assert.Equal(t, "test@example.com", response.Data.AccountID)
+		assert.Equal(t, accountID.String(), response.Data["id"])
+		assert.Equal(t, "test@example.com", response.Data["account_id"])
+
+		// spec: SET-009
+		// Exact safe key set (the fixture carries no expiry, so expires_at is
+		// omitted): encrypted token bytes and nonces are never serialized.
+		assertExactWireKeys(t, response.Data, []string{
+			"id", "account_id", "account_name", "scopes", "created_at", "updated_at",
+		})
 	})
 }
 
@@ -743,25 +866,48 @@ func TestStateValidation(t *testing.T) {
 	})
 }
 
-// spec: SET-002[1]
-func TestOAuthState_ExpiresAfterTenMinutes(t *testing.T) {
-	mock := &MockOAuthService{}
-	handler := NewOAuthHandler(mock, "http://localhost:3000")
+// validateStateAfterShift stores a fresh state under a fixed TIME_BASE, then
+// re-anchors TIME_BASE shiftSeconds into the past and validates the state.
+// With TIME_ACCELERATION=2 the accelerated clock at validation reads
+// (store-time + shiftSeconds + 2*delta) where delta is the real wall-clock
+// time between the two calls: a base shift of D under acceleration A advances
+// accelerated "now" by (A-1)*D, so A=2 makes the advance exactly the shift
+// while keeping wall-clock jitter amplification at 2x (milliseconds in
+// practice, against 30-second margins on both sides of the boundary below).
+// No sleeps, no time.Now() — both sides of the TTL boundary are pinned by
+// deterministic base shifts.
+func validateStateAfterShift(t *testing.T, shiftSeconds int64) bool {
+	t.Helper()
+	handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
 
-	t.Setenv("TIME_ACCELERATION", "60")
+	t.Setenv("TIME_ACCELERATION", "2")
 	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix, 10))
 
 	state := "ttl-state-" + uuid.New().String()[:8]
 	handler.storeState(state)
 
-	// Shift the accelerated clock's base far enough into the past that the
-	// resulting accelerated "now" lands well beyond the state's 10-minute TTL
-	// (a 1000s base shift * 60x acceleration = 60,000 accelerated seconds,
-	// which dwarfs both the 600s TTL and any real-wall-clock jitter between
-	// the two GetCurrentTime() calls involved).
-	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix-1000, 10))
+	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix-shiftSeconds, 10))
+	return handler.validateState(state)
+}
 
-	assert.False(t, handler.validateState(state), "a state older than 10 minutes must be rejected")
+// spec: SET-002[1]
+// Pins BOTH sides of the ten-minute TTL boundary: a state validated just
+// under ten minutes after storage is still accepted, and one validated just
+// over ten minutes after storage is rejected. A single gross shift would pass
+// for any TTL below the shift; the two-sided pin fails if the TTL moves in
+// either direction.
+func TestOAuthState_ExpiresAfterTenMinutes(t *testing.T) {
+	t.Run("state is still valid just under ten minutes after storage", func(t *testing.T) {
+		// spec: SET-002[1]
+		assert.True(t, validateStateAfterShift(t, 570),
+			"a state validated 9m30s after storage must still be accepted (TTL is ten minutes)")
+	})
+
+	t.Run("state is invalid just over ten minutes after storage", func(t *testing.T) {
+		// spec: SET-002[1]
+		assert.False(t, validateStateAfterShift(t, 630),
+			"a state validated 10m30s after storage must be rejected (TTL is ten minutes)")
+	})
 }
 
 // spec: SET-002[2]
@@ -1136,6 +1282,13 @@ func TestListTodoistAccounts(t *testing.T) {
 		scopes, ok := account["scopes"].([]interface{})
 		require.True(t, ok, "wire key 'scopes' must be an array")
 		assert.ElementsMatch(t, []interface{}{"data:read_write", "data:delete"}, scopes)
+
+		// spec: SET-009
+		// The raw wire object must carry EXACTLY the non-sensitive metadata
+		// keys — encrypted token bytes and nonces are never serialized.
+		assertExactWireKeys(t, account, []string{
+			"id", "account_id", "account_name", "expires_at", "scopes", "created_at", "updated_at",
+		})
 	})
 
 	t.Run("returns error on service failure", func(t *testing.T) {
@@ -1240,6 +1393,13 @@ func TestGetTodoistAccountStatus(t *testing.T) {
 		assert.Equal(t, accountName, response.Data["account_name"], "wire key 'account_name'")
 		assert.Equal(t, created.Format(time.RFC3339), response.Data["created_at"], "wire key 'created_at'")
 		assert.Equal(t, updated.Format(time.RFC3339), response.Data["updated_at"], "wire key 'updated_at'")
+
+		// spec: SET-009
+		// Exact safe key set (the fixture carries no expiry, so expires_at is
+		// omitted): encrypted token bytes and nonces are never serialized.
+		assertExactWireKeys(t, response.Data, []string{
+			"id", "account_id", "account_name", "scopes", "created_at", "updated_at",
+		})
 	})
 }
 

--- a/backend/tests/api/system_api_test.go
+++ b/backend/tests/api/system_api_test.go
@@ -24,7 +24,12 @@ import (
 
 // newSystemTestDatabase opens a DB handle exactly like production wiring does
 // (pool config mirrors config.TestConfig() 8/1, same as the sibling
-// setupContactValidationTestRouter). Migrations are applied once by TestMain.
+// setupContactValidationTestRouter). Under the integration_testdb tag the
+// build-tagged TestMain (testmain_integration_test.go) clones a migrated
+// template database and rewrites DATABASE_URL to the clone; under the
+// untagged build there is no TestMain — the tests below self-skip via
+// testing.Short() / unset DATABASE_URL, and an explicitly-set DATABASE_URL
+// must already point at a migrated database.
 func newSystemTestDatabase(t *testing.T) *db.Database {
 	t.Helper()
 
@@ -176,6 +181,27 @@ func TestSystemAPI_ExportData(t *testing.T) {
 		contacts, ok := dataset["contacts"].([]interface{})
 		require.True(t, ok, "dataset must carry a contacts array, got: %T", dataset["contacts"])
 
+		// The fixture contact HAS an interaction and a note in the DB; neither
+		// may surface anywhere in the export envelope — assert over the full
+		// recursive key set of the decoded body. (Kept ahead of the
+		// limit-window guard below so it runs unconditionally.)
+		keys := map[string]bool{}
+		collectKeys(body, keys)
+		assert.False(t, keys["interactions"], "export must not contain an interactions key anywhere")
+		assert.False(t, keys["notes"], "export must not contain a notes key anywhere")
+
+		// ExportData reads at most 1000 contacts (the literal Limit in
+		// SystemHandler.ExportData). The shared test DB accumulates contacts
+		// across runs, so once the live count reaches that window the seeded
+		// contact may legitimately fall outside the export — skip the
+		// membership assertion rather than fail on an artifact of DB growth.
+		const exportLimit = 1000 // mirrors system.go ExportData's Limit
+		liveCount, err := contactRepo.CountContacts(ctx, repository.ListContactsParams{})
+		require.NoError(t, err)
+		if liveCount >= exportLimit {
+			t.Skipf("live contact count %d >= export limit %d: the seeded contact may fall outside ExportData's window; skipping membership assertion", liveCount, exportLimit)
+		}
+
 		var found bool
 		for _, row := range contacts {
 			c, ok := row.(map[string]interface{})
@@ -188,14 +214,6 @@ func TestSystemAPI_ExportData(t *testing.T) {
 			}
 		}
 		assert.True(t, found, fmt.Sprintf("seeded contact %s must appear in the exported contacts", contact.ID))
-
-		// The fixture contact HAS an interaction and a note in the DB; neither
-		// may surface anywhere in the export envelope — assert over the full
-		// recursive key set of the decoded body.
-		keys := map[string]bool{}
-		collectKeys(body, keys)
-		assert.False(t, keys["interactions"], "export must not contain an interactions key anywhere")
-		assert.False(t, keys["notes"], "export must not contain a notes key anywhere")
 	})
 
 	t.Run("Export_ContactsReadFailureReturns500", func(t *testing.T) {

--- a/backend/tests/api/system_api_test.go
+++ b/backend/tests/api/system_api_test.go
@@ -171,6 +171,12 @@ func TestSystemAPI_ExportData(t *testing.T) {
 
 	t.Run("Export_ContactsOnlyNoInteractionsOrNotes", func(t *testing.T) {
 		// spec: SET-030[2]
+		// Snapshot the live contact count BEFORE the export so the guard
+		// below reasons about the dataset the export saw; the margin absorbs
+		// concurrent writers between this read and the export request.
+		liveCount, err := contactRepo.CountContacts(ctx, repository.ListContactsParams{})
+		require.NoError(t, err)
+
 		_, body := exportBody(t)
 
 		envelope, ok := body["data"].(map[string]interface{})
@@ -192,14 +198,16 @@ func TestSystemAPI_ExportData(t *testing.T) {
 
 		// ExportData reads at most 1000 contacts (the literal Limit in
 		// SystemHandler.ExportData). The shared test DB accumulates contacts
-		// across runs, so once the live count reaches that window the seeded
-		// contact may legitimately fall outside the export — skip the
-		// membership assertion rather than fail on an artifact of DB growth.
+		// across runs, so near that window the seeded contact may
+		// legitimately fall outside the export — skip the membership
+		// assertion rather than fail on an artifact of DB growth. The count
+		// was snapshotted before the export; the margin covers contacts
+		// concurrent tests may have added between the snapshot and the
+		// export request.
 		const exportLimit = 1000 // mirrors system.go ExportData's Limit
-		liveCount, err := contactRepo.CountContacts(ctx, repository.ListContactsParams{})
-		require.NoError(t, err)
-		if liveCount >= exportLimit {
-			t.Skipf("live contact count %d >= export limit %d: the seeded contact may fall outside ExportData's window; skipping membership assertion", liveCount, exportLimit)
+		const guardMargin = 50
+		if liveCount >= exportLimit-guardMargin {
+			t.Skipf("live contact count %d within %d of export limit %d: the seeded contact may fall outside ExportData's window; skipping membership assertion", liveCount, guardMargin, exportLimit)
 		}
 
 		var found bool

--- a/backend/tests/api/system_api_test.go
+++ b/backend/tests/api/system_api_test.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSystemTestDatabase opens a DB handle exactly like production wiring does
+// (pool config mirrors config.TestConfig() 8/1, same as the sibling
+// setupContactValidationTestRouter). Migrations are applied once by TestMain.
+func newSystemTestDatabase(t *testing.T) *db.Database {
+	t.Helper()
+
+	dbConfig := config.DatabaseConfig{
+		URL:               os.Getenv("DATABASE_URL"),
+		MaxConns:          8,
+		MinConns:          1,
+		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
+		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
+		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
+	}
+	database, err := db.NewDatabase(context.Background(), dbConfig)
+	require.NoError(t, err, "failed to connect to test database")
+	return database
+}
+
+// setupSystemExportTestRouter wires SystemHandler the way production does
+// (RegisterDataExchangeRoutes on the /api/v1 group, a concrete
+// *repository.ContactRepository), against the given database handle.
+func setupSystemExportTestRouter(database *db.Database) *gin.Engine {
+	contactRepo := repository.NewContactRepository(database.Queries)
+	systemHandler := handlers.NewSystemHandler(contactRepo, config.RuntimeConfig{CRMEnvironment: "test"})
+
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	corsConfig := config.CORSConfig{AllowAll: true}
+	router.Use(api.CORSMiddleware(corsConfig))
+
+	v1 := router.Group("/api/v1")
+	handlers.RegisterDataExchangeRoutes(v1, systemHandler)
+
+	return router
+}
+
+// collectKeys recursively gathers every object key present anywhere in a
+// decoded JSON value, so absence assertions cover the whole envelope rather
+// than one level of it.
+func collectKeys(value interface{}, into map[string]bool) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		for key, child := range v {
+			into[key] = true
+			collectKeys(child, into)
+		}
+	case []interface{}:
+		for _, child := range v {
+			collectKeys(child, into)
+		}
+	}
+}
+
+func TestSystemAPI_ExportData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	database := newSystemTestDatabase(t)
+	defer database.Close()
+	router := setupSystemExportTestRouter(database)
+
+	ctx := context.Background()
+	contactRepo := repository.NewContactRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	noteRepo := repository.NewNoteRepository(database.Queries)
+
+	// Namespaced fixture: a contact that ALSO has an interaction and a note,
+	// so the contacts-only assertion is exercised against a dataset where
+	// interactions/notes genuinely exist and could leak into the export.
+	ns := uuid.New().String()[:8]
+	contactName := "System Export " + ns
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: contactName,
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	}()
+
+	sourceRef := "system-export-test-" + ns
+	description := "export fixture interaction " + ns
+	_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:   contact.ID,
+		Source:      repository.InteractionSourceManual,
+		SourceRef:   &sourceRef,
+		OccurredAt:  accelerated.GetCurrentTime(),
+		Description: &description,
+		Direction:   repository.InteractionDirectionOutbound,
+	})
+	require.NoError(t, err)
+
+	_, err = noteRepo.CreateNotepad(ctx, contact.ID, "export fixture note "+ns)
+	require.NoError(t, err)
+
+	exportBody := func(t *testing.T) (*httptest.ResponseRecorder, map[string]interface{}) {
+		t.Helper()
+		req, _ := http.NewRequest("POST", "/api/v1/export", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		return w, body
+	}
+
+	t.Run("Export_IsJSONAttachmentWrappingEnvelope", func(t *testing.T) {
+		// spec: SET-030[0]
+		w, body := exportBody(t)
+
+		assert.Equal(t, "attachment; filename=crm_export.json", w.Header().Get("Content-Disposition"))
+		assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+		// The download wraps an export envelope: literal wire keys on the
+		// decoded body, not a DTO round-trip.
+		assert.Equal(t, true, body["success"])
+		envelope, ok := body["data"].(map[string]interface{})
+		require.True(t, ok, "body.data must be the export envelope object, got: %T", body["data"])
+		_, hasDataset := envelope["data"].(map[string]interface{})
+		assert.True(t, hasDataset, "the envelope must wrap a data object")
+	})
+
+	t.Run("Export_EnvelopeCarriesVersionAndTimestamp", func(t *testing.T) {
+		// spec: SET-030[1]
+		_, body := exportBody(t)
+
+		envelope, ok := body["data"].(map[string]interface{})
+		require.True(t, ok)
+
+		assert.Equal(t, "1.0", envelope["version"], "envelope must carry the literal version tag")
+
+		exportedAt, ok := envelope["exported_at"].(string)
+		require.True(t, ok, "envelope must carry exported_at as a string, got: %T", envelope["exported_at"])
+		assert.NotEmpty(t, exportedAt)
+	})
+
+	t.Run("Export_ContactsOnlyNoInteractionsOrNotes", func(t *testing.T) {
+		// spec: SET-030[2]
+		_, body := exportBody(t)
+
+		envelope, ok := body["data"].(map[string]interface{})
+		require.True(t, ok)
+		dataset, ok := envelope["data"].(map[string]interface{})
+		require.True(t, ok)
+
+		contacts, ok := dataset["contacts"].([]interface{})
+		require.True(t, ok, "dataset must carry a contacts array, got: %T", dataset["contacts"])
+
+		var found bool
+		for _, row := range contacts {
+			c, ok := row.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if c["id"] == contact.ID.String() {
+				found = true
+				assert.Equal(t, contactName, c["full_name"])
+			}
+		}
+		assert.True(t, found, fmt.Sprintf("seeded contact %s must appear in the exported contacts", contact.ID))
+
+		// The fixture contact HAS an interaction and a note in the DB; neither
+		// may surface anywhere in the export envelope — assert over the full
+		// recursive key set of the decoded body.
+		keys := map[string]bool{}
+		collectKeys(body, keys)
+		assert.False(t, keys["interactions"], "export must not contain an interactions key anywhere")
+		assert.False(t, keys["notes"], "export must not contain a notes key anywhere")
+	})
+
+	t.Run("Export_ContactsReadFailureReturns500", func(t *testing.T) {
+		// spec: SET-030[3]
+		// The repository has no injection seam, so force a genuine read
+		// failure: a handler whose repository sits on an already-closed pool.
+		failingDB := newSystemTestDatabase(t)
+		failingRouter := setupSystemExportTestRouter(failingDB)
+		failingDB.Close()
+
+		req, _ := http.NewRequest("POST", "/api/v1/export", nil)
+		w := httptest.NewRecorder()
+		failingRouter.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, false, body["success"])
+		errObj, ok := body["error"].(map[string]interface{})
+		require.True(t, ok, "error must be an object, got: %T", body["error"])
+		assert.Equal(t, "DATABASE_ERROR", errObj["code"])
+		assert.Equal(t, "Failed to fetch contacts", errObj["message"])
+	})
+}

--- a/backend/tests/api/telegram_auth_api_test.go
+++ b/backend/tests/api/telegram_auth_api_test.go
@@ -1,0 +1,486 @@
+//go:build integration_testdb
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/crypto"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	tgpkg "personal-crm/backend/internal/telegram"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTelegramAuthRouter builds a TelegramHandler over a real TelegramManager
+// wired to a per-test isolated DB clone (newIsolatedRiverTestDB), with the
+// production route surface (handlers.RegisterTelegramRoutes). The clone means
+// the singleton telegram_session row is private to this test, so seeding /
+// deleting it cannot race sibling tests or the package-level session tests.
+//
+// None of the auth endpoints exercised here ever spawn an MTProto client:
+// validation rejects before the manager, the already-connected 409 is decided
+// from the DB session row before the client is created, invalid-token paths
+// hit only the in-memory AuthSessionManager, and Disconnect/GetStatus resolve
+// entirely from DB + in-memory state.
+func setupTelegramAuthRouter(t *testing.T, ctx context.Context) (*gin.Engine, *repository.TelegramSessionRepository) {
+	t.Helper()
+
+	database, _ := newIsolatedRiverTestDB(t, ctx)
+
+	sessionRepo := repository.NewTelegramSessionRepository(database.Queries)
+	updateStateRepo := repository.NewTelegramUpdateStateRepository(database.Queries)
+	chatConfigRepo := repository.NewTelegramChatConfigRepository(database.Queries)
+	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
+	syncRepo := repository.NewSyncRepository(database.Queries)
+
+	// 32 bytes = 64 hex chars
+	encryptor, err := crypto.NewTokenEncryptor("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+
+	telegramCfg := &config.TelegramConfig{
+		GroupMaxMembers:      10,
+		BackfillSince:        "2026-01-01",
+		BurstWindowHours:     2,
+		ReplyBridgeHours:     48,
+		DiscoveryMinMessages: 3,
+	}
+
+	// Phase 4 dependencies (not exercised by the auth endpoints)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	externalContactRepo := repository.NewExternalContactRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(t, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil, cadenceUpdater, assertSvc, cache, nil)
+
+	manager := tgpkg.NewTelegramManager(
+		sessionRepo,
+		updateStateRepo,
+		chatConfigRepo,
+		messageRepo,
+		syncRepo,
+		encryptor,
+		12345,
+		"testhash",
+		telegramCfg,
+		identityService,
+		externalContactRepo,
+		nil,
+		interactionRepo,
+		contactService,
+		contactService,
+		nil,
+		nil, // pool: non-tx publish fallback (test mode)
+		nil, // enqueuer: stale-claim recovery disabled
+	)
+
+	handler := handlers.NewTelegramHandler(manager)
+
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	v1 := router.Group("/api/v1")
+	handlers.RegisterTelegramRoutes(v1, handler)
+
+	return router, sessionRepo
+}
+
+// seedConnectedTelegramSession upserts the singleton session row in the
+// connected state via the real repository (never raw SQL).
+func seedConnectedTelegramSession(t *testing.T, ctx context.Context, repo *repository.TelegramSessionRepository, username, phone string) {
+	t.Helper()
+	userID := int64(987654)
+	_, err := repo.UpsertSession(ctx, repository.UpsertTelegramSessionParams{
+		SessionDataEncrypted: []byte("test-session-data"),
+		EncryptionNonce:      []byte("test-nonce"),
+		PhoneNumber:          &phone,
+		TelegramUserID:       &userID,
+		Username:             &username,
+		AuthState:            "connected",
+	})
+	require.NoError(t, err)
+}
+
+// doTelegramJSON serves method+path with payload against the router. A string
+// payload is sent verbatim (for malformed-body cases); anything else is
+// JSON-marshalled. nil sends no body.
+func doTelegramJSON(t *testing.T, router *gin.Engine, method, path string, payload interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	switch v := payload.(type) {
+	case nil:
+		reader = nil
+	case string:
+		reader = strings.NewReader(v)
+	default:
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if reader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// decodeTelegramWire decodes the raw response body into a generic map so
+// assertions run against LITERAL wire keys, never production DTO tags.
+func decodeTelegramWire(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "body: %s", w.Body.String())
+	return body
+}
+
+// telegramWireErrorCode extracts error.code from the wire envelope.
+func telegramWireErrorCode(t *testing.T, body map[string]interface{}) string {
+	t.Helper()
+	errObj, ok := body["error"].(map[string]interface{})
+	require.True(t, ok, "expected error object in envelope, got: %v", body)
+	code, ok := errObj["code"].(string)
+	require.True(t, ok, "expected error.code string, got: %v", errObj)
+	return code
+}
+
+// telegramWireData extracts the data object from the wire envelope.
+func telegramWireData(t *testing.T, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object in envelope, got: %v", body)
+	return data
+}
+
+// TestTelegramAuthAPI_ValidationErrors proves every listed input-validation
+// branch of the auth endpoints returns 400 VALIDATION_ERROR, and that phone
+// numbers on BOTH valid boundary edges (7 and 15 digits) pass validation —
+// proven by reaching the manager's already-connected conflict (409) instead of
+// a 400, which requires no MTProto client.
+func TestTelegramAuthAPI_ValidationErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	router, _ := setupTelegramAuthRouter(t, ctx)
+
+	t.Run("StartAuth_MissingOrEmptyPhone", func(t *testing.T) {
+		// spec: TGM-007[0]
+		for _, payload := range []interface{}{
+			map[string]string{},                      // field absent
+			map[string]string{"phone_number": ""},    // empty
+			map[string]string{"phone_number": "   "}, // whitespace-only (trimmed)
+		} {
+			w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/start", payload)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "payload %v", payload)
+			assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)), "payload %v", payload)
+		}
+	})
+
+	t.Run("StartAuth_MalformedPhone", func(t *testing.T) {
+		// spec: TGM-007[0]
+		for _, phone := range []string{
+			"1234567",           // no leading +
+			"+123456",           // 6 digits — below the 7-digit minimum
+			"+1234567890123456", // 16 digits — above the 15-digit maximum
+			"+12345ab",          // letters
+			"++1234567",         // double plus
+		} {
+			w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/start", map[string]string{"phone_number": phone})
+			assert.Equal(t, http.StatusBadRequest, w.Code, "phone %q", phone)
+			assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)), "phone %q", phone)
+		}
+	})
+
+	t.Run("StartAuth_BoundaryValidPhonesPassValidation", func(t *testing.T) {
+		// spec: TGM-007[0]
+		// A dedicated harness whose session row is seeded connected: a phone
+		// that PASSES validation reaches the manager and is answered with the
+		// already-connected 409 (decided from the DB row, before any MTProto
+		// client is created). A validation regression would answer 400 instead.
+		bctx := context.Background()
+		brouter, bsessionRepo := setupTelegramAuthRouter(t, bctx)
+		ns := uuid.NewString()[:8]
+		seedConnectedTelegramSession(t, bctx, bsessionRepo, "tg-boundary-"+ns, "+15550000001")
+
+		for _, phone := range []string{
+			"+1234567",         // 7 digits — minimum valid length
+			"+123456789012345", // 15 digits — maximum valid length
+		} {
+			w := doTelegramJSON(t, brouter, http.MethodPost, "/api/v1/telegram/auth/start", map[string]string{"phone_number": phone})
+			assert.Equal(t, http.StatusConflict, w.Code, "phone %q should pass validation and reach the manager", phone)
+			assert.Equal(t, api.ErrCodeConflict, telegramWireErrorCode(t, decodeTelegramWire(t, w)), "phone %q", phone)
+		}
+	})
+
+	t.Run("StartAuth_MalformedBody", func(t *testing.T) {
+		// spec: TGM-007[0]
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/start", "{not-json")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
+	})
+
+	t.Run("VerifyCode_MissingToken", func(t *testing.T) {
+		// spec: TGM-007[0]
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-code", map[string]string{"code": "12345"})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
+	})
+
+	t.Run("VerifyCode_MissingCode", func(t *testing.T) {
+		// spec: TGM-007[0]
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-code", map[string]string{"auth_token": "deadbeef"})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
+	})
+
+	t.Run("VerifyCode_MalformedBody", func(t *testing.T) {
+		// spec: TGM-007[0]
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-code", "{not-json")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
+	})
+
+	t.Run("VerifyPassword_MissingToken", func(t *testing.T) {
+		// spec: TGM-007[0]
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-password", map[string]string{"password": "hunter2"})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
+	})
+
+	t.Run("VerifyPassword_MissingPassword", func(t *testing.T) {
+		// spec: TGM-007[0]
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-password", map[string]string{"auth_token": "deadbeef"})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
+	})
+
+	t.Run("VerifyPassword_MalformedBody", func(t *testing.T) {
+		// spec: TGM-007[0]
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-password", "{not-json")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
+	})
+}
+
+// TestTelegramAuthAPI_StartConflictWhenAlreadyConnected is GROUNDWORK for
+// TGM-007[1] (deliberately uncited): it proves the already-connected half of
+// the then-item (409 CONFLICT decided from the stored session). The
+// auth-in-progress half is unreachable without a live MTProto client — the
+// AuthSessionManager's session field is unexported and set only inside a real
+// StartAuth flow — so the whole item cannot be cited yet.
+func TestTelegramAuthAPI_StartConflictWhenAlreadyConnected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	router, sessionRepo := setupTelegramAuthRouter(t, ctx)
+	ns := uuid.NewString()[:8]
+	seedConnectedTelegramSession(t, ctx, sessionRepo, "tg-conflict-"+ns, "+15550000002")
+
+	w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/start", map[string]string{"phone_number": "+15551234567"})
+	assert.Equal(t, http.StatusConflict, w.Code)
+	body := decodeTelegramWire(t, w)
+	assert.Equal(t, false, body["success"])
+	assert.Equal(t, api.ErrCodeConflict, telegramWireErrorCode(t, body))
+	errObj := body["error"].(map[string]interface{})
+	assert.Contains(t, errObj["message"], "Already connected")
+}
+
+// TestTelegramAuthAPI_InvalidTokenBadRequest is GROUNDWORK for TGM-007[2]
+// (deliberately uncited): it proves the invalid-token half (400 BAD_REQUEST,
+// distinct from the 400 VALIDATION_ERROR of missing fields) for both
+// verify-code and verify-password. The expired half (410) is unreachable
+// deterministically: cleanup() closes the session's Done channel and nils the
+// session pointer atomically under one mutex, so a post-TTL request takes the
+// invalid-token path; the 410 branch only fires in the race window between the
+// token check and the Done check of a LIVE MTProto-backed session, and the TTL
+// timer is a raw time.AfterFunc the accelerated clock cannot advance.
+func TestTelegramAuthAPI_InvalidTokenBadRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	router, _ := setupTelegramAuthRouter(t, ctx)
+
+	for _, tc := range []struct {
+		name    string
+		path    string
+		payload map[string]string
+	}{
+		{"VerifyCode", "/api/v1/telegram/auth/verify-code", map[string]string{"auth_token": "no-such-token", "code": "12345"}},
+		{"VerifyPassword", "/api/v1/telegram/auth/verify-password", map[string]string{"auth_token": "no-such-token", "password": "hunter2"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doTelegramJSON(t, router, http.MethodPost, tc.path, tc.payload)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			body := decodeTelegramWire(t, w)
+			assert.Equal(t, api.ErrCodeBadRequest, telegramWireErrorCode(t, body))
+			errObj := body["error"].(map[string]interface{})
+			assert.Equal(t, "Invalid auth token", errObj["message"])
+		})
+	}
+}
+
+// TestTelegramAuthAPI_CancelAlwaysSucceeds is GROUNDWORK for TGM-007[4]
+// (deliberately uncited): it proves the cancel-always-succeeds half — 200 with
+// {"status":"cancelled"} even with no flow in progress, and idempotently on
+// repeat. The successful-step half (a StartAuth/VerifyCode/VerifyPassword
+// success returning 200 with the flow status) requires a completing MTProto
+// auth flow, for which no stub seam exists.
+func TestTelegramAuthAPI_CancelAlwaysSucceeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	router, _ := setupTelegramAuthRouter(t, ctx)
+
+	for i := 0; i < 2; i++ { // idempotent: "always succeeds"
+		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/cancel", nil)
+		assert.Equal(t, http.StatusOK, w.Code, "cancel call %d", i+1)
+		body := decodeTelegramWire(t, w)
+		assert.Equal(t, true, body["success"], "cancel call %d", i+1)
+		data := telegramWireData(t, body)
+		assert.Equal(t, "cancelled", data["status"], "cancel call %d", i+1)
+	}
+}
+
+// TestTelegramAuthAPI_Disconnect proves both halves of TGM-007[5]: the happy
+// path returns 200 with {"status":"disconnected"} and clears the session row;
+// a failing session-row delete (forced by serving the request with an
+// already-cancelled context, so the repository DELETE fails without any
+// production seam) is a 500 that leaves the row intact for retry.
+func TestTelegramAuthAPI_Disconnect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	t.Run("SucceedsAndClearsSession", func(t *testing.T) {
+		// spec: TGM-007[5]
+		ctx := context.Background()
+		router, sessionRepo := setupTelegramAuthRouter(t, ctx)
+		ns := uuid.NewString()[:8]
+		seedConnectedTelegramSession(t, ctx, sessionRepo, "tg-disc-"+ns, "+15550000003")
+
+		w := doTelegramJSON(t, router, http.MethodDelete, "/api/v1/telegram/auth", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := decodeTelegramWire(t, w)
+		assert.Equal(t, true, body["success"])
+		data := telegramWireData(t, body)
+		assert.Equal(t, "disconnected", data["status"])
+
+		_, err := sessionRepo.GetSession(ctx)
+		assert.ErrorIs(t, err, db.ErrNotFound, "session row should be deleted")
+	})
+
+	t.Run("SessionDeleteFailureIsServerError", func(t *testing.T) {
+		// spec: TGM-007[5]
+		ctx := context.Background()
+		router, sessionRepo := setupTelegramAuthRouter(t, ctx)
+		ns := uuid.NewString()[:8]
+		seedConnectedTelegramSession(t, ctx, sessionRepo, "tg-discfail-"+ns, "+15550000004")
+
+		// A pre-cancelled request context makes the session-row DELETE fail
+		// inside TelegramManager.Disconnect without touching production code.
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		req, err := http.NewRequestWithContext(cancelledCtx, http.MethodDelete, "/api/v1/telegram/auth", nil)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		body := decodeTelegramWire(t, w)
+		assert.Equal(t, false, body["success"])
+		assert.Equal(t, api.ErrCodeInternal, telegramWireErrorCode(t, body))
+
+		// The delete failed, so the row must survive for a retry...
+		sess, err := sessionRepo.GetSession(ctx)
+		require.NoError(t, err, "session row should survive the failed disconnect")
+		assert.Equal(t, "connected", sess.AuthState)
+
+		// ...and the retry with a healthy context succeeds.
+		w = doTelegramJSON(t, router, http.MethodDelete, "/api/v1/telegram/auth", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		_, err = sessionRepo.GetSession(ctx)
+		assert.ErrorIs(t, err, db.ErrNotFound)
+	})
+}
+
+// TestTelegramAuthAPI_Status proves TGM-007[6]: status always answers 200 and
+// reflects the current connection state, asserting the LITERAL wire keys of
+// the payload in both the no-session and stored-connected-session states.
+func TestTelegramAuthAPI_Status(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	t.Run("DisconnectedWithoutSession", func(t *testing.T) {
+		// spec: TGM-007[6]
+		ctx := context.Background()
+		router, _ := setupTelegramAuthRouter(t, ctx)
+
+		w := doTelegramJSON(t, router, http.MethodGet, "/api/v1/telegram/auth/status", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := decodeTelegramWire(t, w)
+		assert.Equal(t, true, body["success"])
+		data := telegramWireData(t, body)
+		assert.Equal(t, false, data["connected"])
+		assert.Equal(t, "disconnected", data["status"])
+		_, hasUsername := data["username"]
+		assert.False(t, hasUsername, "username must be absent when no session exists")
+		_, hasPhone := data["phone_number"]
+		assert.False(t, hasPhone, "phone_number must be absent when no session exists")
+	})
+
+	t.Run("ConnectedFromStoredSession", func(t *testing.T) {
+		// spec: TGM-007[6]
+		ctx := context.Background()
+		router, sessionRepo := setupTelegramAuthRouter(t, ctx)
+		ns := uuid.NewString()[:8]
+		username := "tg-status-" + ns
+		phone := "+15550000005"
+		seedConnectedTelegramSession(t, ctx, sessionRepo, username, phone)
+
+		w := doTelegramJSON(t, router, http.MethodGet, "/api/v1/telegram/auth/status", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := decodeTelegramWire(t, w)
+		assert.Equal(t, true, body["success"])
+		data := telegramWireData(t, body)
+		assert.Equal(t, true, data["connected"])
+		assert.Equal(t, "connected", data["status"])
+		assert.Equal(t, username, data["username"])
+		assert.Equal(t, phone, data["phone_number"])
+	})
+}

--- a/backend/tests/api/telegram_chat_api_test.go
+++ b/backend/tests/api/telegram_chat_api_test.go
@@ -205,13 +205,14 @@ func TestChatAPI_ListChats(t *testing.T) {
 	assert.True(t, large, "large group should be in response")
 }
 
+// spec: TGM-014[0]
 func TestChatAPI_ListChats_ExcludesPrivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
 	t.Parallel()
 
-	router, chatConfigRepo, chatID1, _, cleanup := setupTelegramChatRouter(t)
+	router, chatConfigRepo, chatID1, chatID2, cleanup := setupTelegramChatRouter(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -223,25 +224,53 @@ func TestChatAPI_ListChats_ExcludesPrivate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// A group chat is seeded alongside the excluded private chat so this one
+	// test proves both halves of TGM-014[0]: private (non-group) chats are
+	// filtered out, and each surviving chat carries the literal
+	// effective_tracked wire key.
+	mc3 := int32(3)
+	_, err = chatConfigRepo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
+		TelegramChatID: chatID2,
+		ChatType:       "group",
+		MemberCount:    &mc3,
+		Status:         "tracked",
+	})
+	require.NoError(t, err)
+
 	req, _ := http.NewRequest("GET", "/api/v1/telegram/chats", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp struct {
-		Data []struct {
-			TelegramChatID int64 `json:"telegram_chat_id"`
-		} `json:"data"`
+	// Decode into a raw map so a renamed/dropped literal wire key is caught,
+	// rather than round-tripping invisibly through a typed DTO struct.
+	var raw struct {
+		Data []map[string]interface{} `json:"data"`
 	}
-	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	err = json.Unmarshal(w.Body.Bytes(), &raw)
 	require.NoError(t, err)
 
-	for _, chat := range resp.Data {
-		assert.NotEqual(t, chatID1, chat.TelegramChatID, "private chat should not appear")
+	var foundPrivate, foundGroup bool
+	for _, chat := range raw.Data {
+		idFloat, ok := chat["telegram_chat_id"].(float64)
+		require.True(t, ok, "telegram_chat_id must be present and numeric")
+		id := int64(idFloat)
+		if id == chatID1 {
+			foundPrivate = true
+		}
+		if id == chatID2 {
+			foundGroup = true
+			trackedVal, hasKey := chat["effective_tracked"]
+			assert.True(t, hasKey, "group chat should carry the effective_tracked key")
+			assert.Equal(t, true, trackedVal, "tracked small group should be effective_tracked=true")
+		}
 	}
+	assert.False(t, foundPrivate, "private chat should not appear")
+	assert.True(t, foundGroup, "group chat should appear carrying effective_tracked")
 }
 
+// spec: TGM-014[1]
 func TestChatAPI_UpdateStatus_Ignored(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -282,6 +311,7 @@ func TestChatAPI_UpdateStatus_Ignored(t *testing.T) {
 	assert.False(t, resp.Data.EffectiveTracked)
 }
 
+// spec: TGM-014[1]
 func TestChatAPI_UpdateStatus_TrackedOverridesLarge(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -322,6 +352,47 @@ func TestChatAPI_UpdateStatus_TrackedOverridesLarge(t *testing.T) {
 	assert.True(t, resp.Data.EffectiveTracked)
 }
 
+// spec: TGM-014[1]
+func TestChatAPI_UpdateStatus_Auto(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	router, chatConfigRepo, chatID1, _, cleanup := setupTelegramChatRouter(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Seed as "ignored" so the PATCH to "auto" exercises a real transition,
+	// not a no-op re-write of the default.
+	mc5 := int32(5)
+	_, err := chatConfigRepo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
+		TelegramChatID: chatID1,
+		ChatType:       "group",
+		MemberCount:    &mc5,
+		Status:         "ignored",
+	})
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]string{"status": "auto"})
+	req, _ := http.NewRequest("PATCH", fmt.Sprintf("/api/v1/telegram/chats/%d", chatID1), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var raw struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	err = json.Unmarshal(w.Body.Bytes(), &raw)
+	require.NoError(t, err)
+	assert.Equal(t, "auto", raw.Data["status"])
+	assert.Equal(t, true, raw.Data["effective_tracked"], "small group under auto should be effective_tracked")
+}
+
+// spec: TGM-014[1]
 func TestChatAPI_UpdateStatus_InvalidStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -340,6 +411,7 @@ func TestChatAPI_UpdateStatus_InvalidStatus(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// spec: TGM-014[2]
 func TestChatAPI_UpdateStatus_NotFound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -358,4 +430,23 @@ func TestChatAPI_UpdateStatus_NotFound(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// spec: TGM-014[2]
+func TestChatAPI_UpdateStatus_NonNumericChatID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	router, _, _, _, cleanup := setupTelegramChatRouter(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"status": "ignored"})
+	req, _ := http.NewRequest("PATCH", "/api/v1/telegram/chats/not-a-number", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/backend/tests/api/todoist_api_test.go
+++ b/backend/tests/api/todoist_api_test.go
@@ -4,12 +4,16 @@
 // TodoistHandler: GetSettings and UpdateSettings, which read/write only
 // through oauthService.ListAccounts + syncRepo — no external HTTP.
 //
-// ListProjects/ListLabels (SET-018) are deliberately NOT covered here: they
-// construct todoist.NewSyncClient(accessToken) inline with no injection
-// seam, so their live-provider contract can't be exercised without a real
-// Todoist account or a handler client seam. Closing that gap needs a small
-// production change (inject the existing todoist.ClientFactory into
-// TodoistHandler) before a picker suite can be added.
+// ListProjects/ListLabels (SET-018) are only partially covered here. The
+// no-account-connected 404 branch (SET-018[0]) runs entirely before either
+// handler touches the live provider client (it returns as soon as
+// len(accounts)==0), so it is hermetic and covered below. The remaining
+// SET-018 clauses (deleted-entry filtering, provider-failure 500) construct
+// todoist.NewSyncClient(accessToken) inline with no injection seam, so their
+// live-provider contract can't be exercised without a real Todoist account
+// or a handler client seam. Closing that gap needs a small production
+// change (inject the existing todoist.ClientFactory into TodoistHandler)
+// before the rest of the picker suite can be added.
 package api
 
 import (
@@ -309,5 +313,51 @@ func TestTodoistAPI_UpdateSettings(t *testing.T) {
 		assert.Equal(t, newLabelID, state.Metadata[todoist.MetadataKeyLabelID])
 		_, hasLabelName := state.Metadata[todoist.MetadataKeyLabelName]
 		assert.False(t, hasLabelName, "label_name must be cleared from stored metadata when the label changes")
+	})
+}
+
+// TestTodoistAPI_Pickers_NoAccount proves the ListProjects/ListLabels
+// no-account guard: both routes check len(accounts)==0 and return 404
+// BEFORE constructing a live provider client, so this is testable with no
+// external Todoist access. Each subtest asserts the literal wire shape of
+// the error envelope (raw map, not the DTO struct) so a renamed/mis-typed
+// field is caught.
+func TestTodoistAPI_Pickers_NoAccount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ListProjects_NoAccount_Returns404", func(t *testing.T) {
+		// spec: SET-018[0]
+		router, _, _ := newTodoistAPITest(t)
+
+		w := doTodoistRequest(router, http.MethodGet, "/api/v1/todoist/projects", nil)
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+		var envelope map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		assert.Equal(t, false, envelope["success"])
+		errObj, ok := envelope["error"].(map[string]interface{})
+		require.True(t, ok, "error envelope must carry an 'error' object")
+		assert.Equal(t, "NOT_FOUND", errObj["code"])
+		assert.NotEmpty(t, errObj["message"])
+		_, hasData := envelope["data"]
+		assert.False(t, hasData, "a 404 error response must not carry a 'data' key")
+	})
+
+	t.Run("ListLabels_NoAccount_Returns404", func(t *testing.T) {
+		// spec: SET-018[0]
+		router, _, _ := newTodoistAPITest(t)
+
+		w := doTodoistRequest(router, http.MethodGet, "/api/v1/todoist/labels", nil)
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+		var envelope map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		assert.Equal(t, false, envelope["success"])
+		errObj, ok := envelope["error"].(map[string]interface{})
+		require.True(t, ok, "error envelope must carry an 'error' object")
+		assert.Equal(t, "NOT_FOUND", errObj["code"])
+		assert.NotEmpty(t, errObj["message"])
+		_, hasData := envelope["data"]
+		assert.False(t, hasData, "a 404 error response must not carry a 'data' key")
 	})
 }

--- a/backend/tests/google_oauth_token_integration_test.go
+++ b/backend/tests/google_oauth_token_integration_test.go
@@ -106,6 +106,7 @@ func sealWithKey(t *testing.T, hexKey, plaintext string, nonce []byte) []byte {
 // TestGoogleOAuth_ExchangeRoundTrip verifies that a token exchanged via the fake
 // endpoint is stored encrypted and decrypts back to the same values, and that the
 // access and refresh tokens are stored under distinct nonces.
+// spec: SET-009
 func TestGoogleOAuth_ExchangeRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/backend/tests/todoist_oauth_token_integration_test.go
+++ b/backend/tests/todoist_oauth_token_integration_test.go
@@ -1,0 +1,189 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTodoistOAuthTestService wires a Todoist OAuthService against the shared
+// test DB and returns the service plus the repository so tests can inspect
+// the stored (encrypted) row directly. The token/userinfo endpoints are
+// package-level vars (unlike Google's per-instance setters), so callers must
+// point them at a fake server and restore the originals in t.Cleanup.
+func newTodoistOAuthTestService(t *testing.T) (*todoist.OAuthService, *repository.OAuthRepository, context.Context) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewOAuthRepository(database.Queries)
+	svc, err := todoist.NewOAuthService(cfg, repo, nil)
+	require.NoError(t, err)
+
+	return svc, repo, ctx
+}
+
+// fakeTodoistEndpoints stands in for Todoist's token and userinfo endpoints.
+// The token handler returns whatever access token is currently configured, so
+// a test can rotate it between calls to exercise re-exchange persistence.
+type fakeTodoistEndpoints struct {
+	server      *httptest.Server
+	accessToken string
+}
+
+func newFakeTodoistEndpoints(t *testing.T, userID, email string) *fakeTodoistEndpoints {
+	t.Helper()
+	f := &fakeTodoistEndpoints{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token": f.accessToken,
+			"token_type":   "Bearer",
+		})
+	})
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": userID, "email": email})
+	})
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// withTodoistEndpoints points the package-level Todoist token/userinfo
+// endpoint vars at fake's server and restores the originals in t.Cleanup.
+// ExchangeCode reads these vars directly (no per-instance setter exists on
+// OAuthService, unlike Google's SetTokenEndpoint/SetUserInfoEndpoint), so
+// tests in this file must not run in parallel with each other.
+func withTodoistEndpoints(t *testing.T, fake *fakeTodoistEndpoints) {
+	t.Helper()
+	origToken := todoist.TokenEndpoint
+	origUserInfo := todoist.UserInfoEndpoint
+	todoist.TokenEndpoint = fake.server.URL + "/token"
+	todoist.UserInfoEndpoint = fake.server.URL + "/user"
+	t.Cleanup(func() {
+		todoist.TokenEndpoint = origToken
+		todoist.UserInfoEndpoint = origUserInfo
+	})
+}
+
+// TestTodoistOAuth_ExchangeRoundTrip verifies that a token exchanged via the
+// fake endpoint is stored encrypted (never as plaintext) and decrypts back to
+// the same value, under a populated per-credential nonce. Todoist tokens
+// never carry a refresh token (repo.storeToken always passes a nil refresh
+// ciphertext/nonce), so unlike Google there is only one token to store per
+// credential; the round trip proves that single stored token is encrypted at
+// rest under its own nonce.
+// spec: SET-009
+func TestTodoistOAuth_ExchangeRoundTrip(t *testing.T) {
+	userID := syntheticNS(t)
+	email := userID + "@example.test"
+
+	svc, repo, ctx := newTodoistOAuthTestService(t)
+	fake := newFakeTodoistEndpoints(t, userID, email)
+	fake.accessToken = "fake-todoist-access-token-rt"
+	withTodoistEndpoints(t, fake)
+
+	t.Cleanup(func() {
+		if cred, err := repo.GetByProviderAndAccount(context.Background(), todoist.ProviderName, userID); err == nil {
+			_ = repo.Delete(context.Background(), cred.ID)
+		}
+	})
+
+	status, err := svc.ExchangeCode(ctx, "fake-auth-code")
+	require.NoError(t, err)
+	require.Equal(t, userID, status.AccountID)
+
+	// Decrypt fidelity: the decrypted token matches what the endpoint returned.
+	accessToken, err := svc.GetAccessToken(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-todoist-access-token-rt", accessToken)
+
+	// Encrypted at rest: the stored ciphertext must never equal the plaintext
+	// wire bytes, and a populated nonce must back the encryption.
+	cred, err := repo.GetByProviderAndAccount(ctx, todoist.ProviderName, userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, cred.AccessTokenEncrypted)
+	assert.False(t, bytes.Equal(cred.AccessTokenEncrypted, []byte("fake-todoist-access-token-rt")),
+		"access token must not be stored as plaintext")
+	require.NotEmpty(t, cred.EncryptionNonce, "access token must be stored under a nonce")
+
+	// Todoist never issues a refresh token, so there is nothing to store
+	// under a second nonce here (contrast with Google's distinct-nonces case).
+	assert.Empty(t, cred.RefreshTokenEncrypted, "Todoist tokens carry no refresh token to encrypt")
+	assert.Empty(t, cred.RefreshTokenNonce, "Todoist tokens carry no refresh-token nonce")
+}
+
+// TestTodoistOAuth_ReExchangeUsesDistinctNonce verifies the Todoist analogue
+// of Google's "distinct nonces" guarantee: since Todoist has only one token
+// per credential (no refresh token), the per-token-distinct-nonce invariant
+// instead applies across successive writes of that one token — a re-exchange
+// that rotates the access token must mint a fresh nonce rather than reusing
+// the previous write's nonce (nonce reuse under AES-GCM breaks
+// confidentiality outright).
+// spec: SET-009
+func TestTodoistOAuth_ReExchangeUsesDistinctNonce(t *testing.T) {
+	userID := syntheticNS(t)
+	email := userID + "@example.test"
+
+	svc, repo, ctx := newTodoistOAuthTestService(t)
+	fake := newFakeTodoistEndpoints(t, userID, email)
+	withTodoistEndpoints(t, fake)
+
+	t.Cleanup(func() {
+		if cred, err := repo.GetByProviderAndAccount(context.Background(), todoist.ProviderName, userID); err == nil {
+			_ = repo.Delete(context.Background(), cred.ID)
+		}
+	})
+
+	fake.accessToken = "first-todoist-access-token"
+	_, err := svc.ExchangeCode(ctx, "first-code")
+	require.NoError(t, err)
+
+	first, err := repo.GetByProviderAndAccount(ctx, todoist.ProviderName, userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, first.EncryptionNonce)
+
+	fake.accessToken = "second-todoist-access-token"
+	_, err = svc.ExchangeCode(ctx, "second-code")
+	require.NoError(t, err)
+
+	second, err := repo.GetByProviderAndAccount(ctx, todoist.ProviderName, userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, second.EncryptionNonce)
+
+	assert.False(t, bytes.Equal(first.EncryptionNonce, second.EncryptionNonce),
+		"each write of the token must use its own nonce, not reuse the previous write's nonce")
+
+	// Fidelity: the second exchange's decrypted value reflects the rotation.
+	accessToken, err := svc.GetAccessToken(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "second-todoist-access-token", accessToken)
+}


### PR DESCRIPTION
## Summary

Gap phase PR 2 of the api-citation arc (follows #732): closes 28 of the 34 settings + telegram `api`-surface coverage orphans with new tests. The corpus drops 80 → 52 orphans (settings 24 → 2, telegram 10 → 4). No `settled` flips in this PR — the six remaining orphans are all seam-blocked waiver candidates (below), batched for an explicit decision in the arc's final PR.

Every new test carries a `// spec:` citation and the arc's injected-defect contract: a minimal behavioral defect was temporarily injected into production code to prove the test goes red, then reverted and re-proven green. Response-shape tests assert literal wire keys (never the production DTO round-trip) with pairwise-distinct fixture values.

## What's covered

- **OAuth state/security (SET-002/003/004)**: server-side CSRF state storage proven via single-use consumption; the 10-minute TTL crossed with the accelerated clock; expired-state callback aborts before code exchange; failure redirects carry the literal `provider` param; URL-encoding proven with percent-encoding-requiring characters.
- **Todoist twins (SET-002/003/004/008/009)**: every previously Google-only assertion now has its Todoist twin — auth-URL response, callback error-short-circuit and validate-then-exchange ordering (with single-use state consumption), empty-redirect-body negative guarantee (both providers), success/failure redirect shapes, account list/status/revoke routes (200 shape + malformed-id 400 + unknown-id 404 pairs), and token-at-rest encryption with per-token distinct nonces (new `todoist_oauth_token_integration_test.go`; the Google file's existing assertions now carry the citation).
- **OAuth route wiring (SET-001, SET-005)** — first tests for `RegisterOAuthCallbackRoutes`/`RegisterOAuthRoutes`: callback routes proven reachable without an API key while auth-URL/account routes 401 without one (real auth middleware, production registration order), and provider gating proven both ways (disabled provider exposes zero routes).
- **System export (SET-030[0..3])** — first tests for `SystemHandler`: Content-Disposition attachment + envelope shape, literal `version`/`exported_at` keys, contacts-only dataset (interactions/notes keys absent), and the 500 read-failure path forced via a closed pool.
- **Telegram auth handler (TGM-007[0,5,6])** — first tests for the auth endpoints: field-by-field validation 400s, disconnect happy path, status wire shape.
- **Telegram chats (TGM-014[0..2])**: group-only listing with effective-tracked flag, full accept-set proof for status updates (all three members + rejection), non-numeric chat id 400.

## Not covered — waiver candidates (deliberate)

Six orphans remain, all blocked on missing injection seams; adding a seam is a production change out of scope for a coverage PR:

- `SET-018[1,2]`: `todoist.NewSyncClient` is constructed inline in the handler — live-provider filtering and provider-failure 500 are untestable without a client seam.
- `TGM-007[1,3,4]`: the MTProto auth flow's conflict/401/500/success-step branches require a stubbed Telegram client; no seam exists (channels live on unexported session state written only by the live `client.Run` goroutine).
- `TGM-007[2]`: the expired-token 410 half is deterministically unreachable in the current implementation (cleanup nils the session atomically, so post-TTL requests take the invalid-token 400 path); the invalid-token half is proven by an uncited groundwork test.

## Test plan

- `make spec-coverage`: 52 orphans (was 80), 0 invalid citations; `make spec-lint` green.
- Full backend suites + E2E-diff via pre-push hook; CI runs the full matrix.
