### PR TITLE
test(spec): close final small-domain api gaps, settle three more

### DIFF
--- a/backend/cmd/crm-api/knowledge_route_absence_test.go
+++ b/backend/cmd/crm-api/knowledge_route_absence_test.go
@@ -1,0 +1,128 @@
+//go:build integration_testdb
+
+// Assertion-store route ABSENCE pin against the PRODUCTION route tree.
+//
+// KNW-033 is an invariant over the ENTIRE application route set: no HTTP
+// endpoint exposes assertions, graph nodes, edges, predicates, or provenance.
+// A handler-level test cannot prove an absence claim — only enumerating the
+// real router built by the real registerRoutes can. This file reuses the
+// oauth_routes_boundary_test.go wire-chain harness (buildRouterForOAuthWiring)
+// so the enumerated tree is exactly what run() would serve for each config
+// shape.
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertionStoreStems are lowercase substrings that mark a route as exposing
+// the assertion store. Substring (not whole-segment) matching is deliberate:
+// a rename like /graph-nodes or /assertion-list must still trip the scan.
+// Each stem is derived from the KNW-033 statement text and the internal
+// package surface it names:
+//
+//   - "assert":     assertions themselves (internal/repository/assertion.go,
+//     AssertService) — also covers "assertion"/"assertions".
+//   - "graph":      the knowledge graph as a whole (buildGraphCore, the graph
+//     wire stack).
+//   - "node":       graph nodes (internal/repository/node.go).
+//   - "edge":       graph edges (assertion subject→object links). This stem
+//     is also a substring of "knowledge", which is intentional: a /knowledge
+//     route would itself violate KNW-033's claim that the only client-visible
+//     projection is the contact payload's derived fields.
+//   - "predicate":  predicates (internal/repository/predicate.go).
+//   - "provenance": assertion provenance, named directly by the spec text.
+//
+// False-positive audit (why substring matching is safe here): the current
+// production route set was inspected route-by-route and NO legitimate path
+// contains any of these stems. The known-route sanity assertions below keep
+// the scan honest — an empty or gutted route table cannot silently pass.
+var assertionStoreStems = []string{
+	"assert",
+	"graph",
+	"node",
+	"edge",
+	"predicate",
+	"provenance",
+}
+
+// requireNoAssertionStoreRoutes scans every registered route path for the
+// forbidden stems and fails naming the offending route.
+func requireNoAssertionStoreRoutes(t *testing.T, routes gin.RoutesInfo) {
+	t.Helper()
+	for _, route := range routes {
+		lower := strings.ToLower(route.Path)
+		for _, stem := range assertionStoreStems {
+			assert.NotContains(t, lower, stem,
+				"route %s %s exposes an assertion-store surface (forbidden stem %q) — the assertion store must be invisible to the API",
+				route.Method, route.Path, stem)
+		}
+	}
+}
+
+// requireKnownRoutes guards the scan's own harness: the route table must be
+// nonzero and contain known-legit routes, so a rename or registration failure
+// that empties the tree cannot make the absence scan vacuously green.
+func requireKnownRoutes(t *testing.T, routes gin.RoutesInfo, wantPresent []string) {
+	t.Helper()
+	require.NotEmpty(t, routes, "production route table must not be empty")
+	registered := make(map[string]bool, len(routes))
+	for _, route := range routes {
+		registered[route.Method+" "+route.Path] = true
+	}
+	for _, want := range wantPresent {
+		require.True(t, registered[want],
+			"known-legit route %s must be present — its absence means the router under scan is not the production route tree", want)
+	}
+}
+
+// TestKnowledgeRouteAbsence_AssertionStoreInvisible enumerates the FULL
+// production router per config shape and asserts no route path touches the
+// assertion store. The enabled shape is the maximal route surface (external
+// sync on, both providers configured — the largest tree run() can serve); the
+// disabled shape pins the invariant on the minimal tree too.
+func TestKnowledgeRouteAbsence_AssertionStoreInvisible(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Run("maximal route surface exposes no assertion-store route", func(t *testing.T) {
+		// spec: KNW-033
+		t.Parallel()
+		cfg := oauthWiringConfig(t)
+		cfg.Features.EnableExternalSync = true
+		router := buildRouterForOAuthWiring(t, cfg)
+
+		routes := router.Routes()
+		requireKnownRoutes(t, routes, []string{
+			"GET /health",
+			"GET /api/v1/contacts",
+			// Sync-only route: proves this shape really is the maximal
+			// (external-sync-enabled) surface, not the disabled tree.
+			"GET /api/v1/auth/google/callback",
+		})
+		requireNoAssertionStoreRoutes(t, routes)
+	})
+
+	t.Run("external-sync-disabled surface exposes no assertion-store route", func(t *testing.T) {
+		// spec: KNW-033
+		t.Parallel()
+		cfg := oauthWiringConfig(t)
+		cfg.Features.EnableExternalSync = false
+		router := buildRouterForOAuthWiring(t, cfg)
+
+		routes := router.Routes()
+		requireKnownRoutes(t, routes, []string{
+			"GET /health",
+			"GET /api/v1/contacts",
+		})
+		requireNoAssertionStoreRoutes(t, routes)
+	})
+}

--- a/backend/cmd/crm-api/knowledge_route_absence_test.go
+++ b/backend/cmd/crm-api/knowledge_route_absence_test.go
@@ -82,6 +82,19 @@ func requireKnownRoutes(t *testing.T, routes gin.RoutesInfo, wantPresent []strin
 	}
 }
 
+// requireRouteAbsent proves a config shape actually SHRINKS the route tree.
+// The disabled shape asserts a sync-only route is missing: if the feature
+// flag were ignored (both shapes serving the identical, always-enabled
+// router), the absence scan alone would pass on both shapes and prove
+// nothing about the minimal tree — this assertion fails that defect loudly.
+func requireRouteAbsent(t *testing.T, routes gin.RoutesInfo, wantAbsent string) {
+	t.Helper()
+	for _, route := range routes {
+		require.NotEqual(t, wantAbsent, route.Method+" "+route.Path,
+			"sync-only route %s must be absent from this config shape — its presence means the feature flag did not shape the route tree", wantAbsent)
+	}
+}
+
 // TestKnowledgeRouteAbsence_AssertionStoreInvisible enumerates the FULL
 // production router per config shape and asserts no route path touches the
 // assertion store. The enabled shape is the maximal route surface (external
@@ -123,6 +136,9 @@ func TestKnowledgeRouteAbsence_AssertionStoreInvisible(t *testing.T) {
 			"GET /health",
 			"GET /api/v1/contacts",
 		})
+		// Distinguishability guard: the disabled tree must really be the
+		// minimal shape, not the enabled tree served twice.
+		requireRouteAbsent(t, routes, "GET /api/v1/auth/google/callback")
 		requireNoAssertionStoreRoutes(t, routes)
 	})
 }

--- a/backend/tests/api/calendar_api_test.go
+++ b/backend/tests/api/calendar_api_test.go
@@ -28,6 +28,27 @@ type calendarEventsEnvelope struct {
 	Data    []handlers.CalendarEventResponse `json:"data"`
 }
 
+// calendarRawEnvelope decodes the calendar list payload as raw JSON maps so
+// assertions bind to the literal wire keys ("id", ...) instead of the
+// production CalendarEventResponse struct — a renamed JSON tag on the DTO
+// must turn these tests red rather than silently round-tripping.
+type calendarRawEnvelope struct {
+	Success bool             `json:"success"`
+	Data    []map[string]any `json:"data"`
+}
+
+// rawEventIDs projects the raw event maps onto their literal "id" wire key.
+func rawEventIDs(t *testing.T, data []map[string]any) []string {
+	t.Helper()
+	ids := make([]string, 0, len(data))
+	for _, item := range data {
+		id, ok := item["id"].(string)
+		require.True(t, ok, "each event must expose a string id wire key")
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // newCalendarAPITest builds a fresh, empty per-subtest DB clone
 // (newIsolatedRiverTestDB) and a router carrying only the production
 // calendar route surface (handlers.RegisterCalendarRoutes). Because the
@@ -334,11 +355,11 @@ func TestCalendarAPI_CancelledEventsExcluded(t *testing.T) {
 		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
 		require.Equal(t, http.StatusOK, w.Code)
 
-		var envelope calendarEventsEnvelope
+		var envelope calendarRawEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
 		require.Len(t, envelope.Data, 1, "the cancelled event must be excluded from meeting history")
-		assert.Equal(t, kept.ID.String(), envelope.Data[0].ID)
+		assert.Equal(t, []string{kept.ID.String()}, rawEventIDs(t, envelope.Data))
 	})
 
 	t.Run("UpcomingForContact_ExcludesCancelled", func(t *testing.T) {
@@ -354,11 +375,11 @@ func TestCalendarAPI_CancelledEventsExcluded(t *testing.T) {
 		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events/upcoming")
 		require.Equal(t, http.StatusOK, w.Code)
 
-		var envelope calendarEventsEnvelope
+		var envelope calendarRawEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
 		require.Len(t, envelope.Data, 1, "the cancelled event must be excluded from the contact's upcoming events")
-		assert.Equal(t, kept.ID.String(), envelope.Data[0].ID)
+		assert.Equal(t, []string{kept.ID.String()}, rawEventIDs(t, envelope.Data))
 	})
 
 	t.Run("GlobalUpcoming_ExcludesCancelled", func(t *testing.T) {
@@ -374,11 +395,11 @@ func TestCalendarAPI_CancelledEventsExcluded(t *testing.T) {
 		w := doCalendarGet(router, "/api/v1/events/upcoming")
 		require.Equal(t, http.StatusOK, w.Code)
 
-		var envelope calendarEventsEnvelope
+		var envelope calendarRawEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
 		require.Len(t, envelope.Data, 1, "the cancelled event must be excluded from the global upcoming feed")
-		assert.Equal(t, kept.ID.String(), envelope.Data[0].ID)
+		assert.Equal(t, []string{kept.ID.String()}, rawEventIDs(t, envelope.Data))
 	})
 }
 
@@ -390,6 +411,11 @@ func TestCalendarAPI_CancelledEventsExcluded(t *testing.T) {
 // Three namespaced events with pairwise-distinct times are seeded per
 // endpoint over HTTP — no existing subtest asserts multi-event ordering
 // because every prior seed left exactly one surviving event.
+//
+// Seeding order is deliberately SCRAMBLED (middle, then the extreme the sort
+// puts first, then the extreme it puts last) so it matches neither the
+// expected output order nor its reverse: a query whose ORDER BY is dropped
+// (heap/insertion order) or inverted cannot coincidentally pass.
 func TestCalendarAPI_EventOrdering(t *testing.T) {
 	t.Parallel()
 
@@ -400,20 +426,20 @@ func TestCalendarAPI_EventOrdering(t *testing.T) {
 		ns := "cal-order-history-" + uuid.NewString()[:8]
 		contactID := seedContact("Calendar Order History Test Contact " + ns)
 		now := accelerated.GetCurrentTime()
-		oldest := seedEvent(t, ctx, calendarRepo, ns, "oldest", now.Add(-72*time.Hour), now.Add(-71*time.Hour), []uuid.UUID{contactID}, nil)
 		middle := seedEvent(t, ctx, calendarRepo, ns, "middle", now.Add(-48*time.Hour), now.Add(-47*time.Hour), []uuid.UUID{contactID}, nil)
 		newest := seedEvent(t, ctx, calendarRepo, ns, "newest", now.Add(-24*time.Hour), now.Add(-23*time.Hour), []uuid.UUID{contactID}, nil)
+		oldest := seedEvent(t, ctx, calendarRepo, ns, "oldest", now.Add(-72*time.Hour), now.Add(-71*time.Hour), []uuid.UUID{contactID}, nil)
 
 		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
 		require.Equal(t, http.StatusOK, w.Code)
 
-		var envelope calendarEventsEnvelope
+		var envelope calendarRawEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
 		require.Len(t, envelope.Data, 3)
 		assert.Equal(t,
 			[]string{newest.ID.String(), middle.ID.String(), oldest.ID.String()},
-			[]string{envelope.Data[0].ID, envelope.Data[1].ID, envelope.Data[2].ID},
+			rawEventIDs(t, envelope.Data),
 			"meeting history must be ordered most-recent-first")
 	})
 
@@ -424,20 +450,20 @@ func TestCalendarAPI_EventOrdering(t *testing.T) {
 		ns := "cal-order-upcoming-" + uuid.NewString()[:8]
 		contactID := seedContact("Calendar Order Upcoming Test Contact " + ns)
 		now := accelerated.GetCurrentTime()
-		soonest := seedEvent(t, ctx, calendarRepo, ns, "soonest", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
 		middle := seedEvent(t, ctx, calendarRepo, ns, "middle", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID}, nil)
 		latest := seedEvent(t, ctx, calendarRepo, ns, "latest", now.Add(72*time.Hour), now.Add(73*time.Hour), []uuid.UUID{contactID}, nil)
+		soonest := seedEvent(t, ctx, calendarRepo, ns, "soonest", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
 
 		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events/upcoming")
 		require.Equal(t, http.StatusOK, w.Code)
 
-		var envelope calendarEventsEnvelope
+		var envelope calendarRawEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
 		require.Len(t, envelope.Data, 3)
 		assert.Equal(t,
 			[]string{soonest.ID.String(), middle.ID.String(), latest.ID.String()},
-			[]string{envelope.Data[0].ID, envelope.Data[1].ID, envelope.Data[2].ID},
+			rawEventIDs(t, envelope.Data),
 			"a contact's upcoming events must be ordered soonest-first")
 	})
 
@@ -448,20 +474,20 @@ func TestCalendarAPI_EventOrdering(t *testing.T) {
 		ns := "cal-order-global-" + uuid.NewString()[:8]
 		contactID := seedContact("Calendar Order Global Test Contact " + ns)
 		now := accelerated.GetCurrentTime()
-		soonest := seedEvent(t, ctx, calendarRepo, ns, "soonest", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
 		middle := seedEvent(t, ctx, calendarRepo, ns, "middle", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID}, nil)
 		latest := seedEvent(t, ctx, calendarRepo, ns, "latest", now.Add(72*time.Hour), now.Add(73*time.Hour), []uuid.UUID{contactID}, nil)
+		soonest := seedEvent(t, ctx, calendarRepo, ns, "soonest", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
 
 		w := doCalendarGet(router, "/api/v1/events/upcoming")
 		require.Equal(t, http.StatusOK, w.Code)
 
-		var envelope calendarEventsEnvelope
+		var envelope calendarRawEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
 		require.Len(t, envelope.Data, 3)
 		assert.Equal(t,
 			[]string{soonest.ID.String(), middle.ID.String(), latest.ID.String()},
-			[]string{envelope.Data[0].ID, envelope.Data[1].ID, envelope.Data[2].ID},
+			rawEventIDs(t, envelope.Data),
 			"the global upcoming feed must be ordered soonest-first")
 	})
 }

--- a/backend/tests/api/calendar_api_test.go
+++ b/backend/tests/api/calendar_api_test.go
@@ -81,6 +81,27 @@ func seedEvent(t *testing.T, ctx context.Context, repo *repository.CalendarEvent
 	return ev
 }
 
+// seedEventStatus is seedEvent but with an explicit status (e.g.
+// "cancelled") instead of the hardcoded "confirmed". Used by tests that
+// prove cancelled events are filtered out of contact-facing reads.
+func seedEventStatus(t *testing.T, ctx context.Context, repo *repository.CalendarEventRepository, ns, suffix, status string, start, end time.Time, contactIDs []uuid.UUID) *repository.CalendarEvent {
+	t.Helper()
+	title := "Calendar API Test Event"
+	ev, err := repo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:       ns + "-" + suffix,
+		GcalCalendarID:    ns + "-cal",
+		GoogleAccountID:   ns + "-acct",
+		Title:             &title,
+		StartTime:         start,
+		EndTime:           end,
+		Status:            status,
+		MatchedContactIDs: contactIDs,
+		SyncedAt:          accelerated.GetCurrentTime(),
+	})
+	require.NoError(t, err)
+	return ev
+}
+
 // doCalendarGet serves a GET request against the router and returns the
 // recorder.
 func doCalendarGet(router *gin.Engine, path string) *httptest.ResponseRecorder {
@@ -283,5 +304,164 @@ func TestCalendarAPI_AttendeeRedaction(t *testing.T) {
 		assert.NotContains(t, body, organizerName, "response must not leak the organizer's display name")
 		assert.NotContains(t, body, attendeeEmail, "response must not leak the attendee's raw email")
 		assert.NotContains(t, body, attendeeName, "response must not leak the attendee's display name")
+	})
+}
+
+// spec: CAL-020
+//
+// TestCalendarAPI_CancelledEventsExcluded proves clause (b) of CAL-020 —
+// "every contact-facing read filters out cancelled events" — across every
+// contact-facing read endpoint the calendar HTTP surface exposes
+// (ListEventsForContact, ListUpcomingEventsForContact,
+// ListUpcomingEventsWithContacts): a cancelled event is excluded from that
+// endpoint's response while a sibling non-cancelled event (same namespace,
+// distinct identity) is returned. Clause (a) of CAL-020 — the hard delete —
+// is proven jointly by TestIntegration_CalendarEvent_HardDeleteReadBack in
+// calendar_decline_removal_integration_test.go.
+func TestCalendarAPI_CancelledEventsExcluded(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ContactEvents_ExcludesCancelled", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-cancel-history-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Cancelled History Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		seedEventStatus(t, ctx, calendarRepo, ns, "cancelled", "cancelled", now.Add(-2*time.Hour), now.Add(-time.Hour), []uuid.UUID{contactID})
+		kept := seedEventStatus(t, ctx, calendarRepo, ns, "confirmed", "confirmed", now.Add(-4*time.Hour), now.Add(-3*time.Hour), []uuid.UUID{contactID})
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 1, "the cancelled event must be excluded from meeting history")
+		assert.Equal(t, kept.ID.String(), envelope.Data[0].ID)
+	})
+
+	t.Run("UpcomingForContact_ExcludesCancelled", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-cancel-upcoming-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Cancelled Upcoming Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		seedEventStatus(t, ctx, calendarRepo, ns, "cancelled", "cancelled", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID})
+		kept := seedEventStatus(t, ctx, calendarRepo, ns, "confirmed", "confirmed", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID})
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events/upcoming")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 1, "the cancelled event must be excluded from the contact's upcoming events")
+		assert.Equal(t, kept.ID.String(), envelope.Data[0].ID)
+	})
+
+	t.Run("GlobalUpcoming_ExcludesCancelled", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-cancel-global-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Cancelled Global Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		seedEventStatus(t, ctx, calendarRepo, ns, "cancelled", "cancelled", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID})
+		kept := seedEventStatus(t, ctx, calendarRepo, ns, "confirmed", "confirmed", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID})
+
+		w := doCalendarGet(router, "/api/v1/events/upcoming")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 1, "the cancelled event must be excluded from the global upcoming feed")
+		assert.Equal(t, kept.ID.String(), envelope.Data[0].ID)
+	})
+}
+
+// spec: CAL-021
+//
+// TestCalendarAPI_EventOrdering proves every contact-facing read endpoint
+// imposes an explicit, deterministic order: meeting history is returned
+// most-recent-first and both upcoming feeds are returned soonest-first.
+// Three namespaced events with pairwise-distinct times are seeded per
+// endpoint over HTTP — no existing subtest asserts multi-event ordering
+// because every prior seed left exactly one surviving event.
+func TestCalendarAPI_EventOrdering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ContactEvents_MostRecentFirst", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-order-history-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Order History Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		oldest := seedEvent(t, ctx, calendarRepo, ns, "oldest", now.Add(-72*time.Hour), now.Add(-71*time.Hour), []uuid.UUID{contactID}, nil)
+		middle := seedEvent(t, ctx, calendarRepo, ns, "middle", now.Add(-48*time.Hour), now.Add(-47*time.Hour), []uuid.UUID{contactID}, nil)
+		newest := seedEvent(t, ctx, calendarRepo, ns, "newest", now.Add(-24*time.Hour), now.Add(-23*time.Hour), []uuid.UUID{contactID}, nil)
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 3)
+		assert.Equal(t,
+			[]string{newest.ID.String(), middle.ID.String(), oldest.ID.String()},
+			[]string{envelope.Data[0].ID, envelope.Data[1].ID, envelope.Data[2].ID},
+			"meeting history must be ordered most-recent-first")
+	})
+
+	t.Run("UpcomingForContact_SoonestFirst", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-order-upcoming-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Order Upcoming Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		soonest := seedEvent(t, ctx, calendarRepo, ns, "soonest", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
+		middle := seedEvent(t, ctx, calendarRepo, ns, "middle", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID}, nil)
+		latest := seedEvent(t, ctx, calendarRepo, ns, "latest", now.Add(72*time.Hour), now.Add(73*time.Hour), []uuid.UUID{contactID}, nil)
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events/upcoming")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 3)
+		assert.Equal(t,
+			[]string{soonest.ID.String(), middle.ID.String(), latest.ID.String()},
+			[]string{envelope.Data[0].ID, envelope.Data[1].ID, envelope.Data[2].ID},
+			"a contact's upcoming events must be ordered soonest-first")
+	})
+
+	t.Run("GlobalUpcoming_SoonestFirst", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-order-global-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Order Global Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		soonest := seedEvent(t, ctx, calendarRepo, ns, "soonest", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
+		middle := seedEvent(t, ctx, calendarRepo, ns, "middle", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID}, nil)
+		latest := seedEvent(t, ctx, calendarRepo, ns, "latest", now.Add(72*time.Hour), now.Add(73*time.Hour), []uuid.UUID{contactID}, nil)
+
+		w := doCalendarGet(router, "/api/v1/events/upcoming")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 3)
+		assert.Equal(t,
+			[]string{soonest.ID.String(), middle.ID.String(), latest.ID.String()},
+			[]string{envelope.Data[0].ID, envelope.Data[1].ID, envelope.Data[2].ID},
+			"the global upcoming feed must be ordered soonest-first")
 	})
 }

--- a/backend/tests/api/contact_task_api_test.go
+++ b/backend/tests/api/contact_task_api_test.go
@@ -1,0 +1,457 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/contacttask"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeContactTaskTodoistClient implements todoist.Client. It records call
+// counts so tests can prove which endpoints do (and do NOT) touch the remote
+// task provider, and returns a deterministic per-call task ID.
+type fakeContactTaskTodoistClient struct {
+	mu            sync.Mutex
+	quickAddCalls int
+	syncCalls     int
+	lastTaskID    string
+}
+
+func (f *fakeContactTaskTodoistClient) QuickAdd(_ context.Context, text string, _ string) (*todoist.QuickAddTask, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.quickAddCalls++
+	f.lastTaskID = "ct-api-task-" + uuid.NewString()
+	return &todoist.QuickAddTask{
+		ID:        f.lastTaskID,
+		ProjectID: "ct-api-project",
+		Content:   text,
+	}, nil
+}
+
+func (f *fakeContactTaskTodoistClient) Sync(_ context.Context, _ string, _ []string, _ []todoist.SyncCommand) (*todoist.SyncResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.syncCalls++
+	return &todoist.SyncResponse{SyncToken: "ct-api-sync-token"}, nil
+}
+
+func (f *fakeContactTaskTodoistClient) callCounts() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.quickAddCalls, f.syncCalls
+}
+
+func (f *fakeContactTaskTodoistClient) lastCreatedTaskID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastTaskID
+}
+
+type contactTaskAPIHarness struct {
+	router          *gin.Engine
+	contactRepo     *repository.ContactRepository
+	contactTaskRepo *repository.ContactTaskRepository
+	fakeTodoist     *fakeContactTaskTodoistClient
+}
+
+// setupContactTaskAPIRouter wires the contact-task route surface through the
+// PRODUCTION registration seam (handlers.RegisterContactTaskRoutes) on top of
+// the real service/repository/DB chain, with only the outbound Todoist client
+// faked.
+func setupContactTaskAPIRouter(t *testing.T) (*contactTaskAPIHarness, func()) {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	// Migrations are applied once by TestMain.
+
+	ctx := context.Background()
+	// MaxConns/MinConns mirror config.TestConfig() (8/1) to cap the per-pool
+	// connection ceiling under parallel execution.
+	dbConfig := config.DatabaseConfig{
+		URL:               databaseURL,
+		MaxConns:          8,
+		MinConns:          1,
+		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
+		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
+		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
+	}
+	database, err := db.NewDatabase(ctx, dbConfig)
+	require.NoError(t, err)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	syncRepo := repository.NewSyncRepository(database.Queries)
+
+	// Seed a labeled Todoist sync state under a per-run account so
+	// CreateManualTask's test-mode settings lookup succeeds. The test-mode
+	// lookup takes the FIRST todoist row from ListSyncStates (ordered by
+	// account_id), and sibling suites seed label-less todoist states under
+	// letter-prefixed accounts ("test-account-", "todoist-acct-",
+	// "watchdog-"), so a digit prefix keeps this labeled state first.
+	accountID := "00-ct-api-account-" + uuid.NewString()[:8]
+	syncState, err := syncRepo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
+		Source:    todoist.SourceName,
+		AccountID: stringPtr(accountID),
+		Metadata: map[string]any{
+			todoist.MetadataKeyProjectID:           "ct-api-proj",
+			todoist.MetadataKeyProjectName:         "CRM",
+			todoist.MetadataKeyLabelID:             "ct-api-label",
+			todoist.MetadataKeyLabelName:           "crm",
+			todoist.MetadataKeyIntegrationInstance: "ct-api-instance",
+		},
+	})
+	require.NoError(t, err)
+
+	contactTaskService := service.NewContactTaskServiceForTest(contactTaskRepo, contactRepo, syncRepo, "http://localhost:3000")
+	fakeTodoist := &fakeContactTaskTodoistClient{}
+	contactTaskService.SetTodoistClientFactory(func(string) todoist.Client { return fakeTodoist })
+
+	contactTaskHandler := handlers.NewContactTaskHandler(contactTaskService)
+
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	v1 := router.Group("/api/v1")
+	handlers.RegisterContactTaskRoutes(v1, contactTaskHandler)
+
+	cleanup := func() {
+		_ = syncRepo.DeleteSyncState(ctx, syncState.ID)
+		database.Close()
+	}
+
+	return &contactTaskAPIHarness{
+		router:          router,
+		contactRepo:     contactRepo,
+		contactTaskRepo: contactTaskRepo,
+		fakeTodoist:     fakeTodoist,
+	}, cleanup
+}
+
+// createContactTaskTestContact seeds a contact through the production
+// repository and registers a hard-delete cleanup (FK cascade removes its
+// contact_task rows).
+func createContactTaskTestContact(t *testing.T, h *contactTaskAPIHarness, name string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	contact, err := h.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = h.contactRepo.HardDeleteContact(ctx, contact.ID)
+	})
+	return contact.ID
+}
+
+func decodeContactTaskEnvelope(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	return envelope
+}
+
+func TestContactTaskAPI_ListFilters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	h, cleanup := setupContactTaskAPIRouter(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	suffix := uuid.NewString()[:8]
+	contactID := createContactTaskTestContact(t, h, "Task State Filter API Test "+suffix)
+
+	// Seed one manual-lifecycle task per state in the closed set. Manual
+	// lifecycle carries no per-contact partial unique index, so all five
+	// states can coexist on one contact.
+	stateClosedSet := []string{"managed", "completed", "unmanaged", "dismissed", "pending_remote_create"}
+	externalIDByState := make(map[string]string, len(stateClosedSet))
+	for _, state := range stateClosedSet {
+		externalID := "ct-api-state-" + state + "-" + suffix
+		externalIDByState[state] = externalID
+		_, err := h.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+			ContactID:      contactID,
+			Provider:       todoist.SourceName,
+			Kind:           contacttask.KindReachOut,
+			Lifecycle:      contacttask.LifecycleManual,
+			ExternalTaskID: externalID,
+			State:          state,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("StateFilterEachClosedSetMember", func(t *testing.T) {
+		// spec: CAD-032[0]
+		for _, state := range stateClosedSet {
+			req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks?state="+state, nil)
+			w := httptest.NewRecorder()
+			h.router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, "state=%s should be accepted", state)
+
+			envelope := decodeContactTaskEnvelope(t, w.Body.Bytes())
+			items, ok := envelope["data"].([]any)
+			require.True(t, ok, "data should be an array for state=%s", state)
+			require.Len(t, items, 1, "exactly the one %s task should match", state)
+			task, ok := items[0].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, state, task["state"])
+			assert.Equal(t, externalIDByState[state], task["external_task_id"])
+		}
+	})
+
+	t.Run("UnfilteredListReturnsAllStates", func(t *testing.T) {
+		// spec: CAD-032[0]
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks", nil)
+		w := httptest.NewRecorder()
+		h.router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		envelope := decodeContactTaskEnvelope(t, w.Body.Bytes())
+		items, ok := envelope["data"].([]any)
+		require.True(t, ok, "data should be an array")
+		require.Len(t, items, len(stateClosedSet))
+		seen := make(map[string]bool)
+		for _, item := range items {
+			task, ok := item.(map[string]any)
+			require.True(t, ok)
+			seen[task["state"].(string)] = true
+		}
+		for _, state := range stateClosedSet {
+			assert.True(t, seen[state], "unfiltered list should include the %s task", state)
+		}
+	})
+
+	t.Run("InvalidStateRejected", func(t *testing.T) {
+		// spec: CAD-032[0]
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks?state=archived", nil)
+		w := httptest.NewRecorder()
+		h.router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("InvalidLifecycleRejected", func(t *testing.T) {
+		// spec: CAD-032[0]
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks?lifecycle=recurring", nil)
+		w := httptest.NewRecorder()
+		h.router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("UnknownContactNotFound", func(t *testing.T) {
+		// spec: CAD-032[0]
+		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+uuid.NewString()+"/tasks", nil)
+		w := httptest.NewRecorder()
+		h.router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func postManualTask(t *testing.T, h *contactTaskAPIHarness, contactID uuid.UUID, payload map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	req, _ := http.NewRequest("POST", "/api/v1/contacts/"+contactID.String()+"/tasks", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, req)
+	return w
+}
+
+func TestContactTaskAPI_CreateManualTask(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	h, cleanup := setupContactTaskAPIRouter(t)
+	defer cleanup()
+
+	contactID := createContactTaskTestContact(t, h, "Task Create API Test "+uuid.NewString()[:8])
+
+	t.Run("ValidCreateReturns201WithCreatedTask", func(t *testing.T) {
+		// spec: CAD-032[1]
+		w := postManualTask(t, h, contactID, map[string]any{
+			"kind": "reach_out",
+			"text": "Follow up about the conference",
+		})
+		require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+
+		envelope := decodeContactTaskEnvelope(t, w.Body.Bytes())
+		data, ok := envelope["data"].(map[string]any)
+		require.True(t, ok, "response should carry the created task under the data key")
+
+		// Literal wire keys of the created task.
+		taskID, ok := data["id"].(string)
+		require.True(t, ok, "created task should expose an id key")
+		_, err := uuid.Parse(taskID)
+		require.NoError(t, err, "id should be a UUID")
+		assert.Equal(t, contactID.String(), data["contact_id"])
+		assert.Equal(t, "reach_out", data["kind"])
+		assert.Equal(t, "manual", data["lifecycle"])
+		assert.Equal(t, "managed", data["state"])
+		assert.Equal(t, h.fakeTodoist.lastCreatedTaskID(), data["external_task_id"])
+		require.Contains(t, data, "created_at")
+		content, ok := data["content"].(string)
+		require.True(t, ok, "created task should expose the content key")
+		assert.Contains(t, content, "Follow up about the conference")
+	})
+
+	t.Run("PickableKindSendAccepted", func(t *testing.T) {
+		// spec: CAD-032[1]
+		w := postManualTask(t, h, contactID, map[string]any{
+			"kind": "send",
+			"text": "Send the signed contract",
+		})
+		require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+		envelope := decodeContactTaskEnvelope(t, w.Body.Bytes())
+		data, ok := envelope["data"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "send", data["kind"])
+	})
+
+	t.Run("NonPickableKindRejected", func(t *testing.T) {
+		// spec: CAD-032[1]
+		// action and meet are valid listing-filter kinds but NOT user-pickable
+		// for manual creation.
+		for _, kind := range []string{"action", "meet"} {
+			w := postManualTask(t, h, contactID, map[string]any{
+				"kind": kind,
+				"text": "should be rejected",
+			})
+			assert.Equal(t, http.StatusBadRequest, w.Code, "kind=%s must not be user-pickable", kind)
+		}
+	})
+
+	t.Run("TextLengthBoundary", func(t *testing.T) {
+		// spec: CAD-032[1]
+		w := postManualTask(t, h, contactID, map[string]any{
+			"kind": "reminder",
+			"text": strings.Repeat("a", 1000),
+		})
+		assert.Equal(t, http.StatusCreated, w.Code, "text of exactly 1000 chars should be accepted")
+
+		w = postManualTask(t, h, contactID, map[string]any{
+			"kind": "reminder",
+			"text": strings.Repeat("a", 1001),
+		})
+		assert.Equal(t, http.StatusBadRequest, w.Code, "text of 1001 chars should be rejected")
+	})
+
+	t.Run("NotesLengthBoundary", func(t *testing.T) {
+		// spec: CAD-032[1]
+		w := postManualTask(t, h, contactID, map[string]any{
+			"kind":  "reminder",
+			"text":  "boundary notes task",
+			"notes": strings.Repeat("n", 5000),
+		})
+		assert.Equal(t, http.StatusCreated, w.Code, "notes of exactly 5000 chars should be accepted")
+
+		w = postManualTask(t, h, contactID, map[string]any{
+			"kind":  "reminder",
+			"text":  "boundary notes task overflow",
+			"notes": strings.Repeat("n", 5001),
+		})
+		assert.Equal(t, http.StatusBadRequest, w.Code, "notes of 5001 chars should be rejected")
+	})
+
+	t.Run("MissingTextRejected", func(t *testing.T) {
+		// spec: CAD-032[1]
+		w := postManualTask(t, h, contactID, map[string]any{
+			"kind": "reach_out",
+		})
+		assert.Equal(t, http.StatusBadRequest, w.Code, "text is required")
+	})
+}
+
+func TestContactTaskAPI_DeleteTaskLink(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	h, cleanup := setupContactTaskAPIRouter(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	suffix := uuid.NewString()[:8]
+	contactID := createContactTaskTestContact(t, h, "Task Unlink API Test "+suffix)
+
+	t.Run("UnlinkRemovesOnlyCRMLink", func(t *testing.T) {
+		// spec: CAD-032[2]
+		task, err := h.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+			ContactID:      contactID,
+			Provider:       todoist.SourceName,
+			Kind:           contacttask.KindReachOut,
+			Lifecycle:      contacttask.LifecycleManual,
+			ExternalTaskID: "ct-api-unlink-" + suffix,
+			State:          "managed",
+		})
+		require.NoError(t, err)
+
+		req, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID.String()+"/tasks/"+task.ID.String(), nil)
+		w := httptest.NewRecorder()
+		h.router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNoContent, w.Code)
+		assert.Zero(t, w.Body.Len(), "204 response should carry no content")
+
+		// The CRM link row is gone...
+		_, err = h.contactTaskRepo.GetContactTask(ctx, task.ID)
+		assert.True(t, errors.Is(err, db.ErrNotFound), "CRM link should be removed, got err=%v", err)
+
+		// ...but ONLY the link: the contact is untouched and no remote
+		// provider mutation happened (the Todoist client was never called).
+		_, err = h.contactRepo.GetContact(ctx, contactID)
+		assert.NoError(t, err, "contact should be untouched by unlink")
+		quickAdds, syncs := h.fakeTodoist.callCounts()
+		assert.Zero(t, quickAdds, "unlink must not create remote tasks")
+		assert.Zero(t, syncs, "unlink must not mutate the remote task")
+	})
+
+	t.Run("TaskOfDifferentContactNotFound", func(t *testing.T) {
+		// spec: CAD-032[2]
+		otherContactID := createContactTaskTestContact(t, h, "Task Unlink Other Contact "+suffix)
+		otherTask, err := h.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+			ContactID:      otherContactID,
+			Provider:       todoist.SourceName,
+			Kind:           contacttask.KindReachOut,
+			Lifecycle:      contacttask.LifecycleManual,
+			ExternalTaskID: "ct-api-unlink-other-" + suffix,
+			State:          "managed",
+		})
+		require.NoError(t, err)
+
+		req, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID.String()+"/tasks/"+otherTask.ID.String(), nil)
+		w := httptest.NewRecorder()
+		h.router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code, "task belonging to a different contact should be not-found")
+
+		// The mismatched delete must not remove the other contact's link.
+		fetched, err := h.contactTaskRepo.GetContactTask(ctx, otherTask.ID)
+		require.NoError(t, err, "other contact's task link should survive the mismatched delete")
+		assert.Equal(t, otherContactID, fetched.ContactID)
+	})
+}

--- a/backend/tests/api/contact_task_api_test.go
+++ b/backend/tests/api/contact_task_api_test.go
@@ -245,6 +245,86 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 		}
 	})
 
+	// Second namespaced contact for the kind/lifecycle closed-set loops so the
+	// per-state seeding above keeps its exact unfiltered count. The closed
+	// sets mirror the handler's list-filter oneof lists (ListContactTasksQuery
+	// in internal/api/handlers/contact_task.go) — a member dropped from the
+	// oneof must fail the acceptance loops below.
+	kindClosedSet := []string{"reach_out", "send", "reminder", "meet", "action"}
+	lifecycleClosedSet := []string{"manual", "cadence_due", "followup_loop"}
+
+	filterContactID := createContactTaskTestContact(t, h, "Task Kind Filter API Test "+suffix)
+	expectedByKind := make(map[string][]string, len(kindClosedSet))
+	expectedByLifecycle := make(map[string][]string, len(lifecycleClosedSet))
+	// One manual task per kind...
+	for _, kind := range kindClosedSet {
+		externalID := "ct-api-kindfilter-" + kind + "-" + suffix
+		_, err := h.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+			ContactID:      filterContactID,
+			Provider:       todoist.SourceName,
+			Kind:           kind,
+			Lifecycle:      contacttask.LifecycleManual,
+			ExternalTaskID: externalID,
+			State:          "managed",
+		})
+		require.NoError(t, err)
+		expectedByKind[kind] = append(expectedByKind[kind], externalID)
+		expectedByLifecycle[contacttask.LifecycleManual] = append(expectedByLifecycle[contacttask.LifecycleManual], externalID)
+	}
+	// ...plus one reach_out task per non-manual lifecycle.
+	for _, lifecycle := range []string{contacttask.LifecycleCadenceDue, contacttask.LifecycleFollowUpLoop} {
+		externalID := "ct-api-lcfilter-" + lifecycle + "-" + suffix
+		_, err := h.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+			ContactID:      filterContactID,
+			Provider:       todoist.SourceName,
+			Kind:           contacttask.KindReachOut,
+			Lifecycle:      lifecycle,
+			ExternalTaskID: externalID,
+			State:          "managed",
+		})
+		require.NoError(t, err)
+		expectedByKind[contacttask.KindReachOut] = append(expectedByKind[contacttask.KindReachOut], externalID)
+		expectedByLifecycle[lifecycle] = append(expectedByLifecycle[lifecycle], externalID)
+	}
+
+	listExternalIDs := func(t *testing.T, path string) []string {
+		t.Helper()
+		req, _ := http.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		h.router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "GET %s should be accepted, body: %s", path, w.Body.String())
+		envelope := decodeContactTaskEnvelope(t, w.Body.Bytes())
+		items, ok := envelope["data"].([]any)
+		require.True(t, ok, "data should be an array for %s", path)
+		ids := make([]string, 0, len(items))
+		for _, item := range items {
+			task, ok := item.(map[string]any)
+			require.True(t, ok)
+			ids = append(ids, task["external_task_id"].(string))
+		}
+		return ids
+	}
+
+	t.Run("KindFilterEachClosedSetMember", func(t *testing.T) {
+		// spec: CAD-032[0]
+		for _, kind := range kindClosedSet {
+			got := listExternalIDs(t, "/api/v1/contacts/"+filterContactID.String()+"/tasks?kind="+kind)
+			require.NotEmpty(t, got, "kind=%s should return the seeded task(s), not an empty list", kind)
+			assert.ElementsMatch(t, expectedByKind[kind], got,
+				"kind=%s should return exactly the seeded tasks of that kind", kind)
+		}
+	})
+
+	t.Run("LifecycleFilterEachClosedSetMember", func(t *testing.T) {
+		// spec: CAD-032[0]
+		for _, lifecycle := range lifecycleClosedSet {
+			got := listExternalIDs(t, "/api/v1/contacts/"+filterContactID.String()+"/tasks?lifecycle="+lifecycle)
+			require.NotEmpty(t, got, "lifecycle=%s should return the seeded task(s), not an empty list", lifecycle)
+			assert.ElementsMatch(t, expectedByLifecycle[lifecycle], got,
+				"lifecycle=%s should return exactly the seeded tasks in that lifecycle", lifecycle)
+		}
+	})
+
 	t.Run("InvalidStateRejected", func(t *testing.T) {
 		// spec: CAD-032[0]
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks?state=archived", nil)
@@ -348,7 +428,14 @@ func TestContactTaskAPI_CreateManualTask(t *testing.T) {
 
 	t.Run("TextLengthBoundary", func(t *testing.T) {
 		// spec: CAD-032[1]
+		// Min boundary accept side: a single-character text is valid.
 		w := postManualTask(t, h, contactID, map[string]any{
+			"kind": "reminder",
+			"text": "a",
+		})
+		assert.Equal(t, http.StatusCreated, w.Code, "text of exactly 1 char should be accepted")
+
+		w = postManualTask(t, h, contactID, map[string]any{
 			"kind": "reminder",
 			"text": strings.Repeat("a", 1000),
 		})

--- a/backend/tests/api/contact_validation_test.go
+++ b/backend/tests/api/contact_validation_test.go
@@ -1428,6 +1428,75 @@ func TestContactAPI_GetContactValidation(t *testing.T) {
 	})
 }
 
+// TestContactAPI_KnowledgeProjectionWireKeys binds the client-visible
+// projection clause of KNW-033: the contact payload's derived location,
+// birthday, and how_met fields are the ONLY projection of the knowledge
+// graph, so they must actually appear as wire keys on the contact response.
+// The create path persists these values solely as assertions
+// (KnowledgeCacheUpdater is the sole writer of the derived cache columns —
+// CreateContact/UpdateContact SQL never touch them), so a GET response
+// carrying them proves graph knowledge really is projected into the contact
+// payload. The statement's no-endpoint clause is bound by
+// TestKnowledgeRouteAbsence_AssertionStoreInvisible in
+// cmd/crm-api/knowledge_route_absence_test.go; together the citing set
+// covers both clauses.
+func TestContactAPI_KnowledgeProjectionWireKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	router, cleanup := setupContactValidationTestRouter()
+	defer cleanup()
+
+	// spec: KNW-033
+	ns := uuid.New().String()[:8]
+	location := "Projection City " + ns
+	howMet := "Met at projection test conference " + ns
+	body, err := json.Marshal(map[string]any{
+		"full_name": "Knowledge Projection Test " + ns,
+		"location":  location,
+		"birthday":  "1990-01-15",
+		"how_met":   howMet,
+	})
+	require.NoError(t, err)
+	createReq, _ := http.NewRequest("POST", "/api/v1/contacts", bytes.NewBuffer(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createW := httptest.NewRecorder()
+	router.ServeHTTP(createW, createReq)
+	require.Equal(t, http.StatusCreated, createW.Code, createW.Body.String())
+
+	var createResponse api.APIResponse
+	require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &createResponse))
+	contactID := createResponse.Data.(map[string]interface{})["id"].(string)
+	defer func() {
+		deleteReq, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+contactID, nil)
+		deleteW := httptest.NewRecorder()
+		router.ServeHTTP(deleteW, deleteReq)
+	}()
+
+	getReq, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID, nil)
+	getW := httptest.NewRecorder()
+	router.ServeHTTP(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+
+	var getResponse api.APIResponse
+	require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &getResponse))
+	require.True(t, getResponse.Success)
+	data, ok := getResponse.Data.(map[string]interface{})
+	require.True(t, ok, "contact payload should be a JSON object")
+
+	// Literal wire keys — the projection surface named by the spec.
+	assert.Equal(t, location, data["location"], "contact payload must project the graph-derived location")
+	assert.Equal(t, "1990-01-15T00:00:00Z", data["birthday"], "contact payload must project the graph-derived birthday")
+	assert.Equal(t, howMet, data["how_met"], "contact payload must project the graph-derived how_met")
+}
+
 func TestContactAPI_DuplicateMethodValues(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/backend/tests/api/direction_api_test.go
+++ b/backend/tests/api/direction_api_test.go
@@ -373,6 +373,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("FilterByFollowUpLifecycle", func(t *testing.T) {
+		// spec: CAD-032[0]
 		// Post-046, follow-up tasks are identified by lifecycle=followup_loop
 		// (kind is reach_out for live follow-up rows). The legacy
 		// ?kind=follow_up filter is no longer valid.
@@ -392,6 +393,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	})
 
 	t.Run("FilterByAction_ExcludesFollowUp", func(t *testing.T) {
+		// spec: CAD-032[0]
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID+"/tasks?kind=action", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -407,6 +409,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	})
 
 	t.Run("InvalidKindRejected", func(t *testing.T) {
+		// spec: CAD-032[0]
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID+"/tasks?kind=invalid", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -414,6 +417,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	})
 
 	t.Run("LegacyFollowUpKindRejected", func(t *testing.T) {
+		// spec: CAD-032[0]
 		// kind=follow_up is no longer a valid kind enum post-046; the
 		// validator rejects it at the handler boundary.
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID+"/tasks?kind=follow_up", nil)

--- a/backend/tests/api/direction_api_test.go
+++ b/backend/tests/api/direction_api_test.go
@@ -402,10 +402,14 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 		var resp api.APIResponse
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		items := resp.Data.([]interface{})
-		for _, item := range items {
-			task := item.(map[string]interface{})
-			assert.Equal(t, "action", task["kind"], "should only return action tasks")
-		}
+		// Exactly the seeded action task — non-empty (a filter that matches
+		// nothing must not pass vacuously) and the reach_out follow-up task
+		// seeded above must be excluded.
+		require.Len(t, items, 1, "exactly the seeded action task should match kind=action")
+		task := items[0].(map[string]interface{})
+		assert.Equal(t, "action", task["kind"], "should only return action tasks")
+		assert.Equal(t, "test-kind-action-"+contactID, task["external_task_id"],
+			"the returned task must be the seeded action task, not the follow-up")
 	})
 
 	t.Run("InvalidKindRejected", func(t *testing.T) {

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -536,6 +536,58 @@ func TestIntegration_AttendedAfterDelete_LockSerialization(t *testing.T) {
 	assert.False(t, existsAfterDelete, "after the decline DELETE, the attended branch sees no row → skips the insert")
 }
 
+// spec: CAL-020
+//
+// TestIntegration_CalendarEvent_HardDeleteReadBack proves clause (a) of
+// CAL-020 — "removal is a hard delete" — beyond what
+// TestIntegration_AttendedAfterDelete_LockSerialization already shows (that
+// the FOR SHARE existence probe returns false post-delete). A hard delete
+// and a soft-delete "flag" are indistinguishable to a caller that merely
+// checks existence through the SAME query that would also filter the flag;
+// this test instead does two things a soft-delete could not survive: (1) a
+// direct GetByID read-back returns db.ErrNotFound — unambiguous absence, not
+// a status a read might filter past — and (2) a subsequent Upsert on the
+// EXACT SAME Google identity triple inserts a BRAND NEW row (a distinct
+// UUID) rather than updating the old one, proving ON CONFLICT had nothing
+// left in the table to match against. Clause (b) of CAL-020 — every
+// contact-facing read filters cancelled events — is proven jointly by
+// TestCalendarAPI_CancelledEventsExcluded in
+// backend/tests/api/calendar_api_test.go.
+func TestIntegration_CalendarEvent_HardDeleteReadBack(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+	contact := e.newContact(t, nil, nil)
+
+	accountID := e.gen.Prefix() + "harddelete-readback"
+	stored := e.seedCalendarEvent(t, accountID, contact.ID)
+
+	require.NoError(t, e.calendarRepo.DeleteByGcalID(ctx, stored.GcalEventID, "primary", accountID))
+
+	_, err := e.calendarRepo.GetByID(ctx, stored.ID)
+	require.ErrorIs(t, err, db.ErrNotFound, "hard delete leaves no row for GetByID to find — not a status a read could filter past")
+
+	title := "decline-lock-event"
+	reinserted, err := e.calendarRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:       stored.GcalEventID,
+		GcalCalendarID:    "primary",
+		GoogleAccountID:   accountID,
+		Title:             &title,
+		StartTime:         time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:           time.Date(2026, 3, 1, 11, 0, 0, 0, time.UTC),
+		Status:            "confirmed",
+		Attendees:         []repository.Attendee{},
+		MatchedContactIDs: []uuid.UUID{contact.ID},
+		SyncedAt:          time.Date(2026, 3, 1, 11, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, stored.ID, reinserted.ID,
+		"re-upserting the same Google identity triple after a hard delete inserts a fresh row (a new UUID) because ON CONFLICT had no existing row to match — proving the prior row was truly removed, not merely flagged")
+}
+
 // TestIntegration_CalendarDecline_RecomputeSeesConcurrentInteraction is the
 // regression for the lock-then-aggregate ordering: the recompute acquires the
 // contact FOR UPDATE lock as a SEPARATE statement BEFORE reading the

--- a/backend/tests/calendar_event_integration_test.go
+++ b/backend/tests/calendar_event_integration_test.go
@@ -222,3 +222,70 @@ func TestUpdateContactLastContactedIfLater_OnlyUpdatesWhenLater(t *testing.T) {
 	require.NotNil(t, contactAfterLater.LastContacted)
 	assert.WithinDuration(t, later, *contactAfterLater.LastContacted, time.Second)
 }
+
+// spec: CAL-020
+//
+// TestCalendarEventCountForContact_ExcludesCancelled binds the count read
+// named by CAL-020: CountEventsForContact applies the same cancelled-event
+// filter as the contact-facing list reads, so a cancelled event matched to
+// the contact must not be counted. The count is scoped to a namespaced
+// contact's matched_contact_ids, so the exact == 1 assertion is independent
+// of sibling tests on the shared DB.
+func TestCalendarEventCountForContact_ExcludesCancelled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	t.Parallel()
+	ctx := context.Background()
+
+	// Migrations are applied once by TestMain.
+	dbConfig := config.DatabaseConfig{
+		URL:               databaseURL,
+		MaxConns:          8, // mirrors the lowered TestConfig() ceiling for parallel tests
+		MinConns:          1,
+		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
+		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
+		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
+	}
+	database, err := db.NewDatabase(ctx, dbConfig)
+	require.NoError(t, err)
+	defer database.Close()
+
+	gen, _ := migrationGenerator(t)
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
+
+	accountID := gen.Prefix() + "calendar-count@example.com"
+	defer func() { _ = calendarRepo.DeleteEventsByAccount(ctx, accountID) }()
+
+	now := accelerated.GetCurrentTime()
+	title := "Count Test Meeting"
+	seed := func(suffix, status string, start time.Time) {
+		_, err := calendarRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+			GcalEventID:       "count-" + suffix + "-" + uuid.NewString(),
+			GcalCalendarID:    "primary",
+			GoogleAccountID:   accountID,
+			Title:             &title,
+			StartTime:         start,
+			EndTime:           start.Add(time.Hour),
+			Status:            status,
+			MatchedContactIDs: []uuid.UUID{contact.ID},
+			SyncedAt:          now,
+		})
+		require.NoError(t, err)
+	}
+	seed("cancelled", "cancelled", now.Add(-3*time.Hour))
+	seed("confirmed", "confirmed", now.Add(-2*time.Hour))
+
+	count, err := calendarRepo.CountEventsForContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "the cancelled event must be excluded from the contact's event count")
+}

--- a/spec/cadence-followup.yaml
+++ b/spec/cadence-followup.yaml
@@ -1,7 +1,7 @@
 domain: cadence-followup
 prefix: CAD
 maturity: reviewed
-settled: [ui]
+settled: [ui, api]
 behaviors:
   # --- Cadence computation ---
 

--- a/spec/calendar.yaml
+++ b/spec/calendar.yaml
@@ -1,7 +1,7 @@
 domain: calendar
 prefix: CAL
 maturity: reviewed
-settled: [ui]
+settled: [ui, api]
 behaviors:
   # --- Sync provider config & entry ---
 

--- a/spec/knowledge.yaml
+++ b/spec/knowledge.yaml
@@ -1,7 +1,7 @@
 domain: knowledge
 prefix: KNW
 maturity: reviewed
-settled: [ui]
+settled: [ui, api]
 behaviors:
   # --- Assertion write path ---
 


### PR DESCRIPTION
## Summary

Gap phase PR 4 of the api-citation arc (follows #732/#733/#734): closes the last 6 closable `api`-surface orphans (cadence-followup 3, calendar 2, knowledge 1) and flips **cadence-followup, calendar, and knowledge** to `settled: [ui, api]`. The corpus drops 14 → 8 orphans — and those 8 are exactly the seam-blocked/unobservable waiver candidates (SET-018[1,2], TGM-007[1..4], MAC-007[4], MAC-010[3]) awaiting an explicit waiver decision in a follow-up.

Same contract as the whole arc: injected-defect red/green proof per item, literal wire-key assertions, pairwise-distinct namespaced fixtures, production-seam binding.

## What's covered

- **CAD-032[0..2]** — first handler-level coverage of the contact-task routes (`RegisterContactTaskRoutes` had never been wired into any test router): list filtering across the full state closed set + invalid state/lifecycle 400s + unknown-contact 404 (jointly cited with the existing kind/lifecycle tests); manual task creation with all four boundary pairs (text 1000/1001, notes 5000/5001), pickable-vs-non-pickable kind proof both ways, and 201 wire-shape assertions — with Todoist behind the production `SetTodoistClientFactory` seam recording that unlink flows never call the remote; unlink 204-empty-body with a read-back proving only the link row is removed, and wrong-contact unlink 404.
- **CAL-020** (statement) — the hard-delete claim completed with a `GetByID` → `ErrNotFound` read-back and a re-upsert-inserts-fresh-UUID proof (nothing left for ON CONFLICT to match), plus cancelled-event exclusion asserted per contact-facing HTTP read (all three endpoints, each with a cancelled + confirmed pair; injection-proven per-path by dropping the SQL filter from one query).
- **CAL-021** (statement) — first multi-event ordering proof: three distinct-time events per endpoint; history most-recent-first, both upcoming feeds soonest-first.
- **KNW-033** (statement) — the assertion-store invisibility claim proven over the **real `registerRoutes` route table** (reusing the production-wiring harness from #733) in both maximal (sync-enabled, both providers) and disabled shapes: no route path contains any assertion-store stem (assert/graph/node/edge/predicate/provenance, each stem justified in a comment), with harness sanity checks so a hollow route table cannot pass; injection-proven by registering a `/api/v1/assertions` route.

## Test plan

- `make spec-coverage`: 8 orphans (was 14), 0 invalid; nine domains now settled `[ui, api]`; `make spec-lint` green.
- Full backend suites + E2E-diff via pre-push hook; CI runs the full matrix.
