### PR TITLE
feat(synthetic): measure reseed duration, phases, and settle cost

### DIFF
--- a/.ai/spec/2026-07-24-seed-realism-archetypes.md
+++ b/.ai/spec/2026-07-24-seed-realism-archetypes.md
@@ -1,0 +1,67 @@
+# Seed realism: archetype-driven interaction histories
+
+Status: DESIGN APPROVED (conceptual), pending implementation plan. 2026-07-24.
+
+## Motivation
+
+The synthetic seed's contact population misrepresented how the application actually produces contact state, and that misrepresentation escalated into real (wasted) engineering work. Staging's seed carried a majority of contacts in a "clock-start" shape (bare `last_contacted ≈ created_at` with no directional timestamps and no backing evidence) — a state the production write path essentially never produces. An issue (#737) and a prod-backfill investigation were built on that phantom majority before prod measurement showed the real population is dominated by *mechanistically produced* states: contacts whose timestamp columns are the correct signature of real mutual calendar meetings and directional message history, backed by evidence rows (`calendar_event`, `comms_message`, `phone_call`, interactions).
+
+PR #738 already fixed the mechanism-level defect: the toolkit can no longer seed `last_contacted` directly (`ContactSpec` has no such field; compile-time guarantee pinned by test). What remains is the population-level gap this spec addresses: after a post-#738 reseed, the catalog bulk (~150 contacts in `prod-shaped`) has *no* interaction history at all, while prod's most common contacted state (mutual meeting-backed) barely exists on staging — only a handful of per-source showcase contacts get replayed source history today.
+
+## Guiding principles (settled in design discussion)
+
+1. **Seed the cause, not the endpoint** (existing toolkit contract, now applied to the whole population): contact interaction state is never written directly; it *emerges* from fake sync-source payloads replayed through the real ingestion pipeline (provider normalize → match → dedup → event bus → River consumers). Staging deliberately has no live sync sources (privacy); fake payloads never touch external APIs. This makes distribution drift structurally impossible when app semantics change — the seed cannot express states the app cannot produce.
+2. **Functional coverage, not statistical fidelity.** The seed's job is qualitative: enough samples of each behavior-relevant archetype, at varied points along the relevant distributions, for application functionality to be visible and testable. No prod-mirroring; no committed prod statistics; no machinery to track prod's shape.
+3. **All dates relative.** Archetype definitions are expressed purely in durations and frequencies relative to the seed anchor (`g.at(offset)` convention) — "meets every ~30d, most recent 8d ago", never calendar positions. Every reseed re-anchors the population to "now", so dashboards always show currently-relevant state and nothing breaks as the anchor moves. (Inherently calendar-positional data — birthdays — keeps its existing guarded handling; relative offsets cannot fully protect year-wrap cases.)
+4. **Generator gives texture, fixtures give guarantees.** Any state a tour, trap, or E2E test *depends on* stays pinned to stable, named, hand-authored fixtures. The archetype generator provides population texture, not test contracts.
+
+## Design
+
+### Archetype catalog
+
+Each archetype = a source mix + frequency/direction/recency parameters, all relative, with per-contact jitter (seeded PRNG) so samples are not clones. Initial catalog (~7):
+
+| Archetype | History shape | What it exercises |
+|---|---|---|
+| `mutual-regular` | Recurring attended calendar meetings + occasional two-way email/chat, recent | Prod's dominant contacted state; the mutual/all-four-equal timestamp path |
+| `mutual-drifting` | Was regular; last meeting ~10–16 weeks ago | Staleness/overdue with real history behind it |
+| `outbound-heavy` | User reaches out (email/telegram), rarely or never answered | `last_outreach_at` ≠ `last_contacted` semantics (the #737/#738 split) |
+| `inbound-only` | They write; user hasn't responded | Response-pending surfaces |
+| `dormant` | Genuine mixed history ending ~4–8 months ago | Deep-overdue, reconnect suggestions |
+| `burst-then-quiet` | Interactions clustered in a short window | Messaging aggregation windows |
+| `never-contacted` | No source history | Large slice; a real and behavior-relevant state |
+
+Counts per archetype: qualitative — enough samples with varied jitter to populate the relevant UI surfaces and sort/filter ranges; exact numbers chosen at implementation time per profile.
+
+### Generation mechanics
+
+- Per-contact timeline generated from archetype parameters via the toolkit's seeded PRNG. **New PRNG draws append after all existing draws** (the established discipline: mid-sequence draws shift the shared sequence and break id/handle stability of earlier replays).
+- Timelines are emitted as source payloads through the existing replay adapters and settled via the existing two-gate settle (domain-terminal predicate + River-jobs-finalized).
+- Direction/mutuality is expressed in source terms (who sent which message, calendar attendance), never as interaction-row fields — the interaction model classifies.
+
+### Layering onto existing profiles
+
+- The archetype population replaces the current bare catalog bulk as the *sole* source of interaction state: catalog contacts keep their identity fixtures (names, birthdays, cadences, how-met, lives-in) but interaction state only ever comes from replayed history. Each catalog contact is assigned an archetype.
+- Hand-authored fixture cohorts stay unchanged and explicitly labeled: 1900-sentinel birthdays, unicode/descender names, no-method slot, pending/unmatched candidates, follow-up loop, soft-deleted, merged pairs, import candidates, and the per-source showcase contacts.
+- **Both `prod-shaped` and `dev` profiles get archetypes** — dev with smaller counts. `minimal-scoped` (golden-pinned) is untouched.
+
+### Constraints
+
+- Determinism: population is a pure function of (seed, namespace, anchor), consistent with existing factory rules.
+- Reseed duration: no hard ceiling (reseeds are rare and non-blocking), but the reseed should log its duration and payload volumes so growth is observable.
+- Todoist is out of scope (feeds tasks, not interactions). The three documented direct-write exceptions (relationship signals, follow-up loop, import candidates) remain as-is.
+- Namespace isolation, cleanup, and `SeedAllowed` env-gating are unchanged.
+
+## Non-goals
+
+- Mirroring prod's exact distribution, or committing measured prod statistics.
+- Wiring any live sync source into staging (permanently out for privacy).
+- Migrating/repairing existing staging rows: a full reseed on a post-#738 image supersedes them. (Operational note: staging's current clock-start rows persist until a reseed actually runs — the auto-reseed skips its wipe when a sync account is connected (`--require-oauth-empty`), so a one-time forced `make staging-reset` may be needed.)
+- Changing the E2E `/test/seed/*` HTTP fixture path (its `last_contacted = now` default is a separate deferred #738 item).
+
+## Open questions for the implementation plan
+
+1. **Replay-adapter inventory vs archetype needs:** which sources have replay adapters today, and is calendar (critical for `mutual-regular`/`mutual-drifting` attended meetings) among them? Any archetype requiring a missing adapter either gets the adapter built or its source mix adjusted.
+2. **Existing catalog cohort migration:** the current overdue/recent/never-contacted index cohorts predate #738 — determine what (if anything) still makes them overdue post-#738, and how they map onto archetypes without breaking tours that select contacts by stable index.
+3. **Tour/trap dependency audit:** enumerate which staging states tours and traps actually depend on, so those get pinned fixtures before the population underneath them changes.
+4. **Reseed runtime measurement:** measure the settled reseed wall-clock at implementation scale; no ceiling, but the number informs payload sizing.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,3 +29,5 @@ linters:
       # - backend/internal/accelerated/time.go (wrapper implementation)
       # - backend/internal/api/middleware.go (latency measurement)
       # - backend/internal/api/handlers/system.go:83 (TIME_BASE setting)
+      # - backend/internal/synthetic/replay/replay.go (Stopwatch: seed/settle
+      #   duration measurement — infrastructure timing, not domain time)

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -921,10 +921,6 @@ func writeSeedSummary(w io.Writer, res synthetic.ProfileResult, partial bool) er
 func writeSeedTimings(w io.Writer, t synthetic.SeedTimings) error {
 	s := t.Settle
 	gateTotal := s.GateAWait + s.GateBWait + s.CaptureWait
-	inlineDen := s.GateACalls
-	if inlineDen == 0 {
-		inlineDen = 1 // avoid a bare 0/0; the numerator is 0 too, so the line still reads honestly
-	}
 	avgGateBPolls := 0.0
 	if s.Calls > 0 {
 		avgGateBPolls = float64(s.GateBPolls) / float64(s.Calls)
@@ -939,7 +935,7 @@ func writeSeedTimings(w io.Writer, t synthetic.SeedTimings) error {
 		formatSeedDuration(t.Total),
 		s.Calls,
 		formatSeedDuration(s.GateAWait), formatSeedDuration(s.GateBWait), formatSeedDuration(s.CaptureWait),
-		s.GateAInlineHits, inlineDen, s.GateBPolls, avgGateBPolls,
+		s.GateAInlineHits, s.GateACalls, s.GateBPolls, avgGateBPolls,
 		formatSeedDuration(t.Total-gateTotal),
 		len(t.Phases)); err != nil {
 		return fmt.Errorf("write seed timings: %w", err)

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -948,7 +948,10 @@ func writeSeedTimings(w io.Writer, t synthetic.SeedTimings) error {
 		// A phase that seeds no source payloads prints `-`, so "none by design"
 		// reads differently from "expected payloads, got none".
 		payloads := "-"
-		if p.Payloads > 0 {
+		switch {
+		case p.Payloads == 1:
+			payloads = "1 payload"
+		case p.Payloads > 1:
 			payloads = fmt.Sprintf("%d payloads", p.Payloads)
 		}
 		if _, err := fmt.Fprintf(w, "    %-26s %9s   %s\n",

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -833,9 +833,10 @@ func runSeed(ctx context.Context, opts runOptions, deps adminDeps) error {
 	}
 	res, err := deps.seed.Seed(ctx, params)
 	if err != nil {
+		writePartialSeedSummary(deps.stdout, res)
 		return fmt.Errorf("seed: %w", err)
 	}
-	return writeSeedSummary(deps.stdout, res)
+	return writeSeedSummary(deps.stdout, res, false)
 }
 
 // runResetAndSeed hard-wipes the live data tables then reseeds. The CRM_ENV gate
@@ -851,15 +852,40 @@ func runResetAndSeed(ctx context.Context, opts runOptions, deps adminDeps) error
 	}
 	res, err := deps.seed.ResetAndSeed(ctx, params)
 	if err != nil {
+		writePartialSeedSummary(deps.stdout, res)
 		return fmt.Errorf("reset-and-seed: %w", err)
 	}
-	return writeSeedSummary(deps.stdout, res)
+	return writeSeedSummary(deps.stdout, res, false)
+}
+
+// writePartialSeedSummary prints the DEGRADED summary for a failed seed — the
+// timing block plus whatever counts accumulated — so a reseed that died six
+// minutes in says which phase it was running and what it had cost. It prints
+// nothing when the run never reached the profile (a harness-build or preflight
+// failure leaves a zero result, and a summary of nothing is noise), and it
+// deliberately swallows its own write error: the caller is already returning the
+// seed failure, which is the error that matters.
+func writePartialSeedSummary(w io.Writer, res synthetic.ProfileResult) {
+	if res.Timings.Total == 0 {
+		return
+	}
+	_ = writeSeedSummary(w, res, true)
 }
 
 // writeSeedSummary prints the counts-only seed summary (no PII). The bare
 // namespace is printed (NOT the synth-<ns>- prefix — an internal detail).
-func writeSeedSummary(w io.Writer, res synthetic.ProfileResult) error {
-	if _, err := fmt.Fprintf(w, "seed summary (profile=%s namespace=%s prng_seed=%d):\n"+
+// partial marks a run that FAILED: the counts and timings are whatever had
+// accumulated, and the header says so, so a partial summary is never mistaken
+// for a successful run.
+func writeSeedSummary(w io.Writer, res synthetic.ProfileResult, partial bool) error {
+	marker := ""
+	if partial {
+		marker = " (PARTIAL — run failed)"
+		if res.Timings.Current != "" {
+			marker = fmt.Sprintf(" (PARTIAL — run failed during phase %q)", res.Timings.Current)
+		}
+	}
+	if _, err := fmt.Fprintf(w, "seed summary (profile=%s namespace=%s prng_seed=%d)%s:\n"+
 		"  contacts:             %d\n"+
 		"  gmail_settled:        %d\n"+
 		"  telegram_settled:     %d\n"+
@@ -871,13 +897,73 @@ func writeSeedSummary(w io.Writer, res synthetic.ProfileResult) error {
 		"  stranded_messages:    %d\n"+
 		"  unmatched_calendar:   %d\n"+
 		"  orphan_meeting_notes: %d\n",
-		res.Profile, res.Namespace, res.Seed,
+		res.Profile, res.Namespace, res.Seed, marker,
 		res.Contacts, res.GmailSettled, res.TelegramSettled, res.GCalSettled, res.GChatSettled,
 		res.IMessageSettled, res.UnmatchedExternal, res.StrandedTelegram, res.StrandedMessages,
 		res.UnmatchedCalendar, res.OrphanMeetingNote); err != nil {
 		return fmt.Errorf("write seed summary: %w", err)
 	}
+	return writeSeedTimings(w, res.Timings)
+}
+
+// writeSeedTimings prints the wall-clock block: total duration, the settle
+// accounting, and every phase with its payload volume.
+//
+// The attribution model is NESTED, and the summary says so rather than inviting
+// a wrong reading: a phase timer ENCOMPASSES the Settle calls made inside it,
+// and the gate timers nest inside those. So `outside_gates` (duration minus
+// total gate wait) is close to an accounting identity — PostgreSQL and River
+// work performed WHILE a gate waits is already counted as gate wait — and it is
+// labelled as bookkeeping, not evidence. What is actually falsifiable is
+// gate_polls: waitGateA evaluates its predicate BEFORE the first sleep, so a
+// high inline-hit rate with low poll counts means gate wait is genuine worker/DB
+// throughput, while a low rate with many polls is latency that batching removes.
+func writeSeedTimings(w io.Writer, t synthetic.SeedTimings) error {
+	s := t.Settle
+	gateTotal := s.GateAWait + s.GateBWait + s.CaptureWait
+	inlineDen := s.GateACalls
+	if inlineDen == 0 {
+		inlineDen = 1 // avoid a bare 0/0; the numerator is 0 too, so the line still reads honestly
+	}
+	avgGateBPolls := 0.0
+	if s.Calls > 0 {
+		avgGateBPolls = float64(s.GateBPolls) / float64(s.Calls)
+	}
+	if _, err := fmt.Fprintf(w,
+		"  duration:             %s\n"+
+			"  settle_calls:         %d\n"+
+			"  gate_wait:            gate_a=%s gate_b=%s capture=%s   (nested inside phases)\n"+
+			"  gate_polls:           gate_a=inline-hits %d/%d  gate_b=polls %d (avg %.1f/call)\n"+
+			"  outside_gates:        %s   (bookkeeping: duration − gate wait; NOT a hypothesis test)\n"+
+			"  phases (%d):\n",
+		formatSeedDuration(t.Total),
+		s.Calls,
+		formatSeedDuration(s.GateAWait), formatSeedDuration(s.GateBWait), formatSeedDuration(s.CaptureWait),
+		s.GateAInlineHits, inlineDen, s.GateBPolls, avgGateBPolls,
+		formatSeedDuration(t.Total-gateTotal),
+		len(t.Phases)); err != nil {
+		return fmt.Errorf("write seed timings: %w", err)
+	}
+	for _, p := range t.Phases {
+		// A phase that seeds no source payloads prints `-`, so "none by design"
+		// reads differently from "expected payloads, got none".
+		payloads := "-"
+		if p.Payloads > 0 {
+			payloads = fmt.Sprintf("%d payloads", p.Payloads)
+		}
+		if _, err := fmt.Fprintf(w, "    %-26s %9s   %s\n",
+			p.Name, formatSeedDuration(p.Duration), payloads); err != nil {
+			return fmt.Errorf("write seed phase timing: %w", err)
+		}
+	}
 	return nil
+}
+
+// formatSeedDuration renders a duration as plain seconds. Duration.String would
+// switch units across the ranges these numbers span ("1m12.97s" vs "412ms"),
+// which makes a phase table impossible to scan or diff.
+func formatSeedDuration(d time.Duration) string {
+	return fmt.Sprintf("%.2fs", d.Seconds())
 }
 
 func runMintPairingToken(ctx context.Context, opts runOptions, deps adminDeps) error {
@@ -1484,6 +1570,12 @@ func (a seedAdapter) ResetAndSeed(ctx context.Context, params synthetic.SeedPara
 
 // runProfile builds the namespaced harness, runs the profile, and enforces the
 // seed-and-leave (success) / full-teardown (error) lifecycle.
+//
+// On failure it returns the PARTIAL ProfileResult alongside the error rather
+// than discarding it: which phase was running, how long the run had taken, and
+// how many payloads had landed IS the diagnostic, and the entrypoints print it
+// as a degraded summary. The error return is unchanged, so the exit code still
+// reflects failure — this adds diagnostics, it swallows nothing.
 func (a seedAdapter) runProfile(ctx context.Context, params synthetic.SeedParams) (synthetic.ProfileResult, error) {
 	h, teardown, err := synthetic.NewHarnessWithDBForNamespace(ctx, a.database, params.Namespace, params.Seed)
 	if err != nil {
@@ -1497,9 +1589,9 @@ func (a seedAdapter) runProfile(ctx context.Context, params synthetic.SeedParams
 		// the partial world is still standing) ALONGSIDE the seed error — silently
 		// dropping it would hide that the "no leave-behind" guarantee was not met.
 		if tdErr := teardown(context.Background()); tdErr != nil {
-			return synthetic.ProfileResult{}, fmt.Errorf("seed failed: %w; AND partial-world teardown also failed (data may remain): %v", err, tdErr)
+			return res, fmt.Errorf("seed failed: %w; AND partial-world teardown also failed (data may remain): %v", err, tdErr)
 		}
-		return synthetic.ProfileResult{}, err
+		return res, err
 	}
 	// Success: Quiesce (stop client, LEAVE the rows).
 	if qErr := h.Quiesce(ctx); qErr != nil {

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -833,7 +833,7 @@ func runSeed(ctx context.Context, opts runOptions, deps adminDeps) error {
 	}
 	res, err := deps.seed.Seed(ctx, params)
 	if err != nil {
-		writePartialSeedSummary(deps.stdout, res)
+		writeSeedSummaryOnError(deps.stdout, res, err)
 		return fmt.Errorf("seed: %w", err)
 	}
 	return writeSeedSummary(deps.stdout, res, false)
@@ -852,24 +852,33 @@ func runResetAndSeed(ctx context.Context, opts runOptions, deps adminDeps) error
 	}
 	res, err := deps.seed.ResetAndSeed(ctx, params)
 	if err != nil {
-		writePartialSeedSummary(deps.stdout, res)
+		writeSeedSummaryOnError(deps.stdout, res, err)
 		return fmt.Errorf("reset-and-seed: %w", err)
 	}
 	return writeSeedSummary(deps.stdout, res, false)
 }
 
-// writePartialSeedSummary prints the DEGRADED summary for a failed seed — the
-// timing block plus whatever counts accumulated — so a reseed that died six
-// minutes in says which phase it was running and what it had cost. It prints
-// nothing when the run never reached the profile (a harness-build or preflight
-// failure leaves a zero result, and a summary of nothing is noise), and it
-// deliberately swallows its own write error: the caller is already returning the
-// seed failure, which is the error that matters.
-func writePartialSeedSummary(w io.Writer, res synthetic.ProfileResult) {
+// errSeedWorldIntact marks a failure that happened AFTER the profile finished
+// seeding — the world is complete and was NOT torn down. Such a run must not be
+// labelled PARTIAL: an operator who reads "run failed" against a good staging
+// world re-runs --reset-and-seed, which wipes it. That is the inverse of the
+// mistake the marker exists to prevent, and the more expensive one.
+var errSeedWorldIntact = errors.New("seed completed; a post-seed step failed")
+
+// writeSeedSummaryOnError prints the summary for a seed run that returned an
+// error. It marks the summary PARTIAL only when the PROFILE failed — a
+// post-seed failure (errSeedWorldIntact) leaves a complete world, so it prints
+// as an ordinary summary and the returned error carries the bad news.
+//
+// It prints nothing when the run never reached the profile (a harness-build or
+// preflight failure leaves a zero result, and a summary of nothing is noise),
+// and it deliberately swallows its own write error: the caller is already
+// returning the seed failure, which is the error that matters.
+func writeSeedSummaryOnError(w io.Writer, res synthetic.ProfileResult, err error) {
 	if res.Timings.Total == 0 {
 		return
 	}
-	_ = writeSeedSummary(w, res, true)
+	_ = writeSeedSummary(w, res, !errors.Is(err, errSeedWorldIntact))
 }
 
 // writeSeedSummary prints the counts-only seed summary (no PII). The bare
@@ -903,7 +912,21 @@ func writeSeedSummary(w io.Writer, res synthetic.ProfileResult, partial bool) er
 		res.UnmatchedCalendar, res.OrphanMeetingNote); err != nil {
 		return fmt.Errorf("write seed summary: %w", err)
 	}
-	return writeSeedTimings(w, res.Timings)
+	if err := writeSeedTimings(w, res.Timings); err != nil {
+		return err
+	}
+	if !partial {
+		return nil
+	}
+	// A failed profile run is torn down before this prints, so the counts above
+	// describe what HAD been seeded, not rows an operator can go look at. Without
+	// this they read as current DB state.
+	if _, err := fmt.Fprintf(w,
+		"  note: the partial world these counts describe has been torn down "+
+			"(unless the error reports that teardown also failed).\n"); err != nil {
+		return fmt.Errorf("write seed summary note: %w", err)
+	}
+	return nil
 }
 
 // writeSeedTimings prints the wall-clock block: total duration, the settle
@@ -1592,9 +1615,17 @@ func (a seedAdapter) runProfile(ctx context.Context, params synthetic.SeedParams
 		}
 		return res, err
 	}
-	// Success: Quiesce (stop client, LEAVE the rows).
+	// Success: Quiesce (stop client, LEAVE the rows). A Quiesce failure is NOT a
+	// seed failure — the profile completed and teardown did not run, so the world
+	// is intact. Tagging it errSeedWorldIntact keeps the summary out of the
+	// PARTIAL branch; the error itself still fails the command.
+	//
+	// Quiesce returns nil unconditionally today, so this branch is unreachable
+	// and has no test — the tag is here so the classification is already correct
+	// if Quiesce ever grows a failure, rather than mislabelling a good world as a
+	// failed run the day it does.
 	if qErr := h.Quiesce(ctx); qErr != nil {
-		return res, fmt.Errorf("quiesce after seed: %w", qErr)
+		return res, fmt.Errorf("%w: quiesce after seed: %w", errSeedWorldIntact, qErr)
 	}
 	return res, nil
 }

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -99,6 +99,9 @@ func (f *fakeGmailBackfillResetter) ResetGmailBackfillCursors(_ context.Context)
 
 // fakeSeedRunner records which seed path ran (additive vs reset) and the params
 // it received, so dispatch + flag-mapping can be asserted without a DB/harness.
+// It returns `result` on BOTH paths, mirroring the real seedAdapter: a failed
+// run carries its PARTIAL ProfileResult out alongside the error, and the
+// entrypoints print that as a degraded summary.
 type fakeSeedRunner struct {
 	result     synthetic.ProfileResult
 	err        error
@@ -107,30 +110,24 @@ type fakeSeedRunner struct {
 	lastParams synthetic.SeedParams
 }
 
-func (f *fakeSeedRunner) Seed(_ context.Context, params synthetic.SeedParams) (synthetic.ProfileResult, error) {
-	f.seedCalls++
-	f.lastParams = params
-	if f.err != nil {
-		return synthetic.ProfileResult{}, f.err
-	}
+func (f *fakeSeedRunner) stamp(params synthetic.SeedParams) synthetic.ProfileResult {
 	res := f.result
 	res.Profile = params.Profile
 	res.Namespace = params.Namespace
 	res.Seed = params.Seed
-	return res, nil
+	return res
+}
+
+func (f *fakeSeedRunner) Seed(_ context.Context, params synthetic.SeedParams) (synthetic.ProfileResult, error) {
+	f.seedCalls++
+	f.lastParams = params
+	return f.stamp(params), f.err
 }
 
 func (f *fakeSeedRunner) ResetAndSeed(_ context.Context, params synthetic.SeedParams) (synthetic.ProfileResult, error) {
 	f.resetCalls++
 	f.lastParams = params
-	if f.err != nil {
-		return synthetic.ProfileResult{}, f.err
-	}
-	res := f.result
-	res.Profile = params.Profile
-	res.Namespace = params.Namespace
-	res.Seed = params.Seed
-	return res, nil
+	return f.stamp(params), f.err
 }
 
 func newTestDeps() (adminDeps, *bytes.Buffer, *fakeTokenMinter, *fakeHostLister, *fakeHostRevoker, *fakeRematchRunner) {

--- a/backend/cmd/crm-admin/seed_summary_integration_test.go
+++ b/backend/cmd/crm-admin/seed_summary_integration_test.go
@@ -1,0 +1,59 @@
+//go:build integration_testdb
+
+// Proves the seed FAILURE lifecycle end-to-end at the adapter level: a run that
+// errors returns its PARTIAL ProfileResult alongside the error instead of
+// discarding it. The unit tests above cover the rendering and the entrypoints'
+// printing, but both drive a fake seedRunner — only this test proves the real
+// seedAdapter carries the partial result out, which is what makes the whole
+// diagnostic path real rather than decorative.
+//
+// The harness starts a live River client, so this owns an ISOLATED per-test
+// clone rather than the shared package DB.
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedAdapterRunProfileCarriesPartialResultOnFailure(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	database, _ := newJobsTestDB(t, ctx)
+
+	adapter := seedAdapter{
+		database: database,
+		support:  repository.NewSyntheticSupportRepository(database.Queries),
+	}
+	// An unknown profile fails inside RunProfile — after the harness is built, so
+	// the run is real and the result is genuinely partial — without needing a
+	// mid-seed injection seam in the profile itself.
+	params := synthetic.SeedParams{
+		Namespace: "partialfail",
+		Seed:      1,
+		Profile:   synthetic.Profile("no-such-profile"),
+	}
+
+	res, err := adapter.runProfile(ctx, params)
+
+	require.Error(t, err, "the profile failure is still surfaced")
+	// A discarded result would be the zero ProfileResult; these fields are the
+	// discriminator that the partial one came back.
+	require.Equal(t, params.Profile, res.Profile)
+	require.Equal(t, params.Namespace, res.Namespace)
+	require.Equal(t, params.Seed, res.Seed)
+	require.NotZero(t, res.Timings.Total, "a failed run still reports how long it took")
+}

--- a/backend/cmd/crm-admin/seed_summary_integration_test.go
+++ b/backend/cmd/crm-admin/seed_summary_integration_test.go
@@ -50,6 +50,10 @@ func TestSeedAdapterRunProfileCarriesPartialResultOnFailure(t *testing.T) {
 	res, err := adapter.runProfile(ctx, params)
 
 	require.Error(t, err, "the profile failure is still surfaced")
+	// A genuine profile failure must stay in the PARTIAL branch: the world was
+	// torn down, so labelling it world-intact would tell an operator to trust
+	// counts for rows that no longer exist.
+	require.NotErrorIs(t, err, errSeedWorldIntact)
 	// A discarded result would be the zero ProfileResult; these fields are the
 	// discriminator that the partial one came back.
 	require.Equal(t, params.Profile, res.Profile)

--- a/backend/cmd/crm-admin/seed_summary_test.go
+++ b/backend/cmd/crm-admin/seed_summary_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/synthetic"
+	"personal-crm/backend/internal/synthetic/replay"
+
+	"github.com/stretchr/testify/require"
+)
+
+// timingFixture is a ProfileResult carrying a representative timing block: two
+// completed phases (one with payloads, one without) and settle accounting whose
+// numbers are chosen so every derived figure in the summary is distinguishable
+// from every other — an arithmetic slip in the rendering cannot coincidentally
+// print the right string.
+func timingFixture() synthetic.ProfileResult {
+	return synthetic.ProfileResult{
+		Profile:   synthetic.ProfileProdShaped,
+		Namespace: "prodshaped",
+		Seed:      42,
+		Contacts:  179,
+		Timings: synthetic.SeedTimings{
+			Total: 100 * time.Second,
+			Phases: []synthetic.PhaseTiming{
+				{Name: "catalog-contacts", Duration: 9500 * time.Millisecond, Payloads: 0},
+				{Name: "per-source-settled", Duration: 48 * time.Second, Payloads: 60},
+			},
+			Settle: replay.SettleTimings{
+				Calls:           104,
+				GateAWait:       40 * time.Second,
+				GateBWait:       18 * time.Second,
+				CaptureWait:     9 * time.Second,
+				GateACalls:      100,
+				GateAPolls:      210,
+				GateAInlineHits: 88,
+				GateBPolls:      520,
+			},
+		},
+	}
+}
+
+func TestWriteSeedSummaryRendersTimingBlock(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeSeedSummary(&buf, timingFixture(), false))
+	out := buf.String()
+
+	require.Contains(t, out, "seed summary (profile=prod-shaped namespace=prodshaped prng_seed=42):")
+	require.NotContains(t, out, "PARTIAL", "a successful run is never marked partial")
+	require.Contains(t, out, "  duration:             100.00s")
+	require.Contains(t, out, "  settle_calls:         104")
+	require.Contains(t, out, "gate_a=40.00s gate_b=18.00s capture=9.00s")
+	// The falsifiability discriminator: the inline-hit rate is over gate-A
+	// invocations (100), NOT over Settle calls (104) — a nil-predicate Settle
+	// evaluates nothing and must not dilute the rate.
+	require.Contains(t, out, "gate_a=inline-hits 88/100")
+	require.Contains(t, out, "gate_b=polls 520 (avg 5.0/call)")
+	// 100s total − (40+18+9)s of gate wait.
+	require.Contains(t, out, "  outside_gates:        33.00s")
+	require.Contains(t, out, "NOT a hypothesis test", "the residual is labelled as bookkeeping")
+}
+
+func TestWriteSeedSummaryRendersEveryPhaseWithPayloadVolume(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeSeedSummary(&buf, timingFixture(), false))
+	out := buf.String()
+
+	require.Contains(t, out, "  phases (2):")
+	// A phase with no source payloads prints `-`, so "none by design" reads
+	// differently from "expected payloads, got none".
+	require.Regexp(t, `\n    catalog-contacts\s+9\.50s\s+-\n`, out)
+	require.Regexp(t, `\n    per-source-settled\s+48\.00s\s+60 payloads\n`, out)
+}
+
+func TestWriteSeedSummaryRendersPartialFailure(t *testing.T) {
+	res := timingFixture()
+	// A run that died mid-block: the phases before it completed, the failing one
+	// is named, and the counts are whatever had accumulated.
+	res.Timings.Current = "per-source-settled"
+	res.Timings.Phases = res.Timings.Phases[:1]
+
+	var buf bytes.Buffer
+	require.NoError(t, writeSeedSummary(&buf, res, true))
+	out := buf.String()
+
+	require.Contains(t, out, `(PARTIAL — run failed during phase "per-source-settled")`)
+	require.Contains(t, out, "  phases (1):")
+	// The failing phase is NAMED in the header but must not appear as a completed
+	// row: the phase table is exactly the blocks that finished.
+	require.Equal(t, []string{"catalog-contacts"}, phaseTableNames(out))
+}
+
+// phaseTableNames extracts the phase rows (four-space-indented) from a rendered
+// summary, so a test can assert the table's contents rather than substring
+// presence — the failing phase's NAME appears in the header either way.
+func phaseTableNames(summary string) []string {
+	var names []string
+	for _, line := range strings.Split(summary, "\n") {
+		if !strings.HasPrefix(line, "    ") {
+			continue
+		}
+		names = append(names, strings.Fields(line)[0])
+	}
+	return names
+}
+
+// A failure BEFORE any phase started (an unknown profile, a preflight error
+// inside RunProfile) still gets a partial marker — just without a phase name.
+func TestWriteSeedSummaryPartialWithoutRunningPhase(t *testing.T) {
+	res := timingFixture()
+	res.Timings.Current = ""
+	res.Timings.Phases = nil
+
+	var buf bytes.Buffer
+	require.NoError(t, writeSeedSummary(&buf, res, true))
+	out := buf.String()
+
+	require.Contains(t, out, "(PARTIAL — run failed):")
+	require.Contains(t, out, "  phases (0):")
+}
+
+// The minimal-scoped / empty case: a result with no timings at all renders
+// without panicking and without a division by zero on the poll averages.
+func TestWriteSeedSummaryZeroTimings(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeSeedSummary(&buf, synthetic.ProfileResult{
+		Profile: synthetic.ProfileMinimalScoped, Namespace: "ns",
+	}, false))
+	out := buf.String()
+
+	require.Contains(t, out, "  duration:             0.00s")
+	require.Contains(t, out, "gate_a=inline-hits 0/1")
+	require.Contains(t, out, "gate_b=polls 0 (avg 0.0/call)")
+	require.Contains(t, out, "  phases (0):")
+}
+
+// --- entrypoint failure lifecycle -------------------------------------------
+
+// Both seed entrypoints print the degraded summary BEFORE returning the error.
+// Without this the timing block is stamped but never seen, and a reseed that
+// died six minutes in is a bare error with nothing to diagnose from.
+func TestRunSeedEntrypointsPrintPartialSummaryOnFailure(t *testing.T) {
+	partial := synthetic.SeedTimings{
+		Total:   90 * time.Second,
+		Current: "per-source-settled",
+		Phases:  []synthetic.PhaseTiming{{Name: "catalog-contacts", Duration: time.Second}},
+		Settle:  replay.SettleTimings{Calls: 12},
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts runOptions
+	}{
+		{"seed", runOptions{doSeed: true, seedYes: true}},
+		{"reset-and-seed", runOptions{resetAndSeed: true, seedYes: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps, stdout, _, _, _, _ := newTestDeps()
+			deps.seed = &fakeSeedRunner{
+				result: synthetic.ProfileResult{Contacts: 37, Timings: partial},
+				err:    errors.New("replay gmail 3 msg 1: boom"),
+			}
+
+			err := run(context.Background(), tc.opts, deps)
+			require.Error(t, err, "the seed failure is still surfaced")
+			require.Contains(t, err.Error(), "boom")
+
+			out := stdout.String()
+			require.Contains(t, out, `(PARTIAL — run failed during phase "per-source-settled")`)
+			require.Contains(t, out, "  contacts:             37", "the counts that accumulated are reported")
+			require.Contains(t, out, "  duration:             90.00s")
+			require.Contains(t, out, "  settle_calls:         12")
+		})
+	}
+}
+
+// A failure BEFORE the profile ran (the additive drain preflight, a harness
+// build) leaves a zero result. Printing a summary of nothing would be noise, so
+// the degraded summary is suppressed and only the error surfaces.
+func TestRunSeedPrintsNoSummaryWhenProfileNeverRan(t *testing.T) {
+	deps, stdout, _, _, _, _ := newTestDeps()
+	deps.seed = &fakeSeedRunner{err: errors.New("refusing additive --seed: 4 queued river_job row(s)")}
+
+	err := run(context.Background(), runOptions{doSeed: true, seedYes: true}, deps)
+	require.Error(t, err)
+	require.False(t, strings.Contains(stdout.String(), "seed summary"),
+		"a run that never reached the profile prints no summary, got %q", stdout.String())
+}

--- a/backend/cmd/crm-admin/seed_summary_test.go
+++ b/backend/cmd/crm-admin/seed_summary_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -183,6 +184,44 @@ func TestRunSeedEntrypointsPrintPartialSummaryOnFailure(t *testing.T) {
 			require.Contains(t, out, "  settle_calls:         12")
 		})
 	}
+}
+
+// A POST-SEED failure — Quiesce, which runs after the profile completed and
+// after teardown was skipped — must NOT print as PARTIAL. The world is fully
+// seeded and intact; an operator who reads "run failed" against a good staging
+// world re-runs --reset-and-seed and wipes it, which is the inverse of the
+// mistake the marker exists to prevent and the more expensive one.
+func TestRunSeedPrintsCompleteSummaryWhenOnlyPostSeedStepFailed(t *testing.T) {
+	deps, stdout, _, _, _, _ := newTestDeps()
+	deps.seed = &fakeSeedRunner{
+		result: synthetic.ProfileResult{Contacts: 170, Timings: synthetic.SeedTimings{Total: 71 * time.Second}},
+		// The shape seedAdapter.runProfile produces on a Quiesce failure.
+		err: fmt.Errorf("%w: quiesce after seed: %w", errSeedWorldIntact, errors.New("stop river client")),
+	}
+
+	err := run(context.Background(), runOptions{doSeed: true, seedYes: true}, deps)
+
+	require.Error(t, err, "the command still fails")
+	require.Contains(t, err.Error(), "quiesce after seed")
+	out := stdout.String()
+	require.NotContains(t, out, "PARTIAL", "a completed seed is never labelled a failed run")
+	require.NotContains(t, out, "torn down", "an intact world is not described as torn down")
+	require.Contains(t, out, "  contacts:             170")
+}
+
+// The counterpart: a genuine PROFILE failure still gets the marker, and says the
+// rows it counts no longer exist.
+func TestWriteSeedSummaryOnErrorMarksProfileFailurePartial(t *testing.T) {
+	res := timingFixture()
+	res.Timings.Current = "per-source-settled"
+
+	var partialBuf, intactBuf bytes.Buffer
+	writeSeedSummaryOnError(&partialBuf, res, errors.New("replay gmail 3 msg 1: boom"))
+	writeSeedSummaryOnError(&intactBuf, res, fmt.Errorf("%w: quiesce", errSeedWorldIntact))
+
+	require.Contains(t, partialBuf.String(), "PARTIAL")
+	require.Contains(t, partialBuf.String(), "has been torn down")
+	require.NotContains(t, intactBuf.String(), "PARTIAL")
 }
 
 // A failure BEFORE the profile ran (the additive drain preflight, a harness

--- a/backend/cmd/crm-admin/seed_summary_test.go
+++ b/backend/cmd/crm-admin/seed_summary_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// timingFixture is a ProfileResult carrying a representative timing block: two
-// completed phases (one with payloads, one without) and settle accounting whose
-// numbers are chosen so every derived figure in the summary is distinguishable
-// from every other — an arithmetic slip in the rendering cannot coincidentally
-// print the right string.
+// timingFixture is a ProfileResult carrying a representative timing block:
+// completed phases covering all three payload renderings (none, one, many) and
+// settle accounting whose numbers are chosen so every derived figure in the
+// summary is distinguishable from every other — an arithmetic slip in the
+// rendering cannot coincidentally print the right string.
 func timingFixture() synthetic.ProfileResult {
 	return synthetic.ProfileResult{
 		Profile:   synthetic.ProfileProdShaped,
@@ -29,6 +29,7 @@ func timingFixture() synthetic.ProfileResult {
 			Total: 100 * time.Second,
 			Phases: []synthetic.PhaseTiming{
 				{Name: "catalog-contacts", Duration: 9500 * time.Millisecond, Payloads: 0},
+				{Name: "follow-up-loop", Duration: 1500 * time.Millisecond, Payloads: 1},
 				{Name: "per-source-settled", Duration: 48 * time.Second, Payloads: 60},
 			},
 			Settle: replay.SettleTimings{
@@ -70,11 +71,14 @@ func TestWriteSeedSummaryRendersEveryPhaseWithPayloadVolume(t *testing.T) {
 	require.NoError(t, writeSeedSummary(&buf, timingFixture(), false))
 	out := buf.String()
 
-	require.Contains(t, out, "  phases (2):")
+	require.Contains(t, out, "  phases (3):")
 	// A phase with no source payloads prints `-`, so "none by design" reads
 	// differently from "expected payloads, got none".
 	require.Regexp(t, `\n    catalog-contacts\s+9\.50s\s+-\n`, out)
 	require.Regexp(t, `\n    per-source-settled\s+48\.00s\s+60 payloads\n`, out)
+	// Singular for one — a "1 payloads" row in a summary a human reads once per
+	// reseed is the kind of thing that erodes trust in the numbers beside it.
+	require.Regexp(t, `\n    follow-up-loop\s+1\.50s\s+1 payload\n`, out)
 }
 
 func TestWriteSeedSummaryRendersPartialFailure(t *testing.T) {
@@ -82,17 +86,17 @@ func TestWriteSeedSummaryRendersPartialFailure(t *testing.T) {
 	// A run that died mid-block: the phases before it completed, the failing one
 	// is named, and the counts are whatever had accumulated.
 	res.Timings.Current = "per-source-settled"
-	res.Timings.Phases = res.Timings.Phases[:1]
+	res.Timings.Phases = res.Timings.Phases[:2]
 
 	var buf bytes.Buffer
 	require.NoError(t, writeSeedSummary(&buf, res, true))
 	out := buf.String()
 
 	require.Contains(t, out, `(PARTIAL — run failed during phase "per-source-settled")`)
-	require.Contains(t, out, "  phases (1):")
+	require.Contains(t, out, "  phases (2):")
 	// The failing phase is NAMED in the header but must not appear as a completed
 	// row: the phase table is exactly the blocks that finished.
-	require.Equal(t, []string{"catalog-contacts"}, phaseTableNames(out))
+	require.Equal(t, []string{"catalog-contacts", "follow-up-loop"}, phaseTableNames(out))
 }
 
 // phaseTableNames extracts the phase rows (four-space-indented) from a rendered

--- a/backend/cmd/crm-admin/seed_summary_test.go
+++ b/backend/cmd/crm-admin/seed_summary_test.go
@@ -138,7 +138,9 @@ func TestWriteSeedSummaryZeroTimings(t *testing.T) {
 	out := buf.String()
 
 	require.Contains(t, out, "  duration:             0.00s")
-	require.Contains(t, out, "gate_a=inline-hits 0/1")
+	// 0/0, not a fudged 0/1: a run with no gate-A invocations had no denominator,
+	// and inventing one would misreport the rate the whole block exists to show.
+	require.Contains(t, out, "gate_a=inline-hits 0/0")
 	require.Contains(t, out, "gate_b=polls 0 (avg 0.0/call)")
 	require.Contains(t, out, "  phases (0):")
 }

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -9,6 +9,7 @@ import (
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/synthetic/replay"
 
 	"github.com/google/uuid"
 )
@@ -153,6 +154,49 @@ type ProfileResult struct {
 	// it into a call-vs-row count would muddy that invariant. Counts-only / no PII.
 	OutboundOnlyContacts  int
 	MutualMessageContacts int
+	// Timings is the run's wall-clock measurement. It is EXCLUDED from every
+	// equality assertion (durations are wall-clock and never equal across runs) —
+	// the determinism test zeroes it on both sides before comparing, deliberately
+	// keeping the rest of the struct under strict equality.
+	Timings SeedTimings
+}
+
+// SeedTimings carries wall-clock measurement of a profile run: how long the run
+// took in total, how long each phase took and how many source payloads it drove,
+// and what the settle gates cost. Durations are REAL time, not accelerated —
+// reseed cost is infrastructure timing, and an accelerated measurement under
+// TIME_ACCELERATION would report a fictional number (the same reasoning the
+// settle budgets use; see replay.Stopwatch).
+//
+// No PII: durations and counts only.
+type SeedTimings struct {
+	// Total is the whole-run duration, stamped by RunProfile on BOTH the success
+	// and the failure path — a reseed that failed after six minutes is exactly
+	// the case the number is for.
+	Total time.Duration
+	// Phases are the completed phases in execution order. A run that failed
+	// carries the phases that finished before the failure.
+	Phases []PhaseTiming
+	// Current names the phase that was RUNNING when the run returned: empty on a
+	// clean run, populated on a failure. Without it the partial summary cannot
+	// name the failing phase (the phase-stop closure only records when reached).
+	Current string
+	// Settle is the harness's cumulative settle accounting, refreshed on every
+	// return path so an early settle failure still reports what it cost.
+	Settle replay.SettleTimings
+}
+
+// PhaseTiming is one comment-delimited seeding block's cost. Name is a stable
+// identifier (it is what a before/after comparison across a population change is
+// keyed on), so renaming one is a deliberate act, not a refactor.
+type PhaseTiming struct {
+	Name     string
+	Duration time.Duration
+	// Payloads is the number of source payloads this phase drove through a replay
+	// seam. Phases that seed no source payloads (contact creation, notes, graph
+	// assertions, entity/signal writes) report 0 — "none by design", which the
+	// summary renders as `-` so it reads differently from "expected some, got none".
+	Payloads int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -280,20 +324,57 @@ func ProfileParams(name Profile) (SeedParams, error) {
 // RunProfile only SEEDS; the caller decides the lifecycle — Quiesce on success
 // (seed-and-leave), the teardown closure on error (stop client + clean the
 // partial world).
+// The whole-run duration is stamped on BOTH paths — a run that failed carries a
+// partial ProfileResult (elapsed time, the phases that completed, the phase that
+// was running) and the callers print it as a degraded summary before surfacing
+// the error. Without that, a failed reseed is a bare error with nothing to
+// diagnose from.
 func RunProfile(ctx context.Context, h *Harness, params SeedParams) (ProfileResult, error) {
+	sw := replay.NewStopwatch()
 	res := ProfileResult{Profile: params.Profile, Namespace: h.Namespace(), Seed: params.Seed}
+	var err error
 	switch params.Profile {
 	case ProfileMinimalScoped:
-		return runMinimalScoped(ctx, h, params, res)
+		res, err = runMinimalScoped(ctx, h, params, res)
 	case ProfileDev, ProfileProdShaped:
-		return runCatalogProfile(ctx, h, params, res)
+		res, err = runCatalogProfile(ctx, h, params, res)
 	default:
-		return res, fmt.Errorf("synthetic: RunProfile: unknown profile %q", params.Profile)
+		err = fmt.Errorf("synthetic: RunProfile: unknown profile %q", params.Profile)
+	}
+	res.Timings.Total = sw.Elapsed()
+	return res, err
+}
+
+// newPhaseTimer returns the `phase` starter for one profile run, writing into
+// the supplied SeedTimings. phase(name) marks the named phase as running (so an
+// error return from inside it can be attributed) and returns the stop func;
+// stop(payloads) appends the completed PhaseTiming and clears Current. The stop
+// func is called EXPLICITLY at the block's end rather than deferred, so the span
+// boundary is visible at both ends and a misplacement is obvious rather than silent.
+//
+// The closures draw no generator PRNG and allocate no source ids, so they are
+// position-free: inserting them between existing blocks cannot shift the
+// deterministic id/handle sequence the source replays depend on.
+func newPhaseTimer(t *SeedTimings) func(name string) func(payloads int) {
+	return func(name string) func(payloads int) {
+		sw := replay.NewStopwatch()
+		t.Current = name
+		return func(payloads int) {
+			t.Phases = append(t.Phases, PhaseTiming{Name: name, Duration: sw.Elapsed(), Payloads: payloads})
+			t.Current = ""
+		}
 	}
 }
 
 // runMinimalScoped is exactly today's SeedAll (the byte-stable golden shape).
-func runMinimalScoped(ctx context.Context, h *Harness, params SeedParams, res ProfileResult) (ProfileResult, error) {
+// It reports a single phase so all three profiles surface timings uniformly.
+func runMinimalScoped(ctx context.Context, h *Harness, params SeedParams, res ProfileResult) (out ProfileResult, err error) {
+	// Refresh the settle accounting on EVERY return path (including an early
+	// settle failure, which is precisely the case the instrumentation exists for).
+	defer func() { out.Timings.Settle = h.SettleStats() }()
+	phase := newPhaseTimer(&res.Timings)
+
+	stop := phase("seed-all")
 	seedRes, err := SeedAll(ctx, h, params)
 	if err != nil {
 		return res, err
@@ -301,6 +382,7 @@ func runMinimalScoped(ctx context.Context, h *Harness, params SeedParams, res Pr
 	res.Contacts = len(seedRes.GmailContactIDs) + len(seedRes.TelegramContactIDs)
 	res.GmailSettled = len(seedRes.GmailContactIDs)
 	res.TelegramSettled = len(seedRes.TelegramContactIDs)
+	stop(res.Contacts)
 	return res, nil
 }
 
@@ -321,7 +403,19 @@ func runMinimalScoped(ctx context.Context, h *Harness, params SeedParams, res Pr
 // review rows (anarlog_title discovery), and comms_message without interaction_id
 // (GChat MatchUnknown is match-only, writes no comms_message). Building these is a
 // factory/replay addition deferred to a follow-on.
-func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res ProfileResult) (ProfileResult, error) {
+func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res ProfileResult) (out ProfileResult, err error) {
+	// Refresh the settle accounting on EVERY return path. Reading it only after
+	// the last block would return an EMPTY accumulator on an early settle
+	// failure — precisely the case the instrumentation exists for. The named
+	// result makes the deferred write land on the value actually returned; every
+	// `return res, …` below is unchanged.
+	defer func() { out.Timings.Settle = h.SettleStats() }()
+	// phase(name) … stop(payloads) brackets each seeding block below. `payloads`
+	// counts SOURCE payloads driven through a replay seam: where a ProfileResult
+	// counter already increments once per replay call, the phase reports that
+	// counter's delta (self-maintaining); otherwise it keeps a local tally.
+	phase := newPhaseTimer(&res.Timings)
+
 	gen := h.Generator()
 	n := params.Counts.SeededContacts
 	if n <= 0 {
@@ -347,6 +441,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// birthday, so the toolkit-authored date fact (a `birthday`, single-cardinality)
 	// can occupy a fresh slot rather than superseding a contact-create birthday.
 	catalogContactsWithoutBirthday := make([]uuid.UUID, 0, n)
+	stop := phase("catalog-contacts")
 	for i := 0; i < n; i++ {
 		opts := catalogOptionsFor(i, n, gen.Anchor(), gen.Prefix())
 		spec := gen.Contact(opts...)
@@ -374,6 +469,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			cadenceBearingCatalogIDs = append(cadenceBearingCatalogIDs, contact.ID)
 		}
 	}
+	stop(0)
 
 	// Give a realistic fraction of catalog contacts a notepad note — every third
 	// contact by index (⌈n/3⌉ total), a personal-CRM-like density — so contact-detail
@@ -382,6 +478,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// literal body), so this pass is ordering-safe: it cannot shift the deterministic
 	// id/handle sequence the source replays below depend on. Bodies are unprefixed
 	// literals (SeedNote adds the namespace prefix) so no gen.Note() draw is needed.
+	stop = phase("catalog-notes")
 	for i, contactID := range catalogContactIDs {
 		if i%3 != 0 {
 			continue
@@ -391,6 +488,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.ContactsWithNotes++
 	}
+	stop(0)
 
 	// A few settled interactions on DEDICATED contacts per source so every source
 	// surface has matched content WITHOUT clobbering the catalog's cadence states.
@@ -411,6 +509,10 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		messagesPer = 1
 	}
 
+	// res.SettledInteractions increments once per replay call in this block, so
+	// its delta IS the phase's payload count.
+	stop = phase("per-source-settled")
+	settledBefore := res.SettledInteractions
 	for i := 0; i < perSource; i++ {
 		// Gmail-settled (email match).
 		gmSpec := gen.Contact(factory.WithEmail())
@@ -491,9 +593,11 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.IMessageSettled++
 	}
+	stop(res.SettledInteractions - settledBefore)
 
 	// --- PRODUCIBLE pending states -----------------------------------------
 	// Unmatched external_contact (Imports queue) via ReplayMacContacts MatchUnknown.
+	stop = phase("pending-unmatched-external")
 	for i := 0; i < params.Counts.UnmatchedExternal; i++ {
 		spec, err := gen.MacContact(gen.Contact(factory.WithEmail()), factory.MatchUnknown, h.MacHostID())
 		if err != nil {
@@ -504,7 +608,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.UnmatchedExternal++
 	}
+	stop(params.Counts.UnmatchedExternal)
 	// Stranded telegram_message via ReplayTelegram MatchUnknown.
+	stop = phase("pending-stranded-telegram")
 	for i := 0; i < params.Counts.StrandedTelegram; i++ {
 		spec := gen.TelegramMessage(gen.Contact(factory.WithTelegram()), factory.MatchUnknown)
 		if _, err := h.ReplayTelegram(ctx, uuid.Nil, spec); err != nil {
@@ -512,7 +618,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.StrandedTelegram++
 	}
+	stop(params.Counts.StrandedTelegram)
 	// Stranded messages_message via ReplayIMessage MatchUnknown.
+	stop = phase("pending-stranded-messages")
 	for i := 0; i < params.Counts.StrandedMessages; i++ {
 		spec, err := gen.IMessage(gen.Contact(factory.WithPhone()), factory.MatchUnknown, h.MacHostID())
 		if err != nil {
@@ -523,7 +631,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.StrandedMessages++
 	}
+	stop(params.Counts.StrandedMessages)
 	// Unmatched calendar attendee via ReplayGCal MatchUnknown.
+	stop = phase("pending-unmatched-calendar")
 	for i := 0; i < params.Counts.UnmatchedCalendar; i++ {
 		spec := gen.GCalEvent(gen.Contact(factory.WithEmail()), factory.MatchUnknown)
 		if _, err := h.ReplayGCal(ctx, uuid.Nil, spec); err != nil {
@@ -531,7 +641,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.UnmatchedCalendar++
 	}
+	stop(params.Counts.UnmatchedCalendar)
 	// Orphan meeting_note via the existing meeting-note repo.
+	stop = phase("pending-orphan-notes")
 	for i := 0; i < params.Counts.OrphanMeetingNote; i++ {
 		if _, err := h.SeedOrphanMeetingNote(ctx,
 			fmt.Sprintf("synthetic orphan note %d", i),
@@ -540,6 +652,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.OrphanMeetingNote++
 	}
+	stop(0)
 
 	// Graph (SP1) text-fact assertions spread across the catalog person nodes
 	// (node.id == contact.id). Seeded LAST so the generator-PRNG advancement these
@@ -555,6 +668,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// proposition_key, and successive assertions land on distinct contacts
 	// (i % len), so the single-cardinality predicates (home_address/job_title)
 	// never supersede a same-subject prior.
+	stop = phase("graph-text-facts")
 	if len(catalogContactIDs) > 0 {
 		for i := 0; i < params.Counts.SeededAssertions; i++ {
 			subject := catalogContactIDs[i%len(catalogContactIDs)]
@@ -565,6 +679,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			res.SeededAssertions++
 		}
 	}
+	stop(0)
 
 	// Graph (SP1) value-type + edge assertions. These ride the SAME "seeded LAST"
 	// rule as the text-fact spread above: the gen.BoolFact / gen.DateFact /
@@ -577,6 +692,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// nodes — all auto-if-confident → accepted. Bounded by the catalog size so a
 	// distinct subject per fact keeps the single-cardinality bool predicates from
 	// superseding one another.
+	stop = phase("graph-bool-facts")
 	boolFacts := params.Counts.SeededBoolFacts
 	if boolFacts > len(catalogContactIDs) {
 		boolFacts = len(catalogContactIDs)
@@ -589,6 +705,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededBoolFacts++
 	}
+	stop(0)
 
 	// The FIRST clock-anchored birthday date-fact (the "today" fixture) asserted
 	// DIRECTLY through the assert path (distinct from the contact-create
@@ -598,6 +715,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// Seeded on a catalog contact that carries no contact-path birthday so it
 	// occupies a fresh single-cardinality slot. Anchor-relative (UTC) so no
 	// time.Now() and the fixture tracks the reseed clock.
+	stop = phase("graph-birthday-today")
 	if len(catalogContactsWithoutBirthday) > 0 {
 		plan := BirthdayFixturePlan(gen.Anchor())
 		bday := BirthdayFixtureDate(gen.Anchor(), plan[0].OffsetDays)
@@ -609,6 +727,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		h.SetDateFactContactID(catalogContactsWithoutBirthday[0])
 		res.SeededDateFacts++
 	}
+	stop(0)
 
 	// Person→person EDGE assertions among already-seeded catalog person nodes (no
 	// new entity nodes — those are a later PR). knows/introduced_by are
@@ -618,6 +737,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// catalog size so each subject is distinct (the single-cardinality introduced_by
 	// never supersedes). Both endpoints are person nodes, so the existing per-node
 	// assertion teardown sweep (subject OR object) already removes them.
+	stop = phase("graph-person-edges")
 	relationships := params.Counts.SeededRelationships
 	if len(catalogContactIDs) < 2 {
 		relationships = 0 // an edge needs two distinct nodes
@@ -634,6 +754,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededRelationships++
 	}
+	stop(0)
 
 	// Entity nodes (org/topic/tag pool) + person→entity EDGE assertions. Seeded
 	// LAST because gen.Entity DRAWS the name PRNG (givenName) — appending it after
@@ -645,6 +766,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// objects from it repeatedly — prod-like (many people share a few orgs/topics/
 	// tags). place entity nodes + lives_in edges are NOT seeded here; they ride the
 	// contact-create authority flip via WithLocation (Phase 1 above).
+	stop = phase("graph-entities")
 	var orgNodeIDs, topicNodeIDs, tagNodeIDs []uuid.UUID
 	for j := 0; j < params.Counts.SeededEntities; j++ {
 		subtype := catalogEntitySubtypes[j%len(catalogEntitySubtypes)]
@@ -662,6 +784,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededEntities++
 	}
+	stop(0)
 
 	// Person→entity edges cycle works_at→org / interested_in→topic / tagged_as→tag,
 	// all auto-if-confident → accepted. The subject is a distinct catalog contact
@@ -671,6 +794,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// predicates are accepted; the proposed surface is covered by the person→person
 	// sibling_of edge above. A subtype with an empty pool is skipped (only possible
 	// when SeededEntities < 3, which the profiles avoid).
+	stop = phase("graph-entity-edges")
 	entityEdges := params.Counts.SeededEntityEdges
 	if entityEdges > len(catalogContactIDs) {
 		entityEdges = len(catalogContactIDs)
@@ -709,6 +833,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededEntityEdges++
 	}
+	stop(0)
 
 	// relationship_signal rows (SP1 derived storage) on a subset of the catalog
 	// person nodes. In prod these are computed from comms analysis; SP1 has no
@@ -720,6 +845,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// rotated key from a small fixed pool (a few signal kinds repeat across people,
 	// prod-like) and a deterministic value; as_of is the generator anchor (no
 	// time.Now()).
+	stop = phase("graph-signals")
 	signals := params.Counts.SeededSignals
 	if signals > len(catalogContactIDs) {
 		signals = len(catalogContactIDs)
@@ -735,6 +861,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededSignals++
 	}
+	stop(0)
 
 	// Cadence tasks (Todoist) on the cadence-bearing catalog contacts. ReplayTodoist
 	// drives the REAL CadenceSyncProvider reconcile, which reads
@@ -752,6 +879,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// finalized its external id. `completed`/`dismissed` are prod-impossible for this
 	// lifecycle (a completed cadence row is deleted by the next reconcile; a skip routes
 	// to a managed replacement, never to dismissed), so they are not seeded here.
+	stop = phase("tasks")
 	if params.Counts.SeededTasks > 0 && len(cadenceBearingCatalogIDs) > 0 {
 		if _, err := h.ReplayTodoist(ctx, cadenceBearingCatalogIDs); err != nil {
 			return res, fmt.Errorf("profile %s: replay todoist: %w", params.Profile, err)
@@ -785,6 +913,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededContactsWithManualTasks = spread.ContactsWithManualTasks
 		res.SeededContactsWithMultipleManualTasks = spread.ContactsWithMultipleManualTasks
 	}
+	stop(0)
 
 	// Merge + soft-delete scenarios. Seeded LAST: each draws gen.Contact (name PRNG)
 	// + gen.BoolFact, so appending them after every other generator-driven block keeps
@@ -796,6 +925,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// statement). The assertions are BOOL facts (value_bool, not value_text) so they
 	// add no live value_text on the surviving merge winner — keeping the determinism
 	// ordering guard's "entity pool seq > text-fact seq" invariant intact.
+	stop = phase("soft-deleted")
 	for i := 0; i < params.Counts.SeededSoftDeleted; i++ {
 		if _, err := h.SeedSoftDeletedContact(ctx, gen.Contact(),
 			gen.BoolFact(softDeleteFactPredicate, true)); err != nil {
@@ -803,6 +933,8 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededSoftDeleted++
 	}
+	stop(0)
+	stop = phase("merged")
 	for i := 0; i < params.Counts.SeededMerged; i++ {
 		// Distinct winner/loser predicates so the re-pointed loser fact lands beside the
 		// winner's own without single-cardinality supersession.
@@ -814,6 +946,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededMerged++
 	}
+	stop(0)
 
 	// Import-source candidates so EVERY Imports subtab has unmatched content (item
 	// 13). Seeded LAST — the very end of the generator-driven sequence — because
@@ -835,6 +968,11 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// Teardown reclaims them via the existing external_contact source_id-prefix sweep
 	// (gcontacts/gmail_correspondence/anarlog carry an ns-prefixed source_id) and the
 	// telegram-peer sweep (the discovery candidate is keyed by the bare peer id).
+	//
+	// Only the anarlog + telegram-discovery halves drive replay payloads; the two
+	// Google candidates are direct repo upserts, so they are not counted here.
+	stop = phase("import-candidates")
+	importPayloads := 0
 	for i := 0; i < params.Counts.ImportCandidatesPerSource; i++ {
 		// gcontacts (direct repo upsert).
 		if _, err := h.SeedExternalContactCandidate(ctx, gen.ExternalContactCandidate(importSourceGContacts)); err != nil {
@@ -857,6 +995,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: replay anarlog candidate %d: %w", params.Profile, i, err)
 		}
 		res.UnmatchedAnarlogHumans++
+		importPayloads++
 
 		// telegram discovery: a group conversation of telegramDiscoveryMessages messages
 		// sharing ONE chat + unknown sender (distinct message ids), built by copying the
@@ -873,7 +1012,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: replay telegram discovery %d: %w", params.Profile, i, err)
 		}
 		res.TelegramDiscovery++
+		importPayloads += len(discoverySpecs)
 	}
+	stop(importPayloads)
 
 	// --- The "awaiting reply" scenario (has_pending_followup) -----------------------
 	//
@@ -896,6 +1037,8 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// the seed cannot ASSERT on last_outreach_at here (the job has not run yet); the
 	// coverage check asserts it post-Quiesce, which is the honest place to prove the chain
 	// actually landed.
+	stop = phase("follow-up-loop")
+	followUpPayloads := 0
 	if params.Counts.SeededTasks > 0 {
 		fuSpec := gen.Contact(factory.WithEmail(), factory.WithCadence(followUpScenarioCadence))
 		fuContact, err := h.SeedContact(ctx, fuSpec)
@@ -907,12 +1050,14 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: replay gcal for awaiting-reply contact: %w", params.Profile, err)
 		}
 		res.SettledInteractions++
+		followUpPayloads++
 		if _, err := h.SeedPendingFollowUp(ctx, fuContact.ID, fuContact.FullName); err != nil {
 			return res, fmt.Errorf("profile %s: seed pending follow-up: %w", params.Profile, err)
 		}
 		res.SeededTasks++
 		res.SeededPendingFollowUps = 1
 	}
+	stop(followUpPayloads)
 
 	// --- Two-sided message-direction cohort (F4) --------------------------------
 	//
@@ -933,6 +1078,8 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// carries a single outbound interaction: last_outreach_at set (CAD-006),
 	// last_contacted / last_interaction_at NULL (an outbound touches neither), so
 	// these pass the PR1 lockstep gate unchanged (NULL last_contacted → exempt).
+	stop = phase("direction-cohort")
+	directionPayloads := 0
 	obGmailSpec := gen.Contact(factory.WithEmail())
 	obGmailContact, err := h.SeedContact(ctx, obGmailSpec)
 	if err != nil {
@@ -943,6 +1090,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		return res, fmt.Errorf("profile %s: replay outbound gmail: %w", params.Profile, err)
 	}
 	res.OutboundOnlyContacts++
+	directionPayloads++
 
 	obGChatSpec := gen.Contact(factory.WithEmail())
 	obGChatContact, err := h.SeedContact(ctx, obGChatSpec)
@@ -954,6 +1102,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		return res, fmt.Errorf("profile %s: replay outbound gchat: %w", params.Profile, err)
 	}
 	res.OutboundOnlyContacts++
+	directionPayloads++
 
 	obIMsgSpec := gen.Contact(factory.WithPhone())
 	obIMsgContact, err := h.SeedContact(ctx, obIMsgSpec)
@@ -969,6 +1118,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		return res, fmt.Errorf("profile %s: replay outbound imessage: %w", params.Profile, err)
 	}
 	res.OutboundOnlyContacts++
+	directionPayloads++
 
 	// One MUTUAL (reply-bridged) telegram contact. Telegram runs its aggregation
 	// engine INLINE in ReplayTelegram (worker-free), so the promote is reliable.
@@ -990,6 +1140,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	if _, err := h.ReplayTelegram(ctx, mutualContact.ID, tgOutbound); err != nil {
 		return res, fmt.Errorf("profile %s: replay mutual telegram outbound: %w", params.Profile, err)
 	}
+	directionPayloads++
 	tgReply := tgOutbound // clone: same peer + chat, so the bridge can fire
 	tgReply.TelegramMessageID = tgOutbound.TelegramMessageID + 1
 	tgReply.Out = false
@@ -998,8 +1149,10 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	if _, err := h.ReplayTelegram(ctx, mutualContact.ID, tgReply); err != nil {
 		return res, fmt.Errorf("profile %s: replay mutual telegram reply: %w", params.Profile, err)
 	}
+	directionPayloads++
 	h.SetMutualMessageContactID(mutualContact.ID)
 	res.MutualMessageContacts++
+	stop(directionPayloads)
 
 	// --- Additional clock-anchored birthday fixtures (seeded LAST) --------------
 	//
@@ -1014,6 +1167,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// assertion, so even the no-method slot qualifies): plan[i] lands on
 	// catalogContactsWithoutBirthday[i], reserving the full ordered set (today first)
 	// so the coverage/determinism tests can classify each subject-scoped.
+	stop = phase("birthday-fixtures")
 	plan := BirthdayFixturePlan(gen.Anchor())
 	seededCount := min(len(catalogContactsWithoutBirthday), len(plan))
 	for i := 1; i < seededCount; i++ {
@@ -1024,6 +1178,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededDateFacts++
 	}
 	h.SetBirthdayFixtureIDs(catalogContactsWithoutBirthday[:seededCount])
+	stop(0)
 
 	return res, nil
 }

--- a/backend/internal/synthetic/profiles_timing_test.go
+++ b/backend/internal/synthetic/profiles_timing_test.go
@@ -1,0 +1,70 @@
+package synthetic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The phase timer's contract has two halves, and the second is the one that is
+// easy to get wrong: the stop closure records a phase only when REACHED, so an
+// error return from inside a block records nothing — which is exactly why
+// `Current` exists. Without it the degraded summary cannot name the phase a
+// failed reseed died in, and the whole failure-diagnostic path is unimplementable.
+
+func TestPhaseTimerRecordsNameDurationAndPayloads(t *testing.T) {
+	var timings SeedTimings
+	phase := newPhaseTimer(&timings)
+
+	stop := phase("per-source-settled")
+	require.Equal(t, "per-source-settled", timings.Current, "a running phase is named while it runs")
+	time.Sleep(time.Millisecond)
+	stop(60)
+
+	require.Len(t, timings.Phases, 1)
+	require.Equal(t, "per-source-settled", timings.Phases[0].Name)
+	require.Equal(t, 60, timings.Phases[0].Payloads)
+	require.Positive(t, timings.Phases[0].Duration, "a completed phase reports a real duration")
+	require.Empty(t, timings.Current, "a completed phase is no longer marked as running")
+}
+
+func TestPhaseTimerAppendsInExecutionOrder(t *testing.T) {
+	var timings SeedTimings
+	phase := newPhaseTimer(&timings)
+
+	for _, name := range []string{"catalog-contacts", "catalog-notes", "per-source-settled"} {
+		phase(name)(0)
+	}
+
+	require.Equal(t,
+		[]string{"catalog-contacts", "catalog-notes", "per-source-settled"},
+		[]string{timings.Phases[0].Name, timings.Phases[1].Name, timings.Phases[2].Name},
+		"phases append in execution order — the order a before/after comparison reads")
+}
+
+// The failure shape: phases that completed are recorded, the one that was
+// running is named in Current, and nothing after it appears. This is precisely
+// what runCatalogProfile leaves behind when a block returns an error.
+func TestPhaseTimerLeavesFailingPhaseNamed(t *testing.T) {
+	var timings SeedTimings
+	phase := newPhaseTimer(&timings)
+
+	phase("catalog-contacts")(0)
+	phase("catalog-notes")(0)
+	phase("per-source-settled") // never stopped: the block errored out
+
+	require.Len(t, timings.Phases, 2, "only completed phases are recorded")
+	require.Equal(t, "per-source-settled", timings.Current, "the failing phase stays named")
+}
+
+// A phase that seeds no source payloads reports 0, which the summary renders as
+// `-`. Pinned so "none by design" cannot drift into an inflated payload count.
+func TestPhaseTimerZeroPayloadPhases(t *testing.T) {
+	var timings SeedTimings
+	phase := newPhaseTimer(&timings)
+
+	phase("graph-signals")(0)
+
+	require.Zero(t, timings.Phases[0].Payloads)
+}

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -655,8 +655,10 @@ func (h *Harness) waitGateA(ctx context.Context, predicate gateA) error {
 	if predicate == nil {
 		return nil
 	}
-	// Accounting is recorded on EVERY exit path (satisfied, or timed out) so a
-	// failed reseed still reports what its gates cost.
+	// The deferred record runs on every exit path, so a gate that TIMED OUT still
+	// reports what it cost — that is true by construction, not by test: the unit
+	// tests pin the satisfied paths only (a timeout case would cost
+	// defaultSettleTimeout of wall clock to reach the same line).
 	sw := NewStopwatch()
 	polls := 0
 	inlineHit := false

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -59,6 +59,113 @@ func realTimeBudget(d time.Duration) (open func() bool, cancel func()) {
 	return func() bool { return tctx.Err() == nil }, c
 }
 
+// Stopwatch measures REAL elapsed wall-clock time. It is the single audited
+// real-clock site in the synthetic toolkit: seed/reseed duration is
+// INFRASTRUCTURE timing (how long an operation took), not domain time, so
+// accelerated.GetCurrentTime() would report a duration scaled by
+// TIME_ACCELERATION — a fictional number, useless for the one purpose the
+// measurement has. This is the same judgment the settle budgets already make
+// (see defaultSettleTimeout / realTimeBudget), and the same class as the request
+// latency measurement in internal/api/middleware.go, which .golangci.yml names
+// among the sanctioned //nolint:forbidigo exceptions.
+//
+// Exported because both package synthetic (whole-run + per-phase timing) and
+// this package (settle accounting) need it, and synthetic imports replay — the
+// reverse import would cycle.
+type Stopwatch struct {
+	start time.Time
+}
+
+// NewStopwatch starts a stopwatch at the current real wall-clock instant.
+func NewStopwatch() *Stopwatch {
+	//nolint:forbidigo // Wall-clock time for reseed/settle duration measurement, not domain time (see Stopwatch).
+	return &Stopwatch{start: time.Now()}
+}
+
+// Elapsed reports the real time since the stopwatch was started. time.Since uses
+// the monotonic reading captured at start, so it is immune to wall-clock jumps.
+func (s *Stopwatch) Elapsed() time.Duration { return time.Since(s.start) }
+
+// SettleTimings is the harness's cumulative settle accounting: how many Settle
+// calls a run made, how long each gate waited, and — the falsifiability
+// discriminator — how much of that wait was POLLING versus genuine worker/DB
+// throughput. A gate satisfied on its first check cost ~one query; one that
+// polled many times cost real latency that batching can remove.
+//
+// Counts and durations only — no PII. Excluded from determinism equality
+// (durations are wall-clock and never equal across runs).
+type SettleTimings struct {
+	// Calls is the number of Settle invocations.
+	Calls int
+	// GateAWait / GateBWait / CaptureWait are the cumulative time spent in the
+	// domain terminal predicate, the River-job finalization gate, and the
+	// full-union event-id rebuild. GateA/GateB nest inside the caller's phase
+	// timer, and Capture follows them within the same Settle.
+	GateAWait   time.Duration
+	GateBWait   time.Duration
+	CaptureWait time.Duration
+	// GateACalls is the number of waitGateA invocations that actually evaluated a
+	// predicate (an adapter may pass nil). It is the denominator of the
+	// inline-hit rate — Calls would overcount, since a nil-predicate Settle
+	// evaluates nothing.
+	GateACalls int
+	// GateAPolls is the total number of predicate evaluations across all gate-A
+	// waits; GateAInlineHits is how many of those waits were satisfied by the
+	// FIRST evaluation, before any sleep. A high inline-hit rate means gate A
+	// cost ~one query per Settle; a low one means real polling latency.
+	GateAPolls      int
+	GateAInlineHits int
+	// GateBPolls is the total number of gate-B count-query iterations. Divided by
+	// Calls it gives the average polls per Settle: ~1 means no polling overhead,
+	// a large value means the reseed is waiting on River workers.
+	GateBPolls int
+}
+
+// recordSettleCall / recordGateA / recordGateB / recordCapture accumulate the
+// settle accounting. They take a DEDICATED mutex rather than the ledger's
+// createdMu: captureEventIDs already takes createdMu inside its own body, so
+// reusing it here would risk a re-entrant lock the moment recording moves inside
+// a locked region. Same discipline (mutex-guarded accumulator), separate lock.
+func (h *Harness) recordSettleCall() {
+	h.settleMu.Lock()
+	defer h.settleMu.Unlock()
+	h.settle.Calls++
+}
+
+func (h *Harness) recordGateA(wait time.Duration, polls int, inlineHit bool) {
+	h.settleMu.Lock()
+	defer h.settleMu.Unlock()
+	h.settle.GateACalls++
+	h.settle.GateAWait += wait
+	h.settle.GateAPolls += polls
+	if inlineHit {
+		h.settle.GateAInlineHits++
+	}
+}
+
+func (h *Harness) recordGateB(wait time.Duration, polls int) {
+	h.settleMu.Lock()
+	defer h.settleMu.Unlock()
+	h.settle.GateBWait += wait
+	h.settle.GateBPolls += polls
+}
+
+func (h *Harness) recordCapture(wait time.Duration) {
+	h.settleMu.Lock()
+	defer h.settleMu.Unlock()
+	h.settle.CaptureWait += wait
+}
+
+// SettleStats returns a snapshot of the run's cumulative settle accounting.
+// Exported so package synthetic can fold it into the profile result; safe to
+// call at any point, including from an error path, so a failed reseed still
+// reports whatever settling had completed.
+func (h *Harness) SettleStats() SettleTimings {
+	h.settleMu.Lock()
+	defer h.settleMu.Unlock()
+	return h.settle
+}
+
 // created is the ID ledger the harness/adapters accumulate during a run so
 // Cleanup can delete by exact id (never by a DB-wide source/kind value) and
 // Gate B can scope to this replay's contacts. eventIDs is the UNION of
@@ -212,6 +319,12 @@ type Harness struct {
 
 	created   *created
 	createdMu sync.Mutex
+
+	// settle is the cumulative settle accounting (call count, per-gate wait, poll
+	// counts) a profile run reads via SettleStats. Guarded by its OWN mutex — see
+	// recordSettleCall.
+	settle   SettleTimings
+	settleMu sync.Mutex
 
 	stopped bool
 }
@@ -525,6 +638,7 @@ type gateA func(ctx context.Context) (bool, error)
 // source is the aggregation source for Gate B's messaging-aggregate companion
 // (e.g. "messages"/"gchat"); pass "" for sources with no aggregate jobs.
 func (h *Harness) Settle(ctx context.Context, predicate gateA, source string) error {
+	h.recordSettleCall()
 	// Gate A — domain terminal predicate.
 	if err := h.waitGateA(ctx, predicate); err != nil {
 		return err
@@ -541,12 +655,23 @@ func (h *Harness) waitGateA(ctx context.Context, predicate gateA) error {
 	if predicate == nil {
 		return nil
 	}
+	// Accounting is recorded on EVERY exit path (satisfied, or timed out) so a
+	// failed reseed still reports what its gates cost.
+	sw := NewStopwatch()
+	polls := 0
+	inlineHit := false
+	defer func() { h.recordGateA(sw.Elapsed(), polls, inlineHit) }()
 	open, cancel := realTimeBudget(defaultSettleTimeout)
 	defer cancel()
 	var lastErr error
 	for open() {
+		polls++
 		ok, err := predicate(ctx)
 		if err == nil && ok {
+			// An inline hit is a gate satisfied BEFORE the first sleep: it cost one
+			// query, not polling latency. A gate that timed out is never one, however
+			// few evaluations it managed.
+			inlineHit = polls == 1
 			return nil
 		}
 		lastErr = err
@@ -556,12 +681,16 @@ func (h *Harness) waitGateA(ctx context.Context, predicate gateA) error {
 }
 
 func (h *Harness) waitGateB(ctx context.Context, source string) error {
+	sw := NewStopwatch()
+	polls := 0
+	defer func() { h.recordGateB(sw.Elapsed(), polls) }()
 	contactIDs := h.snapshotContactIDs()
 	open, cancel := realTimeBudget(defaultSettleTimeout)
 	defer cancel()
 	var lastEventJobs, lastAggJobs int64
 	var lastErr error
 	for open() {
+		polls++
 		eventJobs, err := h.support.CountUnfinalizedRiverJobsForEventsByContacts(ctx, contactIDs)
 		if err != nil {
 			lastErr = err
@@ -590,6 +719,8 @@ func (h *Harness) waitGateB(ctx context.Context, source string) error {
 // captureEventIDs grows created.eventIDs to the UNION of contact-scoped cascade
 // events and adapter-direct root events (by synthetic source/source_id prefix).
 func (h *Harness) captureEventIDs(ctx context.Context) error {
+	sw := NewStopwatch()
+	defer func() { h.recordCapture(sw.Elapsed()) }()
 	contactIDs := h.snapshotContactIDs()
 	seen := map[uuid.UUID]struct{}{}
 	var union []uuid.UUID

--- a/backend/internal/synthetic/replay/settle_timings_test.go
+++ b/backend/internal/synthetic/replay/settle_timings_test.go
@@ -1,0 +1,116 @@
+package replay
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The settle accumulator is what makes the reseed's cost attributable, and its
+// load-bearing claim is narrow: an INLINE HIT is a gate satisfied by the first
+// predicate evaluation, before any sleep, and therefore cost ~one query rather
+// than polling latency. These tests pin that distinction directly — a gate that
+// polls must never be counted as an inline hit, and vice versa — because the
+// whole falsifiability argument for "is the reseed waiting on polling or on
+// worker throughput" rests on it.
+//
+// waitGateA touches only the accumulator, so a zero-value Harness is a complete
+// fixture: no DB, no River client.
+
+func TestWaitGateAAccountsInlineHit(t *testing.T) {
+	h := &Harness{}
+	calls := 0
+
+	require.NoError(t, h.waitGateA(context.Background(), func(context.Context) (bool, error) {
+		calls++
+		return true, nil
+	}))
+
+	stats := h.SettleStats()
+	require.Equal(t, 1, calls, "a satisfied predicate is evaluated exactly once")
+	require.Equal(t, 1, stats.GateACalls)
+	require.Equal(t, 1, stats.GateAPolls)
+	require.Equal(t, 1, stats.GateAInlineHits, "satisfied before the first sleep")
+	require.Zero(t, stats.Calls, "waitGateA alone is not a Settle call")
+}
+
+func TestWaitGateAAccountsPollsWithoutInlineHit(t *testing.T) {
+	h := &Harness{}
+	const wantPolls = 3
+	calls := 0
+
+	require.NoError(t, h.waitGateA(context.Background(), func(context.Context) (bool, error) {
+		calls++
+		return calls >= wantPolls, nil
+	}))
+
+	stats := h.SettleStats()
+	require.Equal(t, wantPolls, stats.GateAPolls)
+	require.Zero(t, stats.GateAInlineHits, "a gate that slept before succeeding is not an inline hit")
+	require.GreaterOrEqual(t, stats.GateAWait, time.Duration(wantPolls-1)*settlePollInterval,
+		"the recorded wait covers the sleeps between evaluations")
+}
+
+// A predicate that ERRORS still polls; the accounting must reflect the cost
+// rather than silently dropping it, because an erroring gate is exactly the
+// expensive case worth seeing in the summary.
+func TestWaitGateAAccountsErroringPredicate(t *testing.T) {
+	h := &Harness{}
+	calls := 0
+
+	require.NoError(t, h.waitGateA(context.Background(), func(context.Context) (bool, error) {
+		calls++
+		if calls < 2 {
+			return false, errors.New("not ready")
+		}
+		return true, nil
+	}))
+
+	stats := h.SettleStats()
+	require.Equal(t, 2, stats.GateAPolls)
+	require.Zero(t, stats.GateAInlineHits)
+}
+
+// A nil predicate evaluates nothing, so it must not inflate the inline-hit
+// DENOMINATOR — that denominator is what the reported hit rate is divided by.
+func TestWaitGateANilPredicateIsNotAccounted(t *testing.T) {
+	h := &Harness{}
+
+	require.NoError(t, h.waitGateA(context.Background(), nil))
+
+	stats := h.SettleStats()
+	require.Zero(t, stats.GateACalls)
+	require.Zero(t, stats.GateAPolls)
+	require.Zero(t, stats.GateAInlineHits)
+}
+
+// Accounting accumulates ACROSS gates: the summary reports run totals, so a
+// second gate must add to the first rather than replace it.
+func TestSettleStatsAccumulateAcrossGates(t *testing.T) {
+	h := &Harness{}
+	always := func(context.Context) (bool, error) { return true, nil }
+
+	require.NoError(t, h.waitGateA(context.Background(), always))
+	require.NoError(t, h.waitGateA(context.Background(), always))
+	h.recordSettleCall()
+	h.recordSettleCall()
+	h.recordGateB(7*time.Millisecond, 4)
+	h.recordCapture(3 * time.Millisecond)
+
+	stats := h.SettleStats()
+	require.Equal(t, 2, stats.Calls)
+	require.Equal(t, 2, stats.GateACalls)
+	require.Equal(t, 2, stats.GateAInlineHits)
+	require.Equal(t, 4, stats.GateBPolls)
+	require.Equal(t, 7*time.Millisecond, stats.GateBWait)
+	require.Equal(t, 3*time.Millisecond, stats.CaptureWait)
+}
+
+func TestStopwatchMeasuresRealElapsedTime(t *testing.T) {
+	sw := NewStopwatch()
+	time.Sleep(2 * time.Millisecond)
+	require.GreaterOrEqual(t, sw.Elapsed(), 2*time.Millisecond)
+}

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -329,6 +329,12 @@ func TestSyntheticProfile_MinimalScopedMatchesSeedAll(t *testing.T) {
 	require.Equal(t, 1, res.GmailSettled)
 	require.Equal(t, 1, res.TelegramSettled)
 	require.Equal(t, 2, res.Contacts)
+	// minimal-scoped reports its one `seed-all` phase, so all three profiles
+	// surface timings uniformly — otherwise this path's phase bracket could be
+	// dropped without any test noticing.
+	require.Len(t, res.Timings.Phases, 1, "minimal-scoped reports its single phase")
+	require.Equal(t, "seed-all", res.Timings.Phases[0].Name)
+	require.Positive(t, res.Timings.Settle.Calls, "minimal-scoped reports settle accounting")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -1118,6 +1124,23 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.Greater(t, remaining, int64(0), "prod-shaped profile seeds contacts")
 }
 
+// catalogProfilePhaseCount is how many comment-delimited seeding blocks
+// runCatalogProfile brackets with a phase timer. It is pinned so a block added
+// (or a stop() call lost) without a phase is caught here rather than silently
+// dropping a row from the reseed summary.
+const catalogProfilePhaseCount = 22
+
+// phaseShape projects phase timings onto their DETERMINISTIC components — name
+// and payload volume — dropping the wall-clock duration, so a run-to-run
+// comparison asserts the seeding shape without asserting the impossible.
+func phaseShape(phases []synthetic.PhaseTiming) []string {
+	out := make([]string, 0, len(phases))
+	for _, p := range phases {
+		out = append(out, fmt.Sprintf("%s=%d", p.Name, p.Payloads))
+	}
+	return out
+}
+
 // TestSyntheticProfile_ProdShapedDeterministic proves the prod-shaped seed is
 // deterministic: two runs at the same (namespace, seed, anchor) produce
 // byte-identical ProfileResult counts AND an identical fingerprint of the
@@ -1151,23 +1174,6 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 // proposition_key and the edge object node id are NOT fingerprinted (they embed
 // the per-run subject/object UUID, so they are not run-stable); a person→person
 // edge therefore contributes only its (predicate_key, status) to the fingerprint.
-// catalogProfilePhaseCount is how many comment-delimited seeding blocks
-// runCatalogProfile brackets with a phase timer. It is pinned so a block added
-// (or a stop() call lost) without a phase is caught here rather than silently
-// dropping a row from the reseed summary.
-const catalogProfilePhaseCount = 22
-
-// phaseShape projects phase timings onto their DETERMINISTIC components — name
-// and payload volume — dropping the wall-clock duration, so a run-to-run
-// comparison asserts the seeding shape without asserting the impossible.
-func phaseShape(phases []synthetic.PhaseTiming) []string {
-	out := make([]string, 0, len(phases))
-	for _, p := range phases {
-		out = append(out, fmt.Sprintf("%s=%d", p.Name, p.Payloads))
-	}
-	return out
-}
-
 func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -1307,6 +1313,15 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// counter, including counters added later, under strict equality.
 	require.NotZero(t, res1.Timings.Total, "the run must report a wall-clock duration")
 	require.Positive(t, res1.Timings.Settle.Calls, "the run must report settle accounting")
+	// Each of the four instrumented settle hunks gets its own witness. Calls alone
+	// would stay green if the Gate-B or capture recording were deleted — and those
+	// are two of the five numbers the reseed summary prints, so a silent zero would
+	// read as "gate B is free" and invert this PR's measured conclusion. waitGateB
+	// always polls at least once and captureEventIDs always runs, so both are
+	// non-zero on any real run.
+	require.Positive(t, res1.Timings.Settle.GateAPolls, "gate A accounting is recorded")
+	require.Positive(t, res1.Timings.Settle.GateBPolls, "gate B accounting is recorded")
+	require.Positive(t, res1.Timings.Settle.CaptureWait, "capture accounting is recorded")
 	require.Empty(t, res1.Timings.Current, "a clean run leaves no phase marked as running")
 	require.Len(t, res1.Timings.Phases, catalogProfilePhaseCount,
 		"every catalog-profile seeding block reports a phase")

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -1150,6 +1151,23 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 // proposition_key and the edge object node id are NOT fingerprinted (they embed
 // the per-run subject/object UUID, so they are not run-stable); a person→person
 // edge therefore contributes only its (predicate_key, status) to the fingerprint.
+// catalogProfilePhaseCount is how many comment-delimited seeding blocks
+// runCatalogProfile brackets with a phase timer. It is pinned so a block added
+// (or a stop() call lost) without a phase is caught here rather than silently
+// dropping a row from the reseed summary.
+const catalogProfilePhaseCount = 22
+
+// phaseShape projects phase timings onto their DETERMINISTIC components — name
+// and payload volume — dropping the wall-clock duration, so a run-to-run
+// comparison asserts the seeding shape without asserting the impossible.
+func phaseShape(phases []synthetic.PhaseTiming) []string {
+	out := make([]string, 0, len(phases))
+	for _, p := range phases {
+		out = append(out, fmt.Sprintf("%s=%d", p.Name, p.Payloads))
+	}
+	return out
+}
+
 func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -1282,6 +1300,22 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 
 	res1, fp1, ent1, ext1, task1, bday1 := run()
 	res2, fp2, ent2, ext2, task2, bday2 := run()
+
+	// Timings are wall-clock and will never be equal across runs, so they are the
+	// one field excluded from the whole-struct equality below. Zeroing the nested
+	// struct — rather than comparing field-by-field around it — keeps every other
+	// counter, including counters added later, under strict equality.
+	require.NotZero(t, res1.Timings.Total, "the run must report a wall-clock duration")
+	require.Positive(t, res1.Timings.Settle.Calls, "the run must report settle accounting")
+	require.Empty(t, res1.Timings.Current, "a clean run leaves no phase marked as running")
+	require.Len(t, res1.Timings.Phases, catalogProfilePhaseCount,
+		"every catalog-profile seeding block reports a phase")
+	// Phase NAMES and payload volumes ARE deterministic (durations are not), so
+	// they are compared through a duration-free projection.
+	require.Equal(t, phaseShape(res1.Timings.Phases), phaseShape(res2.Timings.Phases),
+		"phase names + payload volumes must be deterministic across runs")
+	res1.Timings = synthetic.SeedTimings{}
+	res2.Timings = synthetic.SeedTimings{}
 
 	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
 	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")


### PR DESCRIPTION
PR1 of the seed-realism archetype arc (`.ai/log/plan/2026-07-24-seed-realism-archetypes-arc.md`). Adds whole-run, per-phase, and settle-gate wall-clock measurement to the synthetic profile seed, surfaced through `ProfileResult` and printed by `crm-admin`. Also commits the design spec this arc implements (`.ai/spec/2026-07-24-seed-realism-archetypes.md`), previously untracked.

Landing measurement **before** the population grows is what makes PR5's "reseed at the new scale" number meaningful — otherwise it is a number with nothing to compare against.

**Zero change to the seeded world.** No new `gen.*` call, no new row, no reordered block; the golden test, every coherence gate, and every existing count are byte-identical. That is what makes PR2 and PR3 safe to author in parallel behind this. Timing fields are excluded from the determinism test's whole-struct equality, and that exclusion is mutation-verified as load-bearing.

## Measured baseline

`CRM_ENV=testing crm-admin --reset-and-seed --profile prod-shaped --yes` against a clean scratch DB (local Docker Postgres 16): **71.38s**, 170 contacts (`res.Contacts`; +9 merge/soft-delete contacts gives the 179 raw rows), 106 Settle calls. `gate_a=24.06s gate_b=43.19s capture=0.36s`, `gate_a=inline-hits 56/104`, `gate_b=polls 912 (avg 8.6/call)`. `per-source-settled` alone is 62.96s (88%) for 60 payloads; the 150-contact catalog costs 0.86s.

## Attribution — Settle-dominance CONFIRMED, one sub-claim REFUTED

The plan made the cost attribution a *deliverable rather than a premise*: the arc's Q4 hypothesis was motivated by code structure, and this instrumentation is what confirms or refutes it.

Total gate wait is 67.61s = **94.7%** of the reseed — nowhere near the ~15% that would have refuted the hypothesis. PR5's sizing premise stands and the arc's open branch does not need taking.

The discriminator refines the *mechanism*. Gate B is the largest term at 8.6 polls/call (8.6 x 50ms ~= 0.43s/Settle x 106 ~= 45.6s, accounting for essentially all of `GateBWait`), so that time is the reseed genuinely waiting on River workers, not gate machinery burning CPU — batching wins there by letting those waits **overlap**, not by removing polling overhead. Gate A's 48 non-inline waits (56/104 hit inline) are the directly removable latency.

**INV-7's `captureEventIDs` sub-claim is refuted at this scale**: the full-union rebuild costs **0.36s, 0.5%** of the reseed. It is expected to grow as the arc multiplies event volume ~10x, so PR5 should re-read this line after the population moves — but PR2 must not size its work against it today.

`outside_gates` (3.77s) is reported as bookkeeping only; the attribution model is nested, so that residual is close to an accounting identity.

## Documented coverage gap

The plan specified two injected-failure integration tests. Both would need either a test-only injection seam inside `runCatalogProfile` (unrequested production-path machinery) or a 30s forced Gate-A timeout, so neither was built. The substitutes are real tests but not equivalent: `TestSeedAdapterRunProfileCarriesPartialResultOnFailure` fails in `RunProfile`'s `default:` branch and never enters `runCatalogProfile`, so it exercises neither the defer-based settle refresh, nor `Timings.Current`, nor a truncated `Phases` slice — the chain "a real block errors -> `Current` populated -> the CLI names the failing phase" is covered as three separately-pinned links, never composed. The `waitGateA` timeout exit is structurally correct but not reached by any test.

Residual risk is low: review hand-traced all 51 `return res` sites and confirmed each falls inside an open phase bracket, and `catalogProfilePhaseCount = 22` catches a lost bracket.

Also: `--reset-and-seed`'s Quiesce-failure branch is unreachable today (`Quiesce` always returns `nil`), so its `errSeedWorldIntact` classification is defensive and untested by design.

## Verification

`make lint` 0 issues; `make test` green end to end (unit, full integration, frontend 73/73); full pre-push gate green including E2E. Each new gate was mutation-verified to fail on an injected defect — no-op'ing `recordGateB`, no-op'ing `recordCapture`, dropping minimal-scoped's `stop()`, and removing the determinism test's `Timings` zeroing each produce the expected failure.