### PR TITLE
test(spec): close machost/ingest/notes/imports api gaps, settle three

### DIFF
--- a/backend/internal/api/handlers/ingest_test.go
+++ b/backend/internal/api/handlers/ingest_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"personal-crm/backend/internal/events"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These are unit tests against the per-family payload-version validators
+// directly (no HTTP/DB harness needed — they're pure functions operating
+// on an IngestEventRequest's raw JSON payload). validateCallPayloadVersion
+// and validateExternalContactPayloadVersion already have below/above
+// version coverage at the API-integration level (phone_call_ingest and
+// external_contact_ingest test files); raw_message and meeting_note don't,
+// so both halves are covered here for those two families, plus the
+// below-minimum half for call (rounding out ING-005[0] across all three
+// families named in the spec).
+
+// spec: ING-005[0]
+func TestValidateRawMessagePayload_VersionBelowMin_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "messages",
+		SourceID: "guid-below-min",
+		Kind:     string(events.KindRawMessageReceived),
+		Payload:  json.RawMessage(`{"version":0}`),
+	}
+	ierr := validateRawMessagePayload(0, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "version")
+}
+
+// spec: ING-005[1]
+func TestValidateRawMessagePayload_VersionTooHigh_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "messages",
+		SourceID: "guid-too-high",
+		Kind:     string(events.KindRawMessageReceived),
+		Payload:  json.RawMessage(`{"version":999}`),
+	}
+	ierr := validateRawMessagePayload(0, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "upgrade Pi")
+}
+
+// spec: ING-005[0]
+func TestValidateMeetingNotePayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "anarlog_sessions",
+		SourceID: "session-below-min",
+		Kind:     string(events.KindMeetingNoteRecorded),
+		Payload:  json.RawMessage(`{"version":0}`),
+	}
+	ierr := validateMeetingNotePayloadVersion(0, events.KindMeetingNoteRecorded, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "version")
+}
+
+// spec: ING-005[1]
+func TestValidateMeetingNotePayloadVersion_VersionTooHigh_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "anarlog_sessions",
+		SourceID: "session-too-high",
+		Kind:     string(events.KindMeetingNoteRecorded),
+		Payload:  json.RawMessage(`{"version":999}`),
+	}
+	ierr := validateMeetingNotePayloadVersion(0, events.KindMeetingNoteRecorded, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "upgrade Pi")
+}
+
+// spec: ING-005[0]
+func TestValidateCallPayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "phone_calls",
+		SourceID: "call-below-min",
+		Kind:     string(events.KindCallReceived),
+		Payload:  json.RawMessage(`{"version":0}`),
+	}
+	ierr := validateCallPayloadVersion(0, events.KindCallReceived, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "version")
+}

--- a/backend/internal/api/handlers/ingest_test.go
+++ b/backend/internal/api/handlers/ingest_test.go
@@ -11,13 +11,13 @@ import (
 
 // These are unit tests against the per-family payload-version validators
 // directly (no HTTP/DB harness needed — they're pure functions operating
-// on an IngestEventRequest's raw JSON payload). validateCallPayloadVersion
-// and validateExternalContactPayloadVersion already have below/above
-// version coverage at the API-integration level (phone_call_ingest and
-// external_contact_ingest test files); raw_message and meeting_note don't,
-// so both halves are covered here for those two families, plus the
-// below-minimum half for call (rounding out ING-005[0] across all three
-// families named in the spec).
+// on an IngestEventRequest's raw JSON payload). Both halves of the
+// version envelope (below-minimum rejection and above-maximum rejection
+// with the "upgrade Pi" signal) are pinned here for ALL FOUR daemon
+// families the spec names: message, external-contact, meeting-note, and
+// call. The API-integration level additionally exercises the
+// external_contact and call version gates end-to-end
+// (external_contact_ingest and phone_call_ingest test files).
 
 // spec: ING-005[0]
 func TestValidateRawMessagePayload_VersionBelowMin_Rejected(t *testing.T) {
@@ -76,6 +76,34 @@ func TestValidateMeetingNotePayloadVersion_VersionTooHigh_Rejected(t *testing.T)
 }
 
 // spec: ING-005[0]
+func TestValidateExternalContactPayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "icloud_contacts",
+		SourceID: "ext-below-min",
+		Kind:     string(events.KindExternalContactUpserted),
+		Payload:  json.RawMessage(`{"version":0}`),
+	}
+	ierr := validateExternalContactPayloadVersion(0, events.KindExternalContactUpserted, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "version")
+}
+
+// spec: ING-005[1]
+func TestValidateExternalContactPayloadVersion_VersionTooHigh_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "icloud_contacts",
+		SourceID: "ext-too-high",
+		Kind:     string(events.KindExternalContactUpserted),
+		Payload:  json.RawMessage(`{"version":999}`),
+	}
+	ierr := validateExternalContactPayloadVersion(0, events.KindExternalContactUpserted, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "upgrade Pi")
+}
+
+// spec: ING-005[0]
 func TestValidateCallPayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "phone_calls",
@@ -87,4 +115,18 @@ func TestValidateCallPayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
 	require.NotNil(t, ierr)
 	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
 	require.Contains(t, ierr.Message, "version")
+}
+
+// spec: ING-005[1]
+func TestValidateCallPayloadVersion_VersionTooHigh_Rejected(t *testing.T) {
+	ev := IngestEventRequest{
+		Source:   "phone_calls",
+		SourceID: "call-too-high",
+		Kind:     string(events.KindCallReceived),
+		Payload:  json.RawMessage(`{"version":999}`),
+	}
+	ierr := validateCallPayloadVersion(0, events.KindCallReceived, ev)
+	require.NotNil(t, ierr)
+	require.Equal(t, ingestCodePayloadInvalid, ierr.Code)
+	require.Contains(t, ierr.Message, "upgrade Pi")
 }

--- a/backend/internal/api/handlers/mac_host_test.go
+++ b/backend/internal/api/handlers/mac_host_test.go
@@ -28,6 +28,10 @@ type stubMacHostService struct {
 	rotateResult *service.RotateAPIKeyResult
 	rotateErr    error
 	rotateCalls  int
+
+	heartbeatResult *repository.MacHost
+	heartbeatErr    error
+	heartbeatCalls  int
 }
 
 func (s *stubMacHostService) RotateAPIKey(_ context.Context, _ uuid.UUID, _ string, _ string) (*service.RotateAPIKeyResult, error) {
@@ -42,6 +46,10 @@ func (s *stubMacHostService) PairWithToken(_ context.Context, _ string, _ string
 	panic("PairWithToken not expected in this test")
 }
 func (s *stubMacHostService) Heartbeat(_ context.Context, _ uuid.UUID, _ repository.HeartbeatPayload) (*repository.MacHost, error) {
+	s.heartbeatCalls++
+	if s.heartbeatResult != nil || s.heartbeatErr != nil {
+		return s.heartbeatResult, s.heartbeatErr
+	}
 	panic("Heartbeat not expected in this test")
 }
 func (s *stubMacHostService) CommitCursor(_ context.Context, _ repository.CommitMacHostCursorParams) error {
@@ -136,6 +144,54 @@ func TestRotateKey_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 	require.False(t, resp.Success)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, api.ErrCodeNotFound, resp.Error.Code)
+}
+
+// TestHeartbeat_HostRevokedBetweenMiddlewareAndTx covers the
+// handler's db.ErrNotFound -> 401 UNKNOWN_HOST branch: the host was
+// revoked between the middleware's read and the heartbeat write.
+// spec: MAC-011[3]
+func TestHeartbeat_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hostID := uuid.New()
+	stubHost := &repository.MacHost{
+		ID:         hostID,
+		Hostname:   "test-host",
+		APIKeyHash: "test-hash",
+	}
+	stub := &stubMacHostService{heartbeatErr: db.ErrNotFound}
+	handler := NewMacHostHandler(stub, nil)
+
+	r := gin.New()
+	r.Use(auth.MacHostAuthMiddleware(
+		&fakeHostRepo{host: stubHost},
+		alwaysMatch,
+		auth.DefaultMacHostAuthLimiterConfig()))
+	r.POST("/api/v1/host/:id/heartbeat", handler.Heartbeat)
+
+	body, err := json.Marshal(map[string]any{
+		"daemon_version":   "1.0.0",
+		"protocol_version": 1,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/host/"+hostID.String()+"/heartbeat",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", hostID.String())
+	req.Header.Set("Authorization", "Bearer test-hash")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, stub.heartbeatCalls, "service must be invoked exactly once")
+
+	var body2 map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body2))
+	errObj, ok := body2["error"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "UNKNOWN_HOST", errObj["code"])
 }
 
 // TestRotateKey_MissingPairingToken covers the handler's body

--- a/backend/internal/api/handlers/mac_host_test.go
+++ b/backend/internal/api/handlers/mac_host_test.go
@@ -146,6 +146,59 @@ func TestRotateKey_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 	require.Equal(t, api.ErrCodeNotFound, resp.Error.Code)
 }
 
+// TestRotateKey_ConcurrentRotationLoser_MapsStaleAuthTo401 covers the
+// handler's service.ErrAPIKeyStaleAuth → 401 STALE_AUTH mapping: the
+// key was rotated out from under the caller between the middleware
+// read and the rotate tx's CAS check. The service stub returns the
+// sentinel deterministically (the CAS-detection semantics themselves
+// are proven at the service layer by
+// TestMacHostRotateKey_ConcurrentRotation_DifferentTokens/_SameToken),
+// so this pins the wire contract without a real race.
+// spec: MAC-010[2]
+func TestRotateKey_ConcurrentRotationLoser_MapsStaleAuthTo401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hostID := uuid.New()
+	stubHost := &repository.MacHost{
+		ID:         hostID,
+		Hostname:   "test-host",
+		APIKeyHash: "test-hash",
+	}
+	stub := &stubMacHostService{rotateErr: service.ErrAPIKeyStaleAuth}
+	handler := NewMacHostHandler(stub, nil)
+
+	r := gin.New()
+	r.Use(auth.MacHostAuthMiddleware(
+		&fakeHostRepo{host: stubHost},
+		alwaysMatch,
+		auth.DefaultMacHostAuthLimiterConfig()))
+	r.POST("/api/v1/host/:id/rotate-key", handler.RotateKey)
+
+	body, err := json.Marshal(map[string]any{"pairing_token": "fresh-token"})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/host/"+hostID.String()+"/rotate-key",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", hostID.String())
+	req.Header.Set("Authorization", "Bearer test-hash")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, stub.rotateCalls, "service must be invoked exactly once")
+
+	var resp struct {
+		Success bool          `json:"success"`
+		Error   *api.APIError `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.False(t, resp.Success)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, "STALE_AUTH", resp.Error.Code, "loser must surface the literal STALE_AUTH code")
+}
+
 // TestHeartbeat_HostRevokedBetweenMiddlewareAndTx covers the
 // handler's db.ErrNotFound -> 401 UNKNOWN_HOST branch: the host was
 // revoked between the middleware's read and the heartbeat write.

--- a/backend/internal/auth/mac_host_middleware_test.go
+++ b/backend/internal/auth/mac_host_middleware_test.go
@@ -151,6 +151,47 @@ func TestMacHostAuth_AmbiguousAuth_ApiKeyScheme(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// spec: MAC-007[2]
+func TestMacHostAuth_MissingOrEmptyBearer_401(t *testing.T) {
+	id := uuid.New()
+	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{
+		id: {ID: id, APIKeyHash: "shared-secret"},
+	}}
+
+	cases := []struct {
+		name       string
+		authHeader string
+		setHeader  bool
+	}{
+		{name: "absent Authorization header", setHeader: false},
+		{name: "empty Authorization header", authHeader: "", setHeader: true},
+		{name: "Bearer prefix with empty token", authHeader: "Bearer ", setHeader: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmp := &countingComparator{}
+			r := newMacAuthTestRouter(t, repo, cmp.Compare, DefaultMacHostAuthLimiterConfig())
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("X-Mac-Host-ID", id.String())
+			if tc.setHeader {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+			require.Equal(t, int64(0), cmp.calls.Load(), "bcrypt must not run on missing-bearer path")
+
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(strings.NewReader(w.Body.String())).Decode(&body))
+			errObj, ok := body["error"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "MISSING_BEARER", errObj["code"], "must hit the dedicated MISSING_BEARER branch")
+		})
+	}
+}
+
 // spec: MAC-007[3]
 func TestMacHostAuth_RevokedOrMissingHost_401(t *testing.T) {
 	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{}}

--- a/backend/internal/repository/sync_test.go
+++ b/backend/internal/repository/sync_test.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Pure unit coverage of extractBackfillComplete: the flag is opaque to
+// the backend, so absent keys and malformed values must default to
+// false rather than erroring or defaulting to true.
+// spec: MAC-015[2]
+func TestExtractBackfillComplete(t *testing.T) {
+	cases := []struct {
+		name     string
+		metadata []byte
+		want     bool
+	}{
+		{name: "nil metadata", metadata: nil, want: false},
+		{name: "empty metadata", metadata: []byte(``), want: false},
+		{name: "absent key", metadata: []byte(`{"other_key":"x"}`), want: false},
+		{name: "null value", metadata: []byte(`{"backfill_complete":null}`), want: false},
+		{name: "non-bool string value", metadata: []byte(`{"backfill_complete":"true"}`), want: false},
+		{name: "non-bool numeric value", metadata: []byte(`{"backfill_complete":1}`), want: false},
+		{name: "malformed JSON", metadata: []byte(`{not-json`), want: false},
+		{name: "true value", metadata: []byte(`{"backfill_complete":true}`), want: true},
+		{name: "false value", metadata: []byte(`{"backfill_complete":false}`), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractBackfillComplete(tc.metadata)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/backend/internal/service/ingest_call_test.go
+++ b/backend/internal/service/ingest_call_test.go
@@ -151,6 +151,7 @@ func TestVerifyCallInvariants_HostIDMismatch(t *testing.T) {
 	require.Contains(t, rej.Message, "host_id")
 }
 
+// spec: ING-036
 func TestVerifyCallInvariants_RejectsUnknownSource(t *testing.T) {
 	host := uuid.New()
 	env := validCallEnv(t, events.KindCallReceived, host, "uniq-4")
@@ -158,9 +159,16 @@ func TestVerifyCallInvariants_RejectsUnknownSource(t *testing.T) {
 	rej := verifyCallInvariants(env, host)
 	require.NotNil(t, rej)
 	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
-	require.Contains(t, rej.Message, "source")
+	// The mutated env.Source also diverges from payload.Source, so pin
+	// the message to the ALLOWLIST branch (which runs first) — a plain
+	// "source" substring would also match the payload-vs-envelope check.
+	require.Contains(t, rej.Message, "not supported on call kinds")
 }
 
+// TestVerifyCallInvariants_RejectsSourceIDMismatch pins the call
+// family's verbatim dedup-key rule: envelope source_id must equal
+// payload.call_unique_id.
+// spec: ING-036
 func TestVerifyCallInvariants_RejectsSourceIDMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validCallEnv(t, events.KindCallReceived, host, "uniq-5")
@@ -171,6 +179,7 @@ func TestVerifyCallInvariants_RejectsSourceIDMismatch(t *testing.T) {
 	require.Contains(t, rej.Message, "source_id")
 }
 
+// spec: ING-036
 func TestVerifyCallInvariants_RejectsPeerNormalizedMismatch(t *testing.T) {
 	// T17: payload peer_normalized doesn't match Pi's re-canonicalization.
 	host := uuid.New()

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -157,6 +157,7 @@ func TestVerifyRawMessageInvariants_HostMismatch(t *testing.T) {
 
 // TestVerifyRawMessageInvariants_SourceMismatch rejects an envelope
 // whose source is not "messages" (currently the only supported one).
+// spec: ING-036
 func TestVerifyRawMessageInvariants_SourceMismatch(t *testing.T) {
 	host := uuid.New()
 	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
@@ -187,7 +188,9 @@ func TestVerifyRawMessageInvariants_PayloadSourceVsEnvelopeSource(t *testing.T) 
 
 // TestVerifyRawMessageInvariants_GuidMismatch rejects when payload.Guid
 // disagrees with env.SourceID — the staging-table dedup key and the
-// event-log dedup key MUST be the same string.
+// event-log dedup key MUST be the same string (the message family's
+// verbatim source_id-matches-dedup-key rule).
+// spec: ING-036
 func TestVerifyRawMessageInvariants_GuidMismatch(t *testing.T) {
 	host := uuid.New()
 	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
@@ -331,6 +334,7 @@ func TestVerifyExternalContactInvariants_HostMismatch(t *testing.T) {
 	require.Contains(t, rej.Message, "host_id")
 }
 
+// spec: ING-036
 func TestVerifyExternalContactInvariants_SourceMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validUpsertedEnv(host, "CN-1")
@@ -401,6 +405,10 @@ func TestVerifyExternalContactInvariants_BadSourceIDShape_Delete(t *testing.T) {
 	require.Contains(t, rej.Message, "source_id")
 }
 
+// TestVerifyExternalContactInvariants_SourceIDEntityPrefixMismatch pins
+// the composite-key half of the dedup recipe: the <entity>@<hash>
+// source_id's entity prefix must match the payload's own entity_id.
+// spec: ING-036
 func TestVerifyExternalContactInvariants_SourceIDEntityPrefixMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validUpsertedEnv(host, "CN-1")
@@ -883,6 +891,7 @@ func TestHandleExternalContactUpserted_AnarlogBlockUsesFailEmpty(t *testing.T) {
 // TestVerifyExternalContactInvariants_HashMismatchRejected proves the
 // Pi-side JCS recomputation catches a daemon-supplied source_id whose
 // hash does NOT match the canonical SHA-256(JCS(payload \ {host_id})).
+// spec: ING-036
 func TestVerifyExternalContactInvariants_HashMismatchRejected(t *testing.T) {
 	host := uuid.New()
 	env := validUpsertedEnv(host, "CN-1")
@@ -1154,6 +1163,7 @@ func TestVerifyMeetingNoteInvariants_HostMismatch(t *testing.T) {
 	require.Contains(t, rej.Message, "host_id")
 }
 
+// spec: ING-036
 func TestVerifyMeetingNoteInvariants_SourceMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validMeetingNoteRecordedEnv(t, host, uuid.NewString())
@@ -1181,6 +1191,10 @@ func TestVerifyMeetingNoteInvariants_NonUUIDSourceID(t *testing.T) {
 	require.Contains(t, rej.Message, "not a UUID")
 }
 
+// TestVerifyMeetingNoteInvariants_HashMismatch pins the meeting_note
+// half of the server-recomputed content-hash rule: a source_id whose
+// hash suffix does not match the recomputation is rejected.
+// spec: ING-036
 func TestVerifyMeetingNoteInvariants_HashMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validMeetingNoteRecordedEnv(t, host, uuid.NewString())

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -1206,6 +1206,21 @@ func TestVerifyMeetingNoteInvariants_HashMismatch(t *testing.T) {
 	require.Equal(t, ingestRejectMeetingNoteHashMismatch, rej.Code)
 }
 
+// TestVerifyMeetingNoteInvariants_EntityPrefixMismatch pins the composite
+// key's entity-prefix branch: a source_id whose prefix is a VALID but
+// DIFFERENT session UUID (regex shape intact, original hash suffix kept)
+// must be rejected on the prefix check, which runs before the hash check.
+// spec: ING-036
+func TestVerifyMeetingNoteInvariants_EntityPrefixMismatch(t *testing.T) {
+	host := uuid.New()
+	env := validMeetingNoteRecordedEnv(t, host, uuid.NewString())
+	hashSuffix := env.SourceID[len(env.SourceID)-64:]
+	env.SourceID = uuid.NewString() + "@" + hashSuffix
+	rej := verifyMeetingNoteInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "entity prefix does not match payload source_id")
+}
+
 func TestVerifyMeetingNoteInvariants_DeleteAcceptsUnknownSentinel(t *testing.T) {
 	host := uuid.New()
 	sessionUUID := uuid.NewString()

--- a/backend/tests/api/contact_method_operations_test.go
+++ b/backend/tests/api/contact_method_operations_test.go
@@ -1337,6 +1337,89 @@ func TestMethodOps_ConflictErrorTranslatesTo400(t *testing.T) {
 	}
 }
 
+// --- Rematch job id propagation ----------------------------------------------
+
+// stubApplierResult returns a fixed successful result, so the handler's
+// response assembly (contactMethodOperationsToResponse) can be exercised
+// directly without standing up a live rematch registry + event bus. The
+// registry/dispatcher mechanics (whether a job gets minted for a given
+// method type) are pinned at the service level in
+// backend/tests/rematch_integration_test.go
+// (TestRematch_ApplyMethodOperations_FiresForNewMethodOnly); this is the
+// HTTP-mapping half only.
+type stubApplierResult struct {
+	result *service.ApplyContactMethodsResult
+}
+
+func (s stubApplierResult) ApplyOperations(context.Context, uuid.UUID, []service.ContactMethodOperation) (*service.ApplyContactMethodsResult, error) {
+	return s.result, nil
+}
+
+// TestMethodOps_RematchJobIDPropagatesToResponse proves the operations
+// response carries rematch_job_id on the literal wire, both when a job was
+// minted and when it wasn't (the field is omitempty, so no job means the
+// key is absent rather than an empty string).
+// spec: IMP-019[1]
+func TestMethodOps_RematchJobIDPropagatesToResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("job minted surfaces literal rematch_job_id", func(t *testing.T) {
+		t.Parallel()
+		jobID := uuid.New()
+		router := newMethodOpsRouter(stubApplierResult{result: &service.ApplyContactMethodsResult{
+			Methods:      []repository.ContactMethod{},
+			RematchJobID: jobID,
+			Results:      []service.ContactMethodOperationResult{},
+		}})
+
+		body, err := json.Marshal(map[string]any{
+			"operations": []map[string]any{addOp("email", uniqueEmail())},
+		})
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/contacts/"+uuid.NewString()+"/methods", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope struct {
+			Data map[string]interface{} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		got, ok := envelope.Data["rematch_job_id"]
+		require.True(t, ok, "rematch_job_id key missing from operations response")
+		assert.Equal(t, jobID.String(), got)
+	})
+
+	t.Run("no job minted omits the key", func(t *testing.T) {
+		t.Parallel()
+		router := newMethodOpsRouter(stubApplierResult{result: &service.ApplyContactMethodsResult{
+			Methods:      []repository.ContactMethod{},
+			RematchJobID: uuid.Nil,
+			Results:      []service.ContactMethodOperationResult{},
+		}})
+
+		body, err := json.Marshal(map[string]any{
+			"operations": []map[string]any{addOp("email", uniqueEmail())},
+		})
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/contacts/"+uuid.NewString()+"/methods", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope struct {
+			Data map[string]interface{} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		_, ok := envelope.Data["rematch_job_id"]
+		assert.False(t, ok, "rematch_job_id key must be omitted when no job was minted")
+	})
+}
+
 // --- The route surface ------------------------------------------------------
 
 // TestMethodRoutes_NoDesiredSetPut asserts PUT /contacts/:id/methods is NOT

--- a/backend/tests/api/import_suggestions_api_test.go
+++ b/backend/tests/api/import_suggestions_api_test.go
@@ -1,0 +1,319 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// suggestionItem is the literal-wire-key decode of one SuggestionItemResponse
+// entry: a generic map so assertions bind to the actual JSON keys the
+// handler emits, never a round trip through the production DTO.
+type suggestionItem = map[string]interface{}
+
+// getSuggestions fetches the suggestions list with the given query string and
+// decodes the raw response body, returning the item list (as generic maps)
+// plus the response meta (also generic, so pagination keys are asserted
+// literally).
+func getSuggestions(t *testing.T, router http.Handler, query string) ([]suggestionItem, map[string]interface{}) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", "/api/v1/imports/suggestions?"+query, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var response struct {
+		Success bool                   `json:"success"`
+		Data    []suggestionItem       `json:"data"`
+		Meta    map[string]interface{} `json:"meta"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.True(t, response.Success)
+	return response.Data, response.Meta
+}
+
+// seedLinkedRowWithPendingMethod seeds a gcontacts external row linked
+// (imported) to a fresh contact, carrying exactly one pending method
+// suggestion for an email the external row itself carries (so it survives
+// the "still on the external row" appliability check) but the contact does
+// NOT yet have (so it survives the "not already on contact" drift check).
+// Returns the contact and the refreshed external row (post SetMethodSuggestions).
+func seedLinkedRowWithPendingMethod(
+	t *testing.T,
+	ctx context.Context,
+	contactRepo *repository.ContactRepository,
+	externalRepo *repository.ExternalContactRepository,
+	suffix string,
+) (*repository.Contact, *repository.ExternalContact) {
+	t.Helper()
+
+	name := fmt.Sprintf("Suggestion Method %s", suffix)
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+	})
+
+	pendingEmail := fmt.Sprintf("pending-method-%s@example.com", suffix)
+	displayName := name
+	external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "gcontacts",
+		SourceID:    "sugg-method-" + suffix,
+		DisplayName: &displayName,
+		Emails:      []repository.EmailEntry{{Value: pendingEmail, Type: "home"}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = externalRepo.Delete(ctx, external.ID)
+	})
+
+	_, err = externalRepo.UpdateMatch(ctx, external.ID, &contact.ID, repository.MatchStatusImported)
+	require.NoError(t, err)
+	_, err = externalRepo.SetMethodSuggestions(ctx, external.ID, []repository.PendingMethodSuggestion{
+		{Type: "email", Value: pendingEmail},
+	})
+	require.NoError(t, err)
+
+	updated, err := externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	return contact, updated
+}
+
+// findSuggestionItemIndex returns the index of the item whose kind/id match,
+// or -1. kind is "method" (id = suggestion.external_contact_id) or "contact"
+// (id = candidate.id).
+func findSuggestionItemIndex(items []suggestionItem, kind, id string) int {
+	for i, item := range items {
+		if item["kind"] != kind {
+			continue
+		}
+		switch kind {
+		case "method":
+			sugg, ok := item["suggestion"].(map[string]interface{})
+			if ok && sugg["external_contact_id"] == id {
+				return i
+			}
+		case "contact":
+			cand, ok := item["candidate"].(map[string]interface{})
+			if ok && cand["id"] == id {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// The method-suggestion group rides on top of the confidence-ranked
+// candidates, but ONLY on page 1 — the group is small and always returned
+// in full above the fold; paginating to page 2 must never repeat it.
+// spec: IMP-022[0]
+func TestImportSuggestionsAPI_MethodGroupOnlyOnFirstPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, externalRepo, contactRepo, _, cleanup := setupImportTestRouter()
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	_, methodExternal := seedLinkedRowWithPendingMethod(t, ctx, contactRepo, externalRepo, suffix)
+
+	// A plain unmatched candidate under the same source, so page 1 has both
+	// a method item and a contact item to order against each other.
+	candidateName := fmt.Sprintf("Suggestion Candidate %s", suffix)
+	candidateExternal, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "gcontacts",
+		SourceID:    "sugg-candidate-" + suffix,
+		DisplayName: &candidateName,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = externalRepo.Delete(ctx, candidateExternal.ID)
+	})
+
+	// Page 1: the method group is present and rides above the candidate
+	// group. A large limit is used so both seeded items are guaranteed to
+	// land on page 1 regardless of how many other gcontacts rows the shared
+	// DB accumulates from concurrent tests — the handler always emits ALL
+	// method items before ANY candidate item, so comparing OUR two indices
+	// still proves the ordering even with unrelated neighbors in the list.
+	page1Items, _ := getSuggestions(t, router, "source=gcontacts&limit=10000&page=1")
+	methodIdx := findSuggestionItemIndex(page1Items, "method", methodExternal.ID.String())
+	require.GreaterOrEqual(t, methodIdx, 0, "seeded method suggestion must surface on page 1")
+	candidateIdx := findSuggestionItemIndex(page1Items, "contact", candidateExternal.ID.String())
+	require.GreaterOrEqual(t, candidateIdx, 0, "seeded candidate must surface on page 1")
+	assert.Less(t, methodIdx, candidateIdx, "method group must ride on top of the candidate group")
+
+	// Page 2: the method group must NOT repeat, even though the same source
+	// filter is in effect.
+	page2Items, _ := getSuggestions(t, router, "source=gcontacts&limit=10000&page=2")
+	assert.Equal(t, -1, findSuggestionItemIndex(page2Items, "method", methodExternal.ID.String()),
+		"method group must not repeat past page 1")
+}
+
+// Contact candidates are confidence-ranked (shared sort with
+// /imports/candidates) and paginate over the candidate group only, with no
+// overlap between pages. Asserted through the /imports/suggestions endpoint
+// itself, not the shared sort helper.
+// spec: IMP-022[1]
+func TestImportSuggestionsAPI_CandidatesRankedAndPaginated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, externalRepo, contactRepo, contactMethodRepo, cleanup := setupImportTestRouter()
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	source := "test-rank-" + suffix
+	strPtr := func(s string) *string { return &s }
+
+	// High confidence: shared name AND email (method overlap).
+	highName := fmt.Sprintf("Rankcand High %s", suffix)
+	highEmail := fmt.Sprintf("rank-high-%s@example.com", suffix)
+	highContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: highName})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, highContact.ID) })
+	_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: highContact.ID, Type: "email", Value: highEmail,
+	})
+	require.NoError(t, err)
+	externalHigh, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: source, SourceID: "rank-high-" + suffix, DisplayName: strPtr(highName),
+		Emails: []repository.EmailEntry{{Value: highEmail, Type: "home"}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = externalRepo.Delete(ctx, externalHigh.ID) })
+
+	// Medium confidence: shared name only.
+	medName := fmt.Sprintf("Rankcand Medium %s", suffix)
+	medContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: medName})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, medContact.ID) })
+	externalMed, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: source, SourceID: "rank-med-" + suffix, DisplayName: strPtr(medName),
+		Emails: []repository.EmailEntry{{Value: fmt.Sprintf("rank-med-other-%s@example.com", suffix), Type: "home"}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = externalRepo.Delete(ctx, externalMed.ID) })
+
+	// Low/no confidence: no plausible match at all, sorts after all suggested
+	// candidates.
+	lowName := fmt.Sprintf("Rankcand Zzzlow %s", suffix)
+	externalLow, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: source, SourceID: "rank-low-" + suffix, DisplayName: strPtr(lowName),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = externalRepo.Delete(ctx, externalLow.ID) })
+
+	// limit=1 forces exactly one candidate per page across 3 pages, proving
+	// both rank order AND page-boundary correctness (no overlap).
+	page1, meta1 := getSuggestions(t, router, "source="+source+"&limit=1&page=1")
+	page2, meta2 := getSuggestions(t, router, "source="+source+"&limit=1&page=2")
+	page3, meta3 := getSuggestions(t, router, "source="+source+"&limit=1&page=3")
+
+	requireOneCandidate := func(items []suggestionItem) map[string]interface{} {
+		require.Len(t, items, 1)
+		require.Equal(t, "contact", items[0]["kind"])
+		cand, ok := items[0]["candidate"].(map[string]interface{})
+		require.True(t, ok)
+		return cand
+	}
+	cand1 := requireOneCandidate(page1)
+	cand2 := requireOneCandidate(page2)
+	cand3 := requireOneCandidate(page3)
+
+	assert.Equal(t, externalHigh.ID.String(), cand1["id"], "page 1 must be the highest-confidence candidate")
+	assert.Equal(t, externalMed.ID.String(), cand2["id"], "page 2 must be the medium-confidence candidate")
+	assert.Equal(t, externalLow.ID.String(), cand3["id"], "page 3 must be the unsuggested candidate")
+
+	assert.NotEqual(t, cand1["id"], cand2["id"])
+	assert.NotEqual(t, cand2["id"], cand3["id"])
+	assert.NotEqual(t, cand1["id"], cand3["id"])
+
+	for pageNum, meta := range map[int]map[string]interface{}{1: meta1, 2: meta2, 3: meta3} {
+		require.NotNil(t, meta, "page %d meta", pageNum)
+		pagination, ok := meta["pagination"].(map[string]interface{})
+		require.True(t, ok, "page %d pagination meta missing", pageNum)
+		assert.Equal(t, float64(pageNum), pagination["page"], "page %d", pageNum)
+		assert.Equal(t, float64(1), pagination["limit"], "page %d", pageNum)
+		assert.Equal(t, float64(3), pagination["total"], "page %d", pageNum)
+		assert.Equal(t, float64(3), pagination["pages"], "page %d", pageNum)
+	}
+}
+
+// Each candidate's allowed_actions is the server-side derivation for its
+// source: a link-only source (gmail_correspondence) never offers "import";
+// an ordinary source offers all three. Asserted on the literal wire key.
+// spec: IMP-022[2]
+func TestImportSuggestionsAPI_CandidateAllowedActionsPerSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, externalRepo, _, _, cleanup := setupImportTestRouter()
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	strPtr := func(s string) *string { return &s }
+
+	ordinaryName := fmt.Sprintf("Allowed Ordinary %s", suffix)
+	ordinary, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "gcontacts", SourceID: "allowed-ordinary-" + suffix, DisplayName: strPtr(ordinaryName),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = externalRepo.Delete(ctx, ordinary.ID) })
+
+	linkOnlyName := fmt.Sprintf("Allowed LinkOnly %s", suffix)
+	linkOnly, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "gmail_correspondence", SourceID: "allowed-linkonly-" + suffix, DisplayName: strPtr(linkOnlyName),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = externalRepo.Delete(ctx, linkOnly.ID) })
+
+	ordinaryItems, _ := getSuggestions(t, router, "source=gcontacts&limit=10000")
+	idx := findSuggestionItemIndex(ordinaryItems, "contact", ordinary.ID.String())
+	require.GreaterOrEqual(t, idx, 0, "seeded ordinary-source candidate must surface")
+	ordinaryCand := ordinaryItems[idx]["candidate"].(map[string]interface{})
+	ordinaryActions, ok := ordinaryCand["allowed_actions"].([]interface{})
+	require.True(t, ok, "allowed_actions missing from ordinary candidate wire response")
+	assert.ElementsMatch(t, []interface{}{"import", "link", "ignore"}, ordinaryActions,
+		"ordinary source must allow import, link, and ignore")
+
+	linkOnlyItems, _ := getSuggestions(t, router, "source=gmail_correspondence&limit=10000")
+	idx = findSuggestionItemIndex(linkOnlyItems, "contact", linkOnly.ID.String())
+	require.GreaterOrEqual(t, idx, 0, "seeded link-only-source candidate must surface")
+	linkOnlyCand := linkOnlyItems[idx]["candidate"].(map[string]interface{})
+	linkOnlyActions, ok := linkOnlyCand["allowed_actions"].([]interface{})
+	require.True(t, ok, "allowed_actions missing from link-only candidate wire response")
+	assert.ElementsMatch(t, []interface{}{"link", "ignore"}, linkOnlyActions,
+		"link-only source must allow only link and ignore")
+
+	assert.NotEqual(t, ordinaryActions, linkOnlyActions, "the two sources must declare pairwise-distinct action sets")
+}

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -62,6 +62,7 @@ func setupImportTestRouter() (*gin.Engine, *repository.ExternalContactRepository
 
 	// Create handler
 	importHandler := handlers.NewImportHandler(externalRepo, nil, contactService, matchService, enrichmentService, suggestionService)
+	suggestionHandler := handlers.NewSuggestionHandler(suggestionService)
 
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
@@ -76,6 +77,10 @@ func setupImportTestRouter() (*gin.Engine, *repository.ExternalContactRepository
 		imports.POST("/candidates/:id/import", importHandler.ImportContact)
 		imports.POST("/candidates/:id/link", importHandler.LinkContact)
 		imports.POST("/candidates/:id/ignore", importHandler.IgnoreContact)
+		// suggestions is a sibling static route (mirrors the production
+		// ordering in RegisterImportRoutes) — the server-declared
+		// allowed_actions per candidate live here.
+		imports.GET("/suggestions", suggestionHandler.ListSuggestions)
 	}
 
 	cleanup := func() {
@@ -2128,7 +2133,7 @@ func TestImportAPI_ImportValidation(t *testing.T) {
 	}
 
 	t.Parallel()
-	router, externalRepo, _, _, cleanup := setupImportTestRouter()
+	router, externalRepo, contactRepo, _, cleanup := setupImportTestRouter()
 	defer cleanup()
 
 	ctx := context.Background()
@@ -2169,9 +2174,56 @@ func TestImportAPI_ImportValidation(t *testing.T) {
 	})
 
 	t.Run("ImportContact_AlreadyImported", func(t *testing.T) {
-		// Skip: This test's expected behavior depends on specific API response format
-		// that may vary. Core import functionality is validated by E2E tests.
-		t.Skip("Skipping: already-imported behavior validated by E2E tests")
+		// Create an external contact with a name so the first import succeeds.
+		displayName := "Already Imported Candidate " + uuid.New().String()[:8]
+		external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:      "test",
+			SourceID:    uuid.New().String(),
+			DisplayName: &displayName,
+			Emails: []repository.EmailEntry{
+				{Value: "already-imported-" + uuid.New().String()[:8] + "@example.com", Type: "home"},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, external)
+
+		defer func() {
+			_ = externalRepo.Delete(ctx, external.ID)
+		}()
+
+		// First import succeeds and flips match_status away from unmatched.
+		firstReq, _ := http.NewRequest("POST", "/api/v1/imports/candidates/"+external.ID.String()+"/import", nil)
+		firstReq.Header.Set("Content-Type", "application/json")
+		firstW := httptest.NewRecorder()
+		router.ServeHTTP(firstW, firstReq)
+		require.Equal(t, http.StatusCreated, firstW.Code)
+
+		var firstResponse api.APIResponse
+		require.NoError(t, json.Unmarshal(firstW.Body.Bytes(), &firstResponse))
+		contactData := firstResponse.Data.(map[string]interface{})["contact"].(map[string]interface{})
+		contactID, err := uuid.Parse(contactData["id"].(string))
+		require.NoError(t, err)
+		defer func() {
+			_ = contactRepo.HardDeleteContact(ctx, contactID)
+		}()
+
+		// Re-importing the now-processed candidate is rejected (400).
+		req, _ := http.NewRequest("POST", "/api/v1/imports/candidates/"+external.ID.String()+"/import", nil)
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		// spec: IMP-011[0]
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var response api.APIResponse
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.False(t, response.Success)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
+		assert.Equal(t, string(repository.MatchStatusImported), response.Error.Details)
 	})
 
 	t.Run("ImportContact_NoName", func(t *testing.T) {
@@ -2247,6 +2299,99 @@ func TestImportAPI_ImportValidation(t *testing.T) {
 		require.NotNil(t, response.Error)
 		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
 	})
+}
+
+// TestImportAPI_LinkOnlySourcePolicy proves the whole IMP-014 invariant on
+// the wire: a link-only source (gmail_correspondence) never has "import"
+// among its server-declared allowed_actions (the suggestions surface), AND
+// a crafted import request against that same candidate is rejected
+// server-side (403) rather than merely hidden by the UI.
+// spec: IMP-014
+func TestImportAPI_LinkOnlySourcePolicy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, externalRepo, _, _, cleanup := setupImportTestRouter()
+	defer cleanup()
+
+	ctx := context.Background()
+
+	suffix := uuid.New().String()[:8]
+	displayName := "Link Only Policy " + suffix
+	external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "gmail_correspondence",
+		SourceID:    "gmail-correspondence-" + suffix,
+		DisplayName: &displayName,
+		Emails: []repository.EmailEntry{
+			{Value: "link-only-" + suffix + "@example.com", Type: "home"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, external)
+
+	defer func() {
+		_ = externalRepo.Delete(ctx, external.ID)
+	}()
+
+	// Half 1: the server declares the allowed actions per candidate — a
+	// link-only candidate's entry never offers "import". Asserted on the
+	// literal wire keys (generic map decode), not a round trip through the
+	// CandidateSuggestionResponse DTO.
+	sugReq, _ := http.NewRequest("GET", "/api/v1/imports/suggestions?source=gmail_correspondence&limit=1000", nil)
+	sugW := httptest.NewRecorder()
+	router.ServeHTTP(sugW, sugReq)
+	require.Equal(t, http.StatusOK, sugW.Code)
+
+	var sugResponse api.APIResponse
+	require.NoError(t, json.Unmarshal(sugW.Body.Bytes(), &sugResponse))
+	items, ok := sugResponse.Data.([]interface{})
+	require.True(t, ok, "suggestions response data was not a list")
+
+	var found bool
+	for _, raw := range items {
+		item, ok := raw.(map[string]interface{})
+		if !ok || item["kind"] != "contact" {
+			continue
+		}
+		candidate, ok := item["candidate"].(map[string]interface{})
+		if !ok || candidate["id"] != external.ID.String() {
+			continue
+		}
+		found = true
+		allowed, ok := candidate["allowed_actions"].([]interface{})
+		require.True(t, ok, "allowed_actions missing from candidate wire response")
+		assert.NotContains(t, allowed, "import", "link-only source must never declare import as allowed")
+		assert.Contains(t, allowed, "link")
+		assert.Contains(t, allowed, "ignore")
+	}
+	require.True(t, found, "seeded link-only candidate not present in suggestions response")
+
+	// Half 2: the policy is enforced server-side, not merely hidden
+	// client-side — a crafted import request is rejected with 403 and the
+	// row stays unmatched.
+	importReq, _ := http.NewRequest("POST", "/api/v1/imports/candidates/"+external.ID.String()+"/import", nil)
+	importReq.Header.Set("Content-Type", "application/json")
+	importW := httptest.NewRecorder()
+	router.ServeHTTP(importW, importReq)
+
+	assert.Equal(t, http.StatusForbidden, importW.Code)
+
+	var importResponse api.APIResponse
+	require.NoError(t, json.Unmarshal(importW.Body.Bytes(), &importResponse))
+	assert.False(t, importResponse.Success)
+	require.NotNil(t, importResponse.Error)
+	assert.Equal(t, "VALIDATION_ERROR", importResponse.Error.Code)
+
+	after, err := externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.MatchStatusUnmatched, after.MatchStatus, "row must stay unmatched after a rejected import")
 }
 
 func TestImportAPI_TelegramLinkWithMethodSelection(t *testing.T) {

--- a/backend/tests/api/ingest_host_liveness_test.go
+++ b/backend/tests/api/ingest_host_liveness_test.go
@@ -1,20 +1,29 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
@@ -357,4 +366,308 @@ func TestIngest_ConcurrentRevokeBlocksUntilBatchCommit(t *testing.T) {
 	defer cancel()
 	_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "icloud_contacts")
 	_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, "concurrent-revoke-")
+}
+
+// TestIngest_HostRevokedMidBatch_Returns401UnknownHost exercises the
+// HTTP half of the revoked-mid-batch contract: when IngestBatch aborts
+// with ErrHostRevokedDuringBatch, the handler must answer 401 with the
+// literal UNKNOWN_HOST code so the daemon stops retrying (a 5xx would
+// keep it hammering a revoked pairing).
+//
+// The request rides the PRODUCTION auth path (IngestAuthMiddleware →
+// MacHostAuthMiddleware with a real paired host), so the middleware's
+// own host lookup PASSES — the 401 asserted here can only come from
+// the handler's ErrHostRevokedDuringBatch mapping, fed by a stub
+// liveness checker that reports the host revoked at the tx-internal
+// re-check. liveness.calls is asserted to pin that provenance.
+//
+// Deliberately serial (no t.Parallel): pairs the singleton mac_host on
+// the shared DB and hard-deletes all hosts in cleanup, same as the
+// mac_host_* test files.
+//
+// spec: ING-006[1]
+func TestIngest_HostRevokedMidBatch_Returns401UnknownHost(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.External.APIKey = macHostTestKey
+	cfg.Features.EnableEventBusIngest = true
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	hostRepo := repository.NewMacHostRepository(database.Queries)
+	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	// bcrypt cost 4 keeps the real-bcrypt auth path tolerably fast.
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, externalRepo, nil, database.Pool, 4)
+
+	plain, _, err := macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pair, err := macService.PairWithToken(ctx, plain, "ing006-revoked-mid-batch", "0.1.0", 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		// Same sweep as setupMacHostEnv: hosts + tokens + any push
+		// sync-state rows pairing created.
+		states, _ := database.Queries.ListSyncStates(cleanCtx)
+		for _, s := range states {
+			if s.Strategy == "push" {
+				_ = database.Queries.DeleteSyncState(cleanCtx, s.ID)
+			}
+		}
+		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
+		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
+	})
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, nil, eventRepo)
+	// Stub liveness: the host row IS active in the DB (auth middleware
+	// passes), but the tx-internal FOR UPDATE re-check reports it
+	// revoked — the mid-batch revocation race this behavior is about.
+	liveness := &stubFailingHostLiveness{}
+	svc := service.NewIngestService(database, eventBus, nil, nil, nil, externalRepo, liveness, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	ingestHandler := handlers.NewIngestHandler(svc)
+
+	// gin mode is set once for the package in gin_test.go's init().
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+	ingestAuth := auth.IngestAuthMiddleware(
+		auth.APIKeyMiddleware(cfg),
+		auth.MacHostAuthMiddleware(hostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+	)
+	ingestGroup := router.Group("/api/v1/ingest")
+	ingestGroup.Use(ingestAuth)
+	ingestGroup.POST("/events", ingestHandler.IngestEvents)
+
+	// A fully-valid external_contact.upserted event whose payload claims
+	// the AUTHENTICATED host — nothing about the event itself is wrong,
+	// so the only failure in play is the revocation.
+	entityID := "ing006-revoked-" + uuid.NewString()[:8]
+	payload, err := events.Marshal(events.KindExternalContactUpserted, events.ExternalContactUpsertedPayload{
+		Version:  1,
+		HostID:   pair.HostID,
+		Source:   "icloud_contacts",
+		EntityID: entityID,
+	})
+	require.NoError(t, err)
+	hashHex, err := service.ComputeContentHash(payload)
+	require.NoError(t, err)
+	sourceID := entityID + "@" + hashHex
+
+	body, err := json.Marshal(map[string]any{
+		"events": []any{map[string]any{
+			"source":      "icloud_contacts",
+			"source_id":   sourceID,
+			"kind":        string(events.KindExternalContactUpserted),
+			"payload":     payload,
+			"observed_at": accelerated.GetCurrentTime(),
+		}},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", pair.HostID.String())
+	req.Header.Set("Authorization", "Bearer "+pair.APIKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+	// Assert the LITERAL wire error code, not a round-tripped DTO.
+	var respBody map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respBody))
+	errObj, ok := respBody["error"].(map[string]any)
+	require.True(t, ok, "response must carry an error object; body: %s", w.Body.String())
+	require.Equal(t, "UNKNOWN_HOST", errObj["code"], "body: %s", w.Body.String())
+
+	// Provenance: the auth middleware passed (host is active in the DB)
+	// and the 401 came from the batch's tx-internal re-check.
+	require.Equal(t, 1, liveness.calls,
+		"the in-tx liveness re-check must be what fired — a 0 here means the 401 came from the auth middleware instead")
+
+	// The aborted batch persisted nothing.
+	logged, err := eventRepo.FindEventBySource(ctx, "icloud_contacts", sourceID)
+	if err == nil {
+		require.Nil(t, logged, "no event-log row may commit when the batch 401s")
+	} else {
+		require.True(t, errors.Is(err, db.ErrNotFound),
+			"event-log row absence expected; got error %v", err)
+	}
+}
+
+// TestIngest_PayloadHostIDMismatch_RejectedForEveryDaemonFamily pins
+// the cross-family half of the daemon-claims invariant: for EVERY
+// registered daemon family, a payload whose claimed host_id differs
+// from the authenticated host is rejected (PAYLOAD_INVARIANT) instead
+// of trusted. The family list is enumerated from the production ingest
+// kind registry (service.DaemonFamilyViews), so registering a new
+// family without a host-id-mismatch case here fails loudly.
+//
+// Every current family's payload carries a host_id claim (raw_message,
+// external_contact, meeting_note, call) — there is no family that
+// "cannot carry" the claim today; the require on the builders map is
+// what forces a future family to either add a case or document an
+// exemption.
+//
+// Each envelope is fully valid EXCEPT the host claim (source in the
+// family allow-list, source_id matching the family's dedup-key shape
+// incl. server-recomputed content hashes, peer_normalized matching the
+// production re-canonicalization), so the asserted rejection can only
+// come from the host-id re-check. The service is wired with nil family
+// deps: on a regression that skips the check, dispatch degrades to a
+// "not configured" rejection whose message fails the assertions below
+// cleanly rather than panicking.
+//
+// spec: ING-036
+func TestIngest_PayloadHostIDMismatch_RejectedForEveryDaemonFamily(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	t.Parallel()
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, nil, eventRepo)
+	// nil hostLiveness (that re-check is ING-006's concern) and nil
+	// family deps — a host-mismatch rejection fires in the pre-savepoint
+	// verify step, before any dep is touched.
+	svc := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	authHostID := uuid.New()    // the host the request authenticated as
+	claimedHostID := uuid.New() // the differing claim inside the payload
+	require.NotEqual(t, authHostID, claimedHostID)
+	ns := uuid.NewString()[:8] // per-run namespace for dedup keys on the shared DB
+	observed := accelerated.GetCurrentTime()
+
+	// One representative envelope builder per family, keyed by the
+	// registry's family name. Both kinds of a family share one verify
+	// function, so one kind per family exercises the family's check.
+	builders := map[string]func(t *testing.T) *events.Envelope{
+		"raw_message": func(t *testing.T) *events.Envelope {
+			t.Helper()
+			guid := "ing036-" + ns + "-" + uuid.NewString()
+			payload, err := events.Marshal(events.KindRawMessageReceived, events.RawMessageReceivedPayload{
+				Version:     1,
+				HostID:      claimedHostID,
+				Source:      "messages",
+				Guid:        guid,
+				ChatID:      "ing036-chat-" + ns,
+				PeerHandle:  "+15550001111",
+				MessageType: "text",
+				SentAt:      observed,
+			})
+			require.NoError(t, err)
+			return &events.Envelope{
+				Source: "messages", SourceID: guid,
+				Kind: events.KindRawMessageReceived, Payload: payload, ObservedAt: observed,
+			}
+		},
+		"external_contact": func(t *testing.T) *events.Envelope {
+			t.Helper()
+			entityID := "ing036-" + ns + "-" + uuid.NewString()[:8]
+			payload, err := events.Marshal(events.KindExternalContactUpserted, events.ExternalContactUpsertedPayload{
+				Version:  1,
+				HostID:   claimedHostID,
+				Source:   "icloud_contacts",
+				EntityID: entityID,
+			})
+			require.NoError(t, err)
+			hashHex, err := service.ComputeContentHash(payload)
+			require.NoError(t, err)
+			return &events.Envelope{
+				Source: "icloud_contacts", SourceID: entityID + "@" + hashHex,
+				Kind: events.KindExternalContactUpserted, Payload: payload, ObservedAt: observed,
+			}
+		},
+		"meeting_note": func(t *testing.T) *events.Envelope {
+			t.Helper()
+			sessionUUID := uuid.NewString()
+			payload, err := events.Marshal(events.KindMeetingNoteRecorded, events.MeetingNoteRecordedPayload{
+				Version:   1,
+				HostID:    claimedHostID,
+				Source:    "anarlog_sessions",
+				SourceID:  sessionUUID,
+				MeetingAt: observed,
+			})
+			require.NoError(t, err)
+			hashHex, err := service.ComputeContentHash(payload)
+			require.NoError(t, err)
+			return &events.Envelope{
+				Source: "anarlog_sessions", SourceID: sessionUUID + "@" + hashHex,
+				Kind: events.KindMeetingNoteRecorded, Payload: payload, ObservedAt: observed,
+			}
+		},
+		"call": func(t *testing.T) *events.Envelope {
+			t.Helper()
+			callID := "ing036-" + ns + "-" + uuid.NewString()
+			const peer = "+15550002222"
+			normalized := identity.Normalize(peer, identity.DetectIdentifierType(peer))
+			require.NotEmpty(t, normalized)
+			payload, err := events.Marshal(events.KindCallReceived, events.CallPayload{
+				Version:         1,
+				HostID:          claimedHostID,
+				Source:          repository.InteractionSourcePhoneCalls,
+				CallUniqueID:    callID,
+				PeerHandle:      peer,
+				PeerNormalized:  normalized,
+				Service:         "voice",
+				Direction:       "inbound",
+				DurationSeconds: 30,
+				StartedAt:       observed,
+			})
+			require.NoError(t, err)
+			return &events.Envelope{
+				Source: repository.InteractionSourcePhoneCalls, SourceID: callID,
+				Kind: events.KindCallReceived, Payload: payload, ObservedAt: observed,
+			}
+		},
+	}
+
+	families := service.DaemonFamilyViews()
+	require.NotEmpty(t, families)
+	for _, fam := range families {
+		build, ok := builders[fam.Name]
+		require.True(t, ok,
+			"daemon family %q has no host-id-mismatch case in this table — every family must re-check the daemon's host claim (add a builder, or document why the family cannot carry one)", fam.Name)
+		t.Run(fam.Name, func(t *testing.T) {
+			env := build(t)
+			accepted, duplicate, rejections, needsAttention, err := svc.IngestBatch(
+				ctx, []*events.Envelope{env}, []int{0}, &authHostID,
+			)
+			require.NoError(t, err)
+			require.Equal(t, 0, accepted, "a mismatched host claim must never be accepted")
+			require.Equal(t, 0, duplicate)
+			require.Empty(t, needsAttention)
+			require.Len(t, rejections, 1)
+			require.Equal(t, 0, rejections[0].Index)
+			require.Equal(t, "PAYLOAD_INVARIANT", rejections[0].Code)
+			require.Contains(t, rejections[0].Message, "host_id does not match authenticated host",
+				"rejection must come from the host-claim re-check, got: %s", rejections[0].Message)
+
+			// The rejected event left no durable event-log row.
+			logged, ferr := eventRepo.FindEventBySource(ctx, env.Source, env.SourceID)
+			if ferr == nil {
+				require.Nil(t, logged, "no event-log row may persist for a host-mismatch rejection")
+			} else {
+				require.True(t, errors.Is(ferr, db.ErrNotFound),
+					"event-log row absence expected; got error %v", ferr)
+			}
+		})
+	}
 }

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -348,6 +348,7 @@ func TestIngest_MissingFields(t *testing.T) {
 	// spec: ING-004[2]
 	require.Contains(t, indexes, 1)
 	require.Contains(t, indexes[1], "observed_at")
+	// spec: ING-004[0]
 	require.Contains(t, indexes, 2)
 	require.Contains(t, indexes[2], "source")
 	// spec: ING-004[1]

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -211,7 +211,7 @@ func uniqueIngestSource(prefix string) string {
 	return prefix + "-" + uuid.NewString()
 }
 
-// spec: ING-001[0], ING-007[1]
+// spec: ING-001[0], ING-007[1], ING-004[1]
 func TestIngest_ValidBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -350,8 +350,10 @@ func TestIngest_MissingFields(t *testing.T) {
 	require.Contains(t, indexes[1], "observed_at")
 	require.Contains(t, indexes, 2)
 	require.Contains(t, indexes[2], "source")
+	// spec: ING-004[1]
 	require.Contains(t, indexes, 3)
 	require.Contains(t, indexes[3], "kind")
+	// spec: ING-004[3]
 	require.Contains(t, indexes, 4)
 	require.Contains(t, indexes[4], "payload")
 	require.Contains(t, indexes, 5)
@@ -368,7 +370,7 @@ func TestIngest_MissingFields(t *testing.T) {
 // would silently decode null into a zero-value struct, so the ingest
 // boundary must reject it as PAYLOAD_INVALID rather than persist a row
 // with all-zero payload fields.
-// spec: ING-003[0]
+// spec: ING-003[0], ING-004[3]
 func TestIngest_NullPayload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -399,6 +401,7 @@ func TestIngest_NullPayload(t *testing.T) {
 	require.Equal(t, int64(0), count)
 }
 
+// spec: ING-004[1]
 func TestIngest_UnknownKind(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -426,6 +429,7 @@ func TestIngest_UnknownKind(t *testing.T) {
 	require.Equal(t, "UNKNOWN_KIND", resp.Errors[0].Code)
 }
 
+// spec: ING-004[3]
 func TestIngest_PayloadStructurallyInvalid(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -456,6 +460,214 @@ func TestIngest_PayloadStructurallyInvalid(t *testing.T) {
 	require.Equal(t, 1, resp.Rejected)
 	require.Len(t, resp.Errors, 1)
 	require.Equal(t, "PAYLOAD_INVALID", resp.Errors[0].Code)
+}
+
+// ingestMaxSourceLen / ingestMaxSourceIDLen mirror the unexported
+// maxSourceLen / maxSourceIDLen constants in
+// internal/api/handlers/ingest.go (64 / 255 chars). Hardcoded here the
+// same way TestIngest_BatchTooLarge hardcodes 501 — this package can't
+// reference the handlers package's unexported constants directly.
+const (
+	ingestMaxSourceLen   = 64
+	ingestMaxSourceIDLen = 255
+)
+
+// padUniqueTo returns a string of exactly n bytes: a unique uuid prefix
+// (so the shared DB doesn't see cross-test collisions) padded with 'a'
+// to the exact target length.
+func padUniqueTo(n int) string {
+	id := uuid.NewString()
+	if len(id) >= n {
+		return id[:n]
+	}
+	return id + strings.Repeat("a", n-len(id))
+}
+
+// spec: ING-004[0]
+func TestIngest_SourceLengthBound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	setup := setupIngestTestRouter(t, true)
+
+	t.Run("OverMax_Rejected", func(t *testing.T) {
+		t.Parallel()
+		source := padUniqueTo(ingestMaxSourceLen + 1)
+		ev := buildManualEventReq(t, source, uuid.NewString())
+		batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{ev}}
+		w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var resp handlers.IngestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 0, resp.Accepted)
+		require.Equal(t, 1, resp.Rejected)
+		require.Len(t, resp.Errors, 1)
+		require.Equal(t, "FIELD_TOO_LONG", resp.Errors[0].Code)
+	})
+
+	t.Run("AtMax_Accepted", func(t *testing.T) {
+		t.Parallel()
+		source := padUniqueTo(ingestMaxSourceLen)
+		require.Len(t, source, ingestMaxSourceLen)
+		ev := buildManualEventReq(t, source, uuid.NewString())
+		batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{ev}}
+		w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var resp handlers.IngestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 1, resp.Accepted)
+		require.Equal(t, 0, resp.Rejected)
+
+		count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), count)
+	})
+}
+
+// spec: ING-004[0]
+func TestIngest_SourceIDLengthBound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	setup := setupIngestTestRouter(t, true)
+
+	t.Run("OverMax_Rejected", func(t *testing.T) {
+		t.Parallel()
+		source := uniqueIngestSource("sid-over-max")
+		sourceID := padUniqueTo(ingestMaxSourceIDLen + 1)
+		ev := buildManualEventReq(t, source, sourceID)
+		batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{ev}}
+		w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var resp handlers.IngestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 0, resp.Accepted)
+		require.Equal(t, 1, resp.Rejected)
+		require.Len(t, resp.Errors, 1)
+		require.Equal(t, "FIELD_TOO_LONG", resp.Errors[0].Code)
+	})
+
+	t.Run("AtMax_Accepted", func(t *testing.T) {
+		t.Parallel()
+		source := uniqueIngestSource("sid-at-max")
+		sourceID := padUniqueTo(ingestMaxSourceIDLen)
+		require.Len(t, sourceID, ingestMaxSourceIDLen)
+		ev := buildManualEventReq(t, source, sourceID)
+		batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{ev}}
+		w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var resp handlers.IngestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 1, resp.Accepted)
+		require.Equal(t, 0, resp.Rejected)
+
+		count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), count)
+	})
+}
+
+// TestIngest_PayloadSizeBound exercises the size-bound half of
+// ING-004[3]: payloads over the 64 KiB cap (maxPayloadBytes in
+// internal/api/handlers/ingest.go) are rejected PAYLOAD_TOO_LARGE, and a
+// payload at exactly the cap is accepted. The size check runs before
+// the kind-known / structural checks, so an oversized payload doesn't
+// need to be a valid interaction.manual payload — but the at-bound case
+// does (so it also proves an otherwise-valid event isn't penalized for
+// being large). Description is padded byte-for-byte (plain ASCII, no
+// JSON escaping) so the computed overhead is exact.
+//
+// spec: ING-004[3]
+func TestIngest_PayloadSizeBound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	setup := setupIngestTestRouter(t, true)
+
+	const maxPayloadBytes = 64 << 10 // mirrors handlers.maxPayloadBytes (unexported)
+
+	// Probe: build a valid manual-event payload with a short padding
+	// string to measure the fixed JSON overhead around the Description
+	// field, then compute the exact padding length needed to land the
+	// marshaled payload at exactly maxPayloadBytes.
+	buildPayload := func(t *testing.T, padLen int) json.RawMessage {
+		t.Helper()
+		observed := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+		payload, err := events.Marshal(events.KindInteractionManual, events.InteractionManualPayload{
+			Version:     1,
+			ContactID:   uuid.New(),
+			Direction:   "mutual",
+			OccurredAt:  observed,
+			Description: strings.Repeat("x", padLen),
+		})
+		require.NoError(t, err)
+		return payload
+	}
+
+	probePadLen := 10
+	probe := buildPayload(t, probePadLen)
+	overhead := len(probe) - probePadLen
+	atBoundPadLen := maxPayloadBytes - overhead
+	require.Greater(t, atBoundPadLen, 0)
+
+	t.Run("OverSize_Rejected", func(t *testing.T) {
+		t.Parallel()
+		source := uniqueIngestSource("payload-oversize")
+		observed := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+		payload := buildPayload(t, atBoundPadLen+1)
+		require.Greater(t, len(payload), maxPayloadBytes)
+		ev := handlers.IngestEventRequest{
+			Source:     source,
+			SourceID:   uuid.NewString(),
+			Kind:       string(events.KindInteractionManual),
+			Payload:    payload,
+			ObservedAt: &observed,
+		}
+		batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{ev}}
+		w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var resp handlers.IngestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 0, resp.Accepted)
+		require.Equal(t, 1, resp.Rejected)
+		require.Len(t, resp.Errors, 1)
+		require.Equal(t, "PAYLOAD_TOO_LARGE", resp.Errors[0].Code)
+	})
+
+	t.Run("AtBound_Accepted", func(t *testing.T) {
+		t.Parallel()
+		source := uniqueIngestSource("payload-at-bound")
+		observed := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+		payload := buildPayload(t, atBoundPadLen)
+		require.Equal(t, maxPayloadBytes, len(payload))
+		ev := handlers.IngestEventRequest{
+			Source:     source,
+			SourceID:   uuid.NewString(),
+			Kind:       string(events.KindInteractionManual),
+			Payload:    payload,
+			ObservedAt: &observed,
+		}
+		batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{ev}}
+		w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		var resp handlers.IngestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 1, resp.Accepted)
+		require.Equal(t, 0, resp.Rejected)
+
+		count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), count)
+	})
 }
 
 // spec: ING-002[3]
@@ -691,6 +903,42 @@ func TestIngest_BodyTooLarge_Returns413(t *testing.T) {
 	raw := fmt.Sprintf(`{"events":[{"source":"x","kind":"interaction.manual","payload":{"v":%q},"observed_at":"2026-04-10T12:00:00Z"}]}`, big)
 	w := postIngest(t, setup.router, setup.apiKey, []byte(raw))
 	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "body: %s", w.Body.String())
+}
+
+// TestIngest_NeedsAttentionKeyAbsentWhenNoAttention pins the
+// backward-compat half of the needs-attention contract on the LITERAL
+// wire body: a batch that produces no attention items must omit the
+// needs_attention key ENTIRELY (json omitempty), so daemons that
+// predate the field see a byte-compatible response. Decoding into the
+// production IngestResponse struct cannot distinguish an absent key
+// from `"needs_attention": null` or `[]` — hence the raw map decode
+// with a key-presence check.
+// spec: ING-035[1]
+func TestIngest_NeedsAttentionKeyAbsentWhenNoAttention(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	setup := setupIngestTestRouter(t, true)
+
+	source := uniqueIngestSource("na-key-absent")
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{
+			buildManualEventReq(t, source, uuid.NewString()),
+		},
+	}
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	// Sanity: sibling keys ARE present, so the absence check below is
+	// not vacuously passing on a mis-decoded/empty object.
+	require.Contains(t, raw, "accepted")
+	require.Contains(t, raw, "errors")
+	_, present := raw["needs_attention"]
+	require.False(t, present,
+		"needs_attention must be ABSENT from the wire body (not null or []) when no session needs attention; got: %s", w.Body.String())
 }
 
 // failingRepo is a test double that wraps a real EventRepository and fails

--- a/backend/tests/api/mac_host_auth_test.go
+++ b/backend/tests/api/mac_host_auth_test.go
@@ -108,6 +108,13 @@ func TestMacHost_Auth_MinProtocolVersion_412(t *testing.T) {
 	errObj, ok := body["error"].(map[string]any)
 	require.True(t, ok, "body: %v", body)
 	require.Equal(t, "UPGRADE_REQUIRED", errObj["code"])
+
+	// spec: MAC-012[1]
+	// The 412 body must carry the minimum acceptable protocol version
+	// literally as min_version so the daemon knows what to upgrade to.
+	minVersion, ok := errObj["min_version"]
+	require.True(t, ok, "error body missing min_version key: %v", errObj)
+	require.EqualValues(t, 1, minVersion, "min_version must equal the server floor (mac.MinProtocolVersion)")
 }
 
 func uuidNew() string {

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +24,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -403,6 +406,121 @@ func TestMacHost_Singleton_SecondPairBlocked(t *testing.T) {
 	require.Equal(t, http.StatusConflict, w.Code, "second pair must be 409 from singleton; body: %s", w.Body.String())
 }
 
+// TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState pairs a
+// host, sends a heartbeat carrying distinct values for every
+// daemon-supplied field, then reads the host back through the admin
+// GET route to confirm each field was actually persisted — and
+// separately decodes the heartbeat response body for the literal
+// cursor_epoch/protocol_version/min_protocol_version keys.
+func TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+
+	plain, _, err := env.macService.CreatePairingToken(context.Background())
+	require.NoError(t, err)
+	res, err := env.macService.PairWithToken(context.Background(), plain, "heartbeat-fields-host", "0.1.0", 1)
+	require.NoError(t, err)
+
+	hostHeaders := map[string]string{
+		"X-Mac-Host-ID": res.HostID.String(),
+		"Authorization": "Bearer " + res.APIKey,
+	}
+
+	before := accelerated.GetCurrentTime()
+
+	// Distinct values on every daemon-supplied field. protocol_version
+	// (2) and cursor_epoch (1, from pairing) are pairwise-distinct
+	// numerics; the JSON blobs are distinct from each other and from
+	// the empty defaults the handler substitutes when absent.
+	const heartbeatDaemonVersion = "9.9.9-heartbeat-test"
+	const heartbeatProtocolVersion = 2
+	permissions := json.RawMessage(`{"fda":true,"screen_recording":false}`)
+	sourceHealth := json.RawMessage(`{"messages":{"ok":true},"phone_calls":{"ok":false}}`)
+
+	w := macHTTP(t, env, http.MethodPost, "/api/v1/host/"+res.HostID.String()+"/heartbeat", hostHeaders, map[string]any{
+		"daemon_version":   heartbeatDaemonVersion,
+		"protocol_version": heartbeatProtocolVersion,
+		"permissions":      permissions,
+		"source_health":    sourceHealth,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// spec: MAC-011[1]
+	// spec: MAC-011[2]
+	// Literal wire keys on the heartbeat response body — decoded via a
+	// local struct with matching json tags, not the handler's private
+	// response type.
+	var hbResp struct {
+		OK                 bool  `json:"ok"`
+		CursorEpoch        int64 `json:"cursor_epoch"`
+		ProtocolVersion    int32 `json:"protocol_version"`
+		MinProtocolVersion int32 `json:"min_protocol_version"`
+	}
+	readData(t, w, &hbResp)
+	require.True(t, hbResp.OK)
+	require.Equal(t, res.CursorEpoch, hbResp.CursorEpoch, "cursor_epoch must echo the host's current epoch")
+	require.EqualValues(t, 2, hbResp.ProtocolVersion, "protocol_version must be the server's current version (mac.ProtocolVersion)")
+	require.EqualValues(t, 1, hbResp.MinProtocolVersion, "min_protocol_version must be the server's floor (mac.MinProtocolVersion)")
+
+	// spec: MAC-011[0]
+	// Read the host back via the admin GET route and assert every
+	// heartbeat-supplied field was actually persisted.
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String(), map[string]string{
+		"X-API-Key": env.apiKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var hostView struct {
+		DaemonVersion   string          `json:"daemon_version"`
+		ProtocolVersion int32           `json:"protocol_version"`
+		LastHeartbeatAt *time.Time      `json:"last_heartbeat_at"`
+		Permissions     json.RawMessage `json:"permissions"`
+		SourceHealth    json.RawMessage `json:"source_health"`
+	}
+	readData(t, w, &hostView)
+
+	require.Equal(t, heartbeatDaemonVersion, hostView.DaemonVersion, "daemon_version must be persisted")
+	require.EqualValues(t, heartbeatProtocolVersion, hostView.ProtocolVersion, "protocol_version must be persisted")
+	require.NotNil(t, hostView.LastHeartbeatAt, "last_heartbeat_at must be recorded")
+	require.False(t, hostView.LastHeartbeatAt.Before(before.Add(-time.Second)), "last_heartbeat_at must reflect the heartbeat, not a stale value")
+	require.JSONEq(t, string(permissions), string(hostView.Permissions), "permissions must be persisted verbatim")
+	require.JSONEq(t, string(sourceHealth), string(hostView.SourceHealth), "source_health must be persisted verbatim")
+}
+
+// TestMacHost_GetCursor_PreCommit_EmptyBaseline covers reading a
+// freshly-paired host's cursor before any commit has happened: the
+// cursor must be empty and the epoch must be the host's current
+// (post-pairing) epoch, never a fabricated non-empty value.
+func TestMacHost_GetCursor_PreCommit_EmptyBaseline(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+
+	plain, _, err := env.macService.CreatePairingToken(context.Background())
+	require.NoError(t, err)
+	res, err := env.macService.PairWithToken(context.Background(), plain, "precommit-cursor-host", "0.1.0", 1)
+	require.NoError(t, err)
+
+	hostHeaders := map[string]string{
+		"X-Mac-Host-ID": res.HostID.String(),
+		"Authorization": "Bearer " + res.APIKey,
+	}
+
+	// spec: MAC-015[1]
+	// No commit has happened yet for this host+source.
+	w := macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/messages/cursor", hostHeaders, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var cur struct {
+		Cursor           string `json:"cursor"`
+		CursorEpoch      int64  `json:"cursor_epoch"`
+		BackfillComplete bool   `json:"backfill_complete"`
+	}
+	readData(t, w, &cur)
+	require.Equal(t, "", cur.Cursor, "cursor must be empty before any commit")
+	require.Equal(t, res.CursorEpoch, cur.CursorEpoch, "cursor_epoch must be the host's current epoch")
+	require.False(t, cur.BackfillComplete, "backfill_complete must default to false before any commit")
+}
+
 func TestMacHost_CursorFirstWriteRace(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -448,4 +566,249 @@ func TestMacHost_CursorFirstWriteRace(t *testing.T) {
 	}
 	require.Equal(t, 1, success, "exactly one commit must win")
 	require.Equal(t, N-1, conflict, "all other commits surface ErrCursorBaseMismatch")
+}
+
+// TestMacHost_Pair_PlaintextKeyNeverLeaksInSubsequentReads pairs a host
+// and sweeps every subsequent read surface (heartbeat response, admin
+// ListHosts, admin GetHostAdmin) for the plaintext api key, asserting
+// on the raw response body string rather than any decoded struct —
+// a struct round-trip could not catch a field the production DTO
+// doesn't declare but the handler still serializes ad hoc.
+func TestMacHost_Pair_PlaintextKeyNeverLeaksInSubsequentReads(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+
+	plain, _, err := env.macService.CreatePairingToken(context.Background())
+	require.NoError(t, err)
+
+	// spec: MAC-003[0]
+	w := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, map[string]any{
+		"pairing_token":    plain,
+		"hostname":         "plaintext-sweep-" + uuid.NewString()[:8],
+		"daemon_version":   "0.1.0",
+		"protocol_version": 1,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "pair: %s", w.Body.String())
+	require.Contains(t, w.Body.String(), `"api_key"`, "sanity: pair response must actually carry the key field")
+
+	var pair struct {
+		HostID uuid.UUID `json:"host_id"`
+		APIKey string    `json:"api_key"`
+	}
+	readData(t, w, &pair)
+	require.NotEmpty(t, pair.APIKey)
+
+	hostHeaders := map[string]string{
+		"X-Mac-Host-ID": pair.HostID.String(),
+		"Authorization": "Bearer " + pair.APIKey,
+	}
+
+	// Heartbeat response must never echo the plaintext key back.
+	w = macHTTP(t, env, http.MethodPost, "/api/v1/host/"+pair.HostID.String()+"/heartbeat", hostHeaders, map[string]any{
+		"daemon_version":   "0.1.0",
+		"protocol_version": 1,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "heartbeat: %s", w.Body.String())
+	require.NotContains(t, w.Body.String(), pair.APIKey, "heartbeat response must never contain the plaintext api key")
+	require.NotContains(t, w.Body.String(), `"api_key"`, "heartbeat response must never carry an api_key wire key at all")
+
+	// Admin ListHosts.
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host", map[string]string{"X-API-Key": env.apiKey}, nil)
+	require.Equal(t, http.StatusOK, w.Code, "list hosts: %s", w.Body.String())
+	require.NotContains(t, w.Body.String(), pair.APIKey, "ListHosts response must never contain the plaintext api key")
+	require.NotContains(t, w.Body.String(), `"api_key"`, "ListHosts response must never carry an api_key wire key at all (not even hashed)")
+
+	// Admin GetHostAdmin.
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+pair.HostID.String(), map[string]string{"X-API-Key": env.apiKey}, nil)
+	require.Equal(t, http.StatusOK, w.Code, "get admin: %s", w.Body.String())
+	require.NotContains(t, w.Body.String(), pair.APIKey, "GetHostAdmin response must never contain the plaintext api key")
+	require.NotContains(t, w.Body.String(), `"api_key"`, "GetHostAdmin response must never carry an api_key wire key at all (not even hashed)")
+}
+
+// spec: MAC-003[1]
+// TestMacHost_Pair_ExpiredUnconsumedToken_410 seeds an expired-but-never-
+// consumed pairing token directly (SeedPairingToken accepts an explicit
+// expires_at, the same helper the rotate-key sibling test uses for its
+// TOKEN_EXPIRED case) and drives it through the actual pairing endpoint,
+// asserting the opaque 410 the pairing contract collapses all token-state
+// failures to.
+func TestMacHost_Pair_ExpiredUnconsumedToken_410(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+
+	plaintext := "expired-pair-token-" + uuid.NewString()[:8]
+	hash := sha256.Sum256([]byte(plaintext))
+	_, err := env.database.Queries.SeedPairingToken(context.Background(), db.SeedPairingTokenParams{
+		TokenHash: hex.EncodeToString(hash[:]),
+		ExpiresAt: pgtype.Timestamptz{Time: accelerated.GetCurrentTime().Add(-1 * time.Hour), Valid: true},
+	})
+	require.NoError(t, err)
+
+	w := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, map[string]any{
+		"pairing_token":    plaintext,
+		"hostname":         "expired-token-host-" + uuid.NewString()[:8],
+		"daemon_version":   "0.1.0",
+		"protocol_version": 1,
+	})
+	require.Equal(t, http.StatusGone, w.Code, "expired unconsumed token must surface 410, body: %s", w.Body.String())
+}
+
+// TestMacHost_Heartbeat_TooOldProtocol_NoWriteBefore412 pairs a host,
+// seeds distinguishable state via one accepted heartbeat, then sends a
+// below-floor-protocol heartbeat carrying DIFFERENT values on every
+// mutable field and asserts the 412 rejection AND that none of those
+// fields moved — proving the protocol gate runs before any database
+// write, not merely before the response is sent.
+// spec: MAC-012[0]
+func TestMacHost_Heartbeat_TooOldProtocol_NoWriteBefore412(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+
+	plain, _, err := env.macService.CreatePairingToken(context.Background())
+	require.NoError(t, err)
+	res, err := env.macService.PairWithToken(context.Background(), plain, "protocol-gate-host-"+uuid.NewString()[:8], "0.1.0", 1)
+	require.NoError(t, err)
+
+	hostHeaders := map[string]string{
+		"X-Mac-Host-ID": res.HostID.String(),
+		"Authorization": "Bearer " + res.APIKey,
+	}
+
+	// Seed real, accepted state first so there is something concrete
+	// to prove is untouched by the rejected heartbeat below.
+	seedPermissions := json.RawMessage(`{"fda":true,"screen_recording":false}`)
+	seedSourceHealth := json.RawMessage(`{"messages":{"ok":true}}`)
+	w := macHTTP(t, env, http.MethodPost, "/api/v1/host/"+res.HostID.String()+"/heartbeat", hostHeaders, map[string]any{
+		"daemon_version":   "1.2.3-seed",
+		"protocol_version": 1,
+		"permissions":      seedPermissions,
+		"source_health":    seedSourceHealth,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "seed heartbeat: %s", w.Body.String())
+
+	pre, err := env.hostRepo.GetHost(context.Background(), res.HostID)
+	require.NoError(t, err)
+	require.NotNil(t, pre.LastHeartbeatAt, "seed heartbeat must have recorded last_heartbeat_at")
+
+	// Below-floor protocol_version (server minimum is 1) carrying
+	// DISTINCT values on every mutable field vs. the seed above.
+	w = macHTTP(t, env, http.MethodPost, "/api/v1/host/"+res.HostID.String()+"/heartbeat", hostHeaders, map[string]any{
+		"daemon_version":   "9.9.9-rejected",
+		"protocol_version": 0,
+		"permissions":      json.RawMessage(`{"fda":false,"screen_recording":true}`),
+		"source_health":    json.RawMessage(`{"messages":{"ok":false},"phone_calls":{"ok":true}}`),
+	})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code, "body: %s", w.Body.String())
+
+	post, err := env.hostRepo.GetHost(context.Background(), res.HostID)
+	require.NoError(t, err)
+
+	require.Equal(t, pre.LastHeartbeatAt, post.LastHeartbeatAt, "last_heartbeat_at must be untouched by a 412-rejected heartbeat")
+	require.Equal(t, pre.DaemonVersion, post.DaemonVersion, "daemon_version must be untouched by a 412-rejected heartbeat")
+	require.Equal(t, pre.ProtocolVersion, post.ProtocolVersion, "protocol_version must be untouched by a 412-rejected heartbeat")
+	require.JSONEq(t, string(pre.Permissions), string(post.Permissions), "permissions must be untouched by a 412-rejected heartbeat")
+	require.JSONEq(t, string(pre.SourceHealth), string(post.SourceHealth), "source_health must be untouched by a 412-rejected heartbeat")
+}
+
+// TestMacHost_Cursor_BackfillComplete_DefaultsFalseWhenAbsent commits a
+// cursor whose request body omits the backfill_complete key entirely
+// (not merely sets it false) and asserts the read-back flag is false.
+// spec: MAC-015[2]
+func TestMacHost_Cursor_BackfillComplete_DefaultsFalseWhenAbsent(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+
+	plain, _, err := env.macService.CreatePairingToken(context.Background())
+	require.NoError(t, err)
+	res, err := env.macService.PairWithToken(context.Background(), plain, "backfill-default-host-"+uuid.NewString()[:8], "0.1.0", 1)
+	require.NoError(t, err)
+
+	hostHeaders := map[string]string{
+		"X-Mac-Host-ID": res.HostID.String(),
+		"Authorization": "Bearer " + res.APIKey,
+	}
+
+	// Deliberately no "backfill_complete" key in this map at all.
+	w := macHTTP(t, env, http.MethodPost, "/api/v1/host/"+res.HostID.String()+"/sync/messages/cursor", hostHeaders, map[string]any{
+		"cursor":       "cursor-no-backfill-key",
+		"base_cursor":  "",
+		"cursor_epoch": res.CursorEpoch,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "commit: %s", w.Body.String())
+
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/messages/cursor", hostHeaders, nil)
+	require.Equal(t, http.StatusOK, w.Code, "get cursor: %s", w.Body.String())
+	var cur struct {
+		Cursor           string `json:"cursor"`
+		BackfillComplete bool   `json:"backfill_complete"`
+	}
+	readData(t, w, &cur)
+	require.Equal(t, "cursor-no-backfill-key", cur.Cursor)
+	require.False(t, cur.BackfillComplete, "backfill_complete must default to false when the commit body omits the key")
+}
+
+// TestMacHost_PushSourceAllowlist_HTTP drives the cursor get/commit and
+// known-ids endpoints with an unknown push source and asserts the
+// validation error, then drives one allowed source as acceptance —
+// exercising the handler-level allowlist gate (mac.IsAllowedPushSource)
+// over HTTP rather than only at the unit level.
+// spec: MAC-013
+func TestMacHost_PushSourceAllowlist_HTTP(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+
+	plain, _, err := env.macService.CreatePairingToken(context.Background())
+	require.NoError(t, err)
+	res, err := env.macService.PairWithToken(context.Background(), plain, "allowlist-host-"+uuid.NewString()[:8], "0.1.0", 1)
+	require.NoError(t, err)
+
+	hostHeaders := map[string]string{
+		"X-Mac-Host-ID": res.HostID.String(),
+		"Authorization": "Bearer " + res.APIKey,
+	}
+
+	const unknownSource = "not_a_real_source"
+
+	assertValidationError := func(w *httptest.ResponseRecorder, label string) {
+		require.Equal(t, http.StatusBadRequest, w.Code, "%s: %s", label, w.Body.String())
+		var errBody struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&errBody))
+		require.Equal(t, "VALIDATION_ERROR", errBody.Error.Code, "%s error code", label)
+	}
+
+	// GET cursor rejects unknown source.
+	w := macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+unknownSource+"/cursor", hostHeaders, nil)
+	assertValidationError(w, "GetCursor unknown source")
+
+	// POST cursor (commit) rejects unknown source.
+	w = macHTTP(t, env, http.MethodPost, "/api/v1/host/"+res.HostID.String()+"/sync/"+unknownSource+"/cursor", hostHeaders, map[string]any{
+		"cursor":       "x",
+		"base_cursor":  "",
+		"cursor_epoch": res.CursorEpoch,
+	})
+	assertValidationError(w, "CommitCursor unknown source")
+
+	// GET known-ids rejects unknown source.
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+unknownSource+"/known-ids", hostHeaders, nil)
+	assertValidationError(w, "KnownIDs unknown source")
+
+	// Acceptance: a genuinely allowed source succeeds on all three.
+	const allowedSource = "phone_calls"
+
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+allowedSource+"/cursor", hostHeaders, nil)
+	require.Equal(t, http.StatusOK, w.Code, "GetCursor allowed source: %s", w.Body.String())
+
+	w = macHTTP(t, env, http.MethodPost, "/api/v1/host/"+res.HostID.String()+"/sync/"+allowedSource+"/cursor", hostHeaders, map[string]any{
+		"cursor":       "phone-cursor-1",
+		"base_cursor":  "",
+		"cursor_epoch": res.CursorEpoch,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "CommitCursor allowed source: %s", w.Body.String())
+
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+allowedSource+"/known-ids", hostHeaders, nil)
+	require.Equal(t, http.StatusOK, w.Code, "KnownIDs allowed source: %s", w.Body.String())
 }

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -19,6 +19,7 @@ import (
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/mac"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
@@ -426,12 +427,39 @@ func TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState(t *testing.T) {
 		"Authorization": "Bearer " + res.APIKey,
 	}
 
-	before := accelerated.GetCurrentTime()
+	ctx := context.Background()
 
-	// Distinct values on every daemon-supplied field. protocol_version
-	// (2) and cursor_epoch (1, from pairing) are pairwise-distinct
-	// numerics; the JSON blobs are distinct from each other and from
-	// the empty defaults the handler substitutes when absent.
+	// Bump the host's cursor_epoch twice (1 → 3) so cursor_epoch,
+	// protocol_version (mac.ProtocolVersion = 2), and
+	// min_protocol_version (mac.MinProtocolVersion = 1) are all
+	// pairwise-distinct — a tag swap between any two of the numeric
+	// response fields would otherwise be green when two of them share a
+	// value. BumpMacHostCursorEpoch is the same admin/backup-restore
+	// epoch mechanism the daemon-cache-invalidation flow uses; its
+	// RETURNING value is the independent read the epoch assertion
+	// compares against.
+	_, err = env.database.Queries.BumpMacHostCursorEpoch(ctx, pgtype.UUID{Bytes: res.HostID, Valid: true})
+	require.NoError(t, err)
+	bumpedEpoch, err := env.database.Queries.BumpMacHostCursorEpoch(ctx, pgtype.UUID{Bytes: res.HostID, Valid: true})
+	require.NoError(t, err)
+	require.NotEqual(t, int64(mac.ProtocolVersion), bumpedEpoch, "fixture sanity: epoch must differ from protocol_version")
+	require.NotEqual(t, int64(mac.MinProtocolVersion), bumpedEpoch, "fixture sanity: epoch must differ from min_protocol_version")
+
+	// Stamp last_heartbeat_at to a fixed past value so the post-heartbeat
+	// assertion can require strict advancement from a KNOWN persisted
+	// baseline — without ever comparing the DB's NOW()-written value
+	// against accelerated.GetCurrentTime() (the accelerated clock can sit
+	// far ahead of the wall clock the DB writes with).
+	seededHeartbeatAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, env.hostRepo.SetHeartbeatAtForTest(ctx, res.HostID, seededHeartbeatAt))
+	pre, err := env.hostRepo.GetHost(ctx, res.HostID)
+	require.NoError(t, err)
+	require.NotNil(t, pre.LastHeartbeatAt)
+	require.True(t, pre.LastHeartbeatAt.Equal(seededHeartbeatAt), "fixture sanity: baseline heartbeat stamp persisted")
+
+	// Distinct values on every daemon-supplied field. The JSON blobs are
+	// distinct from each other and from the empty defaults the handler
+	// substitutes when absent.
 	const heartbeatDaemonVersion = "9.9.9-heartbeat-test"
 	const heartbeatProtocolVersion = 2
 	permissions := json.RawMessage(`{"fda":true,"screen_recording":false}`)
@@ -449,7 +477,11 @@ func TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState(t *testing.T) {
 	// spec: MAC-011[2]
 	// Literal wire keys on the heartbeat response body — decoded via a
 	// local struct with matching json tags, not the handler's private
-	// response type.
+	// response type. Each numeric field is compared against an
+	// INDEPENDENT read of the value it must carry (the epoch bump's
+	// RETURNING value; the mac package constants), and the three values
+	// are pairwise-distinct (3 / 2 / 1), so a swapped wire tag cannot
+	// pass.
 	var hbResp struct {
 		OK                 bool  `json:"ok"`
 		CursorEpoch        int64 `json:"cursor_epoch"`
@@ -458,9 +490,9 @@ func TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState(t *testing.T) {
 	}
 	readData(t, w, &hbResp)
 	require.True(t, hbResp.OK)
-	require.Equal(t, res.CursorEpoch, hbResp.CursorEpoch, "cursor_epoch must echo the host's current epoch")
-	require.EqualValues(t, 2, hbResp.ProtocolVersion, "protocol_version must be the server's current version (mac.ProtocolVersion)")
-	require.EqualValues(t, 1, hbResp.MinProtocolVersion, "min_protocol_version must be the server's floor (mac.MinProtocolVersion)")
+	require.Equal(t, bumpedEpoch, hbResp.CursorEpoch, "cursor_epoch must echo the host's current (post-bump) epoch")
+	require.Equal(t, mac.ProtocolVersion, hbResp.ProtocolVersion, "protocol_version must be the server's current version (mac.ProtocolVersion)")
+	require.Equal(t, mac.MinProtocolVersion, hbResp.MinProtocolVersion, "min_protocol_version must be the server's floor (mac.MinProtocolVersion)")
 
 	// spec: MAC-011[0]
 	// Read the host back via the admin GET route and assert every
@@ -482,7 +514,15 @@ func TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState(t *testing.T) {
 	require.Equal(t, heartbeatDaemonVersion, hostView.DaemonVersion, "daemon_version must be persisted")
 	require.EqualValues(t, heartbeatProtocolVersion, hostView.ProtocolVersion, "protocol_version must be persisted")
 	require.NotNil(t, hostView.LastHeartbeatAt, "last_heartbeat_at must be recorded")
-	require.False(t, hostView.LastHeartbeatAt.Before(before.Add(-time.Second)), "last_heartbeat_at must reflect the heartbeat, not a stale value")
+	// last_heartbeat_at is written with the DB's NOW() (wall clock), so
+	// it must never be compared against accelerated.GetCurrentTime() —
+	// under time acceleration the accelerated clock races ahead of the
+	// wall clock and the comparison inverts. Instead: non-zero, and
+	// strictly advanced past the pre-heartbeat persisted baseline.
+	require.False(t, hostView.LastHeartbeatAt.IsZero(), "last_heartbeat_at must be non-zero")
+	require.True(t, hostView.LastHeartbeatAt.After(*pre.LastHeartbeatAt),
+		"last_heartbeat_at must strictly advance past the pre-heartbeat persisted value (pre=%s post=%s)",
+		pre.LastHeartbeatAt, hostView.LastHeartbeatAt)
 	require.JSONEq(t, string(permissions), string(hostView.Permissions), "permissions must be persisted verbatim")
 	require.JSONEq(t, string(sourceHealth), string(hostView.SourceHealth), "source_health must be persisted verbatim")
 }
@@ -590,13 +630,22 @@ func TestMacHost_Pair_PlaintextKeyNeverLeaksInSubsequentReads(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, w.Code, "pair: %s", w.Body.String())
 	require.Contains(t, w.Body.String(), `"api_key"`, "sanity: pair response must actually carry the key field")
+	require.Contains(t, w.Body.String(), `"cursor_epoch"`, "pair response must carry the current cursor epoch on the wire")
 
 	var pair struct {
-		HostID uuid.UUID `json:"host_id"`
-		APIKey string    `json:"api_key"`
+		HostID      uuid.UUID `json:"host_id"`
+		APIKey      string    `json:"api_key"`
+		CursorEpoch int64     `json:"cursor_epoch"`
 	}
 	readData(t, w, &pair)
+	require.NotEqual(t, uuid.Nil, pair.HostID, "pair response must carry the host id")
 	require.NotEmpty(t, pair.APIKey)
+
+	// cursor_epoch must be the host's CURRENT epoch — compare against an
+	// independent repository read of the freshly-created host row.
+	hostRow, err := env.hostRepo.GetHost(context.Background(), pair.HostID)
+	require.NoError(t, err)
+	require.Equal(t, hostRow.CursorEpoch, pair.CursorEpoch, "pair response cursor_epoch must equal the host row's current epoch")
 
 	hostHeaders := map[string]string{
 		"X-Mac-Host-ID": pair.HostID.String(),
@@ -626,31 +675,61 @@ func TestMacHost_Pair_PlaintextKeyNeverLeaksInSubsequentReads(t *testing.T) {
 }
 
 // spec: MAC-003[1]
-// TestMacHost_Pair_ExpiredUnconsumedToken_410 seeds an expired-but-never-
-// consumed pairing token directly (SeedPairingToken accepts an explicit
-// expires_at, the same helper the rotate-key sibling test uses for its
-// TOKEN_EXPIRED case) and drives it through the actual pairing endpoint,
-// asserting the opaque 410 the pairing contract collapses all token-state
-// failures to.
-func TestMacHost_Pair_ExpiredUnconsumedToken_410(t *testing.T) {
+// TestMacHost_Pair_TokenStateFailures_Opaque410 drives all three
+// token-state failures through the actual pairing endpoint — an invalid
+// (never-minted) token, an already-consumed token (successful pair, then
+// reuse), and an expired unconsumed token (seeded past-expiry via
+// SeedPairingToken, the same helper the rotate-key sibling uses for its
+// TOKEN_EXPIRED case) — asserting each collapses to 410 AND that the
+// three response bodies are byte-identical, so the wire response cannot
+// be used to probe WHICH condition failed. The body carries no
+// request-id or timestamp fields (the standard error envelope is
+// {success, error{code, message, details}}), so raw-byte comparison is
+// the strongest possible indistinguishability assertion.
+func TestMacHost_Pair_TokenStateFailures_Opaque410(t *testing.T) {
 
 	env := setupMacHostEnv(t)
+	ctx := context.Background()
 
-	plaintext := "expired-pair-token-" + uuid.NewString()[:8]
-	hash := sha256.Sum256([]byte(plaintext))
-	_, err := env.database.Queries.SeedPairingToken(context.Background(), db.SeedPairingTokenParams{
+	pairBody := func(token string) map[string]any {
+		return map[string]any{
+			"pairing_token":    token,
+			"hostname":         "opaque-410-host-" + uuid.NewString()[:8],
+			"daemon_version":   "0.1.0",
+			"protocol_version": 1,
+		}
+	}
+
+	// State 1: invalid — a token that was never minted.
+	wInvalid := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, pairBody("bogus-pair-token-"+uuid.NewString()[:8]))
+	require.Equal(t, http.StatusGone, wInvalid.Code, "invalid token must surface 410, body: %s", wInvalid.Body.String())
+
+	// State 2: expired — seeded unconsumed with a past expires_at.
+	expiredPlain := "expired-pair-token-" + uuid.NewString()[:8]
+	hash := sha256.Sum256([]byte(expiredPlain))
+	_, err := env.database.Queries.SeedPairingToken(ctx, db.SeedPairingTokenParams{
 		TokenHash: hex.EncodeToString(hash[:]),
 		ExpiresAt: pgtype.Timestamptz{Time: accelerated.GetCurrentTime().Add(-1 * time.Hour), Valid: true},
 	})
 	require.NoError(t, err)
+	wExpired := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, pairBody(expiredPlain))
+	require.Equal(t, http.StatusGone, wExpired.Code, "expired unconsumed token must surface 410, body: %s", wExpired.Body.String())
 
-	w := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, map[string]any{
-		"pairing_token":    plaintext,
-		"hostname":         "expired-token-host-" + uuid.NewString()[:8],
-		"daemon_version":   "0.1.0",
-		"protocol_version": 1,
-	})
-	require.Equal(t, http.StatusGone, w.Code, "expired unconsumed token must surface 410, body: %s", w.Body.String())
+	// State 3: already consumed — a real pair succeeds, then the same
+	// token is replayed. The consume check fires before the singleton
+	// check, so the live host does not turn this into a 409.
+	consumedPlain, _, err := env.macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	wPair := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, pairBody(consumedPlain))
+	require.Equal(t, http.StatusOK, wPair.Code, "seed pair must succeed: %s", wPair.Body.String())
+	wConsumed := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, pairBody(consumedPlain))
+	require.Equal(t, http.StatusGone, wConsumed.Code, "consumed token must surface 410, body: %s", wConsumed.Body.String())
+
+	// Opaqueness: the three failure bodies must be indistinguishable.
+	require.Equal(t, wInvalid.Body.String(), wExpired.Body.String(),
+		"invalid vs expired 410 bodies must be byte-identical")
+	require.Equal(t, wInvalid.Body.String(), wConsumed.Body.String(),
+		"invalid vs consumed 410 bodies must be byte-identical")
 }
 
 // TestMacHost_Heartbeat_TooOldProtocol_NoWriteBefore412 pairs a host,
@@ -796,11 +875,21 @@ func TestMacHost_PushSourceAllowlist_HTTP(t *testing.T) {
 	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+unknownSource+"/known-ids", hostHeaders, nil)
 	assertValidationError(w, "KnownIDs unknown source")
 
-	// Acceptance: a genuinely allowed source succeeds on all three.
-	const allowedSource = "phone_calls"
+	// Acceptance: EVERY source in the fixed allowlist the spec names
+	// must pass the handler gate — asserted on cursor GET for all five
+	// (the cheapest of the three endpoints).
+	allowedSources := []string{"messages", "icloud_contacts", "anarlog_humans", "anarlog_sessions", "phone_calls"}
+	require.Len(t, allowedSources, len(mac.AllowedPushSources),
+		"test table must enumerate the full production allowlist — update both together")
+	for _, src := range allowedSources {
+		require.True(t, mac.IsAllowedPushSource(src), "test table entry %q must be in the production allowlist", src)
+		w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+src+"/cursor", hostHeaders, nil)
+		require.Equal(t, http.StatusOK, w.Code, "GetCursor allowed source %q: %s", src, w.Body.String())
+	}
 
-	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+allowedSource+"/cursor", hostHeaders, nil)
-	require.Equal(t, http.StatusOK, w.Code, "GetCursor allowed source: %s", w.Body.String())
+	// One allowed source additionally exercises commit + known-ids
+	// acceptance end-to-end.
+	const allowedSource = "phone_calls"
 
 	w = macHTTP(t, env, http.MethodPost, "/api/v1/host/"+res.HostID.String()+"/sync/"+allowedSource+"/cursor", hostHeaders, map[string]any{
 		"cursor":       "phone-cursor-1",
@@ -811,4 +900,34 @@ func TestMacHost_PushSourceAllowlist_HTTP(t *testing.T) {
 
 	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/"+allowedSource+"/known-ids", hostHeaders, nil)
 	require.Equal(t, http.StatusOK, w.Code, "KnownIDs allowed source: %s", w.Body.String())
+}
+
+// TestMacHost_PushSourceAllowlist_ServiceReCheck exercises the
+// service-layer defence-in-depth half of the allowlist invariant: a
+// non-HTTP caller that reaches MacHostService.GetCursor / CommitCursor
+// with a source outside the allowlist must be rejected with
+// ErrUnknownPushSource even though the handler gate never ran. The
+// re-check short-circuits before any repository call, so no host needs
+// to be paired.
+// spec: MAC-013
+func TestMacHost_PushSourceAllowlist_ServiceReCheck(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+	ctx := context.Background()
+	hostID := uuid.New()
+	const unknownSource = "not_a_real_source"
+
+	_, err := env.macService.GetCursor(ctx, unknownSource, hostID)
+	require.Error(t, err, "GetCursor must re-check the allowlist at the service layer")
+	require.ErrorIs(t, err, service.ErrUnknownPushSource, "GetCursor rejection must be ErrUnknownPushSource, got %v", err)
+
+	err = env.macService.CommitCursor(ctx, repository.CommitMacHostCursorParams{
+		HostID:       hostID,
+		Source:       unknownSource,
+		BaseCursor:   "",
+		NewCursor:    "x",
+		ClaimedEpoch: 1,
+	})
+	require.Error(t, err, "CommitCursor must re-check the allowlist at the service layer")
+	require.ErrorIs(t, err, service.ErrUnknownPushSource, "CommitCursor rejection must be ErrUnknownPushSource, got %v", err)
 }

--- a/backend/tests/api/mac_host_rotate_key_test.go
+++ b/backend/tests/api/mac_host_rotate_key_test.go
@@ -297,6 +297,7 @@ func callRotateAPIKeyDirect(
 	return env.macService.RotateAPIKey(context.Background(), hostID, startingHash, token)
 }
 
+// spec: MAC-010[2]
 func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -364,6 +365,7 @@ func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
 	require.Equal(t, 1, consumedCount, "exactly one token must be consumed")
 }
 
+// spec: MAC-010[2]
 func TestMacHostRotateKey_ConcurrentRotation_SameToken(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -460,13 +462,16 @@ func TestMacHostRotateKey_PlaintextNeverLeaksInSubsequentReads(t *testing.T) {
 		map[string]any{"pairing_token": token})
 	require.Equal(t, http.StatusOK, w.Code, "rotate: %s", w.Body.String())
 	require.Contains(t, w.Body.String(), `"api_key"`, "sanity: rotate response must actually carry the key field")
+	require.Contains(t, w.Body.String(), `"api_key_rotated_at"`, "rotate response must carry the rotation timestamp on the wire")
 
 	var res struct {
-		APIKey string `json:"api_key"`
+		APIKey          string    `json:"api_key"`
+		APIKeyRotatedAt time.Time `json:"api_key_rotated_at"`
 	}
 	readData(t, w, &res)
 	require.NotEmpty(t, res.APIKey)
 	require.NotEqual(t, oldKey, res.APIKey)
+	require.False(t, res.APIKeyRotatedAt.IsZero(), "api_key_rotated_at must be a real timestamp, not the zero value")
 
 	// Heartbeat with the NEW key must never echo the plaintext key back.
 	w = macHTTP(t, env, http.MethodPost, "/api/v1/host/"+hostID.String()+"/heartbeat",
@@ -506,18 +511,24 @@ func rotateKeyHTTPRequest(env *macHostTestEnv, hostID uuid.UUID, apiKey, pairing
 	return w
 }
 
-// TestMacHostRotateKey_HTTP_StaleAuthOnConcurrentLoss drives the
-// service-level CAS race (already proven directly against
-// MacHostService.RotateAPIKey in TestMacHostRotateKey_ConcurrentRotation_
-// DifferentTokens) over REAL concurrent HTTP requests: two goroutines
-// both authenticate with the SAME still-current key via
-// MacHostAuthMiddleware (both requests race to the finish line before
-// either commits), then race in the handler's compare-and-swap. The
-// loser's stale-auth rejection must surface as 401 STALE_AUTH on the
-// wire — the literal error code the handler maps
-// service.ErrAPIKeyStaleAuth to. Distinct pairing tokens per goroutine
-// so token single-use never intrudes on which side loses the CAS.
-// spec: MAC-010[2]
+// TestMacHostRotateKey_HTTP_StaleAuthOnConcurrentLoss is an UNCITED
+// stress test: two goroutines race real HTTP rotate-key requests with
+// the same still-current key and distinct pairing tokens. Exactly one
+// must succeed; the loser must be rejected 401 — but the loser's error
+// code depends on WHERE its request was when the winner committed, and
+// both interleavings are legal:
+//
+//   - the loser's middleware read the PRE-commit hash (both requests
+//     authenticated before either committed) → the handler's CAS check
+//     fires → 401 STALE_AUTH; or
+//   - the loser's middleware ran AFTER the winner's commit, so its
+//     bearer (the old key) no longer matches the live hash → the
+//     middleware rejects it → 401 INVALID_KEY.
+//
+// The deterministic decompositions live elsewhere: the 401 STALE_AUTH
+// wire mapping is pinned by the handler-level stub test
+// TestRotateKey_ConcurrentRotationLoser_MapsStaleAuthTo401, and the CAS
+// detection semantics by TestMacHostRotateKey_ConcurrentRotation_*.
 func TestMacHostRotateKey_HTTP_StaleAuthOnConcurrentLoss(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -553,18 +564,19 @@ func TestMacHostRotateKey_HTTP_StaleAuthOnConcurrentLoss(t *testing.T) {
 	wg.Wait()
 	close(results)
 
-	successes, staleAuth := 0, 0
+	successes, losers := 0, 0
 	for r := range results {
 		switch r.status {
 		case http.StatusOK:
 			successes++
 		case http.StatusUnauthorized:
-			require.Equal(t, "STALE_AUTH", r.errCode, "loser body: %s", r.body)
-			staleAuth++
+			// Either code is a legal loser outcome; see the test comment.
+			require.Contains(t, []string{"STALE_AUTH", "INVALID_KEY"}, r.errCode, "loser body: %s", r.body)
+			losers++
 		default:
 			t.Fatalf("unexpected rotate-key status %d, body: %s", r.status, r.body)
 		}
 	}
 	require.Equal(t, 1, successes, "exactly one concurrent rotation must succeed")
-	require.Equal(t, 1, staleAuth, "exactly one concurrent rotation must fail 401 STALE_AUTH")
+	require.Equal(t, 1, losers, "exactly one concurrent rotation must fail 401")
 }

--- a/backend/tests/api/mac_host_rotate_key_test.go
+++ b/backend/tests/api/mac_host_rotate_key_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -440,4 +442,129 @@ func TestMacHostRotateKey_OldKeyImmediatelyInvalid(t *testing.T) {
 		})
 	require.Equal(t, http.StatusUnauthorized, w.Code,
 		"old key must be invalid AT COMMIT, not 'eventually'; body=%s", w.Body.String())
+}
+
+// TestMacHostRotateKey_PlaintextNeverLeaksInSubsequentReads rotates a
+// host's key and sweeps every subsequent read surface (heartbeat
+// response, admin ListHosts, admin GetHostAdmin) for the rotated
+// plaintext key, asserting on the raw response body string.
+// spec: MAC-010[0]
+func TestMacHostRotateKey_PlaintextNeverLeaksInSubsequentReads(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+	hostID, oldKey := pairFreshHost(t, env, "rotate-plaintext-sweep-"+uuid.NewString()[:8])
+	token := mintRotateToken(t, env)
+
+	w := macHTTP(t, env, http.MethodPost, "/api/v1/host/"+hostID.String()+"/rotate-key",
+		hostAuthHeaders(hostID, oldKey),
+		map[string]any{"pairing_token": token})
+	require.Equal(t, http.StatusOK, w.Code, "rotate: %s", w.Body.String())
+	require.Contains(t, w.Body.String(), `"api_key"`, "sanity: rotate response must actually carry the key field")
+
+	var res struct {
+		APIKey string `json:"api_key"`
+	}
+	readData(t, w, &res)
+	require.NotEmpty(t, res.APIKey)
+	require.NotEqual(t, oldKey, res.APIKey)
+
+	// Heartbeat with the NEW key must never echo the plaintext key back.
+	w = macHTTP(t, env, http.MethodPost, "/api/v1/host/"+hostID.String()+"/heartbeat",
+		hostAuthHeaders(hostID, res.APIKey),
+		map[string]any{"daemon_version": "0.1.0", "protocol_version": 1})
+	require.Equal(t, http.StatusOK, w.Code, "heartbeat: %s", w.Body.String())
+	require.NotContains(t, w.Body.String(), res.APIKey, "heartbeat response must never contain the rotated plaintext api key")
+	require.NotContains(t, w.Body.String(), `"api_key"`, "heartbeat response must never carry an api_key wire key at all")
+
+	// Admin ListHosts.
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host", map[string]string{"X-API-Key": env.apiKey}, nil)
+	require.Equal(t, http.StatusOK, w.Code, "list hosts: %s", w.Body.String())
+	require.NotContains(t, w.Body.String(), res.APIKey, "ListHosts response must never contain the rotated plaintext api key")
+	require.NotContains(t, w.Body.String(), `"api_key"`, "ListHosts response must never carry an api_key wire key at all (not even hashed)")
+
+	// Admin GetHostAdmin.
+	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+hostID.String(), map[string]string{"X-API-Key": env.apiKey}, nil)
+	require.Equal(t, http.StatusOK, w.Code, "get admin: %s", w.Body.String())
+	require.NotContains(t, w.Body.String(), res.APIKey, "GetHostAdmin response must never contain the rotated plaintext api key")
+	require.NotContains(t, w.Body.String(), `"api_key"`, "GetHostAdmin response must never carry an api_key wire key at all (not even hashed)")
+}
+
+// rotateKeyHTTPRequest builds a rotate-key request against env.router
+// WITHOUT calling testify's require — safe to invoke concurrently from
+// multiple goroutines (unlike macHTTP, which calls t.Helper()/require
+// internally and is documented as main-goroutine-only elsewhere in this
+// package).
+func rotateKeyHTTPRequest(env *macHostTestEnv, hostID uuid.UUID, apiKey, pairingToken string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(map[string]any{"pairing_token": pairingToken})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/host/"+hostID.String()+"/rotate-key", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range hostAuthHeaders(hostID, apiKey) {
+		req.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	return w
+}
+
+// TestMacHostRotateKey_HTTP_StaleAuthOnConcurrentLoss drives the
+// service-level CAS race (already proven directly against
+// MacHostService.RotateAPIKey in TestMacHostRotateKey_ConcurrentRotation_
+// DifferentTokens) over REAL concurrent HTTP requests: two goroutines
+// both authenticate with the SAME still-current key via
+// MacHostAuthMiddleware (both requests race to the finish line before
+// either commits), then race in the handler's compare-and-swap. The
+// loser's stale-auth rejection must surface as 401 STALE_AUTH on the
+// wire — the literal error code the handler maps
+// service.ErrAPIKeyStaleAuth to. Distinct pairing tokens per goroutine
+// so token single-use never intrudes on which side loses the CAS.
+// spec: MAC-010[2]
+func TestMacHostRotateKey_HTTP_StaleAuthOnConcurrentLoss(t *testing.T) {
+
+	env := setupMacHostEnv(t)
+	hostID, oldKey := pairFreshHost(t, env, "rotate-http-race-"+uuid.NewString()[:8])
+	tokenA := mintRotateToken(t, env)
+	tokenB := mintRotateToken(t, env)
+
+	type outcome struct {
+		status  int
+		errCode string
+		body    string
+	}
+	results := make(chan outcome, 2)
+	var wg sync.WaitGroup
+	var start sync.WaitGroup
+	start.Add(1)
+	for _, tok := range []string{tokenA, tokenB} {
+		wg.Add(1)
+		go func(token string) {
+			defer wg.Done()
+			start.Wait()
+			w := rotateKeyHTTPRequest(env, hostID, oldKey, token)
+			var errBody struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			_ = json.Unmarshal(w.Body.Bytes(), &errBody)
+			results <- outcome{status: w.Code, errCode: errBody.Error.Code, body: w.Body.String()}
+		}(tok)
+	}
+	start.Done()
+	wg.Wait()
+	close(results)
+
+	successes, staleAuth := 0, 0
+	for r := range results {
+		switch r.status {
+		case http.StatusOK:
+			successes++
+		case http.StatusUnauthorized:
+			require.Equal(t, "STALE_AUTH", r.errCode, "loser body: %s", r.body)
+			staleAuth++
+		default:
+			t.Fatalf("unexpected rotate-key status %d, body: %s", r.status, r.body)
+		}
+	}
+	require.Equal(t, 1, successes, "exactly one concurrent rotation must succeed")
+	require.Equal(t, 1, staleAuth, "exactly one concurrent rotation must fail 401 STALE_AUTH")
 }

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -2609,19 +2609,29 @@ func TestResolveLink_LinkToEventSuccess(t *testing.T) {
 }
 
 // TestResolveLink_ResponseIncludesUpdatedMeetingNote — the resolve-link
-// success response's data.meeting_note carries the row's POST-resolve
-// state on the wire (not just data.interactions_created). Asserted on
-// literal wire keys via a raw JSON decode, not by round-tripping the
-// production meetingNoteResponse type.
+// success response carries BOTH halves of the NTS-018 success contract
+// on the wire: data.meeting_note with the row's POST-resolve state, and
+// data.interactions_created with the interactions the resolve wrote.
+// Asserted on literal wire keys via a raw JSON decode, not by
+// round-tripping the production meetingNoteResponse type. The fixture
+// tags a resolved participant (contactA) who is NOT an attendee of the
+// linked candidate, so the link deterministically creates exactly one
+// walk-in interaction whose contact + source_ref are known up front.
 // spec: NTS-018[2]
 func TestResolveLink_ResponseIncludesUpdatedMeetingNote(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
 	meetingAt := time.Date(2026, 5, 7, 14, 0, 0, 0, time.UTC)
-	eventA := env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
-	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactB})
+	// Two candidates with zero overlap with the tagged set {contactA} →
+	// conflict_pending (no strict winner).
+	eventB := env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactB})
+	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactC})
 
 	sessionUUID := env.newSessionUUID()
-	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Response Meeting Note Session", nil)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Response Meeting Note Session", []string{anarlogA})
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 
@@ -2632,13 +2642,17 @@ func TestResolveLink_ResponseIncludesUpdatedMeetingNote(t *testing.T) {
 	w = postResolveLink(t, env, row.ID.String(), map[string]any{
 		"action": "link",
 		"kind":   "event",
-		"id":     eventA.String(),
+		"id":     eventB.String(),
 	})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 
 	var wire struct {
 		Data struct {
-			MeetingNote map[string]any `json:"meeting_note"`
+			MeetingNote         map[string]any `json:"meeting_note"`
+			InteractionsCreated []struct {
+				ContactID string `json:"contact_id"`
+				SourceRef string `json:"source_ref"`
+			} `json:"interactions_created"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wire))
@@ -2647,7 +2661,17 @@ func TestResolveLink_ResponseIncludesUpdatedMeetingNote(t *testing.T) {
 	require.Equal(t, row.ID.String(), mn["id"], "meeting_note.id on the wire")
 	require.Equal(t, "linked", mn["linkage_state"], "meeting_note.linkage_state reflects the post-resolve state")
 	require.Equal(t, "event", mn["linked_kind"], "meeting_note.linked_kind carries the resolved kind")
-	require.Equal(t, eventA.String(), mn["linked_id"], "meeting_note.linked_id carries the resolved target")
+	require.Equal(t, eventB.String(), mn["linked_id"], "meeting_note.linked_id carries the resolved target")
+
+	// The interactions the resolve created, on the literal
+	// interactions_created wire key: exactly the tagged contact's
+	// walk-in (contactA is tagged but not an attendee of eventB).
+	require.Len(t, wire.Data.InteractionsCreated, 1,
+		"response must carry the one walk-in interaction the link created; body: %s", w.Body.String())
+	require.Equal(t, env.contactA.String(), wire.Data.InteractionsCreated[0].ContactID,
+		"interactions_created must name the walk-in contact")
+	require.Equal(t, "anarlog:"+sessionUUID+":walkin:"+env.contactA.String(), wire.Data.InteractionsCreated[0].SourceRef,
+		"interactions_created must carry the walk-in source_ref")
 }
 
 // TestResolveLink_AlreadyLinkedReturns409 — calling resolve-link on a
@@ -2775,18 +2799,29 @@ func TestListNeedsAttention_AcceptsDaemonHostAuth(t *testing.T) {
 }
 
 // TestListNeedsAttention_BasicProjection — seed a conflict_pending row
-// and verify the needs-attention list includes it with a populated
-// candidates array.
+// with one candidate of EACH kind (calendar event + phone call) and
+// verify the needs-attention list projects the full candidates array
+// with per-kind preview CONTENT: the event candidate carries the seeded
+// title + attendee count, the phone_call candidate carries the seeded
+// peer handle.
+// spec: NTS-025[2]
 func TestListNeedsAttention_BasicProjection(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
-	meetingAt := time.Date(2026, 5, 7, 13, 0, 0, 0, time.UTC)
-	env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
-	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactB})
+	meetingAt := env.uniqueWindowBase(7)
+	eventTitle := env.sourceIDPrefix + "Projection Event"
+	eventID := env.seedCalendarEventInWindowWithTitle(t, meetingAt, eventTitle, []uuid.UUID{env.contactA})
+	peer := randomTestPhoneNumber(t)
+	answered := true
+	callID := env.seedPhoneCallInWindowFull(t, meetingAt, peer, repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, nil)
 
 	sessionUUID := env.newSessionUUID()
-	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Needs Attention Session", nil)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, env.sourceIDPrefix+"Needs Attention Session", nil)
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState, "sanity: cross-kind candidates land conflict_pending")
 
 	// Scope the list to this test's mac_host so other parallel tests'
 	// rows don't pollute the assertion.
@@ -2809,11 +2844,36 @@ func TestListNeedsAttention_BasicProjection(t *testing.T) {
 	}
 	require.NotNil(t, found, "needs-attention list must contain our seeded row")
 	require.Equal(t, repository.LinkageStateConflictPending, found.LinkageState)
-	require.Len(t, found.Candidates, 2, "both event candidates projected")
-	for _, c := range found.Candidates {
+	require.Len(t, found.Candidates, 2, "both candidates projected")
+
+	var eventCand, callCand *service.NeedsAttentionCandidate
+	for i := range found.Candidates {
+		c := &found.Candidates[i]
 		require.False(t, c.TargetMissing)
 		require.NotNil(t, c.Preview)
+		switch c.Kind {
+		case "event":
+			eventCand = c
+		case "phone_call":
+			callCand = c
+		}
 	}
+
+	// Event candidate: per-kind preview is title + attendee_count.
+	require.NotNil(t, eventCand, "event candidate must be projected")
+	require.Equal(t, eventID, eventCand.ID)
+	require.NotNil(t, eventCand.Preview.Title, "event preview must carry the title")
+	require.Equal(t, eventTitle, *eventCand.Preview.Title, "event preview title must be the seeded event's title")
+	require.NotNil(t, eventCand.Preview.AttendeeCount, "event preview must carry the attendee count")
+	require.Equal(t, 0, *eventCand.Preview.AttendeeCount, "seeded event has no attendee entries")
+	require.Nil(t, eventCand.Preview.PeerHandle, "event preview must not carry a phone-call field")
+
+	// Phone-call candidate: per-kind preview is the peer handle.
+	require.NotNil(t, callCand, "phone_call candidate must be projected")
+	require.Equal(t, callID, callCand.ID)
+	require.NotNil(t, callCand.Preview.PeerHandle, "phone_call preview must carry the peer handle")
+	require.Equal(t, peer, *callCand.Preview.PeerHandle, "phone_call preview peer_handle must be the seeded call's peer")
+	require.Nil(t, callCand.Preview.Title, "phone_call preview must not carry an event field")
 }
 
 // TestListNeedsAttention_NewestFirstOrdering — seed three attention rows
@@ -3081,6 +3141,100 @@ func TestListNeedsAttention_HostFilter(t *testing.T) {
 		}
 	}
 	require.True(t, found, "matching host filter must include this test's row")
+}
+
+// TestListNeedsAttention_HostScope_TwoHosts is the adversarial half of
+// the host_id-scoping contract: with attention rows belonging to TWO
+// different mac_hosts, a run scoped to one host must EXCLUDE the other
+// host's row (each direction), and an unscoped run must return rows
+// from both hosts. The second host is seeded REVOKED (the singleton
+// index only constrains live rows) purely as an FK target for a
+// repository-inserted orphan row; fixtures are namespaced via the env's
+// per-run prefix + fresh session UUIDs.
+// spec: NTS-025[1]
+func TestListNeedsAttention_HostScope_TwoHosts(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	ctx := context.Background()
+
+	// Own (paired) host's attention row: no candidates, no participants
+	// → orphan_needs_review directly at ingest.
+	meetingAt := env.uniqueWindowBase(8)
+	ownSession := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, ownSession, meetingAt, env.sourceIDPrefix+"Own Host Orphan", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	ownRow := findMeetingNoteRow(t, env, ownSession)
+	require.NotNil(t, ownRow)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, ownRow.LinkageState, "sanity: own row lands an attention state")
+
+	// Other host's attention row, inserted via the repository against a
+	// revoked FK-target host row.
+	hostRepo := repository.NewMacHostRepository(env.database.Queries)
+	otherHost, err := hostRepo.SeedRevokedHostForTest(ctx, "mn-scope-other-"+uuid.NewString()[:8], "0.1.0", 1, "unused-hash")
+	require.NoError(t, err)
+	otherHostID := otherHost.ID
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		// The env teardown's DeleteAllMacHosts sweeps the seeded host
+		// row itself; its meeting_note rows are ours to remove.
+		_ = env.meetingRepo.TestHardDeleteByHostID(cleanCtx, otherHostID)
+	})
+
+	otherSession := uuid.New()
+	// The hash columns' CHECK constraints require empty-or-64-hex;
+	// derive namespaced hex values from the session UUID.
+	inputHash := sha256.Sum256([]byte("mn-scope-input-" + otherSession.String()))
+	resolvedHash := sha256.Sum256([]byte("mn-scope-resolved-" + otherSession.String()))
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	_, err = env.meetingRepo.InsertMeetingNoteTx(ctx, tx, repository.InsertMeetingNoteParams{
+		AnarlogSessionID: otherSession,
+		MacHostID:        &otherHostID,
+		LinkageState:     repository.LinkageStateOrphanNeedsReview,
+		InputHash:        hex.EncodeToString(inputHash[:]),
+		ResolvedSetHash:  hex.EncodeToString(resolvedHash[:]),
+		MeetingAt:        meetingAt.Add(time.Minute),
+	})
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	sessionsIn := func(w *httptest.ResponseRecorder) map[string]bool {
+		var resp struct {
+			Data []struct {
+				AnarlogSessionID string `json:"anarlog_session_id"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		got := map[string]bool{}
+		for _, item := range resp.Data {
+			got[item.AnarlogSessionID] = true
+		}
+		return got
+	}
+
+	// Scoped to the paired host: own row present, the other host's row
+	// EXCLUDED.
+	w = getNeedsAttention(t, env, env.pairedHostID.String())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	got := sessionsIn(w)
+	require.True(t, got[ownSession], "own host's row must be present under its own host_id scope")
+	require.False(t, got[otherSession.String()], "the other host's attention row must be EXCLUDED under host_id scoping")
+
+	// Scoped to the other host: the exclusion holds in both directions.
+	w = getNeedsAttention(t, env, otherHostID.String())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	got = sessionsIn(w)
+	require.True(t, got[otherSession.String()], "other host's row must be present under its own host_id scope")
+	require.False(t, got[ownSession], "own host's row must be EXCLUDED under the other host's scope")
+
+	// Unscoped: rows from BOTH hosts are returned.
+	w = getNeedsAttention(t, env, "")
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	got = sessionsIn(w)
+	require.True(t, got[ownSession], "unscoped run must include the paired host's row")
+	require.True(t, got[otherSession.String()], "unscoped run must include the other host's row")
 }
 
 // TestListNeedsAttention_TargetMissingProjection — when a candidate's

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -2608,6 +2608,48 @@ func TestResolveLink_LinkToEventSuccess(t *testing.T) {
 	require.Empty(t, updated.ConflictCandidates, "snapshot cleared on link")
 }
 
+// TestResolveLink_ResponseIncludesUpdatedMeetingNote — the resolve-link
+// success response's data.meeting_note carries the row's POST-resolve
+// state on the wire (not just data.interactions_created). Asserted on
+// literal wire keys via a raw JSON decode, not by round-tripping the
+// production meetingNoteResponse type.
+// spec: NTS-018[2]
+func TestResolveLink_ResponseIncludesUpdatedMeetingNote(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := time.Date(2026, 5, 7, 14, 0, 0, 0, time.UTC)
+	eventA := env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactB})
+
+	sessionUUID := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Response Meeting Note Session", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+
+	w = postResolveLink(t, env, row.ID.String(), map[string]any{
+		"action": "link",
+		"kind":   "event",
+		"id":     eventA.String(),
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var wire struct {
+		Data struct {
+			MeetingNote map[string]any `json:"meeting_note"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wire))
+	mn := wire.Data.MeetingNote
+	require.NotNil(t, mn, "response must include the updated meeting note, not just interactions_created")
+	require.Equal(t, row.ID.String(), mn["id"], "meeting_note.id on the wire")
+	require.Equal(t, "linked", mn["linkage_state"], "meeting_note.linkage_state reflects the post-resolve state")
+	require.Equal(t, "event", mn["linked_kind"], "meeting_note.linked_kind carries the resolved kind")
+	require.Equal(t, eventA.String(), mn["linked_id"], "meeting_note.linked_id carries the resolved target")
+}
+
 // TestResolveLink_AlreadyLinkedReturns409 — calling resolve-link on a
 // row that's not in conflict_pending returns 409.
 // spec: NTS-018[4]
@@ -2772,6 +2814,122 @@ func TestListNeedsAttention_BasicProjection(t *testing.T) {
 		require.False(t, c.TargetMissing)
 		require.NotNil(t, c.Preview)
 	}
+}
+
+// TestListNeedsAttention_NewestFirstOrdering — seed three attention rows
+// under the same host with distinct meeting_at timestamps, seeded out
+// of chronological order, and assert the response orders them
+// newest-first by meeting_at (not by insertion order).
+// spec: NTS-025[1]
+func TestListNeedsAttention_NewestFirstOrdering(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	base := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
+
+	// No candidate events, no participants → each session lands
+	// orphan_needs_review directly at ingest, an attention state.
+	// Seeded oldest-first so a stale insertion-order response would be
+	// caught by this test.
+	oldest := env.newSessionUUID()
+	evOldest := buildMNRecordedEvent(t, env.pairedHostID, oldest, base, "Ordering Oldest", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{evOldest}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	newest := env.newSessionUUID()
+	evNewest := buildMNRecordedEvent(t, env.pairedHostID, newest, base.Add(2*time.Hour), "Ordering Newest", nil)
+	w = postMNIngest(t, env, map[string]any{"events": []any{evNewest}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	middle := env.newSessionUUID()
+	evMiddle := buildMNRecordedEvent(t, env.pairedHostID, middle, base.Add(1*time.Hour), "Ordering Middle", nil)
+	w = postMNIngest(t, env, map[string]any{"events": []any{evMiddle}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	for _, sid := range []string{oldest, middle, newest} {
+		row := findMeetingNoteRow(t, env, sid)
+		require.NotNil(t, row)
+		require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState, "sanity: lands an attention state")
+	}
+
+	// Scoped to this test's own mac_host so other parallel tests'
+	// rows can't shift relative positions.
+	w = getNeedsAttention(t, env, env.pairedHostID.String())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Data []struct {
+			AnarlogSessionID string `json:"anarlog_session_id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	pos := map[string]int{}
+	for i, item := range resp.Data {
+		pos[item.AnarlogSessionID] = i
+	}
+	posNewest, ok := pos[newest]
+	require.True(t, ok, "newest row must be present")
+	posMiddle, ok := pos[middle]
+	require.True(t, ok, "middle row must be present")
+	posOldest, ok := pos[oldest]
+	require.True(t, ok, "oldest row must be present")
+
+	require.Less(t, posNewest, posMiddle, "newest meeting_at must sort before middle")
+	require.Less(t, posMiddle, posOldest, "middle meeting_at must sort before oldest")
+}
+
+// TestListNeedsAttention_OrphanCarriesNoCandidates — an
+// orphan_needs_review row's candidates key is absent-or-empty on the
+// wire; only conflict_pending rows project a populated candidates
+// array. Asserted via raw JSON so a "null" vs "[]" difference doesn't
+// mask a candidate entry sneaking in.
+// spec: NTS-025[2]
+func TestListNeedsAttention_OrphanCarriesNoCandidates(t *testing.T) {
+	type item struct {
+		AnarlogSessionID string          `json:"anarlog_session_id"`
+		LinkageState     string          `json:"linkage_state"`
+		Candidates       json.RawMessage `json:"candidates"`
+	}
+
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := time.Date(2026, 5, 8, 15, 0, 0, 0, time.UTC)
+	sessionUUID := env.newSessionUUID()
+	// No candidate events, no participants → lands orphan_needs_review
+	// directly at ingest.
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Orphan No Candidates", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState, "sanity: lands orphan")
+
+	w = getNeedsAttention(t, env, env.pairedHostID.String())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Data []item `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var found *item
+	for i := range resp.Data {
+		if resp.Data[i].AnarlogSessionID == sessionUUID {
+			found = &resp.Data[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "orphan row must appear in needs-attention")
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, found.LinkageState)
+
+	raw := strings.TrimSpace(string(found.Candidates))
+	require.True(t, raw == "" || raw == "null" || raw == "[]",
+		"orphan_needs_review row's candidates must be absent/null/empty on the wire, got %q", raw)
+
+	var cands []map[string]any
+	if len(found.Candidates) > 0 && raw != "null" {
+		require.NoError(t, json.Unmarshal(found.Candidates, &cands))
+	}
+	require.Empty(t, cands, "orphan_needs_review row must not project any candidate entries")
 }
 
 // TestResolveLink_NoneOfTheseFiresDiscoveryUpsert — none_of_these

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -2809,7 +2809,28 @@ func TestListNeedsAttention_BasicProjection(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := env.uniqueWindowBase(7)
 	eventTitle := env.sourceIDPrefix + "Projection Event"
-	eventID := env.seedCalendarEventInWindowWithTitle(t, meetingAt, eventTitle, []uuid.UUID{env.contactA})
+	// Seed the event inline (not via the zero-attendee helper) with THREE
+	// attendee entries so the preview's attendee_count is nonzero and
+	// distinct from the candidate count (2) — a hardcoded or misprojected
+	// count cannot pass.
+	upserted, err := env.calendarRepo.Upsert(context.Background(), repository.UpsertCalendarEventRequest{
+		GcalEventID:     env.sourceIDPrefix + "cal-proj-" + uuid.NewString()[:8],
+		GcalCalendarID:  "primary",
+		GoogleAccountID: "test-account",
+		Title:           stringPtr(eventTitle),
+		StartTime:       meetingAt,
+		EndTime:         meetingAt.Add(time.Hour),
+		Status:          "confirmed",
+		Attendees: []repository.Attendee{
+			{Email: "a-" + env.sourceIDPrefix + "@example.com"},
+			{Email: "b-" + env.sourceIDPrefix + "@example.com"},
+			{Email: "c-" + env.sourceIDPrefix + "@example.com"},
+		},
+		MatchedContactIDs: []uuid.UUID{env.contactA},
+		SyncedAt:          accelerated.GetCurrentTime(),
+	})
+	require.NoError(t, err)
+	eventID := upserted.ID
 	peer := randomTestPhoneNumber(t)
 	answered := true
 	callID := env.seedPhoneCallInWindowFull(t, meetingAt, peer, repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, nil)
@@ -2828,30 +2849,36 @@ func TestListNeedsAttention_BasicProjection(t *testing.T) {
 	w = getNeedsAttention(t, env, env.pairedHostID.String())
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 
-	var resp struct {
-		Success bool                                 `json:"success"`
-		Data    []service.NeedsAttentionItemResponse `json:"data"`
+	// Decode on LITERAL wire keys (raw maps), never the production response
+	// structs — decoding with the same tags that serialized the payload
+	// would round-trip swapped/renamed keys invisibly.
+	var rawResp struct {
+		Success bool                     `json:"success"`
+		Data    []map[string]interface{} `json:"data"`
 	}
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	require.True(t, resp.Success)
-	require.NotEmpty(t, resp.Data)
-	var found *service.NeedsAttentionItemResponse
-	for i := range resp.Data {
-		if resp.Data[i].AnarlogSessionID.String() == sessionUUID {
-			found = &resp.Data[i]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&rawResp))
+	require.True(t, rawResp.Success)
+	require.NotEmpty(t, rawResp.Data)
+	var found map[string]interface{}
+	for _, row := range rawResp.Data {
+		if row["anarlog_session_id"] == sessionUUID {
+			found = row
 			break
 		}
 	}
 	require.NotNil(t, found, "needs-attention list must contain our seeded row")
-	require.Equal(t, repository.LinkageStateConflictPending, found.LinkageState)
-	require.Len(t, found.Candidates, 2, "both candidates projected")
+	require.Equal(t, string(repository.LinkageStateConflictPending), found["linkage_state"])
 
-	var eventCand, callCand *service.NeedsAttentionCandidate
-	for i := range found.Candidates {
-		c := &found.Candidates[i]
-		require.False(t, c.TargetMissing)
-		require.NotNil(t, c.Preview)
-		switch c.Kind {
+	candidates, ok := found["candidates"].([]interface{})
+	require.True(t, ok, "row must carry a candidates array, got %T", found["candidates"])
+	require.Len(t, candidates, 2, "both candidates projected")
+
+	var eventCand, callCand map[string]interface{}
+	for _, ci := range candidates {
+		c, ok := ci.(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, false, c["target_missing"])
+		switch c["kind"] {
 		case "event":
 			eventCand = c
 		case "phone_call":
@@ -2859,21 +2886,28 @@ func TestListNeedsAttention_BasicProjection(t *testing.T) {
 		}
 	}
 
-	// Event candidate: per-kind preview is title + attendee_count.
+	// Event candidate: per-kind preview is title + attendee_count; the
+	// phone-call key must be ABSENT (omitempty), not merely nil.
 	require.NotNil(t, eventCand, "event candidate must be projected")
-	require.Equal(t, eventID, eventCand.ID)
-	require.NotNil(t, eventCand.Preview.Title, "event preview must carry the title")
-	require.Equal(t, eventTitle, *eventCand.Preview.Title, "event preview title must be the seeded event's title")
-	require.NotNil(t, eventCand.Preview.AttendeeCount, "event preview must carry the attendee count")
-	require.Equal(t, 0, *eventCand.Preview.AttendeeCount, "seeded event has no attendee entries")
-	require.Nil(t, eventCand.Preview.PeerHandle, "event preview must not carry a phone-call field")
+	require.Equal(t, eventID.String(), eventCand["id"])
+	eventPreview, ok := eventCand["preview"].(map[string]interface{})
+	require.True(t, ok, "event candidate must carry a preview object")
+	require.Equal(t, eventTitle, eventPreview["title"], "event preview title must be the seeded event's title")
+	require.Equal(t, float64(3), eventPreview["attendee_count"], "event preview must carry the seeded nonzero attendee count")
+	_, hasPeer := eventPreview["peer_handle"]
+	require.False(t, hasPeer, "event preview must not carry a phone-call key")
 
-	// Phone-call candidate: per-kind preview is the peer handle.
+	// Phone-call candidate: per-kind preview is the peer handle; the event
+	// keys must be absent.
 	require.NotNil(t, callCand, "phone_call candidate must be projected")
-	require.Equal(t, callID, callCand.ID)
-	require.NotNil(t, callCand.Preview.PeerHandle, "phone_call preview must carry the peer handle")
-	require.Equal(t, peer, *callCand.Preview.PeerHandle, "phone_call preview peer_handle must be the seeded call's peer")
-	require.Nil(t, callCand.Preview.Title, "phone_call preview must not carry an event field")
+	require.Equal(t, callID.String(), callCand["id"])
+	callPreview, ok := callCand["preview"].(map[string]interface{})
+	require.True(t, ok, "phone_call candidate must carry a preview object")
+	require.Equal(t, peer, callPreview["peer_handle"], "phone_call preview peer_handle must be the seeded call's peer")
+	_, hasTitle := callPreview["title"]
+	require.False(t, hasTitle, "phone_call preview must not carry an event title key")
+	_, hasCount := callPreview["attendee_count"]
+	require.False(t, hasCount, "phone_call preview must not carry an attendee_count key")
 }
 
 // TestListNeedsAttention_NewestFirstOrdering — seed three attention rows

--- a/backend/tests/api/needs_attention_attendees_test.go
+++ b/backend/tests/api/needs_attention_attendees_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -146,6 +147,109 @@ func TestNeedsAttention_EnrichedAttendees(t *testing.T) {
 		require.False(t, matchedNames[contactB.FullName], "contactB is not in the implied set")
 	}
 	require.True(t, found, "the conflict row must appear in needs-attention")
+}
+
+// TestNeedsAttention_OverlapCountIndependentOfMatchedFlags — a
+// candidate's overlap_count meter is carried straight from the stored
+// snapshot value and does NOT track the per-attendee matched flags
+// computed at read time from attendee display-name matching. Seeds a
+// candidate whose overlap_count (2, from two matched CONTACT ids in the
+// implied set) and whose count of attendee matched=true flags (1,
+// because one attendee's display label doesn't resolve to either
+// contact's name) diverge — proving the two are carried independently.
+// spec: NTS-025[4]
+func TestNeedsAttention_OverlapCountIndependentOfMatchedFlags(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	ctx := context.Background()
+
+	contactA, err := env.contactRepo.GetContact(ctx, env.contactA)
+	require.NoError(t, err)
+	contactB, err := env.contactRepo.GetContact(ctx, env.contactB)
+	require.NoError(t, err)
+
+	// Tag both contactA and contactB so the implied set is {contactA,
+	// contactB} — the same pair both candidate events match on, giving
+	// both an overlap_count of 2 (kept tied → conflict_pending).
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	emailB := fmt.Sprintf("mn-test-1-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+	anarlogB := env.seedAnarlogHumanResolvingTo(t, emailB)
+
+	meetingAt := time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)
+	// First candidate: matches {contactA, contactB} (overlap_count=2)
+	// but names an attendee whose display label resolves to NEITHER
+	// contact's full_name, so only 1 of its 2 attendees is flagged
+	// matched=true.
+	env.seedCalendarEventWithAttendees(t, meetingAt,
+		[]repository.Attendee{
+			{DisplayName: contactA.FullName, Email: "att-a@example.invalid"},
+			{DisplayName: "Unresolvable Attendee Label", Email: "att-x@example.invalid"},
+		},
+		[]uuid.UUID{env.contactA, env.contactB},
+	)
+	// Second candidate: same overlap_count=2 (ties the top so the row
+	// stays conflict_pending), both attendees resolve.
+	env.seedCalendarEventWithAttendees(t, meetingAt.Add(5*time.Minute),
+		[]repository.Attendee{
+			{DisplayName: contactA.FullName, Email: "att-a2@example.invalid"},
+			{DisplayName: contactB.FullName, Email: "att-b2@example.invalid"},
+		},
+		[]uuid.UUID{env.contactA, env.contactB},
+	)
+
+	sessionUUID := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Overlap Independence Session", []string{anarlogA, anarlogB})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+
+	w = getNeedsAttention(t, env, env.pairedHostID.String())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resp needsAttentionListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var foundCandidate bool
+	var overlapCount, matchedTrue int
+	for i := range resp.Data {
+		if resp.Data[i].ID != row.ID {
+			continue
+		}
+		require.Len(t, resp.Data[i].Candidates, 2, "both tied candidates projected")
+		for ci := range resp.Data[i].Candidates {
+			c := resp.Data[i].Candidates[ci]
+			if c.Preview == nil {
+				continue
+			}
+			// Identify the candidate carrying the unresolvable-label
+			// attendee (as opposed to the other tied candidate, whose
+			// attendees both resolve).
+			var hasUnresolvable bool
+			for _, a := range c.Preview.Attendees {
+				if a.Name == "Unresolvable Attendee Label" {
+					hasUnresolvable = true
+				}
+			}
+			if !hasUnresolvable {
+				continue
+			}
+			foundCandidate = true
+			overlapCount = c.OverlapCount
+			for _, a := range c.Preview.Attendees {
+				if a.Matched {
+					matchedTrue++
+				}
+			}
+		}
+	}
+	require.True(t, foundCandidate, "candidate with the mismatched-label attendee must be present")
+	require.Equal(t, 2, overlapCount, "overlap_count is the stored meter value")
+	require.Equal(t, 1, matchedTrue, "only the resolvable-label attendee is flagged matched")
+	require.NotEqual(t, overlapCount, matchedTrue,
+		"overlap_count must be carried independently of the per-attendee matched-flag count")
 }
 
 // contactAEmail recomputes contactA's seeded synthetic email

--- a/backend/tests/api/note_test.go
+++ b/backend/tests/api/note_test.go
@@ -196,8 +196,33 @@ func TestNoteAPI_GetContactNotepad(t *testing.T) {
 	})
 
 	t.Run("GetNote_ContactNotFound_Returns404", func(t *testing.T) {
+		// spec: NTS-004[3]
 		nonExistentID := uuid.New().String()
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+nonExistentID+"/notes", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("GetNote_SoftDeletedContact_Returns404", func(t *testing.T) {
+		// spec: NTS-004[3]
+		contactID := createTestContact(t, router, "Soft Deleted Notepad Get Test User "+uuid.New().String()[:8])
+
+		// Soft-delete the contact via the same DELETE endpoint used by siblings
+		deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		deleteW := httptest.NewRecorder()
+		router.ServeHTTP(deleteW, deleteReq)
+		require.Equal(t, http.StatusNoContent, deleteW.Code, "Failed to soft-delete test contact: %s", deleteW.Body.String())
+
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID+"/notes", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
@@ -397,10 +422,39 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 	})
 
 	t.Run("SaveNote_ContactNotFound_Returns404", func(t *testing.T) {
+		// spec: NTS-005[4]
 		nonExistentID := uuid.New().String()
 		saveReq := handlers.SaveNoteRequest{Body: "Some content"}
 		jsonBody, _ := json.Marshal(saveReq)
 		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+nonExistentID+"/notes", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response api.APIResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.False(t, response.Success)
+		assert.Equal(t, "NOT_FOUND", response.Error.Code)
+	})
+
+	t.Run("SaveNote_SoftDeletedContact_Returns404", func(t *testing.T) {
+		// spec: NTS-005[4]
+		contactID := createTestContact(t, router, "Soft Deleted Notepad Save Test User "+uuid.New().String()[:8])
+
+		// Soft-delete the contact via the same DELETE endpoint used by siblings
+		deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		deleteW := httptest.NewRecorder()
+		router.ServeHTTP(deleteW, deleteReq)
+		require.Equal(t, http.StatusNoContent, deleteW.Code, "Failed to soft-delete test contact: %s", deleteW.Body.String())
+
+		saveReq := handlers.SaveNoteRequest{Body: "Some content"}
+		jsonBody, _ := json.Marshal(saveReq)
+		req, _ := http.NewRequest("PUT", "/api/v1/contacts/"+contactID+"/notes", bytes.NewBuffer(jsonBody))
 		req.Header.Set("Content-Type", "application/json")
 
 		w := httptest.NewRecorder()

--- a/backend/tests/suggestion_service_integration_test.go
+++ b/backend/tests/suggestion_service_integration_test.go
@@ -2,12 +2,16 @@ package tests
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +29,20 @@ func newSuggestionService(env *abReconcileEnv) *service.SuggestionService {
 		env.matchSvc,
 		env.database,
 	)
+}
+
+// newSuggestionRouter builds a Gin router carrying only the production
+// suggestions route surface (the /imports/candidates and /imports/:id
+// routes are also registered per RegisterImportRoutes' fixed ordering, but
+// with nil handlers — safe because these tests never route to them).
+// gin.SetMode is hoisted to TestMain so parallel tests don't race on it.
+func newSuggestionRouter(svc *service.SuggestionService) *gin.Engine {
+	router := gin.New()
+	v1 := router.Group("/api/v1")
+	handlers.RegisterImportRoutes(v1, handlers.ImportRouteDeps{
+		Suggestions: handlers.NewSuggestionHandler(svc),
+	})
+	return router
 }
 
 // seedImportedWithPending seeds a linked imported address-book row carrying
@@ -132,6 +150,7 @@ func TestSuggestions_List_SourceScopeExcludesNonAddressBook(t *testing.T) {
 	}
 }
 
+// spec: IMP-018[0]
 func TestSuggestions_Resolve_AddsMethodAndClearsPending(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -163,6 +182,7 @@ func TestSuggestions_Resolve_AddsMethodAndClearsPending(t *testing.T) {
 	assert.GreaterOrEqual(t, jobs, int64(1))
 }
 
+// spec: IMP-018[3]
 func TestSuggestions_Resolve_Idempotent(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -184,6 +204,65 @@ func TestSuggestions_Resolve_Idempotent(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 0, second.Applied)
+}
+
+// TestSuggestions_Resolve_RequestedSubset_OnlyRequestedConfirmed proves the
+// requested-subset half of IMP-018[0]: with two live pending methods,
+// requesting only one confirms exactly that one (enrichment + pending
+// clear) and leaves the other untouched in pending.
+//
+// spec: IMP-018[0]
+func TestSuggestions_Resolve_RequestedSubset_OnlyRequestedConfirmed(t *testing.T) {
+	t.Parallel()
+	env := setupABReconcileEnv(t)
+	ctx := context.Background()
+	svc := newSuggestionService(env)
+
+	emailX := "resolve-subset-x-" + abSuffix(t) + "@example.com"
+	emailY := "resolve-subset-y-" + abSuffix(t) + "@example.com"
+	contact, external := seedImportedWithPending(t, ctx, env, []string{emailX, emailY})
+
+	res, err := svc.ResolveMethodSuggestions(ctx, external.ID, []repository.PendingMethodSuggestion{
+		{Type: "email", Value: strings.ToLower(emailX)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied, "only the requested method is confirmed")
+
+	require.True(t, contactHasMethod(t, ctx, env, contact.ID, emailX), "requested method is added")
+	require.False(t, contactHasMethod(t, ctx, env, contact.ID, emailY), "unrequested method must NOT be added")
+
+	after, err := env.externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	require.Len(t, after.PendingMethodSuggestions, 1, "unrequested method stays pending")
+	assert.Equal(t, strings.ToLower(emailY), after.PendingMethodSuggestions[0].Value)
+}
+
+// TestSuggestions_Resolve_Unspecified_ConfirmsAllPending proves the
+// unspecified-means-all half of IMP-018[0]: an empty/nil methods list
+// confirms EVERY live pending method (not just one), enriching all of
+// them and fully clearing pending.
+//
+// spec: IMP-018[0]
+func TestSuggestions_Resolve_Unspecified_ConfirmsAllPending(t *testing.T) {
+	t.Parallel()
+	env := setupABReconcileEnv(t)
+	ctx := context.Background()
+	svc := newSuggestionService(env)
+
+	emailX := "resolve-all-x-" + abSuffix(t) + "@example.com"
+	emailY := "resolve-all-y-" + abSuffix(t) + "@example.com"
+	contact, external := seedImportedWithPending(t, ctx, env, []string{emailX, emailY})
+
+	res, err := svc.ResolveMethodSuggestions(ctx, external.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Applied, "unspecified methods must confirm ALL live pending")
+
+	require.True(t, contactHasMethod(t, ctx, env, contact.ID, emailX), "first pending method added")
+	require.True(t, contactHasMethod(t, ctx, env, contact.ID, emailY), "second pending method added")
+
+	after, err := env.externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	assert.Nil(t, after.PendingMethodSuggestions, "pending fully clears")
 }
 
 func TestSuggestions_Resolve_AlreadyOnContact_NotReAdded(t *testing.T) {
@@ -251,6 +330,12 @@ func TestSuggestions_Resolve_MalformedMethod400(t *testing.T) {
 	assert.ErrorIs(t, err, service.ErrSuggestionInvalidMethod)
 }
 
+// TestSuggestions_Dismiss_RecordsStickyAndDropsPending proves the
+// value dimension of IMP-018[1]'s sticky-per-(type,value) stickiness: a
+// dismissed email is sticky and a second PENDING entry of the SAME type
+// but a DIFFERENT value survives.
+//
+// spec: IMP-018[1]
 func TestSuggestions_Dismiss_RecordsStickyAndDropsPending(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -288,6 +373,7 @@ func TestSuggestions_Dismiss_RecordsStickyAndDropsPending(t *testing.T) {
 	}
 }
 
+// spec: IMP-018[3]
 func TestSuggestions_Dismiss_Idempotent(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -310,6 +396,72 @@ func TestSuggestions_Dismiss_Idempotent(t *testing.T) {
 	assert.Equal(t, 0, second.Dismissed, "duplicate dismiss is a no-op")
 }
 
+// TestSuggestions_Dismiss_StickyPerType_SameValueSurvivesDifferentType proves
+// the TYPE dimension of IMP-018[1]'s sticky-per-(type,value) rule: an
+// email pending entry and a telegram pending entry that happen to share
+// the SAME normalized value are independent stickiness keys — dismissing
+// the email entry must not sweep up the telegram entry with the same
+// value. "sticky" + a per-test namespace token normalizes identically for
+// both email (lowercase+trim) and telegram (strip '@'+lowercase) so the
+// VALUE half of the key is deliberately held constant while TYPE differs.
+//
+// spec: IMP-018[1]
+func TestSuggestions_Dismiss_StickyPerType_SameValueSurvivesDifferentType(t *testing.T) {
+	t.Parallel()
+	env := setupABReconcileEnv(t)
+	ctx := context.Background()
+	svc := newSuggestionService(env)
+
+	sfx := abSuffix(t)
+	sharedValue := "sticky" + sfx
+
+	contact, err := env.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Sticky Type " + sfx})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+	display := "Sticky Type Ext " + sfx
+	external, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "telegram",
+		SourceID:    "telegram-sticky-" + sfx,
+		DisplayName: &display,
+		Emails:      []repository.EmailEntry{{Value: sharedValue}},
+		Metadata:    map[string]any{"username": sharedValue},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.externalRepo.Delete(ctx, external.ID) })
+	_, err = env.externalRepo.UpdateMatch(ctx, external.ID, &contact.ID, repository.MatchStatusImported)
+	require.NoError(t, err)
+	external, err = env.externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+
+	res, err := env.reconcile.ReconcileLinkedExternalContactMethods(ctx, repository.ReconcileTarget{
+		ExternalContact:    *external,
+		EffectiveContactID: contact.ID,
+		EffectiveStatus:    repository.MatchStatusImported,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.SuggestionsRecorded)
+	external, err = env.externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	require.Len(t, external.PendingMethodSuggestions, 2, "precondition: email + telegram pending sharing one value")
+
+	// Dismiss ONLY the email entry.
+	dres, err := svc.DismissMethodSuggestions(ctx, external.ID, []repository.PendingMethodSuggestion{
+		{Type: "email", Value: sharedValue},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, dres.Dismissed)
+
+	after, err := env.externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	require.Len(t, after.PendingMethodSuggestions, 1, "the telegram entry with the SAME value must survive an email-only dismiss")
+	assert.Equal(t, "telegram", after.PendingMethodSuggestions[0].Type)
+	assert.Equal(t, sharedValue, after.PendingMethodSuggestions[0].Value)
+	require.Len(t, after.DismissedMethodSuggestions, 1)
+	assert.Equal(t, "email", after.DismissedMethodSuggestions[0].Type)
+}
+
+// spec: IMP-018[2]
 func TestSuggestions_Dismiss_AlreadyOnContact_NotStickyDismissed(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -339,6 +491,49 @@ func TestSuggestions_Dismiss_AlreadyOnContact_NotStickyDismissed(t *testing.T) {
 	assert.Nil(t, after.DismissedMethodSuggestions, "already-applied entry must not be sticky-dismissed")
 }
 
+// TestSuggestions_Dismiss_NoLongerOffered_PrunedNotDismissed proves the
+// second prune reason of IMP-018[2]: a pending method the source no
+// longer offers (the external row's current method set drifted since the
+// suggestion was recorded) is pruned from pending WITHOUT being recorded
+// as a dismissal.
+//
+// spec: IMP-018[2]
+func TestSuggestions_Dismiss_NoLongerOffered_PrunedNotDismissed(t *testing.T) {
+	t.Parallel()
+	env := setupABReconcileEnv(t)
+	ctx := context.Background()
+	svc := newSuggestionService(env)
+
+	email := "dismiss-gone-source-" + abSuffix(t) + "@example.com"
+	_, external := seedImportedWithPending(t, ctx, env, []string{email})
+
+	// Producer resync: the source no longer carries the email at all.
+	// Pending/dismissed columns survive a wholesale upsert untouched
+	// (TestABReconcile_ProducerUpsertPreservesSuggestionColumns), so the
+	// stale pending entry is still there, but the external row's CURRENT
+	// method set (BuildMethodsFromExternal) no longer offers it.
+	_, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      external.Source,
+		SourceID:    external.SourceID,
+		DisplayName: external.DisplayName,
+	})
+	require.NoError(t, err)
+	external, err = env.externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	require.Len(t, external.PendingMethodSuggestions, 1, "precondition: stale pending survives the resync")
+	require.Empty(t, external.Emails, "precondition: the source no longer offers the email")
+
+	res, err := svc.DismissMethodSuggestions(ctx, external.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.Dismissed, "no-longer-offered entry is pruned, not dismissed")
+
+	after, err := env.externalRepo.GetByID(ctx, external.ID)
+	require.NoError(t, err)
+	assert.Nil(t, after.PendingMethodSuggestions, "no-longer-offered entry is pruned from pending")
+	assert.Nil(t, after.DismissedMethodSuggestions, "no-longer-offered entry must not be sticky-dismissed")
+}
+
+// spec: IMP-018[3]
 func TestSuggestions_Resolve_ContactGone(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -410,4 +605,51 @@ func TestSuggestions_DuplicateOfCanonical_ResolvesToCanonicalContact(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, canonContact.ID, res.ContactID)
 	require.True(t, contactHasMethod(t, ctx, env, canonContact.ID, dupEmail), "dup's method enriches the canonical contact")
+}
+
+// TestSuggestionsAPI_Resolve_SoftDeletedContact_Returns410 proves the
+// literal HTTP status half of IMP-018[3]: through the real
+// production route (not the service call directly), a soft-deleted
+// effective contact reports 410 Gone on the wire.
+//
+// spec: IMP-018[3]
+func TestSuggestionsAPI_Resolve_SoftDeletedContact_Returns410(t *testing.T) {
+	t.Parallel()
+	env := setupABReconcileEnv(t)
+	ctx := context.Background()
+	svc := newSuggestionService(env)
+	router := newSuggestionRouter(svc)
+
+	email := "gone-api-resolve-" + abSuffix(t) + "@example.com"
+	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
+	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, contact.ID))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/imports/suggestions/"+external.ID.String()+"/methods/resolve", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusGone, w.Code, "soft-deleted effective contact must report 410 Gone on the wire")
+}
+
+// TestSuggestionsAPI_Dismiss_SoftDeletedContact_Returns410 is the dismiss
+// counterpart: the same soft-deleted-contact-gone check applies to the
+// dismiss action route too.
+//
+// spec: IMP-018[3]
+func TestSuggestionsAPI_Dismiss_SoftDeletedContact_Returns410(t *testing.T) {
+	t.Parallel()
+	env := setupABReconcileEnv(t)
+	ctx := context.Background()
+	svc := newSuggestionService(env)
+	router := newSuggestionRouter(svc)
+
+	email := "gone-api-dismiss-" + abSuffix(t) + "@example.com"
+	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
+	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, contact.ID))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/imports/suggestions/"+external.ID.String()+"/methods/dismiss", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusGone, w.Code, "soft-deleted effective contact must report 410 Gone on the wire")
 }

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -1,7 +1,7 @@
 domain: imports-matching
 prefix: IMP
 maturity: reviewed
-settled: [ui]
+settled: [ui, api]
 behaviors:
   # --- Matching engine ---
 

--- a/spec/ingest.yaml
+++ b/spec/ingest.yaml
@@ -1,7 +1,7 @@
 domain: ingest
 prefix: ING
 maturity: reviewed
-settled: [ui]
+settled: [ui, api]
 behaviors:
   # --- HTTP ingest surface ---
 

--- a/spec/notes-meetings.yaml
+++ b/spec/notes-meetings.yaml
@@ -1,7 +1,7 @@
 domain: notes-meetings
 prefix: NTS
 maturity: reviewed
-settled: [ui]
+settled: [ui, api]
 behaviors:
   # --- Contact notepad note (per-contact freeform scratchpad) ---
 


### PR DESCRIPTION
## Summary

Gap phase PR 3 of the api-citation arc (follows #732/#733): closes all 38 closable mac-host + ingest + notes-meetings + imports-matching `api`-surface orphans and flips **ingest, notes-meetings, and imports-matching** to `settled: [ui, api]`. The corpus drops 52 → 14 orphans. mac-host keeps exactly 2 (MAC-007[4] constant-time comparison — property unobservable by tests; MAC-010[3] — branch unreachable through integration), both batched for the arc's final waiver PR.

Same contract as the prior PRs: every new test carries a `// spec:` citation and an injected-defect red/green proof; response-shape claims are asserted on literal wire keys with pairwise-distinct fixture values; exact-count fixtures are per-run namespaced.

## Highlights

- **mac-host (14 items)**: heartbeat persistence read-backs (all five recorded fields) + response wire keys (`cursor_epoch`, `protocol_version`, `min_protocol_version`, 412 `min_version`); pre-commit cursor baseline; **plaintext-key non-disclosure sweeps** after pairing and after rotation (raw-body containment across ListHosts/GetHostAdmin/heartbeat); expired-unconsumed pairing token 410; stale-auth 401 driven over real concurrent HTTP requests (CAS race, verified non-flaky ×10); 412 no-write-before-reject proof; backfill-complete default (API omission path + `extractBackfillComplete` unit table); push-source allowlist through HTTP (statement citation); missing/empty-bearer 401 middleware branch; revoked-between-auth-and-write heartbeat stub test.
- **ingest (8 items)**: source/source_id length bounds (both sides); kind vocabulary; payload size bound; per-family version floor/ceiling rejections (raw_message, meeting_note, call); revoked-mid-batch 401; `needs_attention` key-absence (raw-body proof that omitempty actually omits — a struct decode can't see this); **cross-family host-id-claim re-check table test** (injection-proven per-family by skipping the check for one family at a time).
- **notes-meetings (6 items)**: soft-deleted-contact 404s for notepad get/save; resolve response carries the updated meeting note; needs-attention newest-first ordering; orphan rows carry no candidates; overlap-count independence from matched flags.
- **imports-matching (10 items)**: un-skipped and fixed the already-imported 400 test (namespaced seeding replaced the pre-toolkit fixture that forced the skip); link-only source policy statement; `rematch_job_id` wire propagation; the full IMP-018 action contract (requested-subset/unspecified-all resolve, type-AND-value dismissal stickiness, both prune reasons without dismissal records, soft-deleted 410 over HTTP for both actions); IMP-022 list shape over HTTP (first-page-only method group, confidence-ranked pagination, per-source `allowed_actions`) in a new `import_suggestions_api_test.go`.

## Test plan

- `make spec-coverage`: 14 orphans (was 52), 0 invalid; ingest/notes-meetings/imports-matching at `api: 0 orphaned` and now enforced; `make spec-lint` green.
- Full backend suites + E2E-diff via pre-push hook; CI runs the full matrix.
