### PR TITLE
fix: snooze gchat rematch on budget exhaustion

### DIFF
--- a/backend/internal/consumer/rematch_dispatcher.go
+++ b/backend/internal/consumer/rematch_dispatcher.go
@@ -8,6 +8,7 @@ import (
 
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/service"
 
@@ -106,15 +107,39 @@ func NewRematchDispatcherWorker(bus eventBusTx, pool *pgxpool.Pool, dispatcher *
 	return &RematchDispatcherWorker{bus: bus, pool: pool, dispatcher: dispatcher}
 }
 
+// rematchBudgetSnoozeDelay is how long a rematch job waits before resuming when
+// a gchat rematch aborts on budget exhaustion. It is comfortably above the
+// "within minutes" rapid-fire cadence that was discarding these jobs, and
+// spaced so repeated snoozes span the steady-state sweep interval
+// (GChatDefaultInterval) — giving the sweep time to advance the backfill floor
+// so a later run fits within budget.
+const rematchBudgetSnoozeDelay = 5 * time.Minute
+
 // Work implements river.Worker. Fetches the event envelope by id and
-// invokes HandleEvent. On error river retries per MaxAttempts (3 from
-// the InsertOpts set in events.consumerJobsForKind).
+// invokes HandleEvent. Budget-exhaustion (google.ErrRematchBudgetExhausted) is
+// a continue-later signal, not a terminal failure, so it is rescheduled via
+// JobSnooze (which bumps MaxAttempts) rather than discarded. Genuine errors
+// propagate so river retries per MaxAttempts (3 from the InsertOpts set in
+// events.consumerJobsForKind) and eventually discards.
 func (w *RematchDispatcherWorker) Work(ctx context.Context, j *river.Job[consumerjobs.RematchDispatcherJobArgs]) error {
 	env, err := w.bus.GetEvent(ctx, j.Args.EventID)
 	if err != nil {
 		return fmt.Errorf("fetch event %s: %w", j.Args.EventID, err)
 	}
-	return w.dispatcher.HandleEvent(ctx, env)
+	if err := w.dispatcher.HandleEvent(ctx, env); err != nil {
+		if errors.Is(err, google.ErrRematchBudgetExhausted) {
+			// Snooze instead of returning a terminal error: three rapid retries
+			// against the same still-exhausted budget would discard the job and
+			// strand the contact's backfill. Snoozing never counts against
+			// MaxAttempts, so the backfill resumes until it completes. A genuine
+			// failure co-occurring with budget exhaustion keeps snoozing until
+			// the budget stops exhausting, then discards normally once it is the
+			// sole remaining error.
+			return river.JobSnooze(rematchBudgetSnoozeDelay)
+		}
+		return err
+	}
+	return nil
 }
 
 // Timeout bounds a single rematch run. Multi-method rematch over large

--- a/backend/internal/consumer/rematch_dispatcher.go
+++ b/backend/internal/consumer/rematch_dispatcher.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -21,6 +22,11 @@ import (
 // stub Run without instantiating the full service graph.
 type rematchRunner interface {
 	Run(ctx context.Context, jobID, contactID uuid.UUID, methods []service.Method) error
+	// FailJob forces the in-memory job terminal. Needed because Run leaves a
+	// budget-exhausted job Running across snoozes; when the worker stops
+	// rescheduling, someone must terminate it or the frontend watcher polls
+	// forever.
+	FailJob(jobID uuid.UUID, reason error)
 }
 
 // RematchDispatcher is the event-bus consumer for contact_methods.added.
@@ -108,18 +114,35 @@ func NewRematchDispatcherWorker(bus eventBusTx, pool *pgxpool.Pool, dispatcher *
 
 // rematchBudgetSnoozeDelay is how long a rematch job waits before resuming when
 // a gchat rematch aborts on budget exhaustion. It is comfortably above the
-// "within minutes" rapid-fire cadence that was discarding these jobs, and
-// spaced so repeated snoozes span the steady-state sweep interval
-// (GChatDefaultInterval) — giving the sweep time to advance the backfill floor
-// so a later run fits within budget.
+// "within minutes" rapid-fire cadence that was discarding these jobs.
 const rematchBudgetSnoozeDelay = 5 * time.Minute
+
+// rematchBudgetSnoozeCeiling bounds how many times one rematch job may snooze on
+// budget exhaustion before the worker gives up.
+//
+// A ceiling is required because a snoozed re-run is NOT guaranteed to make
+// progress: the scan restarts from the account's static onboarding floor every
+// attempt (gchat_rematch.go passes gchatBackfillFloor, which nothing advances)
+// and ScanIdentifier persists no continuation cursor, so an account whose
+// history exceeds the per-run page budget re-scans the same pages and exhausts
+// again — deterministically, forever. Snoozing is only self-resolving for an
+// account that is transiently over budget. Without this ceiling an over-budget
+// account burns a scan every rematchBudgetSnoozeDelay indefinitely while its
+// job shows as running.
+//
+// 12 snoozes ≈ 1 hour of retrying before giving up loudly. Persisting real
+// per-rematch scan progress is the actual fix; until then this converts an
+// infinite loop into a bounded one with a terminal, visible outcome.
+const rematchBudgetSnoozeCeiling = 12
 
 // Work implements river.Worker. Fetches the event envelope by id and
 // invokes HandleEvent. Budget-exhaustion (service.ErrRematchBudgetExhausted) is
 // a continue-later signal, not a terminal failure, so it is rescheduled via
-// JobSnooze (which bumps MaxAttempts) rather than discarded. Genuine errors
-// propagate so river retries per MaxAttempts (3 from the InsertOpts set in
-// events.consumerJobsForKind) and eventually discards.
+// JobSnooze (which rewinds the attempt, so it never counts against MaxAttempts)
+// rather than discarded — up to rematchBudgetSnoozeCeiling times, after which
+// the job is cancelled terminally. Genuine errors propagate so river retries per
+// MaxAttempts (3 from the InsertOpts set in events.consumerJobsForKind) and
+// eventually discards.
 func (w *RematchDispatcherWorker) Work(ctx context.Context, j *river.Job[consumerjobs.RematchDispatcherJobArgs]) error {
 	env, err := w.bus.GetEvent(ctx, j.Args.EventID)
 	if err != nil {
@@ -127,15 +150,33 @@ func (w *RematchDispatcherWorker) Work(ctx context.Context, j *river.Job[consume
 	}
 	if err := w.dispatcher.HandleEvent(ctx, env); err != nil {
 		if errors.Is(err, service.ErrRematchBudgetExhausted) {
+			if snoozes := riverSnoozeCount(j); snoozes >= rematchBudgetSnoozeCeiling {
+				// Out of patience: this backfill has re-scanned from the same
+				// floor rematchBudgetSnoozeCeiling times without completing, so
+				// further snoozes would just repeat it. Push the in-memory job
+				// terminal (Run leaves it Running across snoozes, so the
+				// frontend watcher would otherwise poll forever) and cancel the
+				// River job — JobCancel is immediately terminal, unlike a
+				// returned error which would burn MaxAttempts on more doomed
+				// scans.
+				logger.Error().
+					Str("event_id", env.ID.String()).
+					Str("rematch_job_id", j.Args.RematchJobID.String()).
+					Int("snoozes", snoozes).
+					Msg("rematch_dispatcher: gchat rematch still budget-exhausted after ceiling; giving up (history likely exceeds per-run page budget)")
+				w.dispatcher.runner.FailJob(j.Args.RematchJobID, err)
+				return river.JobCancel(err)
+			}
 			// Snooze instead of returning a terminal error: three rapid retries
 			// against the same still-exhausted budget would discard the job and
 			// strand the contact's backfill. Snoozing never counts against
-			// MaxAttempts, so the backfill resumes until it completes. A genuine
-			// failure co-occurring with budget exhaustion keeps snoozing until
-			// the budget stops exhausting, then discards normally once it is the
-			// sole remaining error. Log at Warn (river logs snoozes only at
-			// Debug) so a backfill stuck snoozing stays visible; rematch_job_id
-			// + event_id attribute it without logging contact PII.
+			// MaxAttempts, so a transiently-over-budget backfill resumes until
+			// it completes. A genuine failure co-occurring with budget
+			// exhaustion keeps snoozing until the budget stops exhausting, then
+			// discards normally once it is the sole remaining error. Log at Warn
+			// (river logs snoozes only at Debug) so a backfill stuck snoozing
+			// stays visible; rematch_job_id + event_id attribute it without
+			// logging contact PII.
 			logger.Warn().
 				Str("event_id", env.ID.String()).
 				Str("rematch_job_id", j.Args.RematchJobID.String()).
@@ -146,6 +187,23 @@ func (w *RematchDispatcherWorker) Work(ctx context.Context, j *river.Job[consume
 		return err
 	}
 	return nil
+}
+
+// riverSnoozeCount reads the snooze tally river maintains in job metadata
+// ("snoozes", incremented on every JobSnooze). Returns 0 when the job row or
+// metadata is absent or unparseable — a missing count must not be read as
+// "ceiling reached", since that would cancel a first-attempt backfill.
+func riverSnoozeCount(j *river.Job[consumerjobs.RematchDispatcherJobArgs]) int {
+	if j.JobRow == nil || len(j.Metadata) == 0 {
+		return 0
+	}
+	var meta struct {
+		Snoozes int `json:"snoozes"`
+	}
+	if err := json.Unmarshal(j.Metadata, &meta); err != nil {
+		return 0
+	}
+	return meta.Snoozes
 }
 
 // Timeout bounds a single rematch run. Multi-method rematch over large

--- a/backend/internal/consumer/rematch_dispatcher.go
+++ b/backend/internal/consumer/rematch_dispatcher.go
@@ -8,7 +8,6 @@ import (
 
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/events"
-	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/service"
 
@@ -116,7 +115,7 @@ func NewRematchDispatcherWorker(bus eventBusTx, pool *pgxpool.Pool, dispatcher *
 const rematchBudgetSnoozeDelay = 5 * time.Minute
 
 // Work implements river.Worker. Fetches the event envelope by id and
-// invokes HandleEvent. Budget-exhaustion (google.ErrRematchBudgetExhausted) is
+// invokes HandleEvent. Budget-exhaustion (service.ErrRematchBudgetExhausted) is
 // a continue-later signal, not a terminal failure, so it is rescheduled via
 // JobSnooze (which bumps MaxAttempts) rather than discarded. Genuine errors
 // propagate so river retries per MaxAttempts (3 from the InsertOpts set in
@@ -127,14 +126,21 @@ func (w *RematchDispatcherWorker) Work(ctx context.Context, j *river.Job[consume
 		return fmt.Errorf("fetch event %s: %w", j.Args.EventID, err)
 	}
 	if err := w.dispatcher.HandleEvent(ctx, env); err != nil {
-		if errors.Is(err, google.ErrRematchBudgetExhausted) {
+		if errors.Is(err, service.ErrRematchBudgetExhausted) {
 			// Snooze instead of returning a terminal error: three rapid retries
 			// against the same still-exhausted budget would discard the job and
 			// strand the contact's backfill. Snoozing never counts against
 			// MaxAttempts, so the backfill resumes until it completes. A genuine
 			// failure co-occurring with budget exhaustion keeps snoozing until
 			// the budget stops exhausting, then discards normally once it is the
-			// sole remaining error.
+			// sole remaining error. Log at Warn (river logs snoozes only at
+			// Debug) so a backfill stuck snoozing stays visible; rematch_job_id
+			// + event_id attribute it without logging contact PII.
+			logger.Warn().
+				Str("event_id", env.ID.String()).
+				Str("rematch_job_id", j.Args.RematchJobID.String()).
+				Dur("snooze", rematchBudgetSnoozeDelay).
+				Msg("rematch_dispatcher: gchat rematch budget exhausted; snoozing to continue backfill")
 			return river.JobSnooze(rematchBudgetSnoozeDelay)
 		}
 		return err

--- a/backend/internal/consumer/rematch_dispatcher.go
+++ b/backend/internal/consumer/rematch_dispatcher.go
@@ -85,8 +85,11 @@ func (d *RematchDispatcher) HandleEvent(ctx context.Context, env *events.Envelop
 	}
 
 	if err := d.runner.Run(ctx, p.RematchJobID, p.ContactID, methods); err != nil {
-		// Run has already marked the in-memory job Failed. Propagate so
-		// River retries per MaxAttempts (3) from InsertOpts.
+		// Run has marked the in-memory job Failed for a genuine error, but
+		// deliberately leaves it Running for the continue-later sentinel
+		// (service.ErrRematchBudgetExhausted). Propagate either way: Work
+		// inspects the error and converts the sentinel into a snooze, while a
+		// genuine error is retried per MaxAttempts (3) from InsertOpts.
 		return fmt.Errorf("rematch run: %w", err)
 	}
 	return nil

--- a/backend/internal/consumer/rematch_dispatcher_test.go
+++ b/backend/internal/consumer/rematch_dispatcher_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,8 @@ func newWorkerForRunner(t *testing.T, runnerErr error) (*RematchDispatcherWorker
 		NewRematchDispatcher(&stubRunner{err: runnerErr}),
 	)
 	job := &river.Job[consumerjobs.RematchDispatcherJobArgs]{
-		Args: consumerjobs.RematchDispatcherJobArgs{EventID: env.ID},
+		JobRow: &rivertype.JobRow{Metadata: []byte(`{}`)},
+		Args:   consumerjobs.RematchDispatcherJobArgs{EventID: env.ID, RematchJobID: uuid.New()},
 	}
 	return worker, job
 }
@@ -108,11 +110,56 @@ func TestRematchDispatcherWorker_Work_MixedError_Snoozes(t *testing.T) {
 		"budget exhaustion co-occurring with a genuine error still snoozes (self-resolving tradeoff)")
 }
 
+// TestRematchDispatcherWorker_Work_BudgetExhausted_CeilingCancels proves the
+// snooze is bounded: the rematch scan restarts from the fixed onboarding floor
+// on every attempt (nothing persists progress), so an account whose history
+// exceeds the per-run page budget exhausts DETERMINISTICALLY — unlimited
+// snoozing would rescan the same pages every 5 minutes forever. At the ceiling
+// (river's metadata "snoozes" counter) Work must (a) mark the in-memory job
+// failed via the runner so the frontend watcher sees a terminal state instead
+// of polling forever, and (b) cancel the River job (JobCancel — immediately
+// terminal, no further budget-burning retry attempts).
+func TestRematchDispatcherWorker_Work_BudgetExhausted_CeilingCancels(t *testing.T) {
+	runnerErr := errors.Join(fmt.Errorf("account acct-1: %w", service.ErrRematchBudgetExhausted))
+	worker, job := newWorkerForRunner(t, runnerErr)
+	job.Metadata = fmt.Appendf(nil, `{"snoozes": %d}`, rematchBudgetSnoozeCeiling)
+
+	err := worker.Work(context.Background(), job)
+
+	var snooze *river.JobSnoozeError
+	require.False(t, errors.As(err, &snooze), "at the ceiling Work must stop snoozing")
+	var cancel *river.JobCancelError
+	require.ErrorAs(t, err, &cancel, "at the ceiling Work must cancel the job (terminal, no retries)")
+
+	runner := worker.dispatcher.runner.(*stubRunner)
+	require.Equal(t, []uuid.UUID{job.Args.RematchJobID}, runner.failedJobIDs(),
+		"giving up must mark the in-memory rematch job failed so the frontend watcher terminates")
+}
+
+// TestRematchDispatcherWorker_Work_BudgetExhausted_BelowCeiling_Snoozes pins the
+// boundary: one snooze below the ceiling still reschedules (the give-up branch
+// must not fire early).
+func TestRematchDispatcherWorker_Work_BudgetExhausted_BelowCeiling_Snoozes(t *testing.T) {
+	runnerErr := errors.Join(fmt.Errorf("account acct-1: %w", service.ErrRematchBudgetExhausted))
+	worker, job := newWorkerForRunner(t, runnerErr)
+	job.Metadata = fmt.Appendf(nil, `{"snoozes": %d}`, rematchBudgetSnoozeCeiling-1)
+
+	err := worker.Work(context.Background(), job)
+
+	var snooze *river.JobSnoozeError
+	require.ErrorAs(t, err, &snooze, "below the ceiling Work must keep snoozing")
+
+	runner := worker.dispatcher.runner.(*stubRunner)
+	require.Empty(t, runner.failedJobIDs(), "below the ceiling the in-memory job must stay untouched")
+}
+
 // stubRunner records Run invocations and returns a configurable error.
 type stubRunner struct {
-	mu    sync.Mutex
-	calls []stubRunCall
-	err   error
+	mu          sync.Mutex
+	calls       []stubRunCall
+	err         error
+	failedJobs  []uuid.UUID
+	failReasons []error
 }
 
 type stubRunCall struct {
@@ -132,6 +179,19 @@ func (s *stubRunner) callCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.calls)
+}
+
+func (s *stubRunner) FailJob(jobID uuid.UUID, reason error) {
+	s.mu.Lock()
+	s.failedJobs = append(s.failedJobs, jobID)
+	s.failReasons = append(s.failReasons, reason)
+	s.mu.Unlock()
+}
+
+func (s *stubRunner) failedJobIDs() []uuid.UUID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]uuid.UUID(nil), s.failedJobs...)
 }
 
 // validEnvelope builds a routable contact_methods.added envelope for tests.

--- a/backend/internal/consumer/rematch_dispatcher_test.go
+++ b/backend/internal/consumer/rematch_dispatcher_test.go
@@ -4,16 +4,82 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/service"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
 	"github.com/stretchr/testify/require"
 )
+
+// envelopeBus is an eventBusTx stub whose GetEvent returns a preconfigured
+// envelope, used to drive RematchDispatcherWorker.Work in unit tests.
+type envelopeBus struct {
+	env *events.Envelope
+	err error
+}
+
+func (b *envelopeBus) PublishTx(context.Context, pgx.Tx, *events.Envelope) error { return nil }
+
+func (b *envelopeBus) GetEvent(context.Context, uuid.UUID) (*events.Envelope, error) {
+	return b.env, b.err
+}
+
+func newWorkerForRunner(t *testing.T, runnerErr error) (*RematchDispatcherWorker, *river.Job[consumerjobs.RematchDispatcherJobArgs]) {
+	t.Helper()
+	env := validEnvelope(t, uuid.New(), uuid.New(), []events.ContactMethodRef{{Type: "email", Value: "a@b.c"}})
+	worker := NewRematchDispatcherWorker(
+		&envelopeBus{env: env},
+		nil, // pool is unused by Work
+		NewRematchDispatcher(&stubRunner{err: runnerErr}),
+	)
+	job := &river.Job[consumerjobs.RematchDispatcherJobArgs]{
+		Args: consumerjobs.RematchDispatcherJobArgs{EventID: env.ID},
+	}
+	return worker, job
+}
+
+// TestRematchDispatcherWorker_Work_BudgetExhausted_Snoozes proves that when the
+// rematch runner reports budget exhaustion (the continue-later sentinel), Work
+// reschedules the job via JobSnooze instead of returning a terminal error that
+// would burn the job's MaxAttempts and discard the backfill. The sentinel is
+// wrapped exactly as production wraps it (per-account context + %w), so this
+// also proves the sentinel survives the wrapping back up to Work.
+func TestRematchDispatcherWorker_Work_BudgetExhausted_Snoozes(t *testing.T) {
+	runnerErr := fmt.Errorf("account acct-1: %w", google.ErrRematchBudgetExhausted)
+	worker, job := newWorkerForRunner(t, runnerErr)
+
+	err := worker.Work(context.Background(), job)
+
+	var snooze *river.JobSnoozeError
+	require.ErrorAs(t, err, &snooze, "budget exhaustion must reschedule via JobSnooze, not discard")
+	require.Positive(t, snooze.Duration, "snooze must use a non-zero backoff")
+	require.NotErrorIs(t, err, google.ErrRematchBudgetExhausted,
+		"the returned reschedule must not carry the sentinel as a terminal error")
+}
+
+// TestRematchDispatcherWorker_Work_GenuineError_Propagates proves a non-budget
+// failure still propagates as a terminal error so river retries and eventually
+// discards it per MaxAttempts — budget-exhaustion handling must not swallow
+// real failures.
+func TestRematchDispatcherWorker_Work_GenuineError_Propagates(t *testing.T) {
+	sentinel := errors.New("gchat api exploded")
+	worker, job := newWorkerForRunner(t, sentinel)
+
+	err := worker.Work(context.Background(), job)
+
+	require.ErrorIs(t, err, sentinel, "genuine errors must propagate so river retries/discards normally")
+	var snooze *river.JobSnoozeError
+	require.NotErrorAs(t, err, &snooze, "genuine errors must not be rescheduled as a snooze")
+}
 
 // stubRunner records Run invocations and returns a configurable error.
 type stubRunner struct {

--- a/backend/internal/consumer/rematch_dispatcher_test.go
+++ b/backend/internal/consumer/rematch_dispatcher_test.go
@@ -11,7 +11,6 @@ import (
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/events"
-	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/service"
 
 	"github.com/google/uuid"
@@ -50,12 +49,15 @@ func newWorkerForRunner(t *testing.T, runnerErr error) (*RematchDispatcherWorker
 // TestRematchDispatcherWorker_Work_BudgetExhausted_Snoozes proves that when the
 // rematch runner reports budget exhaustion (the continue-later sentinel), Work
 // reschedules the job via JobSnooze instead of returning a terminal error that
-// would burn the job's MaxAttempts and discard the backfill. The sentinel is
-// wrapped exactly as production wraps it — per-account context (%w) inside the
-// errors.Join that gchatRematchBase.rematch builds — so this also proves the
-// sentinel survives the full wrapping (Join + %w) back up to Work.
+// would burn the job's MaxAttempts and discard the backfill. The error is
+// wrapped as gchatRematchBase.rematch wraps it (per-account %w inside
+// errors.Join) and driven through the real HandleEvent wrap ("rematch run:
+// %w"), so this exercises Work's errors.Is detection across the Join +
+// HandleEvent layers. The RematchService.Run layer is stubbed here (stubRunner
+// replaces it); its behavior on the sentinel is covered by
+// service.TestRun_BudgetExhausted_KeepsRunning.
 func TestRematchDispatcherWorker_Work_BudgetExhausted_Snoozes(t *testing.T) {
-	runnerErr := errors.Join(fmt.Errorf("account acct-1: %w", google.ErrRematchBudgetExhausted))
+	runnerErr := errors.Join(fmt.Errorf("account acct-1: %w", service.ErrRematchBudgetExhausted))
 	worker, job := newWorkerForRunner(t, runnerErr)
 
 	err := worker.Work(context.Background(), job)
@@ -63,7 +65,7 @@ func TestRematchDispatcherWorker_Work_BudgetExhausted_Snoozes(t *testing.T) {
 	var snooze *river.JobSnoozeError
 	require.ErrorAs(t, err, &snooze, "budget exhaustion must reschedule via JobSnooze, not discard")
 	require.Positive(t, snooze.Duration, "snooze must use a non-zero backoff")
-	require.NotErrorIs(t, err, google.ErrRematchBudgetExhausted,
+	require.NotErrorIs(t, err, service.ErrRematchBudgetExhausted,
 		"the returned reschedule must not carry the sentinel as a terminal error")
 }
 
@@ -94,7 +96,7 @@ func TestRematchDispatcherWorker_Work_GenuineError_Propagates(t *testing.T) {
 // silently discarding backfills mid-budget.
 func TestRematchDispatcherWorker_Work_MixedError_Snoozes(t *testing.T) {
 	runnerErr := errors.Join(
-		fmt.Errorf("account acct-1: %w", google.ErrRematchBudgetExhausted),
+		fmt.Errorf("account acct-1: %w", service.ErrRematchBudgetExhausted),
 		fmt.Errorf("account acct-2: %w", errors.New("oauth token revoked")),
 	)
 	worker, job := newWorkerForRunner(t, runnerErr)

--- a/backend/internal/consumer/rematch_dispatcher_test.go
+++ b/backend/internal/consumer/rematch_dispatcher_test.go
@@ -51,10 +51,11 @@ func newWorkerForRunner(t *testing.T, runnerErr error) (*RematchDispatcherWorker
 // rematch runner reports budget exhaustion (the continue-later sentinel), Work
 // reschedules the job via JobSnooze instead of returning a terminal error that
 // would burn the job's MaxAttempts and discard the backfill. The sentinel is
-// wrapped exactly as production wraps it (per-account context + %w), so this
-// also proves the sentinel survives the wrapping back up to Work.
+// wrapped exactly as production wraps it — per-account context (%w) inside the
+// errors.Join that gchatRematchBase.rematch builds — so this also proves the
+// sentinel survives the full wrapping (Join + %w) back up to Work.
 func TestRematchDispatcherWorker_Work_BudgetExhausted_Snoozes(t *testing.T) {
-	runnerErr := fmt.Errorf("account acct-1: %w", google.ErrRematchBudgetExhausted)
+	runnerErr := errors.Join(fmt.Errorf("account acct-1: %w", google.ErrRematchBudgetExhausted))
 	worker, job := newWorkerForRunner(t, runnerErr)
 
 	err := worker.Work(context.Background(), job)
@@ -69,16 +70,40 @@ func TestRematchDispatcherWorker_Work_BudgetExhausted_Snoozes(t *testing.T) {
 // TestRematchDispatcherWorker_Work_GenuineError_Propagates proves a non-budget
 // failure still propagates as a terminal error so river retries and eventually
 // discards it per MaxAttempts — budget-exhaustion handling must not swallow
-// real failures.
+// real failures. The error is wrapped as production wraps it (per-account %w
+// inside errors.Join).
 func TestRematchDispatcherWorker_Work_GenuineError_Propagates(t *testing.T) {
 	sentinel := errors.New("gchat api exploded")
-	worker, job := newWorkerForRunner(t, sentinel)
+	runnerErr := errors.Join(fmt.Errorf("account acct-1: %w", sentinel))
+	worker, job := newWorkerForRunner(t, runnerErr)
 
 	err := worker.Work(context.Background(), job)
 
 	require.ErrorIs(t, err, sentinel, "genuine errors must propagate so river retries/discards normally")
 	var snooze *river.JobSnoozeError
 	require.NotErrorAs(t, err, &snooze, "genuine errors must not be rescheduled as a snooze")
+}
+
+// TestRematchDispatcherWorker_Work_MixedError_Snoozes locks the documented
+// self-resolving tradeoff for the multi-account fan-out: when one account
+// budget-exhausts and another returns a genuine error, rematch returns an
+// errors.Join of both, and Work snoozes (budget-exhaustion is present). Once the
+// budget stops exhausting on a later run, only the genuine error remains and it
+// discards normally. Guarding this here means a refactor that reordered the
+// checks (e.g. inspecting for a genuine error first) fails loudly instead of
+// silently discarding backfills mid-budget.
+func TestRematchDispatcherWorker_Work_MixedError_Snoozes(t *testing.T) {
+	runnerErr := errors.Join(
+		fmt.Errorf("account acct-1: %w", google.ErrRematchBudgetExhausted),
+		fmt.Errorf("account acct-2: %w", errors.New("oauth token revoked")),
+	)
+	worker, job := newWorkerForRunner(t, runnerErr)
+
+	err := worker.Work(context.Background(), job)
+
+	var snooze *river.JobSnoozeError
+	require.ErrorAs(t, err, &snooze,
+		"budget exhaustion co-occurring with a genuine error still snoozes (self-resolving tradeoff)")
 }
 
 // stubRunner records Run invocations and returns a configurable error.

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -598,6 +598,17 @@ func buildKnownMapFromIdentities(ctx context.Context, commsRepo *repository.Comm
 	return knownMap, nil
 }
 
+// ErrRematchBudgetExhausted is the sentinel ScanIdentifier returns when a
+// rematch scan stops because its per-run page budget ran out before the
+// backfill finished. It is a CONTINUE-LATER signal, not a terminal failure: the
+// scan writes are idempotent and the scan cursor is left unadvanced, so a later
+// re-run resumes the backfill (the steady-state sweep advances the backfill
+// floor between runs, shrinking the remaining work until a run fits in budget).
+// The rematch dispatcher worker detects this sentinel and reschedules the River
+// job via JobSnooze instead of returning a terminal error, so budget exhaustion
+// never counts against the job's MaxAttempts.
+var ErrRematchBudgetExhausted = errors.New("rematch scan budget exhausted; retry to finish backfill")
+
 // ScanIdentifier runs a one-shot, address-scoped historical scan for one
 // connected account: it iterates the account's spaces and upserts only the rows
 // that involve addrNormalized (inbound FROM the address, or outbound TO a space
@@ -650,7 +661,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 	budget := gchatMaxWindowsPerSync
 	for _, space := range spaces {
 		if budget <= 0 {
-			return counters.matched, fmt.Errorf("rematch scan budget exhausted before completing: retry to finish backfill")
+			return counters.matched, fmt.Errorf("before completing: %w", ErrRematchBudgetExhausted)
 		}
 		members, _, memberIncomplete, mErr := paginateMembers(ctx, fetcher, space.Name, &budget)
 		if mErr != nil {
@@ -659,7 +670,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 		if memberIncomplete {
 			// Budget ran out mid-membership → the scan is incomplete; fail so
 			// River retries the whole (idempotent) backfill.
-			return counters.matched, fmt.Errorf("rematch scan budget exhausted paging membership: retry to finish backfill")
+			return counters.matched, fmt.Errorf("paging membership: %w", ErrRematchBudgetExhausted)
 		}
 		// Co-member resolution uses the FULL knownMap (so a space qualifies when
 		// the target address is one of its members); row-writing uses scanMap.
@@ -684,7 +695,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 			return counters.matched, fmt.Errorf("resolve scanned member id: %w", sErr)
 		}
 		if status == deferredBudgetHit {
-			return counters.matched, fmt.Errorf("rematch scan budget exhausted resolving member id: retry to finish backfill")
+			return counters.matched, fmt.Errorf("resolving member id: %w", ErrRematchBudgetExhausted)
 		}
 		idIsMember := false
 		if _, isMe := meIDs[userName]; status == resolvedKnownID && !isMe {
@@ -715,7 +726,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 		if !proven {
 			// Budget ran out mid-window → the scan is incomplete; fail so River
 			// retries the whole (idempotent) backfill rather than dropping history.
-			return counters.matched, fmt.Errorf("rematch scan budget exhausted mid-window: retry to finish backfill")
+			return counters.matched, fmt.Errorf("mid-window: %w", ErrRematchBudgetExhausted)
 		}
 	}
 	return counters.matched, nil

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -12,6 +12,7 @@ import (
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/matching"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	syncpkg "personal-crm/backend/internal/sync"
 
 	"github.com/google/uuid"
@@ -598,17 +599,6 @@ func buildKnownMapFromIdentities(ctx context.Context, commsRepo *repository.Comm
 	return knownMap, nil
 }
 
-// ErrRematchBudgetExhausted is the sentinel ScanIdentifier returns when a
-// rematch scan stops because its per-run page budget ran out before the
-// backfill finished. It is a CONTINUE-LATER signal, not a terminal failure: the
-// scan writes are idempotent and the scan cursor is left unadvanced, so a later
-// re-run resumes the backfill (the steady-state sweep advances the backfill
-// floor between runs, shrinking the remaining work until a run fits in budget).
-// The rematch dispatcher worker detects this sentinel and reschedules the River
-// job via JobSnooze instead of returning a terminal error, so budget exhaustion
-// never counts against the job's MaxAttempts.
-var ErrRematchBudgetExhausted = errors.New("rematch scan budget exhausted; retry to finish backfill")
-
 // ScanIdentifier runs a one-shot, address-scoped historical scan for one
 // connected account: it iterates the account's spaces and upserts only the rows
 // that involve addrNormalized (inbound FROM the address, or outbound TO a space
@@ -661,7 +651,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 	budget := gchatMaxWindowsPerSync
 	for _, space := range spaces {
 		if budget <= 0 {
-			return counters.matched, fmt.Errorf("before completing: %w", ErrRematchBudgetExhausted)
+			return counters.matched, fmt.Errorf("before completing: %w", service.ErrRematchBudgetExhausted)
 		}
 		members, _, memberIncomplete, mErr := paginateMembers(ctx, fetcher, space.Name, &budget)
 		if mErr != nil {
@@ -670,7 +660,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 		if memberIncomplete {
 			// Budget ran out mid-membership → the scan is incomplete; fail so
 			// River retries the whole (idempotent) backfill.
-			return counters.matched, fmt.Errorf("paging membership: %w", ErrRematchBudgetExhausted)
+			return counters.matched, fmt.Errorf("paging membership: %w", service.ErrRematchBudgetExhausted)
 		}
 		// Co-member resolution uses the FULL knownMap (so a space qualifies when
 		// the target address is one of its members); row-writing uses scanMap.
@@ -695,7 +685,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 			return counters.matched, fmt.Errorf("resolve scanned member id: %w", sErr)
 		}
 		if status == deferredBudgetHit {
-			return counters.matched, fmt.Errorf("resolving member id: %w", ErrRematchBudgetExhausted)
+			return counters.matched, fmt.Errorf("resolving member id: %w", service.ErrRematchBudgetExhausted)
 		}
 		idIsMember := false
 		if _, isMe := meIDs[userName]; status == resolvedKnownID && !isMe {
@@ -726,7 +716,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 		if !proven {
 			// Budget ran out mid-window → the scan is incomplete; fail so River
 			// retries the whole (idempotent) backfill rather than dropping history.
-			return counters.matched, fmt.Errorf("mid-window: %w", ErrRematchBudgetExhausted)
+			return counters.matched, fmt.Errorf("mid-window: %w", service.ErrRematchBudgetExhausted)
 		}
 	}
 	return counters.matched, nil

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -49,8 +49,13 @@ var ErrJobNotFound = errors.New("rematch job not found")
 // the eventual completion) while still returning the error, so
 // RematchDispatcherWorker.Work reschedules the River job (JobSnooze) without
 // counting the attempt toward MaxAttempts. The gchat rematch (internal/google)
-// wraps this at its budget-abort sites; re-running the idempotent scan resumes
-// the backfill once the steady-state sweep has advanced the backfill floor.
+// wraps this at its budget-abort sites.
+//
+// A re-run is idempotent but NOT guaranteed to get further: the gchat scan
+// restarts from the account's static onboarding floor and persists no
+// continuation cursor, so rescheduling only resolves a TRANSIENTLY over-budget
+// account. Work therefore bounds the retries (rematchBudgetSnoozeCeiling) and
+// gives up terminally rather than rescanning forever.
 var ErrRematchBudgetExhausted = errors.New("rematch scan budget exhausted; retry to finish backfill")
 
 // JobProgress is the externally-visible snapshot of a rematch job.
@@ -409,6 +414,21 @@ func (s *RematchService) rehydrateOrLookup(jobID, contactID uuid.UUID, methods [
 	}
 	j.resetForRun()
 	return j
+}
+
+// FailJob forces the in-memory job into the terminal Failed state with the
+// given reason. Used by the rematch dispatcher worker when it gives up on a
+// repeatedly budget-exhausted backfill: Run deliberately leaves such a job
+// Running so the frontend watcher keeps polling across snoozes, so something
+// has to push it terminal once the worker stops rescheduling — otherwise the
+// watcher polls a job that will never advance. Unknown job ids are a no-op
+// (the entry may already have been pruned).
+func (s *RematchService) FailJob(jobID uuid.UUID, reason error) {
+	v, ok := s.jobs.Load(jobID)
+	if !ok {
+		return
+	}
+	v.(*job).setFailed(reason)
 }
 
 // GetJob returns a snapshot of the job, or ErrJobNotFound if unknown.

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -42,6 +42,17 @@ const (
 // ErrJobNotFound is returned by GetJob when the job ID is unknown.
 var ErrJobNotFound = errors.New("rematch job not found")
 
+// ErrRematchBudgetExhausted is a continue-later signal a RematchHandler may wrap
+// (via %w) to report that it stopped because a per-run scan/page budget ran out
+// before its backfill finished — NOT a terminal failure. On this sentinel Run
+// leaves the in-memory job Running (so the frontend watcher keeps polling for
+// the eventual completion) while still returning the error, so
+// RematchDispatcherWorker.Work reschedules the River job (JobSnooze) without
+// counting the attempt toward MaxAttempts. The gchat rematch (internal/google)
+// wraps this at its budget-abort sites; re-running the idempotent scan resumes
+// the backfill once the steady-state sweep has advanced the backfill floor.
+var ErrRematchBudgetExhausted = errors.New("rematch scan budget exhausted; retry to finish backfill")
+
 // JobProgress is the externally-visible snapshot of a rematch job.
 type JobProgress struct {
 	ID          uuid.UUID
@@ -348,6 +359,20 @@ func (s *RematchService) Run(ctx context.Context, jobID, contactID uuid.UUID, me
 		for _, handler := range hs {
 			n, handlerErr := handler.Rematch(ctx, contactID, m.Value)
 			if handlerErr != nil {
+				if errors.Is(handlerErr, ErrRematchBudgetExhausted) {
+					// Continue-later signal, not a terminal failure: leave the
+					// in-memory job Running so the frontend watcher keeps polling
+					// for the eventual completion, but still return the error so
+					// RematchDispatcherWorker.Work reschedules (JobSnooze) instead
+					// of the job being marked failed. A later run resumes the
+					// idempotent scan. contactId is third-party PII; jobId + type
+					// attribute the deferral without logging it.
+					logger.Info().
+						Str("jobId", jobID.String()).
+						Str("type", m.Type).
+						Msg("rematch: handler budget-exhausted; job stays running for snooze/retry")
+					return handlerErr
+				}
 				// contactId is a third-party contact UUID; jobId + type attribute
 				// the failure without logging it.
 				logger.Warn().Err(handlerErr).

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -233,6 +233,46 @@ func TestRun_BudgetExhausted_KeepsRunning(t *testing.T) {
 	}
 }
 
+// TestFailJob_MarksJobFailed covers the worker's give-up path: when the
+// budget-snooze ceiling is reached the dispatcher worker cancels the River job
+// and must be able to push the in-memory job to a terminal state — otherwise
+// the frontend watcher (which only stops on a non-running status) polls a
+// cancelled job forever.
+func TestFailJob_MarksJobFailed(t *testing.T) {
+	svc := NewRematchService()
+	jobID := uuid.New()
+	svc.RegisterPending(jobID, uuid.New(), []Method{{Type: "email", Value: "a@b.c"}})
+
+	svc.FailJob(jobID, errors.New("budget exhausted after ceiling"))
+
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != JobStatusFailed {
+		t.Fatalf("FailJob must mark the job failed, got %s", job.Status)
+	}
+	if job.Error == "" {
+		t.Fatal("FailJob must record the failure reason")
+	}
+	if job.CompletedAt == nil {
+		t.Fatal("FailJob must stamp completedAt (terminal state)")
+	}
+}
+
+// TestFailJob_UnknownJobIsNoOp pins that failing an unregistered/pruned job id
+// neither panics nor creates a phantom entry.
+func TestFailJob_UnknownJobIsNoOp(t *testing.T) {
+	svc := NewRematchService()
+	unknown := uuid.New()
+
+	svc.FailJob(unknown, errors.New("whatever"))
+
+	if _, err := svc.GetJob(unknown); !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("unknown job must stay unknown, got err=%v", err)
+	}
+}
+
 func TestRun_PanicPropagatesAsError(t *testing.T) {
 	svc := NewRematchService()
 	svc.Register(panickyHandler{})

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -198,6 +199,37 @@ func TestRun_HandlerErrorFailsJob(t *testing.T) {
 	}
 	if job.Error == "" {
 		t.Fatal("expected non-empty error message")
+	}
+}
+
+func TestRun_BudgetExhausted_KeepsRunning(t *testing.T) {
+	svc := NewRematchService()
+	// Production-shaped wrap: a RematchHandler wraps the sentinel with
+	// per-account context (%w) inside the errors.Join that
+	// gchatRematchBase.rematch builds across connected accounts.
+	wrapped := errors.Join(fmt.Errorf("account acct-1: %w", ErrRematchBudgetExhausted))
+	svc.Register(&stubHandler{typ: "email", err: wrapped})
+
+	jobID := uuid.New()
+	runErr := svc.Run(context.Background(), jobID, uuid.New(), []Method{{Type: "email", Value: "a@b.c"}})
+
+	// Run must still return the sentinel so RematchDispatcherWorker.Work snoozes.
+	if !errors.Is(runErr, ErrRematchBudgetExhausted) {
+		t.Fatalf("Run should return the budget sentinel so the worker snoozes; got %v", runErr)
+	}
+	// ...but must NOT mark the in-memory job failed: the frontend rematch-job
+	// watcher stops polling on any non-running status, so a snoozed backfill
+	// marked failed would show as terminal and its eventual completion's cache
+	// invalidations would never fire.
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != JobStatusRunning {
+		t.Fatalf("budget exhaustion must leave the job running, got %s", job.Status)
+	}
+	if job.Error != "" {
+		t.Fatalf("budget exhaustion must not record an error string, got %q", job.Error)
 	}
 }
 

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -525,6 +525,10 @@
     "tags": ["@area:contacts", "@area:meetings"]
   },
   {
+    "pattern": "^backend/internal/consumer/rematch_dispatcher\\.go$",
+    "tags": ["@area:contacts", "@area:meetings"]
+  },
+  {
     "pattern": "^backend/internal/api/handlers/rematch\\.go$",
     "tags": ["@area:contacts", "@area:meetings"]
   },

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -273,8 +273,10 @@ behaviors:
     then:
       - every handler registered for each method's type runs (email fans out to calendar, gmail, and gchat backfills; telegram and phone link stranded telegram messages)
       - matched historical items are linked to the contact
-      - a handler failure fails the job and it is retried as a whole
-    provenance: [RematchService.Run, CalendarRematchHandler, GmailRematchHandler, UsernameRematchHandler]
+      - a genuine handler failure fails the job and it is retried as a whole
+      - a handler reporting that its own per-run scan budget ran out before finishing is a continue-later signal, not a failure - the job stays running and is rescheduled rather than consuming a retry attempt
+      - rescheduling is bounded - once a budget-exhausted job has been rescheduled up to its ceiling without finishing, it is failed and cancelled rather than retried forever
+    provenance: [RematchService.Run, CalendarRematchHandler, GmailRematchHandler, UsernameRematchHandler, service.ErrRematchBudgetExhausted, RematchDispatcherWorker.Work]
 
   - id: IMP-021
     title: Rematch jobs are pollable from the moment they are announced


### PR DESCRIPTION
Fixes #739.

## Problem

`rematch_dispatcher` jobs for gchat Chat-history rematch were being discarded before the backfill completed. `ScanIdentifier` aborts with a "budget exhausted" error when its per-run page budget runs out — a continue-later signal, not a terminal failure — but River treated it as terminal. Three rapid retries against the same still-exhausted budget burned `MaxAttempts=3` within minutes and discarded the job, stranding that contact's rematch backfill.

## Fix

**Typed sentinel.** `service.ErrRematchBudgetExhausted` (defined in `internal/service`, alongside the `RematchHandler` contract, so both the service and `internal/google` can reference it) replaces the four bare string errors at gchat's budget-abort sites.

**Snooze instead of discard.** `RematchDispatcherWorker.Work` detects the sentinel via `errors.Is` — it survives the per-account `%w` wrap inside the `errors.Join` the rematch runner builds, plus `HandleEvent`'s own wrap — and reschedules via `river.JobSnooze`, which rewinds the attempt so it never counts against `MaxAttempts`. Genuine errors still propagate and discard normally.

**Keep the in-memory job running.** `RematchService.Run` previously called `setFailed` on any handler error. Since the frontend `RematchJobWatcher` stops polling on any non-running status, that surfaced a still-scheduled backfill as terminally failed and meant the eventual completion's cache invalidations never fired. `Run` now leaves the job running for the sentinel while still returning the error so the worker snoozes.

**Bound the snoozing.** A re-run is idempotent but not guaranteed to progress: the scan restarts from the account's static onboarding floor (`gchat_rematch.go` passes `gchatBackfillFloor`, which nothing advances — the sweep advances its own per-space cursors, which the rematch scan does not read) and persists no continuation cursor. Budget consumption is deterministic and history only grows, so an account over the page budget would re-scan the same pages every 5 minutes forever. After `rematchBudgetSnoozeCeiling` (12, ~1 hour) snoozes the worker logs at Error, marks the in-memory job failed via the new `RematchService.FailJob`, and returns `river.JobCancel` — immediately terminal, rather than burning `MaxAttempts` on more doomed scans. The snooze count comes from River's own `snoozes` metadata counter; an absent or unparseable value reads as 0 so a first attempt is never cancelled.

Real progress persistence (a per-rematch continuation cursor) is tracked in #741.

## Tests

- `service`: sentinel leaves the job running and still returns the error; `FailJob` marks a job terminal; `FailJob` on an unknown id is a no-op.
- `consumer`: budget exhaustion snoozes; a genuine error fails terminally; a mixed genuine+budget error snoozes (the documented self-resolving tradeoff); at the ceiling the job is cancelled and the in-memory job failed; one snooze below the ceiling still snoozes.
- The ceiling test was mutation-verified: disabling the ceiling branch makes it fail with "at the ceiling Work must stop snoozing".

## Also

- `IMP-020`'s then list said a handler failure always fails the job and retries it as a whole; extended in place to carve out the continue-later class and the give-up ceiling, with the sentinel and worker added to provenance.
- Corrected `HandleEvent`'s comment, which asserted the old invariant at the exact seam that changed.
- Mapped `backend/internal/consumer/rematch_dispatcher.go` in the E2E test-map so diff-selection stops under-selecting for changes confined to it.

## Known limitation (deliberate)

Because the job now stays running across snoozes, the frontend watcher polls at its fixed 1 Hz for the duration — bounded by the ceiling to ~1 hour worst case for a permanently-over-budget account, versus stopping almost immediately before. At single-user scale on a local network this is not worth a frontend change; it disappears once #741 lands and backfills actually complete.