### PR TITLE
feat(synthetic): add archetype timeline generator

### DIFF
--- a/backend/internal/synthetic/factory/archetype.go
+++ b/backend/internal/synthetic/factory/archetype.go
@@ -444,14 +444,26 @@ func (b *timelineBuilder) sorted() []TimelineEntry {
 //
 // With a calendar it is a single meeting, which the pipeline always classifies
 // as mutual. Without one — a Telegram- or phone-only contact — the same
-// two-wayness has to be EARNED, so the exchange becomes a promotion pair on the
-// chat source: outbound first, inbound messagingPairGap later, both inside the
-// one conversation the timeline holds with that contact.
+// two-wayness has to be EARNED, so the exchange becomes a chat promotion pair.
 func (b *timelineBuilder) addMutualExchange(p sourcePlan, age time.Duration) {
 	if p.meeting != "" {
 		b.add(TimelineEntry{Source: p.meeting, Age: age})
 		return
 	}
+	b.addChatExchange(p, age)
+}
+
+// addChatExchange records a two-way exchange on the chat source: outbound
+// first, inbound messagingPairGap later.
+//
+// Every chat exchange a timeline emits goes into ONE conversation, allocated on
+// first use and held for the rest of the timeline. A contact has a single
+// private chat with you — one Telegram peer, one iMessage thread — so splitting
+// a relationship across two of them would ask the replay layer to mint two
+// separate private conversations with the same person, which is not a state the
+// world produces. Distinct conversations are for distinct THREADS (mail), and
+// for one-sided history that must never bridge.
+func (b *timelineBuilder) addChatExchange(p sourcePlan, age time.Duration) {
 	if b.fallback == 0 {
 		b.fallback = b.conversation()
 	}
@@ -589,8 +601,29 @@ func seriesAges(count int, newest, gapLo, gapHi time.Duration, j timelineJitter)
 
 // addPairsBetweenMeetings places correspondence pairs INSIDE the newest gaps of
 // a meeting series — pair k between meeting k and meeting k+1. Keeping them at
-// the recent end is what holds the mail entries inside mailMaxSpan while the
-// calendar carries the deep history.
+// the recent end is what holds one timeline's mail entries inside a single Gmail
+// sync's reach (replay.gmailBatchMaxSpan, 150 days) while the calendar carries
+// the deep history.
+//
+// That bound is PER BATCH — it spans every instant in the batch, across all the
+// contacts in it — while what a timeline can promise is per contact. The two are
+// not the same number, and the batch one is the larger:
+//
+//	newest mail any archetype emits:  1d  (inbound-only, at its newest bound)
+//	oldest mail any archetype emits: 180d (mutual-drifting, second correspondence
+//	                                       pair at the far end of the second
+//	                                       meeting gap: 112 + 35 + 35 - 2)
+//
+// So mail pooled across archetypes spans up to 179 DAYS against a 150-day limit.
+// That is the arithmetic bound, not a sample; sampling 4,000 namespaces per
+// archetype observes about 173 days, which is the same conclusion with less
+// authority.
+//
+// Pooling every contact's mail into ONE Gmail batch therefore exceeds the limit
+// and is rejected — by design, not by accident: the replay layer raises a named
+// error rather than auto-splitting, because only the caller knows whether
+// splitting a contact's history across two syncs is semantically fine. A caller
+// batching mail across contacts has to bucket by age.
 func addPairsBetweenMeetings(b *timelineBuilder, p sourcePlan, ages []time.Duration, pairs int, j timelineJitter) {
 	for k := 0; k < pairs && k+1 < len(ages); k++ {
 		gap := ages[k+1] - ages[k]
@@ -645,22 +678,28 @@ func buildDormant(b *timelineBuilder, p sourcePlan, j timelineJitter) {
 	newest := pickDuration(j[jitterNewestAge], dormantNewestMin, dormantNewestMax)
 	oldest := pickDuration(j[jitterSpan], newest+dormantSpanMin, dormantOldestMax)
 
-	// The relationship closes with a two-way exchange on the chat source, which
-	// is what makes the history genuinely two-way on more than the calendar.
-	conv := b.conversation()
-	key := b.pair()
-	b.add(TimelineEntry{Source: p.chat, Age: newest + messagingPairGap, Outbound: true, ConversationKey: conv, PairKey: key})
-	b.add(TimelineEntry{Source: p.chat, Age: newest, ConversationKey: conv, PairKey: key})
+	// The relationship closes with a two-way exchange on the chat source, which is
+	// what makes the history genuinely two-way on more than the calendar. It goes
+	// through the same held conversation as any other chat exchange, so a
+	// calendar-less target ends up with one conversation rather than two.
+	b.addChatExchange(p, newest)
 
-	// Meetings fill the rest of the window, evenly, back to the oldest bound. The
-	// step is floored to whole hours so the oldest entry can never overshoot it.
-	first := newest + messagingPairGap + dormantPairInset
+	// Meetings fill the rest of the window, stepping back from the drawn oldest
+	// bound so that bound is hit exactly and the history's depth is the floor it
+	// was drawn against. The step is floored to whole hours, which can only move
+	// the NEWEST meeting further from the closing exchange, never past it.
+	//
+	// Spacing here is deliberately not the 21-35d of the calendar-led archetypes:
+	// dormant's shape is "it ended", not "it had a rhythm", and at two meetings
+	// the gap can reach roughly four months. That is intended texture, and it is
+	// bounded by the dormant window rather than by a spacing rule.
+	newestMeeting := newest + messagingPairGap + dormantPairInset
 	var step time.Duration
 	if meetings > 1 {
-		step = floorHours((oldest - first) / time.Duration(meetings-1))
+		step = floorHours((oldest - newestMeeting) / time.Duration(meetings-1))
 	}
 	for i := 0; i < meetings; i++ {
-		b.addMutualExchange(p, first+time.Duration(i)*step)
+		b.addMutualExchange(p, oldest-time.Duration(i)*step)
 	}
 }
 
@@ -695,11 +734,16 @@ func buildBurstThenQuiet(b *timelineBuilder, p sourcePlan, j timelineJitter) {
 	if filler <= 0 {
 		return
 	}
+	// Under the declared bounds this step is at least five hours (the narrowest
+	// cluster over the largest filler count), so it is always positive and every
+	// filler stays strictly older than the closing pair. It is deliberately NOT
+	// clamped: a clamp would silently reshape the archetype if a future bound
+	// change made the step degenerate — pushing fillers past the pair, or
+	// colliding two ages — where an unclamped step instead trips the tests that
+	// pin the closing pair as the newest group and every age in a conversation as
+	// distinct.
 	openingEnd := oldest - time.Duration(burstOpeningMessages-1)*burstOpeningStride
 	step := floorHours((openingEnd - pairOutbound) / time.Duration(filler+1))
-	if step < time.Hour {
-		step = time.Hour
-	}
 	for i := 1; i <= filler; i++ {
 		b.add(TimelineEntry{
 			Source:          p.chat,

--- a/backend/internal/synthetic/factory/archetype.go
+++ b/backend/internal/synthetic/factory/archetype.go
@@ -1,0 +1,711 @@
+package factory
+
+import (
+	"sort"
+	"time"
+)
+
+// An ARCHETYPE is a relationship shape — "we meet every few weeks", "I keep
+// reaching out and hear nothing back", "we talked a lot in March and then it went
+// quiet". A TIMELINE is that shape resolved into an ordered list of source
+// payloads to replay: which source, how long before the seed anchor, in which
+// direction, and which payloads belong to one conversation.
+//
+// The type is deliberately a PLAN and not a world. It carries no DB handle, no
+// replay adapter and no contact row; everything here is a pure function of
+// (seed, namespace, draw position) plus the archetype and the target's method
+// set. That is what makes the interesting part — the shape — unit-testable
+// without a River queue, and it is why the replay layer, not this one, owns the
+// mapping from Source onto the repository/provider constants.
+
+// Archetype names one relationship shape. The catalog is closed: these seven are
+// the shapes the synthetic seed models.
+type Archetype string
+
+const (
+	// ArchetypeMutualRegular is a live two-way relationship: a recurring meeting
+	// series still running, with occasional correspondence alongside it.
+	ArchetypeMutualRegular Archetype = "mutual-regular"
+	// ArchetypeMutualDrifting is a genuinely two-way relationship whose meeting
+	// series STOPPED a few months ago. It is the archetype that supplies
+	// "contacted AND overdue" — a state the seed produces nowhere else.
+	ArchetypeMutualDrifting Archetype = "mutual-drifting"
+	// ArchetypeOutboundHeavy is one-sided outreach: everything sent, nothing
+	// received. It must never promote to mutual.
+	ArchetypeOutboundHeavy Archetype = "outbound-heavy"
+	// ArchetypeInboundOnly is the mirror: messages arriving, nothing sent back.
+	ArchetypeInboundOnly Archetype = "inbound-only"
+	// ArchetypeDormant is a real two-way history that ended months ago. Like
+	// mutual-drifting it stays overdue, but from further back.
+	ArchetypeDormant Archetype = "dormant"
+	// ArchetypeBurstThenQuiet is one dense conversation in one place, followed by
+	// silence — the shape that exercises message aggregation's burst window.
+	ArchetypeBurstThenQuiet Archetype = "burst-then-quiet"
+	// ArchetypeNeverContacted has no history at all. It is the archetype that
+	// keeps a no-signal contact in the world.
+	ArchetypeNeverContacted Archetype = "never-contacted"
+)
+
+// Source names the payload family a timeline entry is replayed through. It is a
+// LOCAL enum on purpose. Naming google.CalendarSourceName here would pull
+// internal/google into this package's dependency graph, and internal/google
+// imports internal/service — which is exactly the property that lets the
+// synthetic factory live below the service layer without an import cycle. It
+// would compile, which is what makes the mistake easy to miss. The replay layer
+// maps these onto the repository/provider constants.
+type Source string
+
+const (
+	// SourceGCal is a past calendar meeting. It always yields a MUTUAL
+	// interaction, so a timeline never sets a direction on it.
+	SourceGCal Source = "gcal"
+	// SourceEmail is a Gmail message. Direction comes from the payload, and two
+	// messages in one thread on one local day promote to mutual.
+	SourceEmail Source = "email"
+	// SourceGChat is a Google Chat message.
+	SourceGChat Source = "gchat"
+	// SourceTelegram is a private Telegram message.
+	SourceTelegram Source = "telegram"
+	// SourceMessages is an iMessage.
+	SourceMessages Source = "messages"
+)
+
+// MethodSet is what identifiers the target contact actually OWNS. A timeline may
+// only emit sources this set can match:
+//
+//	Email    → gcal / email / gchat
+//	Telegram → telegram
+//	Phone    → messages
+//
+// This is structural, not advisory. Passing a contact id to a replay adapter
+// does not force a match — the payload's identifier does — so a timeline that
+// emitted Telegram for an email-only contact would produce a stranded row and a
+// gate timeout blaming the wrong thing. An empty MethodSet therefore yields an
+// empty timeline for EVERY archetype, which is what makes a contact with no
+// methods at all safe by construction rather than by convention.
+type MethodSet struct {
+	Email    bool
+	Telegram bool
+	Phone    bool
+}
+
+// TimelineEntry is ONE source payload at ONE anchor-relative age.
+type TimelineEntry struct {
+	// Source is the payload family. Always one the MethodSet can match.
+	Source Source
+	// Age is how far BEFORE the seed anchor the payload is dated. Always >= 0,
+	// and always a duration — never a calendar position, so the shape survives a
+	// moving anchor.
+	Age time.Duration
+	// Outbound is the direction the payload expresses. Ignored for SourceGCal,
+	// which is always mutual.
+	Outbound bool
+	// ConversationKey groups entries that share ONE source conversation — a Gmail
+	// ThreadId, a Telegram peer+chat, a GChat SpaceName. Any size: two for a
+	// promotion pair, five to twelve for a burst. Zero means this entry gets its
+	// own conversation.
+	//
+	// Sharing a key is a PLAN-level statement. At replay time the payloads must
+	// also share the source's conversation identifier, and the factory mints a
+	// fresh one per call — so the caller clones the first spec and overwrites only
+	// the message id, direction and timestamp. A group built from independent
+	// factory calls is not a conversation and will never bridge or burst.
+	ConversationKey int
+	// PairKey marks a PROMOTION PAIR: exactly two entries with differing
+	// Outbound, always inside one ConversationKey, carrying the timing contract
+	// below. Zero means this entry is not part of a pair.
+	//
+	// Mutuality is EARNED, not declared. Direction is expressed in source terms
+	// and the interaction model classifies, so a timeline cannot say "make this
+	// mutual" — it constructs the conditions under which the pipeline promotes.
+	PairKey int
+}
+
+// Timeline is one contact's replay plan in CHRONOLOGICAL REPLAY ORDER.
+// Entries[0] is the OLDEST (largest Age); the last entry is the newest.
+//
+// The ordering is a correctness contract, not a presentation choice. The reply
+// bridge promotes only when an inbound session finds an already-existing
+// outbound interaction, so replaying newest-first makes the inbound land first
+// as a plain inbound and the outbound arriving second can never bridge it — two
+// one-sided interactions where a mutual was intended, which is precisely the
+// false "one-sided conversation" signal the archetypes exist to stop producing.
+type Timeline struct {
+	Archetype Archetype
+	Entries   []TimelineEntry
+}
+
+// --- promotion-pair timing --------------------------------------------------
+//
+// The pair timing rule is SOURCE-SPECIFIC, and the single rule underneath both
+// halves is: the pair's ordering must be fixed by CONSTRUCTION, never left to a
+// tie-break the database is free to resolve either way.
+
+const (
+	// messagingPairGap separates the two halves of a messaging promotion pair,
+	// outbound strictly older. Equal timestamps are unsafe on this path: the
+	// aggregation reads order eligible rows only by sent_at, the engine's
+	// defensive sort is stable and therefore preserves an unspecified DB tie
+	// order, and session promotion requires the outbound to precede the inbound —
+	// so an equal-timestamp pair could nondeterministically become one mutual or
+	// two one-sided sessions. Six hours is the gap the existing working fixture
+	// uses, comfortably inside the 48h bridge window and far from any tie. There
+	// is no local-day key on this path, so a moving anchor is harmless.
+	messagingPairGap = 6 * time.Hour
+
+	// threadPairGap separates the two halves of a Gmail promotion pair: ZERO, so
+	// both are dated at the same instant. Gmail's aggregation key includes a local
+	// day computed in the machine's local zone, so ANY nonzero gap can straddle
+	// local midnight depending on where the moving anchor lands — a clock-anchored
+	// fixture that passes until it doesn't. The same instant is the same local
+	// day, unconditionally.
+	threadPairGap = 0
+)
+
+// --- archetype parameter table ----------------------------------------------
+//
+// Every bound is relative to the seed anchor, and every one is a judgement call
+// about what a realistic history looks like rather than a derived constant. The
+// two exceptions — the overdue floors and the mail span bound — are load-bearing
+// and are called out where they are declared.
+
+const timelineDay = 24 * time.Hour
+
+const (
+	// meetingSpacingMin/Max bound the gap between consecutive meetings in a
+	// recurring series. A series is N independent single events (the real fetcher
+	// pre-expands recurrence), so "meets every few weeks" IS N entries at
+	// increasing multiples of a jittered spacing.
+	meetingSpacingMin = 21 * timelineDay
+	meetingSpacingMax = 35 * timelineDay
+
+	// mailPairInset keeps a correspondence pair away from the meetings on either
+	// side of it, so the interleaving is visible rather than coincident.
+	mailPairInset = 2 * timelineDay
+)
+
+const (
+	// mutual-regular: a still-running series with one correspondence pair beside
+	// it. The meeting count is narrow because the count, the spacing bounds and
+	// the total span are not independent: the span is the sum of count-1 gaps, so
+	// only counts whose gap range intersects [regularSpanMin, regularSpanMax]
+	// inside [meetingSpacingMin, meetingSpacingMax] can satisfy all three at once.
+	regularMeetingsMin = 7
+	regularMeetingsMax = 8
+	regularNewestMin   = 3 * timelineDay
+	regularNewestMax   = 14 * timelineDay
+	// regularSpanMin/Max bound the CALENDAR span — oldest meeting to newest.
+	// Deep history is carried by calendar rather than mail because one Gmail sync
+	// reaches only a bounded window forward from its backfill point and silently
+	// drops anything past it, so the mail entries have to stay recent. The
+	// causality is admittedly backwards — a provider bound driving a realism
+	// decision — but it happens to align with reality: a long relationship really
+	// does show up as recurring meetings more than as one continuous thread.
+	regularSpanMin = 180 * timelineDay
+	regularSpanMax = 270 * timelineDay
+	// regularPairs is fixed at one: two correspondence pairs would need at least
+	// nine meetings to keep the span above regularSpanMin, and eleven entries is
+	// past what this archetype should cost.
+	regularPairs = 1
+)
+
+const (
+	// mutual-drifting: the same series, stopped 10-16 weeks ago. The floor is the
+	// point of the archetype — a replayed inbound or mutual writes both
+	// last_contacted and contact_by, so a contact only stays OVERDUE if its newest
+	// two-way entry is older than its cadence period. 70 days keeps it overdue on
+	// weekly, biweekly and monthly cadences at production durations.
+	driftingNewestMin  = 70 * timelineDay
+	driftingNewestMax  = 112 * timelineDay
+	driftingMeetingMin = 3
+	// driftingMeetingMax is lower when the timeline carries two correspondence
+	// pairs, so the entry count stays inside the archetype's budget either way.
+	driftingMeetingMaxOnePair = 6
+	driftingMeetingMaxTwoPair = 4
+)
+
+const (
+	// outbound-heavy: everything sent, nothing received, and structurally unable
+	// to promote — no pairs and no shared conversation.
+	outboundCountMin  = 3
+	outboundCountMax  = 6
+	outboundNewestMin = 2 * timelineDay
+	outboundNewestMax = 20 * timelineDay
+	outboundGapMin    = 5 * timelineDay
+	outboundGapMax    = 25 * timelineDay
+)
+
+const (
+	// inbound-only: the mirror of outbound-heavy, on distinct conversations.
+	inboundCountMin  = 2
+	inboundCountMax  = 5
+	inboundNewestMin = 1 * timelineDay
+	inboundNewestMax = 15 * timelineDay
+	inboundGapMin    = 6 * timelineDay
+	inboundGapMax    = 30 * timelineDay
+)
+
+const (
+	// dormant: real two-way history that ended 4-8 months ago. The 120-day floor
+	// extends the overdue-compatible cadences up to quarterly at production
+	// durations; the oldest bound keeps it dormant rather than prehistoric.
+	dormantNewestMin  = 120 * timelineDay
+	dormantNewestMax  = 150 * timelineDay
+	dormantOldestMax  = 240 * timelineDay
+	dormantSpanMin    = 45 * timelineDay
+	dormantMeetingMin = 2
+	dormantMeetingMax = 7
+	// dormantPairInset separates the closing conversation from the last meeting.
+	dormantPairInset = 5 * timelineDay
+)
+
+const (
+	// burst-then-quiet: one dense conversation in ONE place, then silence. The
+	// entries all share a single conversation because K independent conversations
+	// would be K unrelated interactions that never exercise the burst window at
+	// all — and, for GChat, would cost roughly 3K pages of a 100-page sync budget
+	// instead of 3.
+	burstCountMin  = 5
+	burstCountMax  = 12
+	burstNewestMin = 30 * timelineDay
+	burstNewestMax = 90 * timelineDay
+	// burstWidthMin/Max bound the cluster: oldest entry to newest.
+	burstWidthMin = 2 * timelineDay
+	burstWidthMax = 5 * timelineDay
+	// burstOpeningMessages is how many messages open the conversation inside ONE
+	// aggregation burst window. Aggregation groups messages into a session by a
+	// 2h idle gap, so a cluster spread evenly across days would produce N separate
+	// sessions rather than the burst this archetype exists to exercise.
+	burstOpeningMessages = 3
+	// burstOpeningStride spaces those opening messages. Three of them span twice
+	// the stride, which must stay well inside the 2h window.
+	burstOpeningStride = 40 * time.Minute
+)
+
+// --- per-contact jitter -----------------------------------------------------
+
+// Slot layout of one call's draw vector. The vector is FIXED-SIZE and drawn
+// up-front, before any branch on archetype or method set, so every TimelineFor
+// call costs exactly timelineJitterDraws draws no matter what it returns. That
+// keeps the shared generator's draw accounting independent of which archetype
+// lands on which contact: reassigning archetypes cannot shift the stream, and
+// the draw cost is one number to pin rather than seven.
+const (
+	jitterCount     = 0 // primary count (meetings, or entries)
+	jitterNewestAge = 1 // age of the newest entry
+	jitterPairCount = 2 // how many correspondence pairs
+	jitterSpan      = 3 // total span / cluster width
+
+	jitterGapBase    = 4
+	timelineGapSlots = 16
+
+	jitterPairBase    = jitterGapBase + timelineGapSlots
+	timelinePairSlots = 4
+
+	// timelineJitterDraws is the exact number of PRNG draws one TimelineFor call
+	// consumes. Pinned by the draw-order test.
+	timelineJitterDraws = jitterPairBase + timelinePairSlots
+)
+
+// timelineJitter is one call's draw vector.
+type timelineJitter [timelineJitterDraws]uint64
+
+// gap returns the draw backing the i-th inter-entry gap. The slot pool wraps, so
+// a timeline with more gaps than slots reuses earlier draws rather than
+// consuming a variable number of them.
+func (j timelineJitter) gap(i int) uint64 { return j[jitterGapBase+i%timelineGapSlots] }
+
+// pairSlot returns the draw backing the i-th correspondence pair's placement.
+func (j timelineJitter) pairSlot(i int) uint64 { return j[jitterPairBase+i%timelinePairSlots] }
+
+// drawTimelineJitter fills the vector from the shared PRNG.
+func (g *Generator) drawTimelineJitter() timelineJitter {
+	var j timelineJitter
+	for i := range j {
+		j[i] = g.rng.Uint64()
+	}
+	return j
+}
+
+// pickInt maps a raw draw onto the inclusive range [lo, hi].
+func pickInt(u uint64, lo, hi int) int {
+	if hi <= lo {
+		return lo
+	}
+	return lo + int(u%uint64(hi-lo+1))
+}
+
+// pickDuration maps a raw draw onto [lo, hi] at WHOLE-HOUR granularity, so ages
+// stay legible in the golden snapshots and every derived span is exact.
+func pickDuration(u uint64, lo, hi time.Duration) time.Duration {
+	lo, hi = ceilHours(lo), floorHours(hi)
+	if hi <= lo {
+		return lo
+	}
+	steps := uint64((hi-lo)/time.Hour) + 1
+	return lo + time.Duration(u%steps)*time.Hour
+}
+
+func ceilHours(d time.Duration) time.Duration {
+	h := d / time.Hour
+	if h*time.Hour < d {
+		h++
+	}
+	return h * time.Hour
+}
+
+func floorHours(d time.Duration) time.Duration {
+	return (d / time.Hour) * time.Hour
+}
+
+// --- source selection -------------------------------------------------------
+
+// sourcePlan is the concrete source assignment for one timeline, resolved from
+// the target's method set. An empty field means the role has no source the
+// target can match, and the archetype degrades around it.
+type sourcePlan struct {
+	// meeting is the always-mutual calendar source. Only an email-bearing contact
+	// can be a matched attendee, so this is empty for everyone else.
+	meeting Source
+	// thread is the source whose promotion pair lands at the SAME instant.
+	thread Source
+	// chat is the messaging-aggregation source: burst windows, reply bridge, and
+	// a promotion pair separated by messagingPairGap.
+	chat Source
+}
+
+func (p sourcePlan) empty() bool { return p.meeting == "" && p.thread == "" && p.chat == "" }
+
+// planFor resolves the roles from what the contact owns. The chat role prefers
+// the sources a contact can only have deliberately — a synthetic contact carries
+// a Telegram handle or a phone because someone wanted that source exercised,
+// whereas every email-bearing contact would otherwise fall to GChat and the
+// other two would never be reached. Email-only targets, which is what the frozen
+// catalog is, resolve to exactly {gcal, email, gchat}.
+func planFor(caps MethodSet) sourcePlan {
+	var p sourcePlan
+	if caps.Email {
+		p.meeting = SourceGCal
+		p.thread = SourceEmail
+		p.chat = SourceGChat
+	}
+	switch {
+	case caps.Telegram:
+		p.chat = SourceTelegram
+	case caps.Phone:
+		p.chat = SourceMessages
+	}
+	return p
+}
+
+// directional returns the source to use for one-sided history: the threaded mail
+// source when the target has one, otherwise the chat source.
+func (p sourcePlan) directional() Source {
+	if p.thread != "" {
+		return p.thread
+	}
+	return p.chat
+}
+
+// --- timeline construction --------------------------------------------------
+
+// timelineBuilder accumulates entries and hands out conversation and pair keys.
+// Keys are only ever compared for equality, so a per-timeline counter is enough.
+type timelineBuilder struct {
+	entries  []TimelineEntry
+	convSeq  int
+	pairSeq  int
+	fallback int // shared conversation for chat-carried mutual exchanges
+}
+
+func (b *timelineBuilder) conversation() int {
+	b.convSeq++
+	return b.convSeq
+}
+
+func (b *timelineBuilder) pair() int {
+	b.pairSeq++
+	return b.pairSeq
+}
+
+func (b *timelineBuilder) add(e TimelineEntry) { b.entries = append(b.entries, e) }
+
+// sorted returns the entries OLDEST FIRST. The sort is stable and compares Age
+// strictly, so a same-instant pair keeps the insertion order that puts its
+// outbound half first — which is the order the replay layer needs.
+func (b *timelineBuilder) sorted() []TimelineEntry {
+	out := make([]TimelineEntry, len(b.entries))
+	copy(out, b.entries)
+	sort.SliceStable(out, func(i, k int) bool { return out[i].Age > out[k].Age })
+	return out
+}
+
+// addMutualExchange records ONE two-way event at the given age.
+//
+// With a calendar it is a single meeting, which the pipeline always classifies
+// as mutual. Without one — a Telegram- or phone-only contact — the same
+// two-wayness has to be EARNED, so the exchange becomes a promotion pair on the
+// chat source: outbound first, inbound messagingPairGap later, both inside the
+// one conversation the timeline holds with that contact.
+func (b *timelineBuilder) addMutualExchange(p sourcePlan, age time.Duration) {
+	if p.meeting != "" {
+		b.add(TimelineEntry{Source: p.meeting, Age: age})
+		return
+	}
+	if b.fallback == 0 {
+		b.fallback = b.conversation()
+	}
+	key := b.pair()
+	b.add(TimelineEntry{Source: p.chat, Age: age + messagingPairGap, Outbound: true, ConversationKey: b.fallback, PairKey: key})
+	b.add(TimelineEntry{Source: p.chat, Age: age, ConversationKey: b.fallback, PairKey: key})
+}
+
+// addThreadPair records a correspondence pair in its own thread: two messages at
+// the SAME instant with differing directions, which is what makes the pipeline
+// promote them to a single mutual. A target with no mail source gets nothing —
+// it has no threaded promotion available, and its two-way history is already
+// carried by addMutualExchange.
+func (b *timelineBuilder) addThreadPair(p sourcePlan, age time.Duration) {
+	if p.thread == "" {
+		return
+	}
+	conv := b.conversation()
+	key := b.pair()
+	b.add(TimelineEntry{Source: p.thread, Age: age + threadPairGap, Outbound: true, ConversationKey: conv, PairKey: key})
+	b.add(TimelineEntry{Source: p.thread, Age: age, ConversationKey: conv, PairKey: key})
+}
+
+// addOneSided records count entries in one direction, each on its own
+// conversation and none of them paired, so nothing can promote.
+func (b *timelineBuilder) addOneSided(src Source, outbound bool, ages []time.Duration) {
+	for _, age := range ages {
+		b.add(TimelineEntry{Source: src, Age: age, Outbound: outbound})
+	}
+}
+
+// TimelineFor builds one contact's replay plan.
+//
+// It is deterministic in (seed, namespace, draw position) and draws its
+// per-contact jitter from the SHARED generator PRNG, so it must only ever be
+// called from the append-last block of a seed profile. Inserting a call ahead of
+// an existing generator consumer shifts every later allocation by one, and a
+// shifted numeric identifier can land on an id another contact already owns —
+// which surfaces as a cross-match and a gate timeout, far from the edit that
+// caused it.
+//
+// caps constrains which sources may be emitted, and the constraint is
+// structural: the returned timeline never contains a source caps cannot match,
+// and an empty caps yields an empty timeline for every archetype. The returned
+// Entries slice is OLDEST FIRST and is empty-but-non-nil rather than nil when
+// there is no history, so "no history" and "bug" stay distinguishable at the
+// call site.
+func (g *Generator) TimelineFor(a Archetype, caps MethodSet) Timeline {
+	// Drawn unconditionally, before any branch: see the slot layout above.
+	j := g.drawTimelineJitter()
+
+	tl := Timeline{Archetype: a, Entries: []TimelineEntry{}}
+	plan := planFor(caps)
+	if plan.empty() {
+		// No role has a source this target can match, which is exactly the case an
+		// empty MethodSet produces.
+		return tl
+	}
+
+	var b timelineBuilder
+	switch a {
+	case ArchetypeMutualRegular:
+		buildMutualRegular(&b, plan, j)
+	case ArchetypeMutualDrifting:
+		buildMutualDrifting(&b, plan, j)
+	case ArchetypeOutboundHeavy:
+		buildOutboundHeavy(&b, plan, j)
+	case ArchetypeInboundOnly:
+		buildInboundOnly(&b, plan, j)
+	case ArchetypeDormant:
+		buildDormant(&b, plan, j)
+	case ArchetypeBurstThenQuiet:
+		buildBurstThenQuiet(&b, plan, j)
+	case ArchetypeNeverContacted:
+		// No history at all — the empty timeline IS the archetype.
+	}
+
+	tl.Entries = b.sorted()
+	return tl
+}
+
+// meetingGapBounds narrows the spacing range so that ANY draw inside it keeps
+// the total series span within [spanMin, spanMax]. The span is the sum of
+// count-1 independently jittered gaps, so bounding each gap by spanMin/gaps from
+// below and spanMax/gaps from above bounds the sum — without that narrowing,
+// "spacing 21-35d" and "span 6-9 months" are two constraints that a given
+// meeting count can satisfy separately and violate together. A zero span bound
+// means the archetype does not constrain the total.
+func meetingGapBounds(count int, spanMin, spanMax time.Duration) (time.Duration, time.Duration) {
+	lo, hi := meetingSpacingMin, meetingSpacingMax
+	gaps := count - 1
+	if gaps < 1 {
+		return lo, hi
+	}
+	if spanMin > 0 {
+		if need := ceilHours(ceilDivDuration(spanMin, gaps)); need > lo {
+			lo = need
+		}
+	}
+	if spanMax > 0 {
+		if allow := floorHours(spanMax / time.Duration(gaps)); allow < hi {
+			hi = allow
+		}
+	}
+	if hi < lo {
+		// Unreachable for the declared table — the feasibility test proves the
+		// narrowed range is non-empty for every permitted meeting count — but a
+		// crossed range would otherwise silently invert the bounds.
+		hi = lo
+	}
+	return lo, hi
+}
+
+func ceilDivDuration(d time.Duration, n int) time.Duration {
+	q := d / time.Duration(n)
+	if q*time.Duration(n) < d {
+		q++
+	}
+	return q
+}
+
+// seriesAges returns count ages NEWEST FIRST, starting at newest and stepping
+// back by an independently jittered gap each time.
+func seriesAges(count int, newest, gapLo, gapHi time.Duration, j timelineJitter) []time.Duration {
+	if count < 1 {
+		return nil
+	}
+	ages := make([]time.Duration, count)
+	ages[0] = newest
+	for i := 1; i < count; i++ {
+		ages[i] = ages[i-1] + pickDuration(j.gap(i-1), gapLo, gapHi)
+	}
+	return ages
+}
+
+// addPairsBetweenMeetings places correspondence pairs INSIDE the newest gaps of
+// a meeting series — pair k between meeting k and meeting k+1. Keeping them at
+// the recent end is what holds the mail entries inside mailMaxSpan while the
+// calendar carries the deep history.
+func addPairsBetweenMeetings(b *timelineBuilder, p sourcePlan, ages []time.Duration, pairs int, j timelineJitter) {
+	for k := 0; k < pairs && k+1 < len(ages); k++ {
+		gap := ages[k+1] - ages[k]
+		offset := pickDuration(j.pairSlot(k), mailPairInset, gap-mailPairInset)
+		b.addThreadPair(p, ages[k]+offset)
+	}
+}
+
+func buildMutualRegular(b *timelineBuilder, p sourcePlan, j timelineJitter) {
+	meetings := pickInt(j[jitterCount], regularMeetingsMin, regularMeetingsMax)
+	newest := pickDuration(j[jitterNewestAge], regularNewestMin, regularNewestMax)
+	gapLo, gapHi := meetingGapBounds(meetings, regularSpanMin, regularSpanMax)
+
+	ages := seriesAges(meetings, newest, gapLo, gapHi, j)
+	for _, age := range ages {
+		b.addMutualExchange(p, age)
+	}
+	addPairsBetweenMeetings(b, p, ages, regularPairs, j)
+}
+
+func buildMutualDrifting(b *timelineBuilder, p sourcePlan, j timelineJitter) {
+	pairs := pickInt(j[jitterPairCount], 1, 2)
+	meetingMax := driftingMeetingMaxOnePair
+	if pairs == 2 {
+		meetingMax = driftingMeetingMaxTwoPair
+	}
+	meetings := pickInt(j[jitterCount], driftingMeetingMin, meetingMax)
+	newest := pickDuration(j[jitterNewestAge], driftingNewestMin, driftingNewestMax)
+	gapLo, gapHi := meetingGapBounds(meetings, 0, 0)
+
+	ages := seriesAges(meetings, newest, gapLo, gapHi, j)
+	for _, age := range ages {
+		b.addMutualExchange(p, age)
+	}
+	addPairsBetweenMeetings(b, p, ages, pairs, j)
+}
+
+func buildOutboundHeavy(b *timelineBuilder, p sourcePlan, j timelineJitter) {
+	count := pickInt(j[jitterCount], outboundCountMin, outboundCountMax)
+	newest := pickDuration(j[jitterNewestAge], outboundNewestMin, outboundNewestMax)
+	b.addOneSided(p.directional(), true, seriesAges(count, newest, outboundGapMin, outboundGapMax, j))
+}
+
+func buildInboundOnly(b *timelineBuilder, p sourcePlan, j timelineJitter) {
+	count := pickInt(j[jitterCount], inboundCountMin, inboundCountMax)
+	newest := pickDuration(j[jitterNewestAge], inboundNewestMin, inboundNewestMax)
+	b.addOneSided(p.directional(), false, seriesAges(count, newest, inboundGapMin, inboundGapMax, j))
+}
+
+func buildDormant(b *timelineBuilder, p sourcePlan, j timelineJitter) {
+	meetings := pickInt(j[jitterCount], dormantMeetingMin, dormantMeetingMax)
+	newest := pickDuration(j[jitterNewestAge], dormantNewestMin, dormantNewestMax)
+	oldest := pickDuration(j[jitterSpan], newest+dormantSpanMin, dormantOldestMax)
+
+	// The relationship closes with a two-way exchange on the chat source, which
+	// is what makes the history genuinely two-way on more than the calendar.
+	conv := b.conversation()
+	key := b.pair()
+	b.add(TimelineEntry{Source: p.chat, Age: newest + messagingPairGap, Outbound: true, ConversationKey: conv, PairKey: key})
+	b.add(TimelineEntry{Source: p.chat, Age: newest, ConversationKey: conv, PairKey: key})
+
+	// Meetings fill the rest of the window, evenly, back to the oldest bound. The
+	// step is floored to whole hours so the oldest entry can never overshoot it.
+	first := newest + messagingPairGap + dormantPairInset
+	var step time.Duration
+	if meetings > 1 {
+		step = floorHours((oldest - first) / time.Duration(meetings-1))
+	}
+	for i := 0; i < meetings; i++ {
+		b.addMutualExchange(p, first+time.Duration(i)*step)
+	}
+}
+
+func buildBurstThenQuiet(b *timelineBuilder, p sourcePlan, j timelineJitter) {
+	count := pickInt(j[jitterCount], burstCountMin, burstCountMax)
+	newest := pickDuration(j[jitterNewestAge], burstNewestMin, burstNewestMax)
+	width := pickDuration(j[jitterSpan], burstWidthMin, burstWidthMax)
+
+	conv := b.conversation()
+	oldest := newest + width
+
+	// The conversation OPENS with a handful of messages inside one aggregation
+	// burst window, which is the behaviour this archetype exists to exercise.
+	for i := 0; i < burstOpeningMessages; i++ {
+		b.add(TimelineEntry{
+			Source:          p.chat,
+			Age:             oldest - time.Duration(i)*burstOpeningStride,
+			Outbound:        true,
+			ConversationKey: conv,
+		})
+	}
+
+	// It CLOSES with a promotion pair, so the whole conversation lands as mutual
+	// rather than collapsing into a one-sided session.
+	key := b.pair()
+	pairOutbound := newest + messagingPairGap
+	b.add(TimelineEntry{Source: p.chat, Age: pairOutbound, Outbound: true, ConversationKey: conv, PairKey: key})
+	b.add(TimelineEntry{Source: p.chat, Age: newest, ConversationKey: conv, PairKey: key})
+
+	// Whatever is left fills the middle, thinning out towards the close.
+	filler := count - burstOpeningMessages - 2
+	if filler <= 0 {
+		return
+	}
+	openingEnd := oldest - time.Duration(burstOpeningMessages-1)*burstOpeningStride
+	step := floorHours((openingEnd - pairOutbound) / time.Duration(filler+1))
+	if step < time.Hour {
+		step = time.Hour
+	}
+	for i := 1; i <= filler; i++ {
+		b.add(TimelineEntry{
+			Source:          p.chat,
+			Age:             openingEnd - time.Duration(i)*step,
+			Outbound:        true,
+			ConversationKey: conv,
+		})
+	}
+}

--- a/backend/internal/synthetic/factory/archetype_test.go
+++ b/backend/internal/synthetic/factory/archetype_test.go
@@ -86,6 +86,13 @@ const (
 	wantDormantEntriesMax = 9
 	wantDormantNewestMin  = 120 * dayT
 	wantDormantOldestMax  = 240 * dayT
+	// wantDormantSpanMin is the minimum depth of a dormant history: a two-way
+	// relationship that ended has to have lasted long enough to be one.
+	wantDormantSpanMin = 45 * dayT
+	// wantDormantMeetingGapMax bounds dormant's meeting spacing, which is
+	// deliberately looser than the 21-35d of the calendar-led archetypes — the
+	// archetype's shape is "it ended", not "it had a rhythm".
+	wantDormantMeetingGapMax = 120 * dayT
 
 	wantBurstEntriesMin = 5
 	wantBurstEntriesMax = 12
@@ -522,9 +529,24 @@ func TestTimelineFor_DormantShape(t *testing.T) {
 		require.LessOrEqualf(t, tl.Entries[0].Age, time.Duration(wantDormantOldestMax),
 			"oldest entry %s predates the dormant window — dormant, not prehistoric", tl.Entries[0].Age)
 
+		span := tl.Entries[0].Age - newest
+		require.GreaterOrEqualf(t, span, time.Duration(wantDormantSpanMin),
+			"dormant history is only %s deep — too shallow to be a relationship that ended", span)
+
 		counts := sourcesOf(tl)
 		require.Positivef(t, counts[SourceGCal], "dormant needs at least one meeting")
 		require.Positivef(t, counts[SourceGChat], "dormant needs at least one chat message")
+
+		// Dormant's meetings are stepped across the window rather than held to the
+		// 21-35d rhythm of the live archetypes, so the gap is bounded by the window
+		// itself. Unbounded is the thing to avoid, not wide.
+		meetings := entriesFrom(tl, SourceGCal)
+		for i := 1; i < len(meetings); i++ {
+			gap := meetings[i-1].Age - meetings[i].Age
+			require.Positivef(t, gap, "dormant meeting %d does not advance", i)
+			require.LessOrEqualf(t, gap, time.Duration(wantDormantMeetingGapMax),
+				"dormant meeting gap %s exceeds the dormant window", gap)
+		}
 	}
 }
 
@@ -564,6 +586,16 @@ func TestTimelineFor_BurstThenQuietShape(t *testing.T) {
 			require.False(t, members[1].Outbound)
 		}
 
+		// The conversation CLOSES with that pair: its two entries are the newest
+		// two in the timeline. Without this, a filler entry drifting newer than the
+		// pair would leave the archetype still reporting one well-formed pair and a
+		// legal cluster width, having quietly stopped being "burst then quiet".
+		last := tl.Entries[len(tl.Entries)-1]
+		secondLast := tl.Entries[len(tl.Entries)-2]
+		require.NotZero(t, last.PairKey, "the newest entry is not part of the closing pair")
+		require.Equalf(t, last.PairKey, secondLast.PairKey,
+			"the two newest entries are not the closing pair (%d, %d)", secondLast.PairKey, last.PairKey)
+
 		directions := map[bool]int{}
 		for _, e := range tl.Entries {
 			directions[e.Outbound]++
@@ -593,10 +625,17 @@ func maxWithinWindow(entries []TimelineEntry, window time.Duration) int {
 	return best
 }
 
-// TestTimelineFor_MailEntriesStayInsideProviderReach pins the span bound. The
-// Gmail provider reaches a bounded window forward from one sync's backfill point
-// and SILENTLY drops anything past it — a missing row and a gate timeout naming
-// the wrong cause — which is why deep history is carried by the calendar.
+// TestTimelineFor_MailEntriesStayInsideProviderReach pins the span bound FOR ONE
+// TIMELINE. The Gmail provider reaches a bounded window forward from one sync's
+// backfill point and SILENTLY drops anything past it — a missing row and a gate
+// timeout naming the wrong cause — which is why deep history is carried by the
+// calendar.
+//
+// The scope matters and is easy to misread: the replay layer's limit applies to
+// a whole BATCH, over every instant in it across all contacts, whereas what a
+// timeline can promise is per contact. Pooled across archetypes, mail spans up
+// to 179d against a 150d limit, so a caller batching mail across contacts must
+// bucket by age — see addPairsBetweenMeetings for that arithmetic.
 func TestTimelineFor_MailEntriesStayInsideProviderReach(t *testing.T) {
 	t.Parallel()
 
@@ -613,6 +652,131 @@ func TestTimelineFor_MailEntriesStayInsideProviderReach(t *testing.T) {
 		}
 	}
 	require.Positive(t, checked, "no mail entries were exercised")
+}
+
+// TestTimelineFor_MessagingConversationAgesAreDistinct pins, for EVERY entry of a
+// shared messaging conversation, the property the pair rule only pins for the
+// two members of a pair: no two ages may coincide. Messaging sources order
+// eligible rows by sent_at alone and the aggregation engine's sort is stable
+// relative to an unspecified DB order, so two messages at the same instant in
+// one conversation leave their order to a tie-break the database is free to
+// resolve either way — which is the nondeterminism this whole timing design
+// exists to remove. burst-then-quiet puts five to twelve entries in one
+// conversation, so the guarantee has to hold beyond the pair.
+//
+// Today it holds by arithmetic (opening stride, filler step, pair placement).
+// This makes it hold by assertion, so a future bound change that collided two
+// ages fails here instead of shipping.
+func TestTimelineFor_MessagingConversationAgesAreDistinct(t *testing.T) {
+	t.Parallel()
+
+	messaging := map[Source]bool{SourceGChat: true, SourceTelegram: true, SourceMessages: true}
+	checked := 0
+	for _, caps := range []MethodSet{emailCaps, telegramCaps, phoneCaps, fullCaps} {
+		for _, a := range allArchetypes {
+			for _, tl := range timelineSamples(t, a, caps, 16) {
+				seen := map[int]map[time.Duration]bool{}
+				for i, e := range tl.Entries {
+					if e.ConversationKey == 0 || !messaging[e.Source] {
+						continue
+					}
+					ages, ok := seen[e.ConversationKey]
+					if !ok {
+						ages = map[time.Duration]bool{}
+						seen[e.ConversationKey] = ages
+					}
+					require.Falsef(t, ages[e.Age],
+						"%s entry %d repeats age %s inside conversation %d — the order of the two would fall to a DB tie-break",
+						a, i, e.Age, e.ConversationKey)
+					ages[e.Age] = true
+					checked++
+				}
+			}
+		}
+	}
+	require.Positive(t, checked, "no shared messaging conversations were exercised")
+}
+
+// TestTimelineFor_ChatOnlyTargetsHoldOneConversation pins the other half of that
+// rule. A contact has ONE private chat with you, so every chat exchange a
+// timeline emits for a calendar-less target belongs to the same conversation;
+// two would ask the replay layer to mint two separate private chats with the
+// same person.
+func TestTimelineFor_ChatOnlyTargetsHoldOneConversation(t *testing.T) {
+	t.Parallel()
+
+	// Archetypes whose history is two-way, and therefore chat-carried when the
+	// target has no calendar. The one-sided archetypes deliberately use distinct
+	// conversations so nothing can bridge.
+	twoWay := []Archetype{ArchetypeMutualRegular, ArchetypeMutualDrifting, ArchetypeDormant, ArchetypeBurstThenQuiet}
+	for _, caps := range []MethodSet{telegramCaps, phoneCaps} {
+		for _, a := range twoWay {
+			for _, tl := range timelineSamples(t, a, caps, 16) {
+				keys := map[int]bool{}
+				for _, e := range tl.Entries {
+					keys[e.ConversationKey] = true
+				}
+				require.Lenf(t, keys, 1, "%s gave a chat-only target %d conversations", a, len(keys))
+				require.NotContains(t, keys, 0, "%s left a chat exchange outside a conversation", a)
+			}
+		}
+	}
+}
+
+// TestTimelineFor_CalendarEntriesAreNeverGrouped pins the seam property that
+// makes the batch layer's calendar item type safe without a pair field: a
+// matched calendar event is always mutual, so it is never half of a promotion
+// pair and never part of a conversation. The grouping guards elsewhere catch a
+// violation only incidentally — a construction that produced a calendar pair
+// with genuinely differing directions would slip past all of them.
+func TestTimelineFor_CalendarEntriesAreNeverGrouped(t *testing.T) {
+	t.Parallel()
+
+	checked := 0
+	for _, a := range allArchetypes {
+		for _, tl := range timelineSamples(t, a, emailCaps, sampleCount) {
+			for i, e := range tl.Entries {
+				if e.Source != SourceGCal {
+					continue
+				}
+				require.Zerof(t, e.PairKey, "%s calendar entry %d carries a PairKey", a, i)
+				require.Zerof(t, e.ConversationKey, "%s calendar entry %d carries a ConversationKey", a, i)
+				checked++
+			}
+		}
+	}
+	require.Positive(t, checked, "no calendar entries were exercised")
+}
+
+// TestTimelineFor_OneSidedHistoryPrefersMail pins the other half of the source
+// resolution. One-sided history rides the threaded mail source whenever the
+// target has one — even for a contact whose two-way conversation rides telegram
+// — because a thread is the better carrier for correspondence that never got a
+// reply. Only the chat half of the resolution was pinned before.
+func TestTimelineFor_OneSidedHistoryPrefersMail(t *testing.T) {
+	t.Parallel()
+
+	oneSided := []Archetype{ArchetypeOutboundHeavy, ArchetypeInboundOnly}
+	cases := []struct {
+		caps MethodSet
+		want Source
+	}{
+		{fullCaps, SourceEmail},
+		{MethodSet{Email: true, Telegram: true}, SourceEmail},
+		{MethodSet{Email: true, Phone: true}, SourceEmail},
+		{telegramCaps, SourceTelegram},
+		{phoneCaps, SourceMessages},
+	}
+	for _, tc := range cases {
+		for _, a := range oneSided {
+			for _, tl := range timelineSamples(t, a, tc.caps, 8) {
+				require.NotEmpty(t, tl.Entries)
+				for _, e := range tl.Entries {
+					require.Equalf(t, tc.want, e.Source, "%s at caps %+v rode %q", a, tc.caps, e.Source)
+				}
+			}
+		}
+	}
 }
 
 // --- determinism and variation ----------------------------------------------

--- a/backend/internal/synthetic/factory/archetype_test.go
+++ b/backend/internal/synthetic/factory/archetype_test.go
@@ -1,0 +1,808 @@
+package factory
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/cadence"
+
+	"github.com/stretchr/testify/require"
+)
+
+// updateArchetypeGolden regenerates the committed per-archetype snapshot from the
+// CURRENT generator output (run with `-update`). Off by default so a normal run
+// asserts against the committed file and fails loudly on any drift the range
+// assertions are too loose to notice.
+var updateArchetypeGolden = flag.Bool("update", false, "regenerate the archetype golden snapshot")
+
+const archetypeGoldenPath = "testdata/archetype_golden.txt"
+
+// archetypeAnchor is the pinned anchor for these tests. Timelines are
+// anchor-relative durations, so its value only matters where a test resolves an
+// age into an instant.
+var archetypeAnchor = time.Date(2026, time.March, 4, 9, 30, 0, 0, time.UTC)
+
+// allArchetypes is the closed catalog, in a fixed order so table-driven tests and
+// the golden snapshot are stable.
+var allArchetypes = []Archetype{
+	ArchetypeMutualRegular,
+	ArchetypeMutualDrifting,
+	ArchetypeOutboundHeavy,
+	ArchetypeInboundOnly,
+	ArchetypeDormant,
+	ArchetypeBurstThenQuiet,
+	ArchetypeNeverContacted,
+}
+
+// rangedArchetypes are the six that produce history; never-contacted is excluded
+// wherever a test is about the SHAPE of a history.
+var rangedArchetypes = allArchetypes[:len(allArchetypes)-1]
+
+// The archetype parameter table, restated as LITERALS.
+//
+// The structural assertions below deliberately do NOT read the implementation's
+// own constants. An assertion written against the constant it exists to guard
+// moves with that constant, so widening a bound would silently widen its own
+// test — a gate that cannot fail. These values are the documented table; editing
+// one is a deliberate decision about what the seeded world looks like, and it
+// should have to be made twice.
+const (
+	dayT = 24 * time.Hour
+
+	wantMeetingGapMin = 21 * dayT
+	wantMeetingGapMax = 35 * dayT
+
+	wantRegularEntriesMin  = 6
+	wantRegularEntriesMax  = 10
+	wantRegularNewestMin   = 3 * dayT
+	wantRegularNewestMax   = 14 * dayT
+	wantRegularMeetingsMin = 7
+	wantRegularMeetingsMax = 8
+	wantRegularSpanMin     = 180 * dayT
+	wantRegularSpanMax     = 270 * dayT
+
+	wantDriftingEntriesMin = 5
+	wantDriftingEntriesMax = 8
+	wantDriftingNewestMin  = 70 * dayT
+	wantDriftingNewestMax  = 112 * dayT
+
+	wantOutboundEntriesMin = 3
+	wantOutboundEntriesMax = 6
+	wantOutboundNewestMin  = 2 * dayT
+	wantOutboundNewestMax  = 20 * dayT
+
+	wantInboundEntriesMin = 2
+	wantInboundEntriesMax = 5
+	wantInboundNewestMin  = 1 * dayT
+	wantInboundNewestMax  = 15 * dayT
+
+	wantDormantEntriesMin = 4
+	wantDormantEntriesMax = 9
+	wantDormantNewestMin  = 120 * dayT
+	wantDormantOldestMax  = 240 * dayT
+
+	wantBurstEntriesMin = 5
+	wantBurstEntriesMax = 12
+	wantBurstNewestMin  = 30 * dayT
+	wantBurstNewestMax  = 90 * dayT
+	wantBurstWidthMin   = 2 * dayT
+	wantBurstWidthMax   = 5 * dayT
+	// wantBurstWindow is the aggregation burst window the archetype exists to
+	// exercise; at least two of its messages must fall inside one.
+	wantBurstWindow = 2 * time.Hour
+
+	// wantMessagingPairGap is the deterministic offset between the halves of a
+	// messaging promotion pair, outbound strictly older.
+	wantMessagingPairGap = 6 * time.Hour
+
+	// wantMailMaxSpan is how far one Gmail sync reaches; mail entries past it are
+	// silently dropped by the provider.
+	wantMailMaxSpan = 150 * dayT
+)
+
+var (
+	emailCaps    = MethodSet{Email: true}
+	telegramCaps = MethodSet{Telegram: true}
+	phoneCaps    = MethodSet{Phone: true}
+	fullCaps     = MethodSet{Email: true, Telegram: true, Phone: true}
+)
+
+// timelineSamples draws one timeline per namespace, each from a FRESH generator,
+// so every sample sits at the same draw position and differs only by namespace
+// jitter. That is the shape a seed profile produces (one call per contact) and it
+// gives the structural assertions a population rather than a single point.
+func timelineSamples(t *testing.T, a Archetype, caps MethodSet, n int) []Timeline {
+	t.Helper()
+	out := make([]Timeline, 0, n)
+	for i := 0; i < n; i++ {
+		g := NewGeneratorAt(DefaultSeed, fmt.Sprintf("arch%02d", i), archetypeAnchor)
+		out = append(out, g.TimelineFor(a, caps))
+	}
+	return out
+}
+
+const sampleCount = 64
+
+// --- source families --------------------------------------------------------
+
+func sourcesOf(tl Timeline) map[Source]int {
+	out := map[Source]int{}
+	for _, e := range tl.Entries {
+		out[e.Source]++
+	}
+	return out
+}
+
+func entriesFrom(tl Timeline, src Source) []TimelineEntry {
+	var out []TimelineEntry
+	for _, e := range tl.Entries {
+		if e.Source == src {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func pairGroups(tl Timeline) map[int][]TimelineEntry {
+	out := map[int][]TimelineEntry{}
+	for _, e := range tl.Entries {
+		if e.PairKey == 0 {
+			continue
+		}
+		out[e.PairKey] = append(out[e.PairKey], e)
+	}
+	return out
+}
+
+// --- method awareness -------------------------------------------------------
+
+// An unmatchable source does not produce an interaction — it produces a stranded
+// row and a gate timeout that blames the wrong thing. These three tests are what
+// make that impossible by construction rather than by convention.
+
+func TestTimelineFor_EmailCapsEmitOnlyEmailMatchableSources(t *testing.T) {
+	t.Parallel()
+
+	allowed := map[Source]bool{SourceGCal: true, SourceEmail: true, SourceGChat: true}
+	for _, a := range allArchetypes {
+		for _, tl := range timelineSamples(t, a, emailCaps, sampleCount) {
+			for _, e := range tl.Entries {
+				require.Truef(t, allowed[e.Source],
+					"%s emitted %q for an email-only target (allowed: gcal/email/gchat)", a, e.Source)
+			}
+		}
+	}
+}
+
+func TestTimelineFor_EmptyMethodSetYieldsEmptyTimeline(t *testing.T) {
+	t.Parallel()
+
+	for _, a := range allArchetypes {
+		for _, tl := range timelineSamples(t, a, MethodSet{}, 8) {
+			require.NotNil(t, tl.Entries, "%s: empty caps must still yield a non-nil slice", a)
+			require.Emptyf(t, tl.Entries, "%s emitted %d entries for a target with no contact methods", a, len(tl.Entries))
+		}
+	}
+}
+
+func TestTimelineFor_TelegramCapsNeverEmitEmailOrCalendar(t *testing.T) {
+	t.Parallel()
+
+	for _, a := range rangedArchetypes {
+		nonEmpty := 0
+		for _, tl := range timelineSamples(t, a, telegramCaps, sampleCount) {
+			for _, e := range tl.Entries {
+				require.Equalf(t, SourceTelegram, e.Source,
+					"%s emitted %q for a telegram-only target", a, e.Source)
+			}
+			if len(tl.Entries) > 0 {
+				nonEmpty++
+			}
+		}
+		// A telegram-only contact is seeded deliberately, to get telegram coverage.
+		// Degrading its history to nothing would satisfy the source restriction
+		// above while silently removing the coverage it exists for.
+		require.Equalf(t, sampleCount, nonEmpty, "%s produced an empty timeline for a telegram-only target", a)
+	}
+}
+
+func TestTimelineFor_PhoneCapsEmitOnlyMessages(t *testing.T) {
+	t.Parallel()
+
+	for _, a := range rangedArchetypes {
+		for _, tl := range timelineSamples(t, a, phoneCaps, sampleCount) {
+			require.NotEmptyf(t, tl.Entries, "%s produced an empty timeline for a phone-only target", a)
+			for _, e := range tl.Entries {
+				require.Equalf(t, SourceMessages, e.Source, "%s emitted %q for a phone-only target", a, e.Source)
+			}
+		}
+	}
+}
+
+// TestTimelineFor_ChatRolePrefersDeliberateSources pins the resolution order. A
+// contact only carries a telegram handle or a phone because someone wanted that
+// source exercised; every email-bearing contact would otherwise fall to GChat and
+// the other two would never be reached from a mixed-method target.
+func TestTimelineFor_ChatRolePrefersDeliberateSources(t *testing.T) {
+	t.Parallel()
+
+	for _, tl := range timelineSamples(t, ArchetypeBurstThenQuiet, fullCaps, 8) {
+		for _, e := range tl.Entries {
+			require.Equal(t, SourceTelegram, e.Source, "a telegram-bearing target's burst must ride telegram")
+		}
+	}
+	for _, tl := range timelineSamples(t, ArchetypeBurstThenQuiet, MethodSet{Email: true, Phone: true}, 8) {
+		for _, e := range tl.Entries {
+			require.Equal(t, SourceMessages, e.Source, "a phone-bearing target's burst must ride messages")
+		}
+	}
+}
+
+// --- ordering and basic well-formedness -------------------------------------
+
+func TestTimelineFor_OldestFirstWithNonNegativeAges(t *testing.T) {
+	t.Parallel()
+
+	for _, caps := range []MethodSet{emailCaps, telegramCaps, phoneCaps, fullCaps} {
+		for _, a := range allArchetypes {
+			for _, tl := range timelineSamples(t, a, caps, 16) {
+				for i, e := range tl.Entries {
+					require.GreaterOrEqualf(t, e.Age, time.Duration(0), "%s entry %d has a negative age", a, i)
+					if i == 0 {
+						continue
+					}
+					require.LessOrEqualf(t, e.Age, tl.Entries[i-1].Age,
+						"%s entries are not oldest-first: entry %d (%s) is older than entry %d (%s)",
+						a, i, e.Age, i-1, tl.Entries[i-1].Age)
+				}
+			}
+		}
+	}
+}
+
+func TestTimelineFor_NeverContactedIsEmptyButNotNil(t *testing.T) {
+	t.Parallel()
+
+	for _, caps := range []MethodSet{emailCaps, telegramCaps, phoneCaps, fullCaps} {
+		for _, tl := range timelineSamples(t, ArchetypeNeverContacted, caps, 8) {
+			require.NotNil(t, tl.Entries, "a nil slice would make no-history indistinguishable from a bug")
+			require.Empty(t, tl.Entries)
+			require.Equal(t, ArchetypeNeverContacted, tl.Archetype)
+		}
+	}
+}
+
+func TestTimelineFor_ArchetypeIsEchoed(t *testing.T) {
+	t.Parallel()
+
+	for _, a := range allArchetypes {
+		for _, tl := range timelineSamples(t, a, emailCaps, 4) {
+			require.Equal(t, a, tl.Archetype)
+		}
+	}
+}
+
+// --- promotion pairs --------------------------------------------------------
+
+// TestTimelineFor_PairGroupsAreWellFormed pins the shape the batch replay
+// partition is defined on: exactly two members with differing directions, both
+// inside one conversation, outbound first in slice order. A reversed group would
+// silently fail to promote at replay time and land two one-sided interactions.
+func TestTimelineFor_PairGroupsAreWellFormed(t *testing.T) {
+	t.Parallel()
+
+	for _, caps := range []MethodSet{emailCaps, telegramCaps, phoneCaps, fullCaps} {
+		for _, a := range allArchetypes {
+			for _, tl := range timelineSamples(t, a, caps, 16) {
+				groups := pairGroups(tl)
+				for key, members := range groups {
+					require.Lenf(t, members, 2, "%s PairKey %d has %d members", a, key, len(members))
+					require.NotEqualf(t, members[0].Outbound, members[1].Outbound,
+						"%s PairKey %d members share a direction", a, key)
+					require.Truef(t, members[0].Outbound, "%s PairKey %d does not put its outbound half first", a, key)
+					require.NotZerof(t, members[0].ConversationKey, "%s PairKey %d is not inside a conversation", a, key)
+					require.Equalf(t, members[0].ConversationKey, members[1].ConversationKey,
+						"%s PairKey %d spans two conversations", a, key)
+				}
+			}
+		}
+	}
+}
+
+// TestTimelineFor_ThreadPairsShareOneInstant pins the Gmail timing rule. Gmail's
+// aggregation key includes a LOCAL day, so the assertion that matters is about
+// the resolved local dates, not about a gap bound.
+func TestTimelineFor_ThreadPairsShareOneInstant(t *testing.T) {
+	t.Parallel()
+
+	checked := 0
+	for _, a := range rangedArchetypes {
+		for _, tl := range timelineSamples(t, a, emailCaps, sampleCount) {
+			for key, members := range pairGroups(tl) {
+				if members[0].Source != SourceEmail {
+					continue
+				}
+				require.Equalf(t, members[0].Age, members[1].Age,
+					"%s mail PairKey %d does not share an instant (%s vs %s)", a, key, members[0].Age, members[1].Age)
+				checked++
+			}
+		}
+	}
+	require.Positive(t, checked, "no mail promotion pairs were exercised")
+}
+
+// TestTimelineFor_ThreadPairsLandOnOneLocalDay resolves the pair's ages into
+// instants across a 48-hour anchor sweep and asserts the ACTUAL local dates are
+// equal — proving the same-local-day property directly rather than inferring it.
+// The counterfactual half is what gives the test teeth: a twelve-hour gap, which
+// "under 24 hours" would have permitted, straddles local midnight for some
+// anchors in the same sweep.
+func TestTimelineFor_ThreadPairsLandOnOneLocalDay(t *testing.T) {
+	t.Parallel()
+
+	// The replay layer dates a mail payload at anchor - providerLag - age. The lag
+	// is constant across a pair, so only the ages matter; it is modelled here so
+	// the resolved instants are the ones the pipeline would actually see.
+	const providerLag = 2 * time.Hour
+	resolve := func(anchor time.Time, age time.Duration) time.Time {
+		return anchor.Add(-providerLag - age).Local()
+	}
+
+	straddled := 0
+	pairsChecked := 0
+	for hour := 0; hour < 48; hour++ {
+		anchor := time.Date(2026, time.March, 4, 0, 0, 0, 0, time.UTC).Add(time.Duration(hour) * time.Hour)
+		for i := 0; i < 12; i++ {
+			g := NewGeneratorAt(DefaultSeed, fmt.Sprintf("localday%02d", i), anchor)
+			tl := g.TimelineFor(ArchetypeMutualRegular, emailCaps)
+			for key, members := range pairGroups(tl) {
+				if members[0].Source != SourceEmail {
+					continue
+				}
+				gotY, gotM, gotD := resolve(anchor, members[0].Age).Date()
+				wantY, wantM, wantD := resolve(anchor, members[1].Age).Date()
+				require.Equalf(t, [3]int{wantY, int(wantM), wantD}, [3]int{gotY, int(gotM), gotD},
+					"mail PairKey %d resolved onto two local days at anchor %s", key, anchor)
+				pairsChecked++
+
+				// Counterfactual: the rejected "small gap" formulation.
+				aY, aM, aD := resolve(anchor, members[0].Age).Date()
+				bY, bM, bD := resolve(anchor, members[0].Age-12*time.Hour).Date()
+				if [3]int{aY, int(aM), aD} != [3]int{bY, int(bM), bD} {
+					straddled++
+				}
+			}
+		}
+	}
+	require.Positive(t, pairsChecked, "no mail pairs were resolved")
+	require.Positivef(t, straddled,
+		"the 12h-gap counterfactual never straddled local midnight across the sweep — this test cannot detect the failure it exists for")
+}
+
+// TestTimelineFor_MessagingPairsUseADeterministicGap pins the other half of the
+// timing rule. Messaging sources order eligible rows only by sent_at and the
+// engine's sort is stable relative to an unspecified DB order, so an equal-aged
+// pair could nondeterministically become one mutual or two one-sided sessions.
+func TestTimelineFor_MessagingPairsUseADeterministicGap(t *testing.T) {
+	t.Parallel()
+
+	messaging := map[Source]bool{SourceGChat: true, SourceTelegram: true, SourceMessages: true}
+	checked := 0
+	for _, caps := range []MethodSet{emailCaps, telegramCaps, phoneCaps, fullCaps} {
+		for _, a := range rangedArchetypes {
+			for _, tl := range timelineSamples(t, a, caps, 16) {
+				for key, members := range pairGroups(tl) {
+					if !messaging[members[0].Source] {
+						continue
+					}
+					require.NotEqualf(t, members[0].Age, members[1].Age,
+						"%s messaging PairKey %d is equal-aged, which leaves its order to a DB tie-break", a, key)
+					require.Equalf(t, time.Duration(wantMessagingPairGap), members[0].Age-members[1].Age,
+						"%s messaging PairKey %d gap is %s, want %s", a, key, members[0].Age-members[1].Age, time.Duration(wantMessagingPairGap))
+					require.Truef(t, members[0].Outbound, "%s messaging PairKey %d: the older half must be the outbound one", a, key)
+					checked++
+				}
+			}
+		}
+	}
+	require.Positive(t, checked, "no messaging promotion pairs were exercised")
+}
+
+// --- per-archetype structure ------------------------------------------------
+
+func TestTimelineFor_MutualRegularShape(t *testing.T) {
+	t.Parallel()
+
+	pairCounts := map[int]bool{}
+	for _, tl := range timelineSamples(t, ArchetypeMutualRegular, emailCaps, sampleCount) {
+		require.GreaterOrEqual(t, len(tl.Entries), wantRegularEntriesMin)
+		require.LessOrEqual(t, len(tl.Entries), wantRegularEntriesMax)
+		require.GreaterOrEqual(t, tl.Entries[len(tl.Entries)-1].Age, time.Duration(wantRegularNewestMin))
+		require.LessOrEqual(t, tl.Entries[len(tl.Entries)-1].Age, time.Duration(wantRegularNewestMax))
+
+		meetings := entriesFrom(tl, SourceGCal)
+		require.GreaterOrEqual(t, len(meetings), wantRegularMeetingsMin)
+		require.LessOrEqual(t, len(meetings), wantRegularMeetingsMax)
+
+		// Consecutive meeting spacing, and the total span it sums to.
+		for i := 1; i < len(meetings); i++ {
+			gap := meetings[i-1].Age - meetings[i].Age
+			require.GreaterOrEqualf(t, gap, time.Duration(wantMeetingGapMin), "meeting gap %s below the spacing floor", gap)
+			require.LessOrEqualf(t, gap, time.Duration(wantMeetingGapMax), "meeting gap %s above the spacing ceiling", gap)
+		}
+		span := meetings[0].Age - meetings[len(meetings)-1].Age
+		require.GreaterOrEqualf(t, span, time.Duration(wantRegularSpanMin), "calendar span %s is under six months", span)
+		require.LessOrEqualf(t, span, time.Duration(wantRegularSpanMax), "calendar span %s is over nine months", span)
+
+		groups := pairGroups(tl)
+		require.GreaterOrEqual(t, len(groups), 1)
+		require.LessOrEqual(t, len(groups), 2)
+		pairCounts[len(groups)] = true
+	}
+	require.Equal(t, map[int]bool{1: true}, pairCounts,
+		"mutual-regular carries exactly one correspondence pair — two would need more meetings than its entry budget allows")
+}
+
+func TestTimelineFor_MutualDriftingShape(t *testing.T) {
+	t.Parallel()
+
+	pairCounts := map[int]bool{}
+	for _, tl := range timelineSamples(t, ArchetypeMutualDrifting, emailCaps, sampleCount) {
+		require.GreaterOrEqual(t, len(tl.Entries), wantDriftingEntriesMin)
+		require.LessOrEqual(t, len(tl.Entries), wantDriftingEntriesMax)
+
+		newest := tl.Entries[len(tl.Entries)-1].Age
+		require.GreaterOrEqualf(t, newest, time.Duration(wantDriftingNewestMin), "newest entry %s breaks the drifting overdue floor", newest)
+		require.LessOrEqualf(t, newest, time.Duration(wantDriftingNewestMax), "newest entry %s is older than sixteen weeks", newest)
+
+		meetings := entriesFrom(tl, SourceGCal)
+		require.GreaterOrEqual(t, len(meetings), 3, "a series needs enough meetings for its spacing to mean anything")
+		for i := 1; i < len(meetings); i++ {
+			gap := meetings[i-1].Age - meetings[i].Age
+			require.GreaterOrEqual(t, gap, time.Duration(wantMeetingGapMin))
+			require.LessOrEqual(t, gap, time.Duration(wantMeetingGapMax))
+		}
+
+		groups := pairGroups(tl)
+		require.GreaterOrEqual(t, len(groups), 1)
+		require.LessOrEqual(t, len(groups), 2)
+		pairCounts[len(groups)] = true
+	}
+	require.Equal(t, map[int]bool{1: true, 2: true}, pairCounts,
+		"mutual-drifting must exercise both one and two correspondence pairs")
+}
+
+func TestTimelineFor_OneSidedArchetypesCannotPromote(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		archetype Archetype
+		outbound  bool
+		countMin  int
+		countMax  int
+		newestMin time.Duration
+		newestMax time.Duration
+	}{
+		{ArchetypeOutboundHeavy, true, wantOutboundEntriesMin, wantOutboundEntriesMax, wantOutboundNewestMin, wantOutboundNewestMax},
+		{ArchetypeInboundOnly, false, wantInboundEntriesMin, wantInboundEntriesMax, wantInboundNewestMin, wantInboundNewestMax},
+	}
+	for _, tc := range cases {
+		for _, tl := range timelineSamples(t, tc.archetype, emailCaps, sampleCount) {
+			require.GreaterOrEqual(t, len(tl.Entries), tc.countMin)
+			require.LessOrEqual(t, len(tl.Entries), tc.countMax)
+
+			newest := tl.Entries[len(tl.Entries)-1].Age
+			require.GreaterOrEqual(t, newest, tc.newestMin)
+			require.LessOrEqual(t, newest, tc.newestMax)
+
+			for i, e := range tl.Entries {
+				require.Equalf(t, tc.outbound, e.Outbound, "%s entry %d has the wrong direction", tc.archetype, i)
+				require.Zerof(t, e.PairKey, "%s entry %d is paired — it must not be able to promote", tc.archetype, i)
+				require.Zerof(t, e.ConversationKey, "%s entry %d shares a conversation — it must not be able to promote", tc.archetype, i)
+			}
+		}
+	}
+}
+
+func TestTimelineFor_DormantShape(t *testing.T) {
+	t.Parallel()
+
+	for _, tl := range timelineSamples(t, ArchetypeDormant, emailCaps, sampleCount) {
+		require.GreaterOrEqual(t, len(tl.Entries), wantDormantEntriesMin)
+		require.LessOrEqual(t, len(tl.Entries), wantDormantEntriesMax)
+
+		newest := tl.Entries[len(tl.Entries)-1].Age
+		require.GreaterOrEqualf(t, newest, time.Duration(wantDormantNewestMin), "newest entry %s breaks the dormant overdue floor", newest)
+		require.LessOrEqualf(t, tl.Entries[0].Age, time.Duration(wantDormantOldestMax),
+			"oldest entry %s predates the dormant window — dormant, not prehistoric", tl.Entries[0].Age)
+
+		counts := sourcesOf(tl)
+		require.Positivef(t, counts[SourceGCal], "dormant needs at least one meeting")
+		require.Positivef(t, counts[SourceGChat], "dormant needs at least one chat message")
+	}
+}
+
+func TestTimelineFor_BurstThenQuietShape(t *testing.T) {
+	t.Parallel()
+
+	for _, tl := range timelineSamples(t, ArchetypeBurstThenQuiet, emailCaps, sampleCount) {
+		require.GreaterOrEqual(t, len(tl.Entries), wantBurstEntriesMin)
+		require.LessOrEqual(t, len(tl.Entries), wantBurstEntriesMax)
+
+		newest := tl.Entries[len(tl.Entries)-1].Age
+		require.GreaterOrEqual(t, newest, time.Duration(wantBurstNewestMin))
+		require.LessOrEqual(t, newest, time.Duration(wantBurstNewestMax))
+
+		// ONE conversation, and the entry set IS the cluster — there is no entry
+		// outside it, which is what "then quiet" means.
+		conv := tl.Entries[0].ConversationKey
+		require.NotZero(t, conv, "a zero key would give every message its own space: unrelated interactions, no burst")
+		for i, e := range tl.Entries {
+			require.Equalf(t, conv, e.ConversationKey, "entry %d left the burst's conversation", i)
+			require.Equal(t, SourceGChat, e.Source)
+		}
+
+		width := tl.Entries[0].Age - newest
+		require.GreaterOrEqualf(t, width, time.Duration(wantBurstWidthMin), "cluster width %s is too tight", width)
+		require.LessOrEqualf(t, width, time.Duration(wantBurstWidthMax), "cluster width %s is not a cluster", width)
+
+		// At least two messages inside ONE aggregation burst window. A cluster
+		// spread evenly over days would land N separate sessions instead.
+		require.GreaterOrEqual(t, maxWithinWindow(tl.Entries, wantBurstWindow), 2,
+			"no two messages fall inside a single 2h burst window")
+
+		groups := pairGroups(tl)
+		require.Len(t, groups, 1, "the burst promotes through exactly one pair")
+		for _, members := range groups {
+			require.True(t, members[0].Outbound)
+			require.False(t, members[1].Outbound)
+		}
+
+		directions := map[bool]int{}
+		for _, e := range tl.Entries {
+			directions[e.Outbound]++
+		}
+		require.Positive(t, directions[true], "the burst must be mixed-direction")
+		require.Positive(t, directions[false], "the burst must be mixed-direction")
+	}
+}
+
+// maxWithinWindow returns the largest number of entries whose ages all fall
+// inside one window of the given length.
+func maxWithinWindow(entries []TimelineEntry, window time.Duration) int {
+	ages := make([]time.Duration, len(entries))
+	for i, e := range entries {
+		ages[i] = e.Age
+	}
+	sort.Slice(ages, func(i, k int) bool { return ages[i] < ages[k] })
+	best, start := 0, 0
+	for end := range ages {
+		for ages[end]-ages[start] > window {
+			start++
+		}
+		if n := end - start + 1; n > best {
+			best = n
+		}
+	}
+	return best
+}
+
+// TestTimelineFor_MailEntriesStayInsideProviderReach pins the span bound. The
+// Gmail provider reaches a bounded window forward from one sync's backfill point
+// and SILENTLY drops anything past it — a missing row and a gate timeout naming
+// the wrong cause — which is why deep history is carried by the calendar.
+func TestTimelineFor_MailEntriesStayInsideProviderReach(t *testing.T) {
+	t.Parallel()
+
+	checked := 0
+	for _, a := range allArchetypes {
+		for _, tl := range timelineSamples(t, a, emailCaps, sampleCount) {
+			mail := entriesFrom(tl, SourceEmail)
+			if len(mail) == 0 {
+				continue
+			}
+			span := mail[0].Age - mail[len(mail)-1].Age
+			require.LessOrEqualf(t, span, time.Duration(wantMailMaxSpan), "%s mail entries span %s, past one sync's reach", a, span)
+			checked++
+		}
+	}
+	require.Positive(t, checked, "no mail entries were exercised")
+}
+
+// --- determinism and variation ----------------------------------------------
+
+func TestTimelineFor_DeterministicForOneSeedNamespaceAndPosition(t *testing.T) {
+	t.Parallel()
+
+	for _, a := range allArchetypes {
+		gA := NewGeneratorAt(DefaultSeed, "determinism", archetypeAnchor)
+		gB := NewGeneratorAt(DefaultSeed, "determinism", archetypeAnchor)
+		require.Equal(t, gA.TimelineFor(a, emailCaps), gB.TimelineFor(a, emailCaps), "%s is not reproducible", a)
+
+		// Same generators, one draw further along: still in lockstep with each
+		// other, which is the property a seed profile relies on.
+		require.Equal(t, gA.TimelineFor(a, emailCaps), gB.TimelineFor(a, emailCaps), "%s drifts at the second draw position", a)
+	}
+}
+
+func TestTimelineFor_DistinctNamespacesDrawDistinctJitter(t *testing.T) {
+	t.Parallel()
+
+	for _, a := range rangedArchetypes {
+		gA := NewGeneratorAt(DefaultSeed, "nsA", archetypeAnchor)
+		gB := NewGeneratorAt(DefaultSeed, "nsB", archetypeAnchor)
+		require.NotEqual(t, gA.TimelineFor(a, emailCaps), gB.TimelineFor(a, emailCaps),
+			"%s produced identical timelines for two namespaces", a)
+	}
+}
+
+// TestTimelineFor_MultiSampleVariation is what makes "enough samples at varied
+// points" mechanically checkable at this layer. One sample cannot demonstrate
+// jitter by construction, so the assertion is that two draws from the SAME
+// generator differ in a way a reader would notice: entry count or newest age.
+func TestTimelineFor_MultiSampleVariation(t *testing.T) {
+	t.Parallel()
+
+	for _, a := range rangedArchetypes {
+		g := NewGeneratorAt(DefaultSeed, "variation", archetypeAnchor)
+		first := g.TimelineFor(a, emailCaps)
+		second := g.TimelineFor(a, emailCaps)
+
+		countDiffers := len(first.Entries) != len(second.Entries)
+		newestDiffers := first.Entries[len(first.Entries)-1].Age != second.Entries[len(second.Entries)-1].Age
+		require.Truef(t, countDiffers || newestDiffers,
+			"%s: two draws produced the same entry count (%d) and the same newest age (%s) — the jitter is not observable",
+			a, len(first.Entries), first.Entries[len(first.Entries)-1].Age)
+	}
+}
+
+// --- overdue floors at PRODUCTION cadence durations -------------------------
+
+// Cadence durations are environment-dependent: under CRM_ENV=test/testing annual
+// is two hours and every archetype is trivially overdue, so a floor asserted
+// under the ambient integration environment proves nothing. These tests pin the
+// production table in BOTH directions — the cadences the archetype stays overdue
+// on, and the ones where it silently becomes contacted-but-not-overdue.
+func TestTimelineFor_OverdueFloorsUnderProductionCadences(t *testing.T) {
+	t.Setenv("CRM_ENV", "production")
+
+	cases := []struct {
+		archetype    Archetype
+		floor        time.Duration
+		compatible   []cadence.CadenceType
+		incompatible []cadence.CadenceType
+	}{
+		{
+			archetype:    ArchetypeMutualDrifting,
+			floor:        wantDriftingNewestMin,
+			compatible:   []cadence.CadenceType{cadence.CadenceWeekly, cadence.CadenceBiweekly, cadence.CadenceMonthly},
+			incompatible: []cadence.CadenceType{cadence.CadenceQuarterly, cadence.CadenceBiannual, cadence.CadenceAnnual},
+		},
+		{
+			archetype:    ArchetypeDormant,
+			floor:        wantDormantNewestMin,
+			compatible:   []cadence.CadenceType{cadence.CadenceWeekly, cadence.CadenceBiweekly, cadence.CadenceMonthly, cadence.CadenceQuarterly},
+			incompatible: []cadence.CadenceType{cadence.CadenceBiannual, cadence.CadenceAnnual},
+		},
+	}
+
+	for _, tc := range cases {
+		// The table is a statement about the FLOOR, because the floor is the only
+		// thing the archetype guarantees: a cadence is compatible exactly when
+		// every legal draw outlives its period. Asserting it per-sample would let
+		// a lucky draw certify a cadence the archetype cannot actually hold.
+		for _, ct := range tc.compatible {
+			period := cadence.GetCadenceDuration(ct)
+			require.Greaterf(t, tc.floor, period,
+				"%s on %s: the %s floor does not clear the %s cadence period, so a floor-hugging draw would land contacted and NOT overdue",
+				tc.archetype, ct, tc.floor, period)
+		}
+		for _, ct := range tc.incompatible {
+			period := cadence.GetCadenceDuration(ct)
+			require.LessOrEqualf(t, tc.floor, period,
+				"%s on %s: the %s floor already clears the %s cadence period, so this cadence belongs in the compatible column",
+				tc.archetype, ct, tc.floor, period)
+		}
+
+		for _, tl := range timelineSamples(t, tc.archetype, emailCaps, sampleCount) {
+			newest := tl.Entries[len(tl.Entries)-1].Age
+			require.GreaterOrEqualf(t, newest, tc.floor, "%s newest entry %s breaks its floor", tc.archetype, newest)
+
+			// Every sample therefore stays overdue on every compatible cadence.
+			for _, ct := range tc.compatible {
+				period := cadence.GetCadenceDuration(ct)
+				require.Greaterf(t, newest, period,
+					"%s on %s: newest entry %s is inside the %s cadence period, so the replayed mutual would clear the overdue state",
+					tc.archetype, ct, newest, period)
+			}
+		}
+	}
+}
+
+// TestProductionCadenceDurationsAreRead guards the test above: if the env pin
+// silently stopped working, every floor would pass against test-mode durations
+// (annual = 2h) while proving nothing.
+func TestProductionCadenceDurationsAreRead(t *testing.T) {
+	t.Setenv("CRM_ENV", "production")
+
+	require.Equal(t, time.Duration(7*dayT), cadence.GetCadenceDuration(cadence.CadenceWeekly))
+	require.Equal(t, time.Duration(90*dayT), cadence.GetCadenceDuration(cadence.CadenceQuarterly))
+	require.Equal(t, time.Duration(365*dayT), cadence.GetCadenceDuration(cadence.CadenceAnnual))
+}
+
+// --- parameter-table feasibility --------------------------------------------
+
+// TestMeetingGapBoundsAreFeasible proves the narrowed spacing range is non-empty
+// for every permitted meeting count AND that any draw inside it keeps the total
+// span within bounds. Entry count, spacing and span are not independent — the
+// span is the sum of count-1 gaps — so a count whose feasible range is empty
+// would make the archetype's own documented bounds unsatisfiable.
+func TestMeetingGapBoundsAreFeasible(t *testing.T) {
+	t.Parallel()
+
+	for count := wantRegularMeetingsMin; count <= wantRegularMeetingsMax; count++ {
+		lo, hi := meetingGapBounds(count, wantRegularSpanMin, wantRegularSpanMax)
+		require.LessOrEqualf(t, lo, hi, "meeting count %d has an empty feasible spacing range", count)
+		require.GreaterOrEqualf(t, lo, time.Duration(wantMeetingGapMin), "count %d floor %s is under the spacing floor", count, lo)
+		require.LessOrEqualf(t, hi, time.Duration(wantMeetingGapMax), "count %d ceiling %s is over the spacing ceiling", count, hi)
+
+		gaps := time.Duration(count - 1)
+		require.GreaterOrEqualf(t, gaps*lo, time.Duration(wantRegularSpanMin), "count %d at minimum spacing spans %s, under the floor", count, gaps*lo)
+		require.LessOrEqualf(t, gaps*hi, time.Duration(wantRegularSpanMax), "count %d at maximum spacing spans %s, over the ceiling", count, gaps*hi)
+	}
+}
+
+// --- golden snapshot --------------------------------------------------------
+
+// The range assertions above describe intent; a generator returning different-but
+// -legal garbage would still satisfy them. The snapshot is the drift signal that
+// does not.
+func TestTimelineFor_GoldenSnapshot(t *testing.T) {
+	live := buildArchetypeGolden()
+
+	if *updateArchetypeGolden {
+		require.NoError(t, os.MkdirAll(filepath.Dir(archetypeGoldenPath), 0o755))
+		require.NoError(t, os.WriteFile(archetypeGoldenPath, []byte(strings.Join(live, "\n")+"\n"), 0o644))
+		t.Logf("wrote %s (%d lines)", archetypeGoldenPath, len(live))
+		return
+	}
+
+	wantBytes, err := os.ReadFile(archetypeGoldenPath)
+	require.NoError(t, err, "missing snapshot — regenerate with `go test ./internal/synthetic/factory -run TestTimelineFor_GoldenSnapshot -update`")
+	want := strings.Split(strings.TrimRight(string(wantBytes), "\n"), "\n")
+	require.Equal(t, want, live,
+		"archetype timelines drifted from the committed snapshot; if the change is deliberate, regenerate with -update")
+}
+
+// buildArchetypeGolden renders every archetype under the two palettes that
+// matter — the email-only one the frozen catalog uses, and a telegram-only one
+// that exercises the no-calendar degradation — each from a fresh generator at a
+// pinned (seed, namespace, anchor).
+func buildArchetypeGolden() []string {
+	palettes := []struct {
+		label string
+		caps  MethodSet
+	}{
+		{"email", emailCaps},
+		{"telegram", telegramCaps},
+	}
+	var lines []string
+	for _, p := range palettes {
+		for _, a := range allArchetypes {
+			g := NewGeneratorAt(DefaultSeed, "archetype-golden", archetypeAnchor)
+			tl := g.TimelineFor(a, p.caps)
+			lines = append(lines, fmt.Sprintf("%s/%s entries=%d", p.label, a, len(tl.Entries)))
+			for i, e := range tl.Entries {
+				lines = append(lines, fmt.Sprintf("%s/%s [%02d] source=%s age=%s outbound=%t conv=%d pair=%d",
+					p.label, a, i, e.Source, e.Age, e.Outbound, e.ConversationKey, e.PairKey))
+			}
+		}
+	}
+	return lines
+}

--- a/backend/internal/synthetic/factory/draw_order_test.go
+++ b/backend/internal/synthetic/factory/draw_order_test.go
@@ -56,3 +56,53 @@ func TestWithRecentCreation_DrawsOneRecentOffset(t *testing.T) {
 		t.Fatalf("WithRecentCreation did not draw exactly one recentOffset: got next-raw %d with the option vs %d after one manual recentOffset (expected equal)", withOption, withoutOption)
 	}
 }
+
+// TestTimelineFor_DrawsAFixedCount pins TimelineFor's draw cost, which is what
+// makes it safe to place in a seed profile's append-last block: the cost is one
+// number, and it does not depend on the archetype or the method set. If it did,
+// changing which archetype lands on which contact would shift the shared
+// generator's stream, and a shifted numeric identifier can land on an id another
+// contact already owns.
+//
+// Compares STREAM POSITIONS, not values — the same technique as the two tests
+// above.
+func TestTimelineFor_DrawsAFixedCount(t *testing.T) {
+	t.Parallel()
+
+	archetypes := []Archetype{
+		ArchetypeMutualRegular,
+		ArchetypeMutualDrifting,
+		ArchetypeOutboundHeavy,
+		ArchetypeInboundOnly,
+		ArchetypeDormant,
+		ArchetypeBurstThenQuiet,
+		ArchetypeNeverContacted,
+		Archetype("not-an-archetype"),
+	}
+	capsets := []MethodSet{
+		{},
+		{Email: true},
+		{Telegram: true},
+		{Phone: true},
+		{Email: true, Telegram: true, Phone: true},
+	}
+
+	for _, a := range archetypes {
+		for _, caps := range capsets {
+			gA := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+			_ = gA.TimelineFor(a, caps)
+			withCall := gA.rng.Uint64()
+
+			gB := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+			for i := 0; i < timelineJitterDraws; i++ {
+				gB.rng.Uint64()
+			}
+			withoutCall := gB.rng.Uint64()
+
+			if withCall != withoutCall {
+				t.Fatalf("TimelineFor(%s, %+v) did not draw exactly %d values: got next-raw %d vs %d after %d manual draws",
+					a, caps, timelineJitterDraws, withCall, withoutCall, timelineJitterDraws)
+			}
+		}
+	}
+}

--- a/backend/internal/synthetic/factory/testdata/archetype_golden.txt
+++ b/backend/internal/synthetic/factory/testdata/archetype_golden.txt
@@ -22,12 +22,12 @@ email/inbound-only entries=2
 email/inbound-only [00] source=email age=846h0m0s outbound=false conv=0 pair=0
 email/inbound-only [01] source=email age=241h0m0s outbound=false conv=0 pair=0
 email/dormant entries=8
-email/dormant [00] source=gcal age=4662h0m0s outbound=false conv=0 pair=0
-email/dormant [01] source=gcal age=4468h0m0s outbound=false conv=0 pair=0
-email/dormant [02] source=gcal age=4274h0m0s outbound=false conv=0 pair=0
-email/dormant [03] source=gcal age=4080h0m0s outbound=false conv=0 pair=0
-email/dormant [04] source=gcal age=3886h0m0s outbound=false conv=0 pair=0
-email/dormant [05] source=gcal age=3692h0m0s outbound=false conv=0 pair=0
+email/dormant [00] source=gcal age=4663h0m0s outbound=false conv=0 pair=0
+email/dormant [01] source=gcal age=4469h0m0s outbound=false conv=0 pair=0
+email/dormant [02] source=gcal age=4275h0m0s outbound=false conv=0 pair=0
+email/dormant [03] source=gcal age=4081h0m0s outbound=false conv=0 pair=0
+email/dormant [04] source=gcal age=3887h0m0s outbound=false conv=0 pair=0
+email/dormant [05] source=gcal age=3693h0m0s outbound=false conv=0 pair=0
 email/dormant [06] source=gchat age=3572h0m0s outbound=true conv=1 pair=1
 email/dormant [07] source=gchat age=3566h0m0s outbound=false conv=1 pair=1
 email/burst-then-quiet entries=5
@@ -67,18 +67,18 @@ telegram/inbound-only entries=2
 telegram/inbound-only [00] source=telegram age=846h0m0s outbound=false conv=0 pair=0
 telegram/inbound-only [01] source=telegram age=241h0m0s outbound=false conv=0 pair=0
 telegram/dormant entries=14
-telegram/dormant [00] source=telegram age=4668h0m0s outbound=true conv=2 pair=7
-telegram/dormant [01] source=telegram age=4662h0m0s outbound=false conv=2 pair=7
-telegram/dormant [02] source=telegram age=4474h0m0s outbound=true conv=2 pair=6
-telegram/dormant [03] source=telegram age=4468h0m0s outbound=false conv=2 pair=6
-telegram/dormant [04] source=telegram age=4280h0m0s outbound=true conv=2 pair=5
-telegram/dormant [05] source=telegram age=4274h0m0s outbound=false conv=2 pair=5
-telegram/dormant [06] source=telegram age=4086h0m0s outbound=true conv=2 pair=4
-telegram/dormant [07] source=telegram age=4080h0m0s outbound=false conv=2 pair=4
-telegram/dormant [08] source=telegram age=3892h0m0s outbound=true conv=2 pair=3
-telegram/dormant [09] source=telegram age=3886h0m0s outbound=false conv=2 pair=3
-telegram/dormant [10] source=telegram age=3698h0m0s outbound=true conv=2 pair=2
-telegram/dormant [11] source=telegram age=3692h0m0s outbound=false conv=2 pair=2
+telegram/dormant [00] source=telegram age=4669h0m0s outbound=true conv=1 pair=2
+telegram/dormant [01] source=telegram age=4663h0m0s outbound=false conv=1 pair=2
+telegram/dormant [02] source=telegram age=4475h0m0s outbound=true conv=1 pair=3
+telegram/dormant [03] source=telegram age=4469h0m0s outbound=false conv=1 pair=3
+telegram/dormant [04] source=telegram age=4281h0m0s outbound=true conv=1 pair=4
+telegram/dormant [05] source=telegram age=4275h0m0s outbound=false conv=1 pair=4
+telegram/dormant [06] source=telegram age=4087h0m0s outbound=true conv=1 pair=5
+telegram/dormant [07] source=telegram age=4081h0m0s outbound=false conv=1 pair=5
+telegram/dormant [08] source=telegram age=3893h0m0s outbound=true conv=1 pair=6
+telegram/dormant [09] source=telegram age=3887h0m0s outbound=false conv=1 pair=6
+telegram/dormant [10] source=telegram age=3699h0m0s outbound=true conv=1 pair=7
+telegram/dormant [11] source=telegram age=3693h0m0s outbound=false conv=1 pair=7
 telegram/dormant [12] source=telegram age=3572h0m0s outbound=true conv=1 pair=1
 telegram/dormant [13] source=telegram age=3566h0m0s outbound=false conv=1 pair=1
 telegram/burst-then-quiet entries=5

--- a/backend/internal/synthetic/factory/testdata/archetype_golden.txt
+++ b/backend/internal/synthetic/factory/testdata/archetype_golden.txt
@@ -1,0 +1,90 @@
+email/mutual-regular entries=9
+email/mutual-regular [00] source=gcal age=4843h0m0s outbound=false conv=0 pair=0
+email/mutual-regular [01] source=gcal age=4071h0m0s outbound=false conv=0 pair=0
+email/mutual-regular [02] source=gcal age=3276h0m0s outbound=false conv=0 pair=0
+email/mutual-regular [03] source=gcal age=2528h0m0s outbound=false conv=0 pair=0
+email/mutual-regular [04] source=gcal age=1744h0m0s outbound=false conv=0 pair=0
+email/mutual-regular [05] source=gcal age=1023h0m0s outbound=false conv=0 pair=0
+email/mutual-regular [06] source=email age=651h0m0s outbound=true conv=1 pair=1
+email/mutual-regular [07] source=email age=651h0m0s outbound=false conv=1 pair=1
+email/mutual-regular [08] source=gcal age=270h0m0s outbound=false conv=0 pair=0
+email/mutual-drifting entries=5
+email/mutual-drifting [00] source=gcal age=3920h0m0s outbound=false conv=0 pair=0
+email/mutual-drifting [01] source=gcal age=3156h0m0s outbound=false conv=0 pair=0
+email/mutual-drifting [02] source=email age=3020h0m0s outbound=true conv=1 pair=1
+email/mutual-drifting [03] source=email age=3020h0m0s outbound=false conv=1 pair=1
+email/mutual-drifting [04] source=gcal age=2454h0m0s outbound=false conv=0 pair=0
+email/outbound-heavy entries=3
+email/outbound-heavy [00] source=email age=1189h0m0s outbound=true conv=0 pair=0
+email/outbound-heavy [01] source=email age=734h0m0s outbound=true conv=0 pair=0
+email/outbound-heavy [02] source=email age=148h0m0s outbound=true conv=0 pair=0
+email/inbound-only entries=2
+email/inbound-only [00] source=email age=846h0m0s outbound=false conv=0 pair=0
+email/inbound-only [01] source=email age=241h0m0s outbound=false conv=0 pair=0
+email/dormant entries=8
+email/dormant [00] source=gcal age=4662h0m0s outbound=false conv=0 pair=0
+email/dormant [01] source=gcal age=4468h0m0s outbound=false conv=0 pair=0
+email/dormant [02] source=gcal age=4274h0m0s outbound=false conv=0 pair=0
+email/dormant [03] source=gcal age=4080h0m0s outbound=false conv=0 pair=0
+email/dormant [04] source=gcal age=3886h0m0s outbound=false conv=0 pair=0
+email/dormant [05] source=gcal age=3692h0m0s outbound=false conv=0 pair=0
+email/dormant [06] source=gchat age=3572h0m0s outbound=true conv=1 pair=1
+email/dormant [07] source=gchat age=3566h0m0s outbound=false conv=1 pair=1
+email/burst-then-quiet entries=5
+email/burst-then-quiet [00] source=gchat age=1362h0m0s outbound=true conv=1 pair=0
+email/burst-then-quiet [01] source=gchat age=1361h20m0s outbound=true conv=1 pair=0
+email/burst-then-quiet [02] source=gchat age=1360h40m0s outbound=true conv=1 pair=0
+email/burst-then-quiet [03] source=gchat age=1318h0m0s outbound=true conv=1 pair=1
+email/burst-then-quiet [04] source=gchat age=1312h0m0s outbound=false conv=1 pair=1
+email/never-contacted entries=0
+telegram/mutual-regular entries=14
+telegram/mutual-regular [00] source=telegram age=4849h0m0s outbound=true conv=1 pair=7
+telegram/mutual-regular [01] source=telegram age=4843h0m0s outbound=false conv=1 pair=7
+telegram/mutual-regular [02] source=telegram age=4077h0m0s outbound=true conv=1 pair=6
+telegram/mutual-regular [03] source=telegram age=4071h0m0s outbound=false conv=1 pair=6
+telegram/mutual-regular [04] source=telegram age=3282h0m0s outbound=true conv=1 pair=5
+telegram/mutual-regular [05] source=telegram age=3276h0m0s outbound=false conv=1 pair=5
+telegram/mutual-regular [06] source=telegram age=2534h0m0s outbound=true conv=1 pair=4
+telegram/mutual-regular [07] source=telegram age=2528h0m0s outbound=false conv=1 pair=4
+telegram/mutual-regular [08] source=telegram age=1750h0m0s outbound=true conv=1 pair=3
+telegram/mutual-regular [09] source=telegram age=1744h0m0s outbound=false conv=1 pair=3
+telegram/mutual-regular [10] source=telegram age=1029h0m0s outbound=true conv=1 pair=2
+telegram/mutual-regular [11] source=telegram age=1023h0m0s outbound=false conv=1 pair=2
+telegram/mutual-regular [12] source=telegram age=276h0m0s outbound=true conv=1 pair=1
+telegram/mutual-regular [13] source=telegram age=270h0m0s outbound=false conv=1 pair=1
+telegram/mutual-drifting entries=6
+telegram/mutual-drifting [00] source=telegram age=3926h0m0s outbound=true conv=1 pair=3
+telegram/mutual-drifting [01] source=telegram age=3920h0m0s outbound=false conv=1 pair=3
+telegram/mutual-drifting [02] source=telegram age=3162h0m0s outbound=true conv=1 pair=2
+telegram/mutual-drifting [03] source=telegram age=3156h0m0s outbound=false conv=1 pair=2
+telegram/mutual-drifting [04] source=telegram age=2460h0m0s outbound=true conv=1 pair=1
+telegram/mutual-drifting [05] source=telegram age=2454h0m0s outbound=false conv=1 pair=1
+telegram/outbound-heavy entries=3
+telegram/outbound-heavy [00] source=telegram age=1189h0m0s outbound=true conv=0 pair=0
+telegram/outbound-heavy [01] source=telegram age=734h0m0s outbound=true conv=0 pair=0
+telegram/outbound-heavy [02] source=telegram age=148h0m0s outbound=true conv=0 pair=0
+telegram/inbound-only entries=2
+telegram/inbound-only [00] source=telegram age=846h0m0s outbound=false conv=0 pair=0
+telegram/inbound-only [01] source=telegram age=241h0m0s outbound=false conv=0 pair=0
+telegram/dormant entries=14
+telegram/dormant [00] source=telegram age=4668h0m0s outbound=true conv=2 pair=7
+telegram/dormant [01] source=telegram age=4662h0m0s outbound=false conv=2 pair=7
+telegram/dormant [02] source=telegram age=4474h0m0s outbound=true conv=2 pair=6
+telegram/dormant [03] source=telegram age=4468h0m0s outbound=false conv=2 pair=6
+telegram/dormant [04] source=telegram age=4280h0m0s outbound=true conv=2 pair=5
+telegram/dormant [05] source=telegram age=4274h0m0s outbound=false conv=2 pair=5
+telegram/dormant [06] source=telegram age=4086h0m0s outbound=true conv=2 pair=4
+telegram/dormant [07] source=telegram age=4080h0m0s outbound=false conv=2 pair=4
+telegram/dormant [08] source=telegram age=3892h0m0s outbound=true conv=2 pair=3
+telegram/dormant [09] source=telegram age=3886h0m0s outbound=false conv=2 pair=3
+telegram/dormant [10] source=telegram age=3698h0m0s outbound=true conv=2 pair=2
+telegram/dormant [11] source=telegram age=3692h0m0s outbound=false conv=2 pair=2
+telegram/dormant [12] source=telegram age=3572h0m0s outbound=true conv=1 pair=1
+telegram/dormant [13] source=telegram age=3566h0m0s outbound=false conv=1 pair=1
+telegram/burst-then-quiet entries=5
+telegram/burst-then-quiet [00] source=telegram age=1362h0m0s outbound=true conv=1 pair=0
+telegram/burst-then-quiet [01] source=telegram age=1361h20m0s outbound=true conv=1 pair=0
+telegram/burst-then-quiet [02] source=telegram age=1360h40m0s outbound=true conv=1 pair=0
+telegram/burst-then-quiet [03] source=telegram age=1318h0m0s outbound=true conv=1 pair=1
+telegram/burst-then-quiet [04] source=telegram age=1312h0m0s outbound=false conv=1 pair=1
+telegram/never-contacted entries=0


### PR DESCRIPTION
PR3 of the seed-realism archetype arc (`.ai/log/plan/2026-07-24-seed-realism-archetypes-arc.md`), implementing contract **C1**. Depends on nothing; **nothing calls it yet** — PR5 will be its first consumer.

A pure function from (archetype, available contact methods) to an ordered list of (source, age, direction) payload intents: seven archetypes, per-contact PRNG jitter, source-specific promotion-pair timing, structural method-awareness. No DB, no replay, no profile wiring. Keeping the plan pure is the point — timeline shape is where the realism lives, and it should be unit-testable without a River queue.

Everything is anchor-relative (`Age` durations, never calendar positions), so every reseed re-anchors the whole population to "now".

## The `mutual-regular` parameter row does not close arithmetically

The shipped generator pins the feasible region rather than the documented one. Span is the sum of `count−1` meeting gaps, so the 180-day floor forces at least 7 meetings, while the 6–10 entry budget with two correspondence pairs allows at most 6 — **the two-pair case is infeasible**, and the unique feasible region is 7–8 meetings with exactly one pair (9–10 entries). Every bound the table asserts still holds; the stated ranges are simply not all reachable. The reason travels in the assertion's own failure message, which is where a future reader will meet it.

## What PR5 needs to know before designing its batching

The replay layer's 150-day Gmail limit is **per batch** — every instant across every contact in it — while a timeline can only promise per contact. Mail pooled across archetypes spans up to **179 days** (newest 1d from `inbound-only`, oldest 180d from `mutual-drifting`'s second correspondence pair at the far end of the second meeting gap). So mail batched across contacts must bucket by age or it will trip `ErrBatchGmailSpanExceeded`.

That figure is derived, not sampled. Two independent sampling runs observed ~172.6d and ~173.1d; those are properties of the sample, not the generator, and shipping a decimal as though it were exact would invite sizing a design against noise.

## Two gate defects found by probing rather than by review

Worth recording because both are invisible to a passing suite:

- **Six structural assertions were originally written against the implementation's own constants**, so widening a bound silently widened its own test — `require.LessOrEqual(oldest, dormantOldestMax)` passes for any value of `dormantOldestMax`. All bounds now assert against test-local literals restating the documented table, and each constant was re-probed to confirm it fails.
- **A `mailMaxSpan` constant turned out to be inert** — its probe passed because nothing referenced it. Documentation masquerading as a bound. Deleted, rationale moved into prose. Only a probe that *should* fail and doesn't will find that.

29 injection probes in total, each asserting the target string exists before writing (so a silently-failed injection cannot masquerade as a passing gate) and reading the exit code directly rather than through a pipe.

## Golden snapshot moved — `dormant` only

Flagged explicitly since it is a drift signal. Meeting ages shift +1h in both palettes (meetings now step back from the drawn `oldest` bound rather than forward from the newest, so the bound is hit exactly). `telegram/dormant` additionally moves `conv` 2→1 on entries 00–11, because a chat-only dormant target was getting two distinct conversations with the same peer — two separate private Telegram chats with one person, which is not a state the real world produces. Pair keys renumber 7..2 → 2..7 as the meeting loop now runs oldest-first; keys are only ever compared for equality.

Every other archetype in both palettes is byte-identical. `testdata/golden_stream.txt` is unmodified — the proof that adding this function shifted nothing in the shared PRNG stream.

## Verification

`make lint` 0 issues; `make test` exit 0; `TestSyntheticGolden_GeneratorStreamIsStable` PASS in the integration lane; full pre-push gate green. Import discipline verified mechanically rather than by inspection — `go list -deps ./internal/synthetic/factory | grep -E "internal/(service|google)$"` returns nothing, which matters because reaching for `google.CalendarSourceName` would drag `internal/service` into `factory`'s dependency graph and would still compile.