### PR TITLE
test(synthetic): pin tour-critical fixtures with resolvable markers

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1351,6 +1351,15 @@ type Querier interface {
 	ListOverdueContacts(ctx context.Context, arg ListOverdueContactsParams) ([]*Contact, error)
 	// List past events that haven't updated last_contacted yet
 	ListPastEventsNeedingUpdate(ctx context.Context, arg ListPastEventsNeedingUpdateParams) ([]*CalendarEvent, error)
+	// Pinned tour-fixture proof: the namespace's live contacts with the columns the
+	// fixture assertions read, returned in the SAME order the tours' default contact
+	// list uses (cadence rank ascending == 'most frequent first', then the full_name /
+	// id tiebreakers) — a copy of ListContacts' cadence-desc ORDER BY, so the
+	// positional (B-group) selections the tours make can be checked for degeneracy
+	// against the order they will actually see. Marker resolution is done Go-side over
+	// full_name so the exactly-one-match rule is asserted rather than assumed. Caller
+	// passes a BARE prefix; '%' appended. Test only.
+	ListPinnedFixtureContactsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*ListPinnedFixtureContactsByNamePrefixRow, error)
 	ListPredicatesByStatus(ctx context.Context, status string) ([]*ListPredicatesByStatusRow, error)
 	// All locators for an assertion, oldest first.
 	ListProvenance(ctx context.Context, assertionID pgtype.UUID) ([]*AssertionProvenance, error)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1346,6 +1346,15 @@ type Querier interface {
 	// output and the reconcile diff. Used both by the watchdog (to compute the
 	// resolve set) and by the read endpoint (active breaches only).
 	ListOpenStalenessBreaches(ctx context.Context) ([]*SyncStalenessBreach, error)
+	// Pinned tour-fixture proof: the namespace's live contacts that the overdue
+	// endpoint would return. The predicate is a deliberate copy of ListOverdueContacts
+	// in contact.sql — contact_by set and strictly before TODAY'S DATE, which is a
+	// different comparison from the `now` the fixture's column checks use, and the
+	// reason this read proves something they do not. Scoped to one namespace and
+	// unbounded, because the production query's global LIMIT would let an accumulated
+	// shared test DB push a fixture out of the window and turn a coverage claim into a
+	// flake. Caller passes a BARE prefix; '%' appended. Test only.
+	ListOverdueContactIdsByNamePrefix(ctx context.Context, arg ListOverdueContactIdsByNamePrefixParams) ([]pgtype.UUID, error)
 	// Lists contacts whose contact_by date is before today (overdue).
 	// Returns contacts ordered by how overdue they are (most overdue first).
 	ListOverdueContacts(ctx context.Context, arg ListOverdueContactsParams) ([]*Contact, error)

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1596,7 +1596,8 @@ SELECT
     c.last_outreach_at,
     c.last_response_at,
     c.contact_by,
-    c.birthday
+    c.birthday,
+    c.location
 FROM contact c
 WHERE c.full_name LIKE @name_prefix || '%'
   AND c.deleted_at IS NULL

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1577,3 +1577,30 @@ FROM contact_task ct
 JOIN contact c ON ct.contact_id = c.id
 WHERE c.full_name LIKE @name_prefix || '%'
   AND c.deleted_at IS NULL;
+
+-- name: ListPinnedFixtureContactsByNamePrefix :many
+-- Pinned tour-fixture proof: the namespace's live contacts with the columns the
+-- fixture assertions read, returned in the SAME order the tours' default contact
+-- list uses (cadence rank ascending == 'most frequent first', then the full_name /
+-- id tiebreakers) — a copy of ListContacts' cadence-desc ORDER BY, so the
+-- positional (B-group) selections the tours make can be checked for degeneracy
+-- against the order they will actually see. Marker resolution is done Go-side over
+-- full_name so the exactly-one-match rule is asserted rather than assumed. Caller
+-- passes a BARE prefix; '%' appended. Test only.
+SELECT
+    c.id,
+    c.full_name,
+    c.cadence,
+    c.created_at,
+    c.last_contacted,
+    c.last_outreach_at,
+    c.last_response_at,
+    c.contact_by,
+    c.birthday
+FROM contact c
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+ORDER BY
+  CASE c.cadence WHEN 'weekly' THEN 1 WHEN 'biweekly' THEN 2 WHEN 'monthly' THEN 3 WHEN 'quarterly' THEN 4 WHEN 'biannual' THEN 5 WHEN 'annual' THEN 6 ELSE 7 END ASC,
+  c.full_name ASC,
+  c.id ASC;

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1605,3 +1605,20 @@ ORDER BY
   CASE c.cadence WHEN 'weekly' THEN 1 WHEN 'biweekly' THEN 2 WHEN 'monthly' THEN 3 WHEN 'quarterly' THEN 4 WHEN 'biannual' THEN 5 WHEN 'annual' THEN 6 ELSE 7 END ASC,
   c.full_name ASC,
   c.id ASC;
+
+-- name: ListOverdueContactIdsByNamePrefix :many
+-- Pinned tour-fixture proof: the namespace's live contacts that the overdue
+-- endpoint would return. The predicate is a deliberate copy of ListOverdueContacts
+-- in contact.sql — contact_by set and strictly before TODAY'S DATE, which is a
+-- different comparison from the `now` the fixture's column checks use, and the
+-- reason this read proves something they do not. Scoped to one namespace and
+-- unbounded, because the production query's global LIMIT would let an accumulated
+-- shared test DB push a fixture out of the window and turn a coverage claim into a
+-- flake. Caller passes a BARE prefix; '%' appended. Test only.
+SELECT c.id
+FROM contact c
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND c.contact_by IS NOT NULL
+  AND c.contact_by < sqlc.arg(today)::date
+ORDER BY c.contact_by ASC;

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -574,6 +574,76 @@ func (q *Queries) InsertRiverJobForTest(ctx context.Context, args []byte) error 
 	return err
 }
 
+const ListPinnedFixtureContactsByNamePrefix = `-- name: ListPinnedFixtureContactsByNamePrefix :many
+SELECT
+    c.id,
+    c.full_name,
+    c.cadence,
+    c.created_at,
+    c.last_contacted,
+    c.last_outreach_at,
+    c.last_response_at,
+    c.contact_by,
+    c.birthday
+FROM contact c
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+ORDER BY
+  CASE c.cadence WHEN 'weekly' THEN 1 WHEN 'biweekly' THEN 2 WHEN 'monthly' THEN 3 WHEN 'quarterly' THEN 4 WHEN 'biannual' THEN 5 WHEN 'annual' THEN 6 ELSE 7 END ASC,
+  c.full_name ASC,
+  c.id ASC
+`
+
+type ListPinnedFixtureContactsByNamePrefixRow struct {
+	ID             pgtype.UUID        `json:"id"`
+	FullName       string             `json:"full_name"`
+	Cadence        pgtype.Text        `json:"cadence"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	LastContacted  pgtype.Timestamptz `json:"last_contacted"`
+	LastOutreachAt pgtype.Timestamptz `json:"last_outreach_at"`
+	LastResponseAt pgtype.Timestamptz `json:"last_response_at"`
+	ContactBy      pgtype.Date        `json:"contact_by"`
+	Birthday       pgtype.Date        `json:"birthday"`
+}
+
+// Pinned tour-fixture proof: the namespace's live contacts with the columns the
+// fixture assertions read, returned in the SAME order the tours' default contact
+// list uses (cadence rank ascending == 'most frequent first', then the full_name /
+// id tiebreakers) — a copy of ListContacts' cadence-desc ORDER BY, so the
+// positional (B-group) selections the tours make can be checked for degeneracy
+// against the order they will actually see. Marker resolution is done Go-side over
+// full_name so the exactly-one-match rule is asserted rather than assumed. Caller
+// passes a BARE prefix; '%' appended. Test only.
+func (q *Queries) ListPinnedFixtureContactsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*ListPinnedFixtureContactsByNamePrefixRow, error) {
+	rows, err := q.db.Query(ctx, ListPinnedFixtureContactsByNamePrefix, namePrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ListPinnedFixtureContactsByNamePrefixRow{}
+	for rows.Next() {
+		var i ListPinnedFixtureContactsByNamePrefixRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.FullName,
+			&i.Cadence,
+			&i.CreatedAt,
+			&i.LastContacted,
+			&i.LastOutreachAt,
+			&i.LastResponseAt,
+			&i.ContactBy,
+			&i.Birthday,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ResetSyntheticData = `-- name: ResetSyntheticData :exec
 
 TRUNCATE TABLE

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -574,6 +574,49 @@ func (q *Queries) InsertRiverJobForTest(ctx context.Context, args []byte) error 
 	return err
 }
 
+const ListOverdueContactIdsByNamePrefix = `-- name: ListOverdueContactIdsByNamePrefix :many
+SELECT c.id
+FROM contact c
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND c.contact_by IS NOT NULL
+  AND c.contact_by < $2::date
+ORDER BY c.contact_by ASC
+`
+
+type ListOverdueContactIdsByNamePrefixParams struct {
+	NamePrefix pgtype.Text `json:"name_prefix"`
+	Today      pgtype.Date `json:"today"`
+}
+
+// Pinned tour-fixture proof: the namespace's live contacts that the overdue
+// endpoint would return. The predicate is a deliberate copy of ListOverdueContacts
+// in contact.sql — contact_by set and strictly before TODAY'S DATE, which is a
+// different comparison from the `now` the fixture's column checks use, and the
+// reason this read proves something they do not. Scoped to one namespace and
+// unbounded, because the production query's global LIMIT would let an accumulated
+// shared test DB push a fixture out of the window and turn a coverage claim into a
+// flake. Caller passes a BARE prefix; '%' appended. Test only.
+func (q *Queries) ListOverdueContactIdsByNamePrefix(ctx context.Context, arg ListOverdueContactIdsByNamePrefixParams) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, ListOverdueContactIdsByNamePrefix, arg.NamePrefix, arg.Today)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListPinnedFixtureContactsByNamePrefix = `-- name: ListPinnedFixtureContactsByNamePrefix :many
 SELECT
     c.id,

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -584,7 +584,8 @@ SELECT
     c.last_outreach_at,
     c.last_response_at,
     c.contact_by,
-    c.birthday
+    c.birthday,
+    c.location
 FROM contact c
 WHERE c.full_name LIKE $1 || '%'
   AND c.deleted_at IS NULL
@@ -604,6 +605,7 @@ type ListPinnedFixtureContactsByNamePrefixRow struct {
 	LastResponseAt pgtype.Timestamptz `json:"last_response_at"`
 	ContactBy      pgtype.Date        `json:"contact_by"`
 	Birthday       pgtype.Date        `json:"birthday"`
+	Location       pgtype.Text        `json:"location"`
 }
 
 // Pinned tour-fixture proof: the namespace's live contacts with the columns the
@@ -633,6 +635,7 @@ func (q *Queries) ListPinnedFixtureContactsByNamePrefix(ctx context.Context, nam
 			&i.LastResponseAt,
 			&i.ContactBy,
 			&i.Birthday,
+			&i.Location,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -1557,6 +1557,7 @@ type PinnedFixtureContact struct {
 	LastResponseAt *time.Time
 	ContactBy      *time.Time
 	Birthday       *time.Time
+	Location       *string
 }
 
 // ListPinnedFixtureContactsByNamePrefix returns the namespace's live contacts in
@@ -1602,6 +1603,10 @@ func (r *SyntheticSupportRepository) ListPinnedFixtureContactsByNamePrefix(ctx c
 		if row.Birthday.Valid {
 			t := row.Birthday.Time
 			c.Birthday = &t
+		}
+		if row.Location.Valid {
+			v := row.Location.String
+			c.Location = &v
 		}
 		out = append(out, c)
 	}

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -1542,3 +1542,68 @@ func (r *SyntheticSupportRepository) CountMergedIntoNodesByIds(ctx context.Conte
 	}
 	return r.queries.SyntheticCountMergedIntoNodesByIds(ctx, pgUUIDs(nodeIDs))
 }
+
+// PinnedFixtureContact is one live namespace contact with the columns the pinned
+// tour-fixture assertions read. Rows arrive in the tours' default contact-list
+// order (cadence rank ascending, then full_name / id), so the positional
+// selections the tours make are checkable against the order they will see.
+type PinnedFixtureContact struct {
+	ID             uuid.UUID
+	FullName       string
+	Cadence        *string
+	CreatedAt      *time.Time
+	LastContacted  *time.Time
+	LastOutreachAt *time.Time
+	LastResponseAt *time.Time
+	ContactBy      *time.Time
+	Birthday       *time.Time
+}
+
+// ListPinnedFixtureContactsByNamePrefix returns the namespace's live contacts in
+// the tours' default cadence-desc list order. Used by the coverage checks to
+// resolve each pinned fixture by its name marker (requiring exactly one match) and
+// to assert the ordering the tours' positional selections depend on is
+// non-degenerate.
+func (r *SyntheticSupportRepository) ListPinnedFixtureContactsByNamePrefix(ctx context.Context, namePrefix string) ([]PinnedFixtureContact, error) {
+	rows, err := r.queries.ListPinnedFixtureContactsByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PinnedFixtureContact, 0, len(rows))
+	for _, row := range rows {
+		c := PinnedFixtureContact{
+			ID:       uuid.UUID(row.ID.Bytes),
+			FullName: row.FullName,
+		}
+		if row.Cadence.Valid {
+			v := row.Cadence.String
+			c.Cadence = &v
+		}
+		if row.CreatedAt.Valid {
+			t := row.CreatedAt.Time
+			c.CreatedAt = &t
+		}
+		if row.LastContacted.Valid {
+			t := row.LastContacted.Time
+			c.LastContacted = &t
+		}
+		if row.LastOutreachAt.Valid {
+			t := row.LastOutreachAt.Time
+			c.LastOutreachAt = &t
+		}
+		if row.LastResponseAt.Valid {
+			t := row.LastResponseAt.Time
+			c.LastResponseAt = &t
+		}
+		if row.ContactBy.Valid {
+			t := row.ContactBy.Time
+			c.ContactBy = &t
+		}
+		if row.Birthday.Valid {
+			t := row.Birthday.Time
+			c.Birthday = &t
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -1612,3 +1612,22 @@ func (r *SyntheticSupportRepository) ListPinnedFixtureContactsByNamePrefix(ctx c
 	}
 	return out, nil
 }
+
+// ListOverdueContactIdsByNamePrefix returns the namespace's contacts that the
+// overdue endpoint would return for the given day — same predicate as the
+// production ListOverdueContacts, scoped to one namespace and unbounded so an
+// accumulated shared test DB cannot push a subject outside a global limit window.
+func (r *SyntheticSupportRepository) ListOverdueContactIdsByNamePrefix(ctx context.Context, namePrefix string, today time.Time) ([]uuid.UUID, error) {
+	rows, err := r.queries.ListOverdueContactIdsByNamePrefix(ctx, db.ListOverdueContactIdsByNamePrefixParams{
+		NamePrefix: pgtype.Text{String: namePrefix, Valid: true},
+		Today:      pgtype.Date{Time: today, Valid: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uuid.UUID, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, uuid.UUID(row.Bytes))
+	}
+	return out, nil
+}

--- a/backend/internal/synthetic/factory/domain.go
+++ b/backend/internal/synthetic/factory/domain.go
@@ -56,6 +56,7 @@ type contactConfig struct {
 	location             *string
 	unicodeName          bool
 	descender            bool
+	nameMarker           string
 }
 
 // WithEmail adds an email contact_method (default ON if no method option is
@@ -153,6 +154,17 @@ func WithUnicodeName() ContactOption { return func(c *contactConfig) { c.unicode
 // rendering edge case.
 func WithDescenderName() ContactOption { return func(c *contactConfig) { c.descender = true } }
 
+// WithNameMarker appends a resolution marker token to the contact's display name,
+// so a hand-authored fixture can be resolved over the API by search instead of by
+// an ad-hoc predicate over whatever the population happens to contain. The marker
+// is a caller concern (its convention and its constraints are documented where the
+// fixtures are seeded); the factory only places it. Composes with the name edge
+// cases (unicode / descender) rather than replacing them, and draws no PRNG — a
+// marker must never shift the shared generator stream.
+func WithNameMarker(marker string) ContactOption {
+	return func(c *contactConfig) { c.nameMarker = marker }
+}
+
 // Contact builds a deterministic ContactSpec. With no options it defaults to a
 // single email method (the common case). All identifiers are namespace-prefixed.
 func (g *Generator) Contact(opts ...ContactOption) ContactSpec {
@@ -177,6 +189,9 @@ func (g *Generator) Contact(opts ...ContactOption) ContactSpec {
 		display = given + " Ünïcödé-" + sur
 	case cfg.descender:
 		display = given + " Gregory-" + sur // descenders: g, y, p, q
+	}
+	if cfg.nameMarker != "" {
+		display += " " + cfg.nameMarker
 	}
 	// Namespace-prefixed full_name so the prefix cleanup backstop finds it.
 	fullName := g.Prefix() + display

--- a/backend/internal/synthetic/factory/draw_order_test.go
+++ b/backend/internal/synthetic/factory/draw_order_test.go
@@ -106,3 +106,31 @@ func TestTimelineFor_DrawsAFixedCount(t *testing.T) {
 		}
 	}
 }
+
+// TestWithNameMarker_DrawsZero proves WithNameMarker adds NO generator draw over
+// the identical base build. The pinned fixtures carry markers and are seeded from
+// the profile's append-last block; a marker that drew would make the stream
+// position depend on how many fixtures are pinned, which is exactly the coupling
+// the append-last rule exists to prevent.
+//
+// Compares STREAM POSITIONS, not values — the same technique as the tests above.
+func TestWithNameMarker_DrawsZero(t *testing.T) {
+	t.Parallel()
+
+	gA := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+	specA := gA.Contact(append(baseDrawOrderOpts(), WithNameMarker("fxmarker"))...)
+	withOption := gA.rng.Uint64()
+
+	gB := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+	specB := gB.Contact(baseDrawOrderOpts()...)
+	withoutOption := gB.rng.Uint64()
+
+	if withOption != withoutOption {
+		t.Fatalf("WithNameMarker changed the PRNG stream position: got next-raw %d with the option vs %d without it (expected equal — zero extra draws)", withOption, withoutOption)
+	}
+	// The option must still have DONE something — a no-op would pass the draw check
+	// vacuously while leaving every fixture unresolvable.
+	if specA.FullName != specB.FullName+" fxmarker" {
+		t.Fatalf("WithNameMarker did not append the marker to the display name: got %q, want %q", specA.FullName, specB.FullName+" fxmarker")
+	}
+}

--- a/backend/internal/synthetic/fixtures.go
+++ b/backend/internal/synthetic/fixtures.go
@@ -105,12 +105,17 @@ var PinnedFixtureMarkers = []string{
 // pinnedOverdueFixtures is the (cadence, created-age) table for the two
 // designated overdue fixtures. Both pairs are genuinely overdue under PRODUCTION
 // cadence durations, and both are chosen to close a gap the FROZEN catalog cannot:
-// the catalog supplies backdated cadence-bearing slots only at creation indices 0
-// and 3, so a small world has two distinct old creation ages where the dashboard's
-// urgency-diversity gate needs three. Each pair therefore carries a created age
-// distinct from every catalog ladder entry AND from the other pair's, and a
-// cadence distinct from the two the catalog's backdated slots use — and their
-// days-overdue magnitudes deliberately land in different urgency tiers.
+// at SMALL n the catalog supplies backdated cadence-bearing slots only at creation
+// indices 0 and 3, so such a world has two distinct old creation ages where the
+// dashboard's urgency-diversity gate needs three. Each pair therefore carries a
+// created age distinct from every catalog ladder entry AND from the other pair's,
+// and — again at small n, where the scarcity bites — a cadence distinct from the
+// two the catalog's backdated slots use. That cadence-newness claim is about small
+// worlds only: the overdue ladder rotates, so at n >= 18 a later catalog slot
+// carries quarterly too. Nothing depends on cadence-newness at scale; the
+// load-bearing distinctness is the AGES, which are checked ladder-wide in the unit
+// test and world-wide in the integration gate. Their days-overdue magnitudes
+// deliberately land in different urgency tiers.
 //
 // Neither cadence may be the FIRST-RANKED one (weekly): the contact list's default
 // order is cadence-frequency ascending, and the contacts tour mutates its first
@@ -121,11 +126,16 @@ var PinnedFixtureMarkers = []string{
 // the population is capture-bounded, not just seed-bounded: the tours' overdue
 // evidence is a JSON array that the capture normalizer slices at a cap, dropping
 // the tail. The prod-shaped catalog already supplies 50 overdue contacts, so this
-// pair takes the set to 52 — measured, not assumed. The overdue tours therefore
-// carry an explicit capture cap (OVERDUE_CAPTURE_CAP in
-// frontend/tests/tours/support/pinned-fixtures.ts) and refuse to run above it, so
-// a set that outgrows the cap fails loudly instead of reaching the judge with an
-// unnamed subset missing. Adding a third overdue fixture means re-checking that
+// pair takes the set to 52 — measured, not assumed.
+//
+// What the tours do about that, stated exactly: in BOTH tours that expose the
+// overdue set (dashboard, relationship-loop) every capture carries the explicit
+// OVERDUE_CAPTURE_CAP from frontend/tests/tours/support/pinned-fixtures.ts, and
+// each tour checks the live population against that cap BEFORE its first capture —
+// which it must, because the dashboard's own overdue GET is drained into whichever
+// capture happens to run next, not only into the ones that name the set. A
+// population above the cap therefore stops the tour instead of quietly reaching the
+// judge as an unnamed subset. Adding a third overdue fixture means re-checking that
 // cap, not just this table.
 //
 // Anchor-relative via WithCreatedAge (no time.Now()); a pure table, so it draws no

--- a/backend/internal/synthetic/fixtures.go
+++ b/backend/internal/synthetic/fixtures.go
@@ -136,7 +136,7 @@ const (
 	fixtureSearchCadence      = "biannual"
 )
 
-// fixtureBirthdayOffsetDays places the dedicated birthday fixture inside the
+// FixtureBirthdayOffsetDays places the dedicated birthday fixture inside the
 // birthdays page's ≤7-day highlight window, and away from the offsets the
 // catalog-riding clock-anchored fixtures already occupy so the imminent group
 // gains a distinct additional member.
@@ -147,7 +147,7 @@ const (
 // already past in the current calendar year files under "Already Celebrated This
 // Year" even when the next one is two days away), which is why the tour resolves
 // the fixture's card by identity rather than by section.
-const fixtureBirthdayOffsetDays = 2
+const FixtureBirthdayOffsetDays = 2
 
 // fixtureMergeLocationStems are the two DISTINCT location stems the merge pair
 // carries, drawn from the catalog's pool so places keep repeating across the world
@@ -211,7 +211,7 @@ func buildPinnedTourFixtures(gen *factory.Generator) []pinnedFixturePlan {
 		// Birthday inside the highlight window.
 		{FixtureMarkerBirthday, []factory.ContactOption{
 			factory.WithEmail(),
-			factory.WithBirthday(BirthdayFixtureDate(anchor, fixtureBirthdayOffsetDays)),
+			factory.WithBirthday(BirthdayFixtureDate(anchor, FixtureBirthdayOffsetDays)),
 		}},
 	}
 	for _, pair := range pinnedOverdueFixtures {

--- a/backend/internal/synthetic/fixtures.go
+++ b/backend/internal/synthetic/fixtures.go
@@ -1,0 +1,262 @@
+package synthetic
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/synthetic/factory"
+)
+
+// --- Pinned tour fixtures ---------------------------------------------------
+//
+// THE MARKER CONVENTION — this comment block is the single authority. Cite it;
+// do not restate it at the call sites or in the tours.
+//
+// Every world state the QA tours in frontend/tests/tours/ depend on is seeded as
+// a NAMED, hand-authored fixture instead of being left to whatever the generated
+// population happens to contain. Each fixture contact carries a MARKER appended
+// to its full_name:
+//
+//	"<namespace prefix><Given> <Surname> <marker>"
+//
+// A tour resolves a fixture with ONE API search (GET /contacts?search=<marker>)
+// and then verifies the row it got back carries the expected marker AND the
+// expected state before using it — resolution is verified, never inferred from
+// the search having returned something.
+//
+// A marker is therefore constrained by the search path, which is Postgres FULL
+// TEXT search over full_name plus the contact's method values
+// (to_tsvector('english', …) @@ plainto_tsquery('english', …) — see ListContacts
+// in db/queries/contact.sql), NOT a substring match. So a marker is a SINGLE
+// lowercase alphanumeric token, no hyphens and no spaces: a hyphenated marker is
+// split into several stemmed lexemes whose parts are shared between markers
+// ("fx-no-activity" yields "fx" and "activ"), which is precisely the
+// mis-resolution the pinning exists to remove. The shared "fx" prefix keeps every
+// marker greppable across Go, SQL and TypeScript.
+//
+// A marker must resolve to EXACTLY ONE contact in a seeded world. That is
+// asserted at both ends: the coverage checks require exactly one exact-marker
+// match within the namespace and require the search path to return exactly that
+// row, and the tours require exactly one match before using a fixture.
+const (
+	// FixtureMarkerNoActivity is the contact with no outreach, no response, no
+	// pending follow-up and zero product-visible tasks — the "no recent activity"
+	// and "no tasks yet" subject. Cadence-bearing with recent creation, so it also
+	// supplies the recent-never-connected coherence floor at small catalog sizes.
+	FixtureMarkerNoActivity = "fxnoactivity"
+	// FixtureMarkerOutreach marks the outbound-only contact (last_outreach_at set,
+	// last_contacted NULL) — the "last outreach" subject. Rides an existing seeded
+	// contact from the two-sided direction cohort.
+	FixtureMarkerOutreach = "fxoutreach"
+	// FixtureMarkerResponse marks the reply-bridged telegram mutual contact
+	// (last_response_at set) — the "last response" subject, distinct from the
+	// outreach one. Rides an existing seeded contact.
+	FixtureMarkerResponse = "fxresponse"
+	// FixtureMarkerPending marks the contact carrying a live follow-up loop — the
+	// "awaiting reply" subject. Rides the existing awaiting-reply scenario contact.
+	FixtureMarkerPending = "fxpending"
+	// FixtureMarkerOverdueA / FixtureMarkerOverdueB mark the two designated overdue
+	// contacts. They are STATE guarantees, not subject bindings: the dashboard and
+	// relationship-loop tours pick the most-urgent card POSITIONALLY, and that
+	// positional selection is the behavior under test. Two are seeded because both
+	// tours mutate an overdue contact within one single-worker sweep.
+	FixtureMarkerOverdueA = "fxoverduea"
+	FixtureMarkerOverdueB = "fxoverdueb"
+	// FixtureMarkerMergeTarget / FixtureMarkerMergeSource mark the merge pair: the
+	// contact kept and the contact archived. They differ in cadence AND in location,
+	// so the merge preview surfaces more than one genuine field conflict.
+	FixtureMarkerMergeTarget = "fxmergetarget"
+	FixtureMarkerMergeSource = "fxmergesource"
+	// FixtureMarkerSearch marks the cadence-bearing contact the list-context tour
+	// searches for and navigates from. Never mutated.
+	FixtureMarkerSearch = "fxsearchsubject"
+	// FixtureMarkerDelete marks the disposable delete victim, consumed once per
+	// sweep and re-established by the next reseed.
+	FixtureMarkerDelete = "fxdeletevictim"
+	// FixtureMarkerBirthday marks the dedicated birthday fixture inside the
+	// birthdays page's highlight window. It is a NEW contact rather than one of the
+	// clock-anchored catalog fixtures: those ride catalog slots whose names are
+	// frozen, so a catalog fixture cannot be both unchanged and marker-bearing.
+	FixtureMarkerBirthday = "fxbirthday"
+)
+
+// PinnedFixtureMarkers is every pinned tour-fixture marker, in seeding order for
+// the ones this block seeds followed by the ones that ride existing contacts. The
+// coverage checks iterate it, so a fixture added without a marker entry is not
+// silently unasserted.
+var PinnedFixtureMarkers = []string{
+	FixtureMarkerNoActivity,
+	FixtureMarkerOverdueA,
+	FixtureMarkerOverdueB,
+	FixtureMarkerMergeTarget,
+	FixtureMarkerMergeSource,
+	FixtureMarkerSearch,
+	FixtureMarkerDelete,
+	FixtureMarkerBirthday,
+	FixtureMarkerOutreach,
+	FixtureMarkerResponse,
+	FixtureMarkerPending,
+}
+
+// pinnedOverdueFixtures is the (cadence, created-age) table for the two
+// designated overdue fixtures. Both pairs are genuinely overdue under PRODUCTION
+// cadence durations, and both are chosen to close a gap the FROZEN catalog cannot:
+// the catalog supplies backdated cadence-bearing slots only at creation indices 0
+// and 3, so a small world has two distinct old creation ages where the dashboard's
+// urgency-diversity gate needs three. Each pair therefore carries a created age
+// distinct from every catalog ladder entry AND from the other pair's, and a
+// cadence distinct from the two the catalog's backdated slots use — and their
+// days-overdue magnitudes deliberately land in different urgency tiers.
+//
+// Neither cadence may be the FIRST-RANKED one (weekly): the contact list's default
+// order is cadence-frequency ascending, and the contacts tour mutates its first
+// row. A pinned fixture at rank 1 could displace the catalog contact that row is
+// meant to be and collide with the tour's own fixture reservations.
+//
+// Anchor-relative via WithCreatedAge (no time.Now()); a pure table, so it draws no
+// PRNG.
+var pinnedOverdueFixtures = []struct {
+	marker     string
+	cadence    string
+	createdAge time.Duration
+}{
+	{FixtureMarkerOverdueA, "quarterly", 300 * 24 * time.Hour}, // ~210 days overdue (quarterly period 90d)
+	{FixtureMarkerOverdueB, "biweekly", 20 * 24 * time.Hour},   // ~6 days overdue (biweekly period 14d)
+}
+
+// Cadences for the remaining cadence-bearing fixtures. None is the first-ranked
+// cadence, for the reason given on pinnedOverdueFixtures. The merge pair's two
+// values must differ — a cadence conflict is one of the three the merge preview
+// surfaces.
+const (
+	fixtureNoActivityCadence  = "monthly"
+	fixtureMergeTargetCadence = "monthly"
+	fixtureMergeSourceCadence = "quarterly"
+	fixtureSearchCadence      = "biannual"
+)
+
+// fixtureBirthdayOffsetDays places the dedicated birthday fixture inside the
+// birthdays page's ≤7-day highlight window, and away from the offsets the
+// catalog-riding clock-anchored fixtures already occupy so the imminent group
+// gains a distinct additional member.
+//
+// It is a forward offset, so the fixture's card always reads exactly this many
+// days out — a year-wrap changes which calendar year the next occurrence falls in,
+// never the day count. The page's SECTION for it is date-dependent (an occurrence
+// already past in the current calendar year files under "Already Celebrated This
+// Year" even when the next one is two days away), which is why the tour resolves
+// the fixture's card by identity rather than by section.
+const fixtureBirthdayOffsetDays = 2
+
+// fixtureMergeLocationStems are the two DISTINCT location stems the merge pair
+// carries, drawn from the catalog's pool so places keep repeating across the world
+// (prod-like). Distinct values are what make location a second genuine merge
+// conflict alongside cadence.
+var fixtureMergeLocationStems = [2]string{catalogLocationStems[0], catalogLocationStems[1]}
+
+// pinnedFixturePlan is one pinned fixture's marker paired with the contact spec it
+// is built from.
+type pinnedFixturePlan struct {
+	marker string
+	spec   factory.ContactSpec
+}
+
+// buildPinnedTourFixtures builds every pinned fixture spec, in seeding order.
+// Split out from the seeding loop so the shape rules the fixtures must satisfy can
+// be asserted purely (no DB) over the SPECS THEMSELVES rather than over a
+// restatement of them — an assertion written against a second copy of the
+// constants proves only that the copy matches.
+//
+// Draws the shared name PRNG once per fixture, so it may only be called from the
+// profile's append-last block.
+func buildPinnedTourFixtures(gen *factory.Generator) []pinnedFixturePlan {
+	anchor := gen.Anchor()
+	prefix := gen.Prefix()
+
+	fixtures := []struct {
+		marker string
+		opts   []factory.ContactOption
+	}{
+		// No activity of any kind, plus a cadence and a recent creation date so the
+		// contact also satisfies the recent-never-connected floor at small catalog
+		// sizes.
+		{FixtureMarkerNoActivity, []factory.ContactOption{
+			factory.WithEmail(),
+			factory.WithCadence(fixtureNoActivityCadence),
+			factory.WithRecentCreation(catalogRecentWindow),
+		}},
+		// The merge pair: cadence AND location both differ, so the preview surfaces
+		// two genuine conflicts rather than relying on one.
+		{FixtureMarkerMergeTarget, []factory.ContactOption{
+			factory.WithEmail(),
+			factory.WithCadence(fixtureMergeTargetCadence),
+			factory.WithLocation(prefix + "place-" + fixtureMergeLocationStems[0]),
+		}},
+		{FixtureMarkerMergeSource, []factory.ContactOption{
+			factory.WithEmail(),
+			factory.WithCadence(fixtureMergeSourceCadence),
+			factory.WithLocation(prefix + "place-" + fixtureMergeLocationStems[1]),
+		}},
+		// Searched + cadence-filtered navigation subject: needs a cadence to survive
+		// the has_cadence filter.
+		{FixtureMarkerSearch, []factory.ContactOption{
+			factory.WithEmail(),
+			factory.WithCadence(fixtureSearchCadence),
+		}},
+		// Delete victim: consumed every sweep, so it carries nothing worth losing.
+		{FixtureMarkerDelete, []factory.ContactOption{
+			factory.WithEmail(),
+		}},
+		// Birthday inside the highlight window.
+		{FixtureMarkerBirthday, []factory.ContactOption{
+			factory.WithEmail(),
+			factory.WithBirthday(BirthdayFixtureDate(anchor, fixtureBirthdayOffsetDays)),
+		}},
+	}
+	for _, pair := range pinnedOverdueFixtures {
+		fixtures = append(fixtures, struct {
+			marker string
+			opts   []factory.ContactOption
+		}{pair.marker, []factory.ContactOption{
+			factory.WithEmail(),
+			factory.WithCadence(pair.cadence),
+			factory.WithCreatedAge(pair.createdAge),
+		}})
+	}
+
+	plans := make([]pinnedFixturePlan, 0, len(fixtures))
+	for _, f := range fixtures {
+		plans = append(plans, pinnedFixturePlan{
+			marker: f.marker,
+			spec:   gen.Contact(append(f.opts, factory.WithNameMarker(f.marker))...),
+		})
+	}
+	return plans
+}
+
+// seedPinnedTourFixtures seeds the hand-authored fixtures the QA tours depend on
+// and records each one's contact id against its marker on the harness.
+//
+// It runs at the VERY END of the catalog profile, after every other
+// generator-drawing block, because gen.Contact draws the shared name PRNG:
+// inserting these calls anywhere earlier would shift every later allocation and a
+// shifted numeric identifier can land on an id another contact already owns.
+// Running last also means these contacts are created after the task reconcile, so
+// they carry no cadence task — which is what lets the no-activity fixture hold its
+// zero-visible-tasks property. That is a consequence to understand, not a thing to
+// rely on elsewhere; the coverage check asserts the property directly.
+//
+// The fixtures deliberately carry NO replayed source payloads, so none of them
+// disturbs the settled-interaction accounting.
+func seedPinnedTourFixtures(ctx context.Context, h *Harness, gen *factory.Generator, profile Profile, res *ProfileResult) error {
+	for _, plan := range buildPinnedTourFixtures(gen) {
+		contact, err := h.SeedContact(ctx, plan.spec)
+		if err != nil {
+			return fmt.Errorf("profile %s: seed pinned fixture %s: %w", profile, plan.marker, err)
+		}
+		res.Contacts++
+		h.SetPinnedFixtureID(plan.marker, contact.ID)
+	}
+	return nil
+}

--- a/backend/internal/synthetic/fixtures.go
+++ b/backend/internal/synthetic/fixtures.go
@@ -81,8 +81,11 @@ const (
 	FixtureMarkerBirthday = "fxbirthday"
 )
 
-// PinnedFixtureMarkers is every pinned tour-fixture marker, in seeding order for
-// the ones this block seeds followed by the ones that ride existing contacts. The
+// PinnedFixtureMarkers is every pinned tour-fixture marker: first the ones this
+// block seeds, then the ones that ride contacts other blocks seed. Within each
+// group the order is declaration order and is NOT load-bearing — nothing reads
+// this slice positionally, and the fixtures are not built in this sequence (the
+// overdue pair is appended from its own table, after the birthday fixture). The
 // coverage checks iterate it, so a fixture added without a marker entry is not
 // silently unasserted.
 var PinnedFixtureMarkers = []string{
@@ -113,6 +116,17 @@ var PinnedFixtureMarkers = []string{
 // order is cadence-frequency ascending, and the contacts tour mutates its first
 // row. A pinned fixture at rank 1 could displace the catalog contact that row is
 // meant to be and collide with the tour's own fixture reservations.
+//
+// These two are the ONLY contacts this block adds to the overdue population, and
+// the population is capture-bounded, not just seed-bounded: the tours' overdue
+// evidence is a JSON array that the capture normalizer slices at a cap, dropping
+// the tail. The prod-shaped catalog already supplies 50 overdue contacts, so this
+// pair takes the set to 52 — measured, not assumed. The overdue tours therefore
+// carry an explicit capture cap (OVERDUE_CAPTURE_CAP in
+// frontend/tests/tours/support/pinned-fixtures.ts) and refuse to run above it, so
+// a set that outgrows the cap fails loudly instead of reaching the judge with an
+// unnamed subset missing. Adding a third overdue fixture means re-checking that
+// cap, not just this table.
 //
 // Anchor-relative via WithCreatedAge (no time.Now()); a pure table, so it draws no
 // PRNG.

--- a/backend/internal/synthetic/fixtures_test.go
+++ b/backend/internal/synthetic/fixtures_test.go
@@ -112,7 +112,8 @@ func TestPinnedOverdueFixturesCloseTheDiversityGap(t *testing.T) {
 	// only: the ladder rotates, so a larger world reaches later backdated slots whose
 	// cadences do overlap the fixtures'. Nothing depends on cadence-newness at scale
 	// (see the table's own comment); the AGE half is checked against the whole ladder
-	// here and against the whole world in the integration gate at n = 18 and n = 150.
+	// here and against the whole world in the integration gate, which runs at the two
+	// n values its call sites use — 18 (dev) and 9 (the prod-shaped coverage check).
 	catalogBackdatedCadences := map[string]bool{}
 	catalogCreatedAges := map[time.Duration]bool{}
 	for _, pair := range catalogOverdueLadder {

--- a/backend/internal/synthetic/fixtures_test.go
+++ b/backend/internal/synthetic/fixtures_test.go
@@ -1,0 +1,278 @@
+package synthetic
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/cadence"
+	"personal-crm/backend/internal/synthetic/factory"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureTestAnchor is a fixed anchor for the pure fixture-shape tests. Its value
+// is irrelevant to every assertion below (all of them are anchor-relative), and
+// pinning it keeps the tests off the wall clock.
+var fixtureTestAnchor = time.Date(2026, time.March, 11, 12, 0, 0, 0, time.UTC)
+
+func newFixtureTestGenerator() *factory.Generator {
+	return factory.NewGeneratorAt(factory.DefaultSeed, "fixtureshape", fixtureTestAnchor)
+}
+
+// markerToken is the marker convention's mechanical constraint: a single lowercase
+// alphanumeric token. The contact search path is Postgres full-text search, which
+// splits a hyphenated marker into several stemmed lexemes whose parts are shared
+// between markers — so a marker that violates this resolves to the wrong row (or
+// to several) instead of failing loudly.
+var markerToken = regexp.MustCompile(`^[a-z0-9]+$`)
+
+// TestPinnedFixtureMarkersWellFormed pins the marker convention itself: every
+// marker is a legal single token, they are mutually distinct, and none is a
+// substring of another (a substring pair would make a mis-resolution look like a
+// legitimate hit to any check weaker than the exactly-one rule). Pure — no DB, no
+// PRNG dependency beyond the fixed generator.
+func TestPinnedFixtureMarkersWellFormed(t *testing.T) {
+	t.Parallel()
+
+	require.NotEmpty(t, PinnedFixtureMarkers)
+	seen := map[string]bool{}
+	for _, marker := range PinnedFixtureMarkers {
+		require.Regexp(t, markerToken, marker, "marker %q must be a single lowercase alphanumeric token", marker)
+		require.False(t, seen[marker], "marker %q is declared twice", marker)
+		seen[marker] = true
+	}
+	for _, a := range PinnedFixtureMarkers {
+		for _, b := range PinnedFixtureMarkers {
+			if a == b {
+				continue
+			}
+			require.False(t, strings.Contains(a, b), "marker %q contains marker %q — markers must not nest", a, b)
+		}
+	}
+}
+
+// TestPinnedTourFixturesCarryTheirMarkers proves every built fixture spec actually
+// carries its marker in full_name (the property the whole resolution scheme rests
+// on), that the built set covers exactly the fixtures this block seeds, and that
+// no two fixtures share a full_name.
+func TestPinnedTourFixturesCarryTheirMarkers(t *testing.T) {
+	t.Parallel()
+
+	plans := buildPinnedTourFixtures(newFixtureTestGenerator())
+
+	// The three fixtures that ride EXISTING seeded contacts are declared in
+	// PinnedFixtureMarkers but are not built here, so the built set is the
+	// complement — stated as a set difference rather than a hardcoded count so
+	// adding a fixture to either side cannot silently pass.
+	riders := map[string]bool{
+		FixtureMarkerOutreach: true,
+		FixtureMarkerResponse: true,
+		FixtureMarkerPending:  true,
+	}
+	want := make([]string, 0, len(PinnedFixtureMarkers))
+	for _, marker := range PinnedFixtureMarkers {
+		if !riders[marker] {
+			want = append(want, marker)
+		}
+	}
+
+	built := map[string]bool{}
+	names := map[string]bool{}
+	for _, plan := range plans {
+		require.Contains(t, plan.spec.FullName, plan.marker, "fixture %q must carry its marker in full_name", plan.marker)
+		require.False(t, built[plan.marker], "fixture %q built twice", plan.marker)
+		built[plan.marker] = true
+		require.False(t, names[plan.spec.FullName], "two pinned fixtures share a full_name")
+		names[plan.spec.FullName] = true
+	}
+	require.Len(t, built, len(want), "every non-riding marker is built exactly once")
+	for _, marker := range want {
+		require.True(t, built[marker], "marker %q is declared but never built", marker)
+	}
+}
+
+// TestPinnedOverdueFixturesCloseTheDiversityGap asserts the two designated overdue
+// fixtures do what the frozen catalog cannot: supply the third distinct old
+// creation age and additional cadences the dashboard's urgency-diversity gate
+// needs at small catalog sizes, while staying genuinely overdue under PRODUCTION
+// cadence durations. Prod durations are read from the cadence package's own source
+// of truth (not hardcoded) so the test cannot drift from prod semantics.
+func TestPinnedOverdueFixturesCloseTheDiversityGap(t *testing.T) {
+	t.Setenv("CRM_ENV", "production")
+
+	require.Len(t, pinnedOverdueFixtures, 2, "both overdue tours consume one overdue contact per sweep")
+
+	// The catalog's BACKDATED cadence-bearing slots are creation indices 0 and 3,
+	// both drawn from the overdue ladder — derived here from catalogOptionsFor rather
+	// than restated, so a catalog change is visible to this test.
+	catalogBackdatedCadences := map[string]bool{}
+	catalogCreatedAges := map[time.Duration]bool{}
+	for _, pair := range catalogOverdueLadder {
+		catalogCreatedAges[pair.createdAge] = true
+	}
+	for _, i := range []int{0, 3} {
+		spec := newFixtureTestGenerator().Contact(catalogOptionsFor(i, 5, fixtureTestAnchor, "synth-fixtureshape-")...)
+		require.NotNil(t, spec.Cadence, "catalog index %d must be cadence-bearing", i)
+		require.NotNil(t, spec.CreatedAt, "catalog index %d must be backdated", i)
+		catalogBackdatedCadences[*spec.Cadence] = true
+	}
+
+	const d1Floor = 14 * 24 * time.Hour
+	distinctAges := map[time.Duration]bool{}
+	distinctCadences := map[string]bool{}
+	tiers := map[string]bool{}
+	for _, pair := range pinnedOverdueFixtures {
+		require.True(t, validCadences[pair.cadence], "fixture %s cadence %q must be a migration-005 CHECK cadence", pair.marker, pair.cadence)
+
+		ct, err := cadence.ParseCadence(pair.cadence)
+		require.NoError(t, err)
+		period := cadence.GetCadenceDuration(ct)
+		require.Greater(t, pair.createdAge, period,
+			"fixture %s (%s, age %s) must be overdue under prod durations (age > period %s)", pair.marker, pair.cadence, pair.createdAge, period)
+
+		// Backdated past the coherence gate's 14-day floor, so each fixture is a
+		// genuine backdated-overdue contact rather than a recent one that merely
+		// computes overdue.
+		require.Greater(t, pair.createdAge, d1Floor, "fixture %s must be backdated past the 14d floor", pair.marker)
+
+		// The gap the frozen catalog cannot close: a NEW distinct creation age and a
+		// NEW distinct cadence.
+		require.False(t, catalogCreatedAges[pair.createdAge],
+			"fixture %s created age %s duplicates a catalog ladder entry — it adds no new distinct creation age", pair.marker, pair.createdAge)
+		require.False(t, catalogBackdatedCadences[pair.cadence],
+			"fixture %s cadence %q duplicates a catalog backdated slot's — it adds no new distinct cadence", pair.marker, pair.cadence)
+
+		require.False(t, distinctAges[pair.createdAge], "fixture %s created age %s duplicates the other overdue fixture's", pair.marker, pair.createdAge)
+		distinctAges[pair.createdAge] = true
+		require.False(t, distinctCadences[pair.cadence], "fixture %s cadence %q duplicates the other overdue fixture's", pair.marker, pair.cadence)
+		distinctCadences[pair.cadence] = true
+
+		tiers[overdueUrgencyTier(pair.createdAge-period)] = true
+	}
+
+	// Spanning ≥2 urgency tiers is the property the dashboard's most-urgent ordering
+	// is evidence OF: two overdue fixtures at the same magnitude would be
+	// indistinguishable on the card list.
+	require.GreaterOrEqual(t, len(tiers), 2, "the overdue fixtures must span ≥2 urgency tiers, got %v", tiers)
+}
+
+// overdueUrgencyTier buckets a days-overdue magnitude into the single-digit / tens
+// / hundreds tiers the dashboard's urgency ordering exists to separate — the same
+// split the catalog ladder's own well-formedness test uses.
+func overdueUrgencyTier(overdue time.Duration) string {
+	switch {
+	case overdue < 10*24*time.Hour:
+		return "single-digit"
+	case overdue < 100*24*time.Hour:
+		return "tens"
+	default:
+		return "hundreds"
+	}
+}
+
+// TestPinnedFixturesAvoidTheFirstRankedCadence protects a POSITIONAL selection the
+// contacts tour deliberately keeps: it mutates the first row of the default
+// cadence-ordered list. That order is cadence frequency ascending, so the shortest
+// production cadence ranks first — and the catalog always seeds one at creation
+// index 0. If a pinned fixture also carried it, the fixture could take that row and
+// collide with the tour's own reservations. Derived from the cadence package's
+// durations rather than from the SQL's rank literals.
+func TestPinnedFixturesAvoidTheFirstRankedCadence(t *testing.T) {
+	t.Setenv("CRM_ENV", "production")
+
+	firstRanked := ""
+	var shortest time.Duration
+	for name := range validCadences {
+		ct, err := cadence.ParseCadence(name)
+		require.NoError(t, err)
+		d := cadence.GetCadenceDuration(ct)
+		if shortest == 0 || d < shortest {
+			shortest, firstRanked = d, name
+		}
+	}
+	require.NotEmpty(t, firstRanked)
+	require.Equal(t, firstRanked, catalogOverdueLadder[0].cadence,
+		"catalog creation index 0 must hold the first-ranked cadence, else nothing guarantees the tour's first row is a catalog contact")
+
+	for _, plan := range buildPinnedTourFixtures(newFixtureTestGenerator()) {
+		if plan.spec.Cadence == nil {
+			continue
+		}
+		require.NotEqual(t, firstRanked, *plan.spec.Cadence,
+			"pinned fixture %s must not carry the first-ranked cadence %q", plan.marker, firstRanked)
+	}
+}
+
+// TestPinnedMergeFixturesConflict asserts the merge pair genuinely conflicts on
+// more than one of the three fields the merge preview surfaces (cadence, location,
+// birthday) — the property the merge tour's conflict-toggle capture consumes,
+// which a mere "two distinct contacts" check would not establish.
+func TestPinnedMergeFixturesConflict(t *testing.T) {
+	t.Parallel()
+
+	var target, source *factory.ContactSpec
+	for _, plan := range buildPinnedTourFixtures(newFixtureTestGenerator()) {
+		switch plan.marker {
+		case FixtureMarkerMergeTarget:
+			spec := plan.spec
+			target = &spec
+		case FixtureMarkerMergeSource:
+			spec := plan.spec
+			source = &spec
+		}
+	}
+	require.NotNil(t, target, "merge target fixture must be built")
+	require.NotNil(t, source, "merge source fixture must be built")
+
+	// The preview marks a field conflicting when the SOURCE's value is non-empty and
+	// differs from the target's, so every conflicting field must be set on the source.
+	require.NotNil(t, source.Cadence)
+	require.NotNil(t, target.Cadence)
+	require.NotEqual(t, *target.Cadence, *source.Cadence, "merge pair must differ in cadence")
+
+	require.NotNil(t, source.Location)
+	require.NotNil(t, target.Location)
+	require.NotEqual(t, *target.Location, *source.Location, "merge pair must differ in location — a second genuine conflict beyond cadence")
+}
+
+// TestPinnedBirthdayFixtureLandsInTheHighlightWindow asserts the dedicated
+// birthday fixture is exactly its offset days out — a DATE-INDEPENDENT
+// classification (a year-wrap changes which calendar year the next occurrence
+// falls in, never the day count) — inside the page's ≤7-day highlight window, and
+// on a day the catalog-riding clock-anchored fixtures do not already occupy.
+func TestPinnedBirthdayFixtureLandsInTheHighlightWindow(t *testing.T) {
+	t.Parallel()
+
+	require.Greater(t, fixtureBirthdayOffsetDays, 0, "the fixture must be upcoming, not today or past")
+	require.LessOrEqual(t, fixtureBirthdayOffsetDays, 7, "the fixture must land in the ≤7-day highlight window")
+	for _, planned := range BirthdayFixturePlan(fixtureTestAnchor) {
+		require.NotEqual(t, planned.OffsetDays, fixtureBirthdayOffsetDays,
+			"the dedicated fixture must not duplicate the catalog-riding %s fixture's offset", planned.Role)
+	}
+
+	// Verified against several anchors, including the year boundary and the leap-day
+	// neighbourhood, so the day-count claim is not an artifact of one date.
+	//
+	// The day COUNT is what is pinned, deliberately not the page SECTION. A forward
+	// fixture seeded within `offset` days of December 31 wraps into next January, so
+	// its occurrence in the CURRENT calendar year is already past and the page files
+	// it under "Already Celebrated This Year" — while its next occurrence is still
+	// exactly `offset` days away. That is the page's own behavior, the section is
+	// therefore date-dependent, and pinning it would be a fixture that passes until a
+	// particular week of the year. The date-independent imminent guarantee is the
+	// catalog-riding "today" fixture (offset 0 can never be past-this-year), which
+	// already exists.
+	for _, anchor := range []time.Time{
+		fixtureTestAnchor,
+		time.Date(2026, time.December, 30, 23, 0, 0, 0, time.UTC),
+		time.Date(2026, time.December, 31, 1, 0, 0, 0, time.UTC),
+		time.Date(2028, time.February, 27, 6, 0, 0, 0, time.UTC),
+		time.Date(2027, time.February, 27, 6, 0, 0, 0, time.UTC),
+	} {
+		bday := BirthdayFixtureDate(anchor, fixtureBirthdayOffsetDays)
+		require.Equal(t, fixtureBirthdayOffsetDays, BirthdayDaysUntil(bday, anchor),
+			"birthday fixture must be exactly %d days out at anchor %s", fixtureBirthdayOffsetDays, anchor)
+	}
+}

--- a/backend/internal/synthetic/fixtures_test.go
+++ b/backend/internal/synthetic/fixtures_test.go
@@ -107,6 +107,12 @@ func TestPinnedOverdueFixturesCloseTheDiversityGap(t *testing.T) {
 	// The catalog's BACKDATED cadence-bearing slots are creation indices 0 and 3,
 	// both drawn from the overdue ladder — derived here from catalogOptionsFor rather
 	// than restated, so a catalog change is visible to this test.
+	//
+	// Derived at n = 5, and the cadence half of the claim below is a SMALL-n claim
+	// only: the ladder rotates, so a larger world reaches later backdated slots whose
+	// cadences do overlap the fixtures'. Nothing depends on cadence-newness at scale
+	// (see the table's own comment); the AGE half is checked against the whole ladder
+	// here and against the whole world in the integration gate at n = 18 and n = 150.
 	catalogBackdatedCadences := map[string]bool{}
 	catalogCreatedAges := map[time.Duration]bool{}
 	for _, pair := range catalogOverdueLadder {

--- a/backend/internal/synthetic/fixtures_test.go
+++ b/backend/internal/synthetic/fixtures_test.go
@@ -245,10 +245,10 @@ func TestPinnedMergeFixturesConflict(t *testing.T) {
 func TestPinnedBirthdayFixtureLandsInTheHighlightWindow(t *testing.T) {
 	t.Parallel()
 
-	require.Greater(t, fixtureBirthdayOffsetDays, 0, "the fixture must be upcoming, not today or past")
-	require.LessOrEqual(t, fixtureBirthdayOffsetDays, 7, "the fixture must land in the ≤7-day highlight window")
+	require.Greater(t, FixtureBirthdayOffsetDays, 0, "the fixture must be upcoming, not today or past")
+	require.LessOrEqual(t, FixtureBirthdayOffsetDays, 7, "the fixture must land in the ≤7-day highlight window")
 	for _, planned := range BirthdayFixturePlan(fixtureTestAnchor) {
-		require.NotEqual(t, planned.OffsetDays, fixtureBirthdayOffsetDays,
+		require.NotEqual(t, planned.OffsetDays, FixtureBirthdayOffsetDays,
 			"the dedicated fixture must not duplicate the catalog-riding %s fixture's offset", planned.Role)
 	}
 
@@ -271,8 +271,8 @@ func TestPinnedBirthdayFixtureLandsInTheHighlightWindow(t *testing.T) {
 		time.Date(2028, time.February, 27, 6, 0, 0, 0, time.UTC),
 		time.Date(2027, time.February, 27, 6, 0, 0, 0, time.UTC),
 	} {
-		bday := BirthdayFixtureDate(anchor, fixtureBirthdayOffsetDays)
-		require.Equal(t, fixtureBirthdayOffsetDays, BirthdayDaysUntil(bday, anchor),
-			"birthday fixture must be exactly %d days out at anchor %s", fixtureBirthdayOffsetDays, anchor)
+		bday := BirthdayFixtureDate(anchor, FixtureBirthdayOffsetDays)
+		require.Equal(t, FixtureBirthdayOffsetDays, BirthdayDaysUntil(bday, anchor),
+			"birthday fixture must be exactly %d days out at anchor %s", FixtureBirthdayOffsetDays, anchor)
 	}
 }

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -1040,7 +1040,10 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	stop = phase("follow-up-loop")
 	followUpPayloads := 0
 	if params.Counts.SeededTasks > 0 {
-		fuSpec := gen.Contact(factory.WithEmail(), factory.WithCadence(followUpScenarioCadence))
+		// Marker-bearing: this contact IS the pinned "awaiting reply" fixture, so the
+		// tour resolves it by name rather than probing every contact's detail endpoint
+		// looking for has_pending_followup (the list payload never carries it).
+		fuSpec := gen.Contact(factory.WithEmail(), factory.WithCadence(followUpScenarioCadence), factory.WithNameMarker(FixtureMarkerPending))
 		fuContact, err := h.SeedContact(ctx, fuSpec)
 		if err != nil {
 			return res, fmt.Errorf("profile %s: seed awaiting-reply contact: %w", params.Profile, err)
@@ -1056,16 +1059,18 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		res.SeededTasks++
 		res.SeededPendingFollowUps = 1
+		h.SetPinnedFixtureID(FixtureMarkerPending, fuContact.ID)
 	}
 	stop(followUpPayloads)
 
 	// --- Two-sided message-direction cohort (F4) --------------------------------
 	//
-	// Seeded LAST, after every other generator-driven block: it draws gen.Contact
-	// (name PRNG) + source replays, and appending keeps the deterministic id/handle
+	// Seeded after every other SOURCE-REPLAYING block: it draws gen.Contact (name
+	// PRNG) + source replays, and appending keeps the deterministic id/handle
 	// sequence the earlier source replays depend on unshifted (the message factories
 	// draw ZERO PRNG — only deterministic counters — but gen.Contact does, so this
-	// must still land at the very end).
+	// must still land near the very end). Only the replay-free birthday-fixture and
+	// pinned-fixture blocks follow it.
 	//
 	// Every message-sourced interaction the loops above produce is INBOUND, so the
 	// judge never sees the user reply and reads every conversation as one-sided (a
@@ -1080,7 +1085,8 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// these pass the PR1 lockstep gate unchanged (NULL last_contacted → exempt).
 	stop = phase("direction-cohort")
 	directionPayloads := 0
-	obGmailSpec := gen.Contact(factory.WithEmail())
+	// The gmail one is marker-bearing: it IS the pinned "last outreach" fixture.
+	obGmailSpec := gen.Contact(factory.WithEmail(), factory.WithNameMarker(FixtureMarkerOutreach))
 	obGmailContact, err := h.SeedContact(ctx, obGmailSpec)
 	if err != nil {
 		return res, fmt.Errorf("profile %s: seed outbound gmail contact: %w", params.Profile, err)
@@ -1091,6 +1097,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	}
 	res.OutboundOnlyContacts++
 	directionPayloads++
+	h.SetPinnedFixtureID(FixtureMarkerOutreach, obGmailContact.ID)
 
 	obGChatSpec := gen.Contact(factory.WithEmail())
 	obGChatContact, err := h.SeedContact(ctx, obGChatSpec)
@@ -1130,7 +1137,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// aggregation finds the outbound interaction and PromoteInteractionToMutualTx
 	// flips it in place: one mutual row, last_contacted == last_interaction_at ==
 	// last_outreach_at == last_response_at.
-	mutualSpec := gen.Contact(factory.WithTelegram())
+	// Marker-bearing: this contact IS the pinned "last response" fixture (a mutual
+	// sets last_response_at), distinct from the outreach fixture above.
+	mutualSpec := gen.Contact(factory.WithTelegram(), factory.WithNameMarker(FixtureMarkerResponse))
 	mutualContact, err := h.SeedContact(ctx, mutualSpec)
 	if err != nil {
 		return res, fmt.Errorf("profile %s: seed mutual telegram contact: %w", params.Profile, err)
@@ -1151,6 +1160,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	}
 	directionPayloads++
 	h.SetMutualMessageContactID(mutualContact.ID)
+	h.SetPinnedFixtureID(FixtureMarkerResponse, mutualContact.ID)
 	res.MutualMessageContacts++
 	stop(directionPayloads)
 
@@ -1158,9 +1168,10 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	//
 	// The "today" fixture was seeded above at its historical position. The rest of
 	// the ordered plan (+1 imminent, distant, and the best-effort extras) is
-	// appended HERE, after every other generator/sourceID consumer: gen.DateFact
-	// draws the shared sourceIDSeq, so placing these draws last shifts no downstream
-	// source id. Together with the today fixture they give CON-052 a small set where
+	// appended HERE, after every other sourceIDSeq consumer: gen.DateFact draws the
+	// shared sourceIDSeq, so placing these draws last shifts no downstream source id
+	// (the pinned-fixture block that follows draws only gen.Contact, which does not
+	// touch sourceIDSeq). Together with the today fixture they give CON-052 a small set where
 	// imminent birthdays visibly stand apart from those that recede.
 	//
 	// Allocation degrades with the birthdayless catalog slots (a birthday is an
@@ -1178,6 +1189,17 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededDateFacts++
 	}
 	h.SetBirthdayFixtureIDs(catalogContactsWithoutBirthday[:seededCount])
+	stop(0)
+
+	// --- Pinned tour fixtures (seeded LAST of all) ------------------------------
+	//
+	// The hand-authored contacts the QA tours resolve by name marker. Appended after
+	// every other generator-drawing block, per the marker convention documented in
+	// fixtures.go.
+	stop = phase("pinned-fixtures")
+	if err := seedPinnedTourFixtures(ctx, h, gen, params.Profile, &res); err != nil {
+		return res, err
+	}
 	stop(0)
 
 	return res, nil

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -322,8 +322,8 @@ type Harness struct {
 	// what a tour searches for over the API and what the coverage checks resolve — so
 	// one marker-keyed map replaces what would otherwise be a Set/Get pair per
 	// fixture. A profile records entries via SetPinnedFixtureID; the coverage checks
-	// read them via PinnedFixtureID / PinnedFixtureIDs to scope the per-fixture
-	// assertions to their exact subjects. Like the ids above it is NOT a
+	// read the whole map via PinnedFixtureIDs to scope the per-fixture assertions to
+	// their exact subjects. Like the ids above it is NOT a
 	// ProfileResult field: contact ids come from uuid_generate_v4()
 	// (non-deterministic), so it stays off the counts-only, determinism-compared
 	// result struct.
@@ -934,17 +934,9 @@ func (h *Harness) SetPinnedFixtureID(marker string, id uuid.UUID) {
 	h.pinnedFixtureIDs[marker] = id
 }
 
-// PinnedFixtureID returns the contact recorded for a pinned tour-fixture marker
-// (uuid.Nil when the fixture was not seeded). Read by the coverage checks to scope
-// each fixture's assertions to its exact subject.
-func (h *Harness) PinnedFixtureID(marker string) uuid.UUID {
-	h.createdMu.Lock()
-	defer h.createdMu.Unlock()
-	return h.pinnedFixtureIDs[marker]
-}
-
 // PinnedFixtureIDs returns a copy of the marker→contact map for every pinned
-// tour fixture the profile recorded (nil-safe: an empty map when none ran).
+// tour fixture the profile recorded (nil-safe: an empty map when none ran). Read
+// by the coverage checks to scope each fixture's assertions to its exact subject.
 func (h *Harness) PinnedFixtureIDs() map[string]uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -317,6 +317,18 @@ type Harness struct {
 	// result struct.
 	birthdayFixtureIDs []uuid.UUID
 
+	// pinnedFixtureIDs maps a pinned tour-fixture MARKER to the contact the profile
+	// seeded (or re-used) for it. The marker is the fixture's stable identity — it is
+	// what a tour searches for over the API and what the coverage checks resolve — so
+	// one marker-keyed map replaces what would otherwise be a Set/Get pair per
+	// fixture. A profile records entries via SetPinnedFixtureID; the coverage checks
+	// read them via PinnedFixtureID / PinnedFixtureIDs to scope the per-fixture
+	// assertions to their exact subjects. Like the ids above it is NOT a
+	// ProfileResult field: contact ids come from uuid_generate_v4()
+	// (non-deterministic), so it stays off the counts-only, determinism-compared
+	// result struct.
+	pinnedFixtureIDs map[string]uuid.UUID
+
 	created   *created
 	createdMu sync.Mutex
 
@@ -908,6 +920,39 @@ func (h *Harness) BirthdayFixtureIDs() []uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return append([]uuid.UUID(nil), h.birthdayFixtureIDs...)
+}
+
+// SetPinnedFixtureID records the contact seeded (or re-used) for one pinned
+// tour-fixture marker. Called by the seeding blocks — hence exported. Guarded by
+// the ledger mutex for parity with the other tracked ids.
+func (h *Harness) SetPinnedFixtureID(marker string, id uuid.UUID) {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	if h.pinnedFixtureIDs == nil {
+		h.pinnedFixtureIDs = make(map[string]uuid.UUID)
+	}
+	h.pinnedFixtureIDs[marker] = id
+}
+
+// PinnedFixtureID returns the contact recorded for a pinned tour-fixture marker
+// (uuid.Nil when the fixture was not seeded). Read by the coverage checks to scope
+// each fixture's assertions to its exact subject.
+func (h *Harness) PinnedFixtureID(marker string) uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return h.pinnedFixtureIDs[marker]
+}
+
+// PinnedFixtureIDs returns a copy of the marker→contact map for every pinned
+// tour fixture the profile recorded (nil-safe: an empty map when none ran).
+func (h *Harness) PinnedFixtureIDs() map[string]uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	out := make(map[string]uuid.UUID, len(h.pinnedFixtureIDs))
+	for marker, id := range h.pinnedFixtureIDs {
+		out[marker] = id
+	}
+	return out
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -299,6 +299,207 @@ func assertBirthdayFixtures(t *testing.T, ctx context.Context, support *reposito
 	}
 }
 
+// assertPinnedTourFixtures runs the pinned tour-fixture gate. For every marker in
+// synthetic.PinnedFixtureMarkers it requires that:
+//
+//   - exactly ONE contact in the namespace carries the marker (not "at least one":
+//     a second match would make the tour's choice a silent coin flip, so it has to
+//     be a loud failure here);
+//   - that row is the one the harness recorded, so the id-scoped assertions below
+//     are about the same contact the tour will resolve;
+//   - the API SEARCH the tours actually use returns exactly that row. A marker that
+//     exists in the DB but does not survive full-text tokenization is unresolvable,
+//     and only running the real search path proves that it does.
+//
+// It then asserts each fixture carries the state its consuming tour depends on,
+// and that the ordering the tours' deliberately POSITIONAL selections read is
+// non-degenerate. The tours read a world-wide list where this reads a
+// namespace-scoped one; on staging the seeded namespace IS the world, which is the
+// case these assertions are about.
+func assertPinnedTourFixtures(
+	t *testing.T,
+	ctx context.Context,
+	support *repository.SyntheticSupportRepository,
+	contactRepo *repository.ContactRepository,
+	h *synthetic.Harness,
+	prefix string,
+	anchor time.Time,
+) {
+	t.Helper()
+	now := accelerated.GetCurrentTime()
+
+	rows, err := support.ListPinnedFixtureContactsByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	// A6: the contacts tour hard-throws below five contacts.
+	require.GreaterOrEqual(t, len(rows), 5, "the contacts tour needs ≥5 contacts in the world")
+
+	recorded := h.PinnedFixtureIDs()
+	require.Len(t, recorded, len(synthetic.PinnedFixtureMarkers),
+		"every declared fixture marker must be recorded on the harness — an unrecorded fixture is one nothing can scope an assertion to")
+
+	byMarker := make(map[string]repository.PinnedFixtureContact, len(synthetic.PinnedFixtureMarkers))
+	subjectOf := make(map[uuid.UUID]string, len(synthetic.PinnedFixtureMarkers))
+	for _, marker := range synthetic.PinnedFixtureMarkers {
+		var matches []repository.PinnedFixtureContact
+		for _, row := range rows {
+			if strings.Contains(row.FullName, marker) {
+				matches = append(matches, row)
+			}
+		}
+		require.Len(t, matches, 1, "fixture %q must resolve to exactly one contact in the namespace", marker)
+		require.Equal(t, recorded[marker], matches[0].ID, "fixture %q: the harness-recorded subject must be the marker-resolvable row", marker)
+
+		found, err := contactRepo.ListContacts(ctx, repository.ListContactsParams{Query: marker, Limit: 200})
+		require.NoError(t, err)
+		scoped := make([]uuid.UUID, 0, 1)
+		for _, c := range found {
+			if strings.HasPrefix(c.FullName, prefix) {
+				scoped = append(scoped, c.ID)
+			}
+		}
+		require.Equal(t, []uuid.UUID{matches[0].ID}, scoped,
+			"fixture %q must be returned by the contact SEARCH the tours resolve with, exactly once", marker)
+
+		prior, dup := subjectOf[matches[0].ID]
+		require.False(t, dup, "fixtures %q and %q resolved to the SAME contact — each fixture needs its own subject", prior, marker)
+		subjectOf[matches[0].ID] = marker
+		byMarker[marker] = matches[0]
+	}
+
+	flags, err := support.ListCadenceActivityFlagsByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	flagsByID := make(map[uuid.UUID]repository.CadenceActivityFlags, len(flags))
+	for _, f := range flags {
+		flagsByID[f.ContactID] = f
+	}
+
+	// A1 — the no-recent-activity subject. It also carries the tasks-section empty
+	// state on the SAME page visit, so zero PRODUCT-VISIBLE tasks is part of the
+	// fixture, asserted directly rather than inferred from its seeding position.
+	noActivity := byMarker[synthetic.FixtureMarkerNoActivity]
+	require.Nil(t, noActivity.LastOutreachAt, "no-activity fixture must carry no outreach")
+	require.Nil(t, noActivity.LastResponseAt, "no-activity fixture must carry no response")
+	require.Nil(t, noActivity.LastContacted, "no-activity fixture must never have been connected with")
+	require.True(t, flagsByID[noActivity.ID].HasNone, "no-activity fixture must carry no pending follow-up either")
+	require.NotNil(t, noActivity.Cadence)
+	require.NotEmpty(t, *noActivity.Cadence, "no-activity fixture must be cadence-bearing (the recent-never-connected floor requires one)")
+	require.NotNil(t, noActivity.CreatedAt)
+	require.True(t, noActivity.CreatedAt.After(now.Add(-14*24*time.Hour)),
+		"no-activity fixture must be recently created (it supplies the recent-never-connected floor)")
+	visible, err := support.ListVisibleTaskCountsByContactIds(ctx, []uuid.UUID{noActivity.ID})
+	require.NoError(t, err)
+	require.Len(t, visible, 1)
+	require.Zero(t, visible[0].VisibleCount, "no-activity fixture must have zero product-visible tasks (the tasks empty state rides on it)")
+
+	// A2 / A3 — outreach and response, on DISTINCT contacts (the distinctness is
+	// already guaranteed above; what matters here is that each carries its column).
+	outreach := byMarker[synthetic.FixtureMarkerOutreach]
+	require.NotNil(t, outreach.LastOutreachAt, "outreach fixture must carry last_outreach_at")
+	response := byMarker[synthetic.FixtureMarkerResponse]
+	require.NotNil(t, response.LastResponseAt, "response fixture must carry last_response_at")
+
+	// A4 — the awaiting-reply subject.
+	pending := byMarker[synthetic.FixtureMarkerPending]
+	require.True(t, flagsByID[pending.ID].HasPending, "pending fixture must carry a live follow-up loop")
+
+	// A5 — the two designated overdue contacts. STATE guarantees, not subjects: no
+	// tour resolves them, the dashboard and relationship-loop tours keep their
+	// positional most-urgent selection. What is asserted is that the world contains
+	// them and that each contributes a creation age no other qualifying contact has —
+	// the diversity gap the frozen catalog cannot close on its own.
+	overdueFixtures := []repository.PinnedFixtureContact{
+		byMarker[synthetic.FixtureMarkerOverdueA],
+		byMarker[synthetic.FixtureMarkerOverdueB],
+	}
+	diversityFloor := now.Add(-7 * 24 * time.Hour)
+	for _, f := range overdueFixtures {
+		require.NotNil(t, f.Cadence)
+		require.NotEmpty(t, *f.Cadence, "overdue fixture must be cadence-bearing")
+		require.Nil(t, f.LastContacted, "overdue fixture must be never-connected (an honest empty timeline)")
+		require.NotNil(t, f.CreatedAt)
+		require.True(t, f.CreatedAt.Before(now.Add(-14*24*time.Hour)), "overdue fixture must be backdated past the 14d floor")
+		require.NotNil(t, f.ContactBy)
+		require.True(t, f.ContactBy.Before(now), "overdue fixture's computed contact_by must have elapsed")
+		cadenceType, err := cadence.ParseCadence(*f.Cadence)
+		require.NoError(t, err)
+		require.True(t, cadence.IsOverdueWithConfig(cadenceType, nil, *f.CreatedAt, now),
+			"overdue fixture must be overdue via the production cadence helper")
+	}
+	require.NotEqual(t, *overdueFixtures[0].Cadence, *overdueFixtures[1].Cadence, "the two overdue fixtures must carry distinct cadences")
+	require.False(t, overdueFixtures[0].CreatedAt.Equal(*overdueFixtures[1].CreatedAt), "the two overdue fixtures must carry distinct creation ages")
+	for i, f := range overdueFixtures {
+		other := overdueFixtures[1-i]
+		for _, row := range rows {
+			if row.ID == f.ID || row.ID == other.ID {
+				continue
+			}
+			if row.Cadence == nil || *row.Cadence == "" || row.LastContacted != nil || row.CreatedAt == nil {
+				continue
+			}
+			if !row.CreatedAt.Before(diversityFloor) {
+				continue
+			}
+			require.False(t, row.CreatedAt.Equal(*f.CreatedAt),
+				"overdue fixture %s duplicates another contact's creation age — it adds no NEW distinct age to the diversity set", subjectOf[f.ID])
+		}
+	}
+
+	// A7 — the merge pair. The preview flags a field conflicting only when the
+	// SOURCE's value is non-empty and differs from the target's, so both fields are
+	// checked from that side.
+	mergeTarget := byMarker[synthetic.FixtureMarkerMergeTarget]
+	mergeSource := byMarker[synthetic.FixtureMarkerMergeSource]
+	require.NotNil(t, mergeTarget.Cadence)
+	require.NotNil(t, mergeSource.Cadence)
+	require.NotEqual(t, *mergeTarget.Cadence, *mergeSource.Cadence, "the merge pair must differ in cadence")
+	require.NotNil(t, mergeTarget.Location)
+	require.NotNil(t, mergeSource.Location, "the merge source must carry a location — a conflict needs the source value set")
+	require.NotEqual(t, *mergeTarget.Location, *mergeSource.Location,
+		"the merge pair must differ in location too — one conflicting field is not enough to prove the preview surfaces the ACTUALLY-conflicting ones")
+
+	// A8 — the searched navigation subject must survive the has_cadence filter.
+	searchSubject := byMarker[synthetic.FixtureMarkerSearch]
+	require.NotNil(t, searchSubject.Cadence)
+	require.NotEmpty(t, *searchSubject.Cadence, "the search subject must be cadence-bearing (it is reached through cadence_filter=has_cadence)")
+
+	// A6 — the merge and navigation subjects are what the "≥3 unique-named contacts"
+	// requirement is actually about, so it is discharged over exactly those three.
+	nameCount := map[string]int{}
+	for _, row := range rows {
+		nameCount[row.FullName]++
+	}
+	for _, marker := range []string{synthetic.FixtureMarkerMergeTarget, synthetic.FixtureMarkerMergeSource, synthetic.FixtureMarkerSearch} {
+		require.Equal(t, 1, nameCount[byMarker[marker].FullName],
+			"fixture %q must carry a name unique in the world — the merge selector filters by exact name text", marker)
+	}
+
+	// A10 — the dedicated highlight-window birthday. Pinned by DAY COUNT, which is
+	// date-independent; the page's section for it is not (see the fixture's own
+	// comment), so the section is deliberately not asserted.
+	birthday := byMarker[synthetic.FixtureMarkerBirthday]
+	require.NotNil(t, birthday.Birthday, "the birthday fixture must have a populated birthday cache")
+	require.Equal(t, synthetic.FixtureBirthdayOffsetDays, synthetic.BirthdayDaysUntil(*birthday.Birthday, anchor),
+		"the birthday fixture must be exactly %d days out", synthetic.FixtureBirthdayOffsetDays)
+
+	// B-group non-degeneracy. These selections are deliberately NOT pinned — they
+	// test the ordering itself — so what is asserted is that the ordering is
+	// well-defined for them. rows arrive in the tours' default cadence order.
+	require.GreaterOrEqual(t, len(rows), 2, "the navigation boundary captures need ≥2 contacts in the order")
+	sortKey := func(c repository.PinnedFixtureContact) string {
+		cadenceValue := ""
+		if c.Cadence != nil {
+			cadenceValue = *c.Cadence
+		}
+		return cadenceValue + "\x00" + c.FullName
+	}
+	require.NotEqual(t, sortKey(rows[0]), sortKey(rows[1]),
+		"the first two rows of the default order must have distinct sort keys — a tie there is broken by a per-run random id, so the tour's first-row subject would rebind between sweeps")
+	for _, marker := range synthetic.PinnedFixtureMarkers {
+		require.NotEqual(t, rows[0].ID, byMarker[marker].ID,
+			"pinned fixture %q must not occupy the first row of the default order — the contacts tour mutates that row and reserves the fixtures separately", marker)
+	}
+}
+
 // These profile-orchestration integration tests are SLOW-gated
 // (testsupport.RequireLongTests) and routed to the nightly slow suite via the
 // TestSynthetic name prefix. Each sub-test uses a UNIQUE namespace so
@@ -679,6 +880,9 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
 	// Notes coverage (F6).
 	assertNotesCoverage(t, ctx, support, h, res, params.Counts.SeededContacts)
+	// Pinned tour fixtures: every state the QA tours depend on resolves to exactly
+	// one named contact carrying that state.
+	assertPinnedTourFixtures(t, ctx, support, repository.NewContactRepository(database.Queries), h, h.Generator().Prefix(), h.Generator().Anchor())
 }
 
 // assertNotesCoverage runs the F6 notes gate: the profile seeds a note on a
@@ -855,6 +1059,9 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
 	// Notes coverage (F6).
 	assertNotesCoverage(t, ctx, support, h, res, params.Counts.SeededContacts)
+	// Pinned tour fixtures: every state the QA tours depend on resolves to exactly
+	// one named contact carrying that state.
+	assertPinnedTourFixtures(t, ctx, support, repository.NewContactRepository(database.Queries), h, h.Generator().Prefix(), h.Generator().Anchor())
 
 	// Bio facts (how_met, location, real-year birthdays) ride on the contact-create
 	// authority flip; the catalog carries ≥1 of each. A location additionally mints
@@ -1128,7 +1335,7 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 // runCatalogProfile brackets with a phase timer. It is pinned so a block added
 // (or a stop() call lost) without a phase is caught here rather than silently
 // dropping a row from the reseed summary.
-const catalogProfilePhaseCount = 22
+const catalogProfilePhaseCount = 23
 
 // phaseShape projects phase timings onto their DETERMINISTIC components — name
 // and payload volume — dropping the wall-clock duration, so a run-to-run

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -466,19 +466,21 @@ func assertPinnedTourFixtures(
 	}
 
 	// The tours read the overdue set through GET /contacts/overdue, whose predicate
-	// is the persisted contact_by against today's DATE — not the column checks above.
-	// Assert both fixtures come back from that path, so the chain from "seeded
-	// overdue" to "in the list the tours capture" is proven rather than inferred from
-	// the margins.
-	endpointOverdue, err := contactRepo.ListOverdueContacts(ctx, cadence.Today(now), 1000)
+	// is the persisted contact_by against today's DATE — a strictly different
+	// comparison from the `now` the column checks above use, so a fixture overdue by
+	// less than a day passes every check above and is still absent from the list the
+	// tours capture. Assert both fixtures come back from that predicate. Read
+	// namespace-scoped and unbounded rather than through the production query's
+	// global LIMIT, which an accumulated shared test DB could overflow.
+	endpointOverdue, err := support.ListOverdueContactIdsByNamePrefix(ctx, prefix, cadence.Today(now))
 	require.NoError(t, err)
 	returnedByEndpoint := make(map[uuid.UUID]bool, len(endpointOverdue))
-	for _, c := range endpointOverdue {
-		returnedByEndpoint[c.ID] = true
+	for _, id := range endpointOverdue {
+		returnedByEndpoint[id] = true
 	}
 	for _, f := range overdueFixtures {
 		require.True(t, returnedByEndpoint[f.ID],
-			"overdue fixture %s must be returned by the overdue endpoint the tours read, not merely carry overdue columns", subjectOf[f.ID])
+			"overdue fixture %s must be returned by the overdue endpoint's predicate, not merely carry overdue columns", subjectOf[f.ID])
 	}
 
 	// A7 — the merge pair. The preview flags a field conflicting only when the

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -330,9 +330,10 @@ func assertPinnedTourFixtures(
 
 	rows, err := support.ListPinnedFixtureContactsByNamePrefix(ctx, prefix)
 	require.NoError(t, err)
-	// A6: the contacts tour hard-throws below five contacts. A floor the pinned
-	// block alone already clears, so it records the tour's requirement rather than
-	// gating anything the seed could plausibly lose.
+	// DOCUMENTATION, NOT A GATE — A6: the contacts tour hard-throws below five
+	// contacts, but the pinned block alone seeds eight into this namespace, so this
+	// records the tour's requirement rather than gating anything the seed could
+	// plausibly lose.
 	require.GreaterOrEqual(t, len(rows), 5, "the contacts tour needs ≥5 contacts in the world")
 
 	recorded := h.PinnedFixtureIDs()
@@ -435,10 +436,19 @@ func assertPinnedTourFixtures(
 	}
 	require.NotEqual(t, *overdueFixtures[0].Cadence, *overdueFixtures[1].Cadence, "the two overdue fixtures must carry distinct cadences")
 	require.False(t, overdueFixtures[0].CreatedAt.Equal(*overdueFixtures[1].CreatedAt), "the two overdue fixtures must carry distinct creation ages")
-	for i, f := range overdueFixtures {
-		other := overdueFixtures[1-i]
+	overdueFixtureIDs := make(map[uuid.UUID]bool, len(overdueFixtures))
+	for _, f := range overdueFixtures {
+		overdueFixtureIDs[f.ID] = true
+	}
+	for _, f := range overdueFixtures {
+		// Comparisons are counted: with nothing to compare against, "adds a new age"
+		// is trivially true, and a silently empty loop would look identical to a
+		// satisfied one. The wider system property this contributes to — ≥3 distinct
+		// old creation ages among the cadence-bearing never-connected rows — is gated
+		// by the coherence floor, not here.
+		compared := 0
 		for _, row := range rows {
-			if row.ID == f.ID || row.ID == other.ID {
+			if overdueFixtureIDs[row.ID] {
 				continue
 			}
 			if row.Cadence == nil || *row.Cadence == "" || row.LastContacted != nil || row.CreatedAt == nil {
@@ -447,9 +457,28 @@ func assertPinnedTourFixtures(
 			if !row.CreatedAt.Before(diversityFloor) {
 				continue
 			}
+			compared++
 			require.False(t, row.CreatedAt.Equal(*f.CreatedAt),
 				"overdue fixture %s duplicates another contact's creation age — it adds no NEW distinct age to the diversity set", subjectOf[f.ID])
 		}
+		require.NotZero(t, compared,
+			"overdue fixture %s was compared against no other qualifying contact — the distinct-age claim would pass vacuously", subjectOf[f.ID])
+	}
+
+	// The tours read the overdue set through GET /contacts/overdue, whose predicate
+	// is the persisted contact_by against today's DATE — not the column checks above.
+	// Assert both fixtures come back from that path, so the chain from "seeded
+	// overdue" to "in the list the tours capture" is proven rather than inferred from
+	// the margins.
+	endpointOverdue, err := contactRepo.ListOverdueContacts(ctx, cadence.Today(now), 1000)
+	require.NoError(t, err)
+	returnedByEndpoint := make(map[uuid.UUID]bool, len(endpointOverdue))
+	for _, c := range endpointOverdue {
+		returnedByEndpoint[c.ID] = true
+	}
+	for _, f := range overdueFixtures {
+		require.True(t, returnedByEndpoint[f.ID],
+			"overdue fixture %s must be returned by the overdue endpoint the tours read, not merely carry overdue columns", subjectOf[f.ID])
 	}
 
 	// A7 — the merge pair. The preview flags a field conflicting only when the
@@ -470,17 +499,25 @@ func assertPinnedTourFixtures(
 	require.NotNil(t, searchSubject.Cadence, "the search subject must be cadence-bearing (it is reached through cadence_filter=has_cadence)")
 	require.NotEmpty(t, *searchSubject.Cadence, "the search subject must be cadence-bearing (it is reached through cadence_filter=has_cadence)")
 
-	// A6 — the merge and navigation subjects are what the "≥3 unique-named contacts"
-	// requirement is actually about, so it is discharged over exactly those three.
-	// This check is DOMINATED by the exactly-one-match rule above (any row sharing a
-	// fixture's full_name necessarily contains that fixture's marker, so it would
-	// fail there first) and is kept as a statement of what the tour's exact-name
-	// selector needs, not as an independent gate.
+	// DOCUMENTATION, NOT A GATE — A6: the "≥3 unique-named contacts" requirement is
+	// about the subjects the contacts tour resolves by exact name text. That is five,
+	// not three: the merge pair and the navigation subject go through the tour's
+	// uniqueName check, the delete victim does too, and the birthday card is matched
+	// by hasText on its full name. This check is DOMINATED by the exactly-one-match
+	// rule above (any row sharing a fixture's full_name necessarily contains that
+	// fixture's marker, so it would fail there first) and is kept as a statement of
+	// what the tour's selectors need.
 	nameCount := map[string]int{}
 	for _, row := range rows {
 		nameCount[row.FullName]++
 	}
-	for _, marker := range []string{synthetic.FixtureMarkerMergeTarget, synthetic.FixtureMarkerMergeSource, synthetic.FixtureMarkerSearch} {
+	for _, marker := range []string{
+		synthetic.FixtureMarkerMergeTarget,
+		synthetic.FixtureMarkerMergeSource,
+		synthetic.FixtureMarkerSearch,
+		synthetic.FixtureMarkerDelete,
+		synthetic.FixtureMarkerBirthday,
+	} {
 		require.Equal(t, 1, nameCount[byMarker[marker].FullName],
 			"fixture %q must carry a name unique in the world — the merge selector filters by exact name text", marker)
 	}

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -330,7 +330,9 @@ func assertPinnedTourFixtures(
 
 	rows, err := support.ListPinnedFixtureContactsByNamePrefix(ctx, prefix)
 	require.NoError(t, err)
-	// A6: the contacts tour hard-throws below five contacts.
+	// A6: the contacts tour hard-throws below five contacts. A floor the pinned
+	// block alone already clears, so it records the tour's requirement rather than
+	// gating anything the seed could plausibly lose.
 	require.GreaterOrEqual(t, len(rows), 5, "the contacts tour needs ≥5 contacts in the world")
 
 	recorded := h.PinnedFixtureIDs()
@@ -373,6 +375,12 @@ func assertPinnedTourFixtures(
 		flagsByID[f.ContactID] = f
 	}
 
+	// A9 — the delete victim carries no state of its own (it exists to be consumed),
+	// so it is discharged ENTIRELY by the resolution rules above: it must be
+	// recorded, resolve to exactly one contact, survive the search path, and be a
+	// subject no other fixture shares. There is deliberately nothing further to
+	// assert about it here.
+
 	// A1 — the no-recent-activity subject. It also carries the tasks-section empty
 	// state on the SAME page visit, so zero PRODUCT-VISIBLE tasks is part of the
 	// fixture, asserted directly rather than inferred from its seeding position.
@@ -381,14 +389,14 @@ func assertPinnedTourFixtures(
 	require.Nil(t, noActivity.LastResponseAt, "no-activity fixture must carry no response")
 	require.Nil(t, noActivity.LastContacted, "no-activity fixture must never have been connected with")
 	require.True(t, flagsByID[noActivity.ID].HasNone, "no-activity fixture must carry no pending follow-up either")
-	require.NotNil(t, noActivity.Cadence)
+	require.NotNil(t, noActivity.Cadence, "no-activity fixture must be cadence-bearing (the recent-never-connected floor requires one)")
 	require.NotEmpty(t, *noActivity.Cadence, "no-activity fixture must be cadence-bearing (the recent-never-connected floor requires one)")
-	require.NotNil(t, noActivity.CreatedAt)
+	require.NotNil(t, noActivity.CreatedAt, "no-activity fixture must carry a creation timestamp")
 	require.True(t, noActivity.CreatedAt.After(now.Add(-14*24*time.Hour)),
 		"no-activity fixture must be recently created (it supplies the recent-never-connected floor)")
 	visible, err := support.ListVisibleTaskCountsByContactIds(ctx, []uuid.UUID{noActivity.ID})
 	require.NoError(t, err)
-	require.Len(t, visible, 1)
+	require.Len(t, visible, 1, "the visible-task count query must answer for the no-activity fixture")
 	require.Zero(t, visible[0].VisibleCount, "no-activity fixture must have zero product-visible tasks (the tasks empty state rides on it)")
 
 	// A2 / A3 — outreach and response, on DISTINCT contacts (the distinctness is
@@ -413,12 +421,12 @@ func assertPinnedTourFixtures(
 	}
 	diversityFloor := now.Add(-7 * 24 * time.Hour)
 	for _, f := range overdueFixtures {
-		require.NotNil(t, f.Cadence)
+		require.NotNil(t, f.Cadence, "overdue fixture must be cadence-bearing")
 		require.NotEmpty(t, *f.Cadence, "overdue fixture must be cadence-bearing")
 		require.Nil(t, f.LastContacted, "overdue fixture must be never-connected (an honest empty timeline)")
-		require.NotNil(t, f.CreatedAt)
+		require.NotNil(t, f.CreatedAt, "overdue fixture must carry a creation timestamp")
 		require.True(t, f.CreatedAt.Before(now.Add(-14*24*time.Hour)), "overdue fixture must be backdated past the 14d floor")
-		require.NotNil(t, f.ContactBy)
+		require.NotNil(t, f.ContactBy, "overdue fixture must carry a computed contact_by")
 		require.True(t, f.ContactBy.Before(now), "overdue fixture's computed contact_by must have elapsed")
 		cadenceType, err := cadence.ParseCadence(*f.Cadence)
 		require.NoError(t, err)
@@ -449,21 +457,25 @@ func assertPinnedTourFixtures(
 	// checked from that side.
 	mergeTarget := byMarker[synthetic.FixtureMarkerMergeTarget]
 	mergeSource := byMarker[synthetic.FixtureMarkerMergeSource]
-	require.NotNil(t, mergeTarget.Cadence)
-	require.NotNil(t, mergeSource.Cadence)
+	require.NotNil(t, mergeTarget.Cadence, "the merge target must carry a cadence — the pair conflicts on it")
+	require.NotNil(t, mergeSource.Cadence, "the merge source must carry a cadence — a conflict needs the source value set")
 	require.NotEqual(t, *mergeTarget.Cadence, *mergeSource.Cadence, "the merge pair must differ in cadence")
-	require.NotNil(t, mergeTarget.Location)
+	require.NotNil(t, mergeTarget.Location, "the merge target must carry a location — the pair conflicts on it")
 	require.NotNil(t, mergeSource.Location, "the merge source must carry a location — a conflict needs the source value set")
 	require.NotEqual(t, *mergeTarget.Location, *mergeSource.Location,
 		"the merge pair must differ in location too — one conflicting field is not enough to prove the preview surfaces the ACTUALLY-conflicting ones")
 
 	// A8 — the searched navigation subject must survive the has_cadence filter.
 	searchSubject := byMarker[synthetic.FixtureMarkerSearch]
-	require.NotNil(t, searchSubject.Cadence)
+	require.NotNil(t, searchSubject.Cadence, "the search subject must be cadence-bearing (it is reached through cadence_filter=has_cadence)")
 	require.NotEmpty(t, *searchSubject.Cadence, "the search subject must be cadence-bearing (it is reached through cadence_filter=has_cadence)")
 
 	// A6 — the merge and navigation subjects are what the "≥3 unique-named contacts"
 	// requirement is actually about, so it is discharged over exactly those three.
+	// This check is DOMINATED by the exactly-one-match rule above (any row sharing a
+	// fixture's full_name necessarily contains that fixture's marker, so it would
+	// fail there first) and is kept as a statement of what the tour's exact-name
+	// selector needs, not as an independent gate.
 	nameCount := map[string]int{}
 	for _, row := range rows {
 		nameCount[row.FullName]++

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -681,6 +681,14 @@
     "tags": []
   },
   {
+    "pattern": "^backend/internal/synthetic/",
+    "tags": []
+  },
+  {
+    "pattern": "^backend/internal/repository/synthetic_support\\.go$",
+    "tags": []
+  },
+  {
     "pattern": "^frontend/src/.*/__tests__/",
     "tags": []
   }

--- a/frontend/tests/tours/cadence-followup.tour.ts
+++ b/frontend/tests/tours/cadence-followup.tour.ts
@@ -3,19 +3,29 @@
 // section empty state), CAD-031 (add-task modal), CAD-033 (unlink, skip-listed).
 //
 // Imports ONLY `test` from the fixtures — never `expect`. The recent-activity
-// states (CAD-029) are API-SELECTED: a distinct seeded contact for each required
-// state, throwing fail-loud if a state is absent (a missing state is signal, not
-// a vacuous pass). Provider-dependent parts (populated tasks, task create,
-// unlink) are skip-listed — a provider-less local sweep cannot reach them.
+// states (CAD-029) each have a DEDICATED PINNED CONTACT in the seed, resolved by
+// its name marker and then verified to carry the state, so the tour walks the
+// contact the seed guaranteed rather than whatever the population happened to
+// contain. A missing or ambiguous fixture throws fail-loud (a missing state is
+// signal, not a vacuous pass). Provider-dependent parts (populated tasks, task
+// create, unlink) are skip-listed — a provider-less local sweep cannot reach them.
 
 import { test } from './support/tour-fixtures'
+import {
+  FIXTURE_NO_ACTIVITY,
+  FIXTURE_OUTREACH,
+  FIXTURE_PENDING,
+  FIXTURE_RESPONSE,
+  resolveFixture,
+} from './support/pinned-fixtures'
 
 interface ActivityContact {
   id: string
   full_name: string
   last_outreach_at: string | null
   last_response_at: string | null
-  has_pending_followup: boolean
+  // No has_pending_followup: the list payload always ships it false (only the
+  // detail handler computes it), so a field here would invite reading it.
 }
 
 const CONTACT_ID_PATH = /\/api\/v1\/contacts\/[0-9a-f-]{36}$/
@@ -23,42 +33,70 @@ const CONTACT_ID_PATH = /\/api\/v1\/contacts\/[0-9a-f-]{36}$/
 test('cadence-followup tour — contact-detail cadence surfaces', async ({ page, tour }) => {
   test.setTimeout(480_000)
 
-  // --- API-select a distinct contact for each CAD-029 activity state ---
-  const listResp = await tour.apiCtx.get('/api/v1/contacts?limit=300&sort=cadence&order=desc')
-  const contacts = ((await listResp.json())?.data ?? []) as ActivityContact[]
-
-  const reserved = new Set<string>()
-  const pick = (pred: (c: ActivityContact) => boolean, label: string): ActivityContact => {
-    const c = contacts.find(x => !reserved.has(x.id) && pred(x))
-    if (!c) throw new Error(`cadence-followup tour: no seeded contact with ${label}`)
-    reserved.add(c.id)
-    return c
+  // --- Resolve the pinned contact for each CAD-029 activity state ---
+  // Resolution is by marker; the STATE is then verified on the resolved row, since
+  // a search that returned something is not proof it returned the right thing.
+  const detailOf = async (id: string): Promise<Record<string, unknown>> => {
+    const r = await tour.apiCtx.get(`/api/v1/contacts/${id}`)
+    return ((await r.json())?.data ?? {}) as Record<string, unknown>
   }
-  const outreachContact = pick(c => !!c.last_outreach_at, 'last_outreach_at (CAD-029[0])')
-  const responseContact = pick(c => !!c.last_response_at, 'last_response_at (CAD-029[1])')
+
+  const outreachContact = await resolveFixture<ActivityContact>(
+    tour.apiCtx,
+    FIXTURE_OUTREACH,
+    'CAD-029[0] last_outreach_at'
+  )
+  if (!outreachContact.last_outreach_at) {
+    throw new Error('cadence-followup tour: the outreach fixture carries no last_outreach_at')
+  }
+
+  const responseContact = await resolveFixture<ActivityContact>(
+    tour.apiCtx,
+    FIXTURE_RESPONSE,
+    'CAD-029[1] last_response_at'
+  )
+  if (!responseContact.last_response_at) {
+    throw new Error('cadence-followup tour: the response fixture carries no last_response_at')
+  }
+  if (responseContact.id === outreachContact.id) {
+    throw new Error(
+      'cadence-followup tour: the outreach and response fixtures must be distinct contacts'
+    )
+  }
+
   // has_pending_followup is ONLY computed by the DETAIL handler. The list (and overdue)
   // payloads carry the field as a non-pointer bool with no omitempty, so they ship
   // `has_pending_followup: false` for every contact unconditionally — present, always
-  // false, and therefore meaningless. Selecting on it from the list silently matches
-  // nothing (and `noneContact`'s !has_pending_followup clause below is vacuously true for
-  // the same reason). Probe the detail endpoint, which actually answers.
-  const pendingContact = await (async () => {
-    for (const c of contacts) {
-      const r = await tour.apiCtx.get(`/api/v1/contacts/${c.id}`)
-      if (((await r.json())?.data ?? {}).has_pending_followup) return c
-    }
-    // Loud, never skipped: a world with no live follow-up is a SEED bug (the prod-shaped
-    // profile seeds one), and touring without this state is exactly what produced the
-    // false CAD-036 regression — the judge read the missing state as a missing feature.
-    throw new Error(
-      'cadence-followup tour: no seeded contact with has_pending_followup (CAD-029[2])'
-    )
-  })()
-  reserved.add(pendingContact.id)
-  const noneContact = pick(
-    c => !c.last_outreach_at && !c.last_response_at && !c.has_pending_followup,
-    'no recent-activity signals (CAD-029[3])'
+  // false, and therefore meaningless. Verifying it means one detail probe on the
+  // resolved fixture, where the old selection swept the detail endpoint across the
+  // whole population looking for a hit.
+  const pendingContact = await resolveFixture<ActivityContact>(
+    tour.apiCtx,
+    FIXTURE_PENDING,
+    'CAD-029[2] has_pending_followup'
   )
+  // Loud, never skipped: a world with no live follow-up is a SEED bug (the prod-shaped
+  // profile seeds one), and touring without this state is exactly what produced the
+  // false CAD-036 regression — the judge read the missing state as a missing feature.
+  if (!(await detailOf(pendingContact.id)).has_pending_followup) {
+    throw new Error(
+      'cadence-followup tour: the pending fixture carries no live follow-up (CAD-029[2])'
+    )
+  }
+
+  const noneContact = await resolveFixture<ActivityContact>(
+    tour.apiCtx,
+    FIXTURE_NO_ACTIVITY,
+    'CAD-029[3] no recent-activity signals'
+  )
+  const noneDetail = await detailOf(noneContact.id)
+  if (
+    noneDetail.last_outreach_at ||
+    noneDetail.last_response_at ||
+    noneDetail.has_pending_followup
+  ) {
+    throw new Error('cadence-followup tour: the no-activity fixture carries an activity signal')
+  }
 
   const gotoDetail = async (id: string): Promise<void> => {
     await page.goto(`/contacts/${id}`)

--- a/frontend/tests/tours/cadence-followup.tour.ts
+++ b/frontend/tests/tours/cadence-followup.tour.ts
@@ -36,9 +36,36 @@ test('cadence-followup tour — contact-detail cadence surfaces', async ({ page,
   // --- Resolve the pinned contact for each CAD-029 activity state ---
   // Resolution is by marker; the STATE is then verified on the resolved row, since
   // a search that returned something is not proof it returned the right thing.
+  //
+  // detailOf throws on a non-OK response rather than degrading to {}. An empty
+  // object reads as "no activity signals", so a failed fetch would let the
+  // no-activity check below pass for a reason that has nothing to do with the
+  // contact — the same vacuity the state verification exists to remove.
   const detailOf = async (id: string): Promise<Record<string, unknown>> => {
     const r = await tour.apiCtx.get(`/api/v1/contacts/${id}`)
+    if (!r.ok()) {
+      throw new Error(
+        `cadence-followup tour: contact detail fetch failed (${r.status()}) for ${id}`
+      )
+    }
     return ((await r.json())?.data ?? {}) as Record<string, unknown>
+  }
+
+  // Every CAD-029 state must sit on its OWN contact: the four captures are read as
+  // four distinct relationships, and two states landing on one contact would let a
+  // single page stand in for two behaviors. The seed's markers make that true and
+  // the Go gate proves it per-PR, but staging drift is exactly what a tour-side
+  // check is for, so each resolved subject is claimed here as it is resolved.
+  const reserved = new Map<string, string>()
+  const claim = (id: string, label: string): void => {
+    const prior = reserved.get(id)
+    if (prior) {
+      throw new Error(
+        `cadence-followup tour: ${label} resolved to the same contact as ${prior} — ` +
+          'each CAD-029 activity state needs its own subject'
+      )
+    }
+    reserved.set(id, label)
   }
 
   const outreachContact = await resolveFixture<ActivityContact>(
@@ -49,6 +76,7 @@ test('cadence-followup tour — contact-detail cadence surfaces', async ({ page,
   if (!outreachContact.last_outreach_at) {
     throw new Error('cadence-followup tour: the outreach fixture carries no last_outreach_at')
   }
+  claim(outreachContact.id, 'the outreach fixture')
 
   const responseContact = await resolveFixture<ActivityContact>(
     tour.apiCtx,
@@ -58,11 +86,7 @@ test('cadence-followup tour — contact-detail cadence surfaces', async ({ page,
   if (!responseContact.last_response_at) {
     throw new Error('cadence-followup tour: the response fixture carries no last_response_at')
   }
-  if (responseContact.id === outreachContact.id) {
-    throw new Error(
-      'cadence-followup tour: the outreach and response fixtures must be distinct contacts'
-    )
-  }
+  claim(responseContact.id, 'the response fixture')
 
   // has_pending_followup is ONLY computed by the DETAIL handler. The list (and overdue)
   // payloads carry the field as a non-pointer bool with no omitempty, so they ship
@@ -75,6 +99,7 @@ test('cadence-followup tour — contact-detail cadence surfaces', async ({ page,
     FIXTURE_PENDING,
     'CAD-029[2] has_pending_followup'
   )
+  claim(pendingContact.id, 'the pending fixture')
   // Loud, never skipped: a world with no live follow-up is a SEED bug (the prod-shaped
   // profile seeds one), and touring without this state is exactly what produced the
   // false CAD-036 regression — the judge read the missing state as a missing feature.
@@ -89,6 +114,7 @@ test('cadence-followup tour — contact-detail cadence surfaces', async ({ page,
     FIXTURE_NO_ACTIVITY,
     'CAD-029[3] no recent-activity signals'
   )
+  claim(noneContact.id, 'the no-activity fixture')
   const noneDetail = await detailOf(noneContact.id)
   if (
     noneDetail.last_outreach_at ||

--- a/frontend/tests/tours/contacts.tour.ts
+++ b/frontend/tests/tours/contacts.tour.ts
@@ -120,18 +120,39 @@ test('contacts tour — current ux behaviors', async ({ page, tour }) => {
     throw new Error('tour: the CON-045 birthday fixture carries no birthday')
   }
 
+  // Every resolved subject must be its OWN contact: two of these steps MUTATE
+  // (merge archives the source, delete removes its victim), so a collision would
+  // consume a subject a later step still needs and the tour would fail somewhere
+  // unrelated to the cause. The seed's markers make this true and the Go gate
+  // proves it per-PR; this is the tour-side check for staging drift.
+  const reserved = new Set<string>()
+  for (const [label, c] of [
+    ['CON-043 merge target', target],
+    ['CON-043 merge source', source],
+    ['CON-065 navigation subject', navContact],
+    ['CON-042 delete victim', deleteContact],
+    ['CON-045 highlight-window birthday', birthdayContact],
+  ] as Array<[string, TourContact]>) {
+    if (reserved.has(c.id)) {
+      throw new Error(`tour: the fixture for ${label} resolved to a contact another step reserved`)
+    }
+    reserved.add(c.id)
+  }
+
   // markContact = the first cadence-desc row (guaranteed on list page 1). Left
   // POSITIONAL on purpose — it is the ordering that is under test here — so the
   // only thing asserted is that a pinned fixture has not drifted into that row and
   // collided with a reservation above.
   const markContact = contacts[0]
-  const reserved = new Set<string>([target.id, source.id, navContact.id, deleteContact.id])
   if (reserved.has(markContact.id)) {
     throw new Error(
       'tour: the first cadence-ordered row is a pinned fixture — the seed must keep that row a generated contact'
     )
   }
   reserved.add(markContact.id)
+  // Reads from the full reservation set, so the ?action= subject can never be a
+  // pinned fixture: both of its flows discard rather than commit today, but the
+  // reservation is the fence, not the flows' current behavior.
   const actionParamContact = contacts.find(c => !reserved.has(c.id)) ?? markContact
 
   // Mid-list + first contact for keyboard-nav (read-only; order = default nav).
@@ -505,7 +526,14 @@ test('contacts tour — current ux behaviors', async ({ page, tour }) => {
 
   // Manual name edit in edit mode; the live input value is captured via fields
   // (ariaSnapshot does not reliably emit a textbox's value).
-  const editedMergedName = `${source.full_name} (merged)`
+  //
+  // Deliberately MARKER-FREE, and not derived from either fixture's name. The
+  // merge commits this string onto the surviving contact, so deriving it from the
+  // source would leave a second contact carrying the source's marker — making the
+  // seed no longer the only writer of marker-bearing names, and leaving the source
+  // marker resolving exactly-once to the wrong object on a re-run without a
+  // reseed, which no resolution rule can detect.
+  const editedMergedName = 'Merged Contact (tour edit)'
   await mergeModal.getByRole('heading', { level: 3 }).click() // handleStartEditingName
   const nameInput = mergeModal.getByRole('textbox').first()
   await nameInput.waitFor({ state: 'visible' })

--- a/frontend/tests/tours/contacts.tour.ts
+++ b/frontend/tests/tours/contacts.tour.ts
@@ -12,6 +12,14 @@
 // never expect().
 
 import { test } from './support/tour-fixtures'
+import {
+  FIXTURE_BIRTHDAY,
+  FIXTURE_DELETE,
+  FIXTURE_MERGE_SOURCE,
+  FIXTURE_MERGE_TARGET,
+  FIXTURE_SEARCH,
+  resolveFixture,
+} from './support/pinned-fixtures'
 
 interface TourContact {
   id: string
@@ -52,46 +60,78 @@ test('contacts tour — current ux behaviors', async ({ page, tour }) => {
   for (const c of contacts) nameCount.set(c.full_name, (nameCount.get(c.full_name) ?? 0) + 1)
   const uniqueName = (c: TourContact): boolean => nameCount.get(c.full_name) === 1
 
-  // markContact = the first cadence-desc row (guaranteed on list page 1).
-  const markContact = contacts[0]
-  const reserved = new Set<string>([markContact.id])
+  // The MUTATED and SEARCHED subjects are pinned fixtures, resolved by marker and
+  // then verified — the state each step needs is seeded deliberately rather than
+  // scanned for. inWindow re-reads each resolved subject from THIS list, because
+  // the merge selector's candidate universe is exactly this window: a subject
+  // outside it would be invisible to the selector and would make `uniqueName`
+  // (computed over this list) a claim about a different set.
+  const byId = new Map(contacts.map(c => [c.id, c]))
+  const inWindow = (c: TourContact, label: string): TourContact => {
+    const row = byId.get(c.id)
+    if (!row) {
+      throw new Error(`tour: pinned fixture for ${label} is outside the limit=500 selector window`)
+    }
+    if (!uniqueName(row)) {
+      throw new Error(`tour: pinned fixture for ${label} does not carry a unique name`)
+    }
+    return row
+  }
 
   // CON-043 REQUIRES a cadence-differing pair with unique names (so the
-  // client-side selector filter is unambiguous). Throw if none — a tour error
-  // is signal, not a silent evidence-less capture.
-  let target: TourContact | undefined
-  let source: TourContact | undefined
-  for (let i = 0; i < contacts.length && !target; i++) {
-    const a = contacts[i]
-    if (reserved.has(a.id) || !a.cadence || !uniqueName(a)) continue
-    for (let j = i + 1; j < contacts.length; j++) {
-      const b = contacts[j]
-      if (reserved.has(b.id) || !b.cadence || !uniqueName(b)) continue
-      if (a.cadence !== b.cadence) {
-        target = a
-        source = b
-        break
-      }
-    }
+  // client-side selector filter is unambiguous), and the preview only surfaces a
+  // conflict toggle for a field the SOURCE actually differs on.
+  const target = inWindow(
+    await resolveFixture<TourContact>(tour.apiCtx, FIXTURE_MERGE_TARGET, 'CON-043 merge target'),
+    'CON-043 merge target'
+  )
+  const source = inWindow(
+    await resolveFixture<TourContact>(tour.apiCtx, FIXTURE_MERGE_SOURCE, 'CON-043 merge source'),
+    'CON-043 merge source'
+  )
+  if (!target.cadence || !source.cadence || target.cadence === source.cadence) {
+    throw new Error('tour: the CON-043 merge fixtures must both carry a cadence, and differ')
   }
-  if (!target || !source) {
-    throw new Error('tour: CON-043 requires a cadence-differing, unique-named pair; seed lacks one')
-  }
-  reserved.add(target.id)
-  reserved.add(source.id)
 
   // CON-065 walks a searched + cadence-filtered list, so it needs a distinct
   // contact with a cadence (survives cadence_filter=has_cadence) and a unique
   // name (the search resolves to its row unambiguously). Never mutated below.
-  const navContact = contacts.find(c => !reserved.has(c.id) && c.cadence && uniqueName(c))
-  if (!navContact) {
-    throw new Error('tour: CON-065 needs a distinct cadence-bearing, unique-named contact')
+  const navContact = inWindow(
+    await resolveFixture<TourContact>(tour.apiCtx, FIXTURE_SEARCH, 'CON-065 navigation subject'),
+    'CON-065 navigation subject'
+  )
+  if (!navContact.cadence) {
+    throw new Error('tour: the CON-065 fixture must carry a cadence (the list is cadence-filtered)')
   }
-  reserved.add(navContact.id)
 
-  const deleteContact = contacts.find(c => !reserved.has(c.id))
-  if (!deleteContact) throw new Error('tour: no distinct contact left for the delete step')
-  reserved.add(deleteContact.id)
+  const deleteContact = inWindow(
+    await resolveFixture<TourContact>(tour.apiCtx, FIXTURE_DELETE, 'CON-042 delete victim'),
+    'CON-042 delete victim'
+  )
+
+  // CON-045's birthday card. Resolved so the capture waits for a card that is
+  // genuinely in the seed's imminent group, not merely the first card rendered.
+  const birthdayContact = await resolveFixture<TourContact>(
+    tour.apiCtx,
+    FIXTURE_BIRTHDAY,
+    'CON-045 highlight-window birthday'
+  )
+  if (!birthdayContact.birthday) {
+    throw new Error('tour: the CON-045 birthday fixture carries no birthday')
+  }
+
+  // markContact = the first cadence-desc row (guaranteed on list page 1). Left
+  // POSITIONAL on purpose — it is the ordering that is under test here — so the
+  // only thing asserted is that a pinned fixture has not drifted into that row and
+  // collided with a reservation above.
+  const markContact = contacts[0]
+  const reserved = new Set<string>([target.id, source.id, navContact.id, deleteContact.id])
+  if (reserved.has(markContact.id)) {
+    throw new Error(
+      'tour: the first cadence-ordered row is a pinned fixture — the seed must keep that row a generated contact'
+    )
+  }
+  reserved.add(markContact.id)
   const actionParamContact = contacts.find(c => !reserved.has(c.id)) ?? markContact
 
   // Mid-list + first contact for keyboard-nav (read-only; order = default nav).
@@ -203,7 +243,15 @@ test('contacts tour — current ux behaviors', async ({ page, tour }) => {
   // system/time GET (which would deadlock on the warm 5m-stale cache).
   await page.goto('/birthdays')
   await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH) // the limit=1000 load
-  await page.getByTestId('birthday-card').first().waitFor({ state: 'visible', timeout: 20_000 })
+  // Wait for the PINNED fixture's own card, not merely the first one rendered: the
+  // judged quality is that imminent birthdays stand apart from distant ones, and a
+  // page whose only card is a distant one would satisfy `.first()`. No `.first()`
+  // on the filtered locator either — two cards matching a fixture name would be a
+  // strict-mode failure, which is the loud outcome that case deserves.
+  await page
+    .getByTestId('birthday-card')
+    .filter({ hasText: birthdayContact.full_name })
+    .waitFor({ state: 'visible', timeout: 20_000 })
   // DECISION 1 (capture weight): the con045 verifier's birthday ground-truth
   // ([0] grouping / [1] gift candidates / [3] placeholder names) needs only
   // { full_name, birthday } per birthday-bearing contact — NOT the full

--- a/frontend/tests/tours/dashboard.tour.ts
+++ b/frontend/tests/tours/dashboard.tour.ts
@@ -66,6 +66,25 @@ async function readOverdueCards(
 test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, tour }) => {
   test.setTimeout(480_000)
 
+  // --- Reserve the overdue set (by API) for CAD-026/027 tier + order evidence ---
+  //
+  // Read BEFORE the first capture, and EVERY capture in this tour carries
+  // OVERDUE_CAPTURE_CAP. The landing `page.goto('/')` below redirects to the
+  // dashboard, whose widget fires its own parameterless overdue GET; that
+  // page-context response is buffered and drained by whichever capture runs next,
+  // so the overdue array reaches captures as a drained response body long before
+  // the first one that names it in `fields`. A cap check placed after those
+  // captures would be checking evidence that had already been sliced.
+  const overdueResp = await tour.apiCtx.get('/api/v1/contacts/overdue')
+  const overdueRows = ((await overdueResp.json())?.data ?? []) as OverdueRow[]
+  if (overdueRows.length === 0) {
+    throw new Error('dashboard tour: no overdue contacts in the seed — cannot tour CAD-026/027/028')
+  }
+  assertOverdueFitsCapture(overdueRows.length, 'dashboard')
+  const lastContactedById = new Map<string, string | null>(
+    overdueRows.map(r => [r.id, r.last_contacted ?? null])
+  )
+
   // --- DSH-001: the dashboard is the default landing surface ---
   await page.goto('/')
   // Best-effort mid-redirect capture: the in-flight state (and its screenshot)
@@ -81,6 +100,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   // defect).
   try {
     await tour.capture(page, {
+      arrayCap: OVERDUE_CAPTURE_CAP,
       behaviors: ['DSH-001'],
       note: 'mid-redirect state at the app root (best-effort; may already show the destination)',
       pair: { id: 'redirect', role: 'inflight' },
@@ -91,6 +111,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   await page.waitForURL(u => new URL(u).pathname === '/dashboard')
   await page.getByRole('heading', { name: 'Action Required' }).waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-001'],
     note: 'app root redirected to the dashboard (default landing)',
     pair: { id: 'landing', role: 'landing' },
@@ -104,6 +125,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
     .first()
     .evaluate(el => getComputedStyle(el).position)
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-002', 'DSH-003', 'DSH-007'],
     note: 'dashboard shell: global nav, header Add Contact, no dashboard search',
     pair: { id: 'dashboard', role: 'dashboard' },
@@ -114,27 +136,11 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   await page.goto('/contacts')
   await page.getByPlaceholder('Search contacts...').waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-007'],
     note: 'contact list search input (contact text search)',
     pair: { id: 'contacts-search', role: 'contacts-search' },
   })
-
-  // --- Reserve the overdue set (by API) for CAD-026/027 tier + order evidence ---
-  //
-  // Every capture from here on carries OVERDUE_CAPTURE_CAP: the overdue array
-  // reaches a capture either as a `fields` value or as the drained body of an
-  // overdue GET, and which capture drains a given response depends on where the
-  // fetch lands in the buffer — so the cap is set for the whole region rather than
-  // reasoned about per call site.
-  const overdueResp = await tour.apiCtx.get('/api/v1/contacts/overdue')
-  const overdueRows = ((await overdueResp.json())?.data ?? []) as OverdueRow[]
-  if (overdueRows.length === 0) {
-    throw new Error('dashboard tour: no overdue contacts in the seed — cannot tour CAD-026/027/028')
-  }
-  assertOverdueFitsCapture(overdueRows.length, 'dashboard')
-  const lastContactedById = new Map<string, string | null>(
-    overdueRows.map(r => [r.id, r.last_contacted ?? null])
-  )
 
   // --- CAD-026 / CAD-027[0]: overdue cards + urgency (default) order ---
   await page.goto('/dashboard')

--- a/frontend/tests/tours/dashboard.tour.ts
+++ b/frontend/tests/tours/dashboard.tour.ts
@@ -9,6 +9,7 @@
 // loading / error / caught-up overdue states deterministic (no seed luck).
 
 import { test } from './support/tour-fixtures'
+import { assertOverdueFitsCapture, OVERDUE_CAPTURE_CAP } from './support/pinned-fixtures'
 import type { Page } from '@playwright/test'
 
 interface OverdueRow {
@@ -119,11 +120,18 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   })
 
   // --- Reserve the overdue set (by API) for CAD-026/027 tier + order evidence ---
+  //
+  // Every capture from here on carries OVERDUE_CAPTURE_CAP: the overdue array
+  // reaches a capture either as a `fields` value or as the drained body of an
+  // overdue GET, and which capture drains a given response depends on where the
+  // fetch lands in the buffer — so the cap is set for the whole region rather than
+  // reasoned about per call site.
   const overdueResp = await tour.apiCtx.get('/api/v1/contacts/overdue')
   const overdueRows = ((await overdueResp.json())?.data ?? []) as OverdueRow[]
   if (overdueRows.length === 0) {
     throw new Error('dashboard tour: no overdue contacts in the seed — cannot tour CAD-026/027/028')
   }
+  assertOverdueFitsCapture(overdueRows.length, 'dashboard')
   const lastContactedById = new Map<string, string | null>(
     overdueRows.map(r => [r.id, r.last_contacted ?? null])
   )
@@ -136,6 +144,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
     .first()
     .waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-026', 'CAD-027'],
     note: 'overdue list, urgency (default) sort: cards + count + tiers',
     pair: { id: 'sort', role: 'sort-urgency' },
@@ -145,6 +154,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   // --- CAD-027[1]: name order ---
   await page.getByRole('button', { name: 'Name' }).click()
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-027'],
     note: 'overdue list, name sort (alphabetical)',
     pair: { id: 'sort', role: 'sort-name' },
@@ -154,6 +164,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   // --- CAD-027[2]: last-contacted order ---
   await page.getByRole('button', { name: 'Last Contacted' }).click()
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-027'],
     note: 'overdue list, recency sort (longest wait first; never-connected ranked by added date)',
     pair: { id: 'sort', role: 'sort-last-contacted' },
@@ -163,6 +174,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   // --- CAD-028 / DSH-005: mark-as-contacted on the dashboard (mutating) ---
   await page.getByRole('button', { name: 'Most Urgent' }).click() // back to default
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-028', 'DSH-005'],
     note: 'before mark-as-contacted (dashboard overdue list)',
     pair: { id: 'mark', role: 'mark-before' },
@@ -171,6 +183,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   await tour.waitForApi(page, 'POST', /\/contacts\/[0-9a-f-]{36}\/interactions$/)
   await tour.waitForApi(page, 'GET', OVERDUE_PATH) // the invalidation refetch
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-028', 'DSH-005'],
     note: 'after mark-as-contacted: mutual interaction + overdue refetch (no reload)',
     pair: { id: 'mark', role: 'mark-after' },
@@ -186,6 +199,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   await page.locator('.max-w-7xl [class*="animate-pulse"]').first().waitFor({ state: 'visible' })
   const overdueLoadingSkeletons = await page.locator('.max-w-7xl [class*="animate-pulse"]').count()
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-004'],
     note: 'overdue loading state (route held): placeholder shown, not empty/caught-up',
     pair: { id: 'dsh004', role: 'loading' },
@@ -204,6 +218,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   await page.goto('/dashboard')
   await page.getByText('Error loading overdue contacts').waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-004'],
     note: 'overdue error state (500): error carries the reason, not caught-up',
     pair: { id: 'dsh004', role: 'error' },
@@ -220,6 +235,7 @@ test('dashboard tour — DSH + dashboard-hosted CAD behaviors', async ({ page, t
   await page.goto('/dashboard')
   await page.getByRole('heading', { name: /All caught up/ }).waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-003', 'CAD-026'],
     note: 'caught-up empty state: add + view-list affordances',
     pair: { id: 'caughtup', role: 'caught-up' },

--- a/frontend/tests/tours/relationship-loop.tour.ts
+++ b/frontend/tests/tours/relationship-loop.tour.ts
@@ -24,6 +24,7 @@
 // 'tasks-empty', 'mark-after'), never these.
 
 import { test } from './support/tour-fixtures'
+import { assertOverdueFitsCapture, OVERDUE_CAPTURE_CAP } from './support/pinned-fixtures'
 import type { Page } from '@playwright/test'
 
 interface OverdueRow {
@@ -69,6 +70,22 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
 }) => {
   test.setTimeout(480_000)
 
+  // A world with nobody overdue is a seeding problem, not a state to tour —
+  // the journey has no signal to follow. Fail loudly. Read BEFORE the first
+  // capture, because the landing capture already drains the dashboard's overdue
+  // GET into its evidence: a cap check that ran afterwards would be checking a
+  // capture that had already been truncated. Every capture in this tour carries
+  // OVERDUE_CAPTURE_CAP for the same reason — the overdue array reaches them
+  // both as a `fields` value and as a drained response body.
+  const overdueResp = await tour.apiCtx.get('/api/v1/contacts/overdue')
+  const overdueRows = ((await overdueResp.json())?.data ?? []) as OverdueRow[]
+  if (overdueRows.length === 0) {
+    throw new Error(
+      'relationship-loop tour: no overdue contacts in the seed — the loop has no signal to follow'
+    )
+  }
+  assertOverdueFitsCapture(overdueRows.length, 'relationship-loop')
+
   // --- 1. Land: the app opens on the dashboard (DSH-001) ---
   // Arm the overdue-fetch listener BEFORE navigating: the dashboard issues its
   // overdue GET once, during landing, and the step-1 landing capture() below
@@ -80,20 +97,11 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
   await page.waitForURL(u => new URL(u).pathname === '/dashboard')
   await page.getByRole('heading', { name: 'Action Required' }).waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-001', 'CAD-038'],
     note: 'journey start: app root landed on the dashboard',
     pair: { id: 'relationship-loop', role: 'loop-landing' },
   })
-
-  // A world with nobody overdue is a seeding problem, not a state to tour —
-  // the journey has no signal to follow. Fail loudly.
-  const overdueResp = await tour.apiCtx.get('/api/v1/contacts/overdue')
-  const overdueRows = ((await overdueResp.json())?.data ?? []) as OverdueRow[]
-  if (overdueRows.length === 0) {
-    throw new Error(
-      'relationship-loop tour: no overdue contacts in the seed — the loop has no signal to follow'
-    )
-  }
 
   // --- 2. Read the needs-attention signal (CAD-026) ---
   await overdueLoaded // the landing overdue GET (armed pre-nav; race-safe, gh #707)
@@ -113,6 +121,7 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
     throw new Error('relationship-loop tour: the most-urgent overdue card has no View-details link')
   }
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-026', 'CAD-038'],
     note: 'needs-attention signal read: overdue cards + count (default most-urgent sort)',
     pair: { id: 'relationship-loop', role: 'signal' },
@@ -131,6 +140,7 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
   await page.getByRole('button', { name: 'Log Interaction' }).waitFor({ state: 'visible' })
   await page.getByRole('heading', { name: 'Tasks', level: 3 }).waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-029', 'CAD-030', 'CAD-038'],
     note: 'contact detail reached from the signal: recent activity, cadence, queued tasks',
     pair: { id: 'relationship-loop', role: 'detail-before' },
@@ -143,6 +153,7 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
   await page.getByRole('button', { name: 'Log Interaction' }).click()
   await page.getByRole('heading', { name: /Log Interaction with/ }).waitFor({ state: 'visible' })
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-038'],
     note: 'log-interaction modal open: direction defaults to mutual, date to today',
     pair: { id: 'relationship-loop', role: 'act' },
@@ -158,6 +169,7 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
   // page reflecting the action without a reload.
   await tour.waitForApi(page, 'GET', new RegExp(`/api/v1/contacts/${targetId}$`))
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['CAD-029', 'CAD-038'],
     note: 'detail after the action: mutual interaction POSTed, relationship state refetched in place',
     pair: { id: 'relationship-loop', role: 'detail-after' },
@@ -199,6 +211,7 @@ test('relationship-loop tour — dashboard signal → contact → act → reflec
 
   const cardsAfter = await readOverdueCards(page)
   await tour.capture(page, {
+    arrayCap: OVERDUE_CAPTURE_CAP,
     behaviors: ['DSH-005', 'CAD-038'],
     note: 'back on the dashboard: did the widget drop the contact we just acted on?',
     pair: { id: 'relationship-loop', role: 'loop-return' },

--- a/frontend/tests/tours/support/pinned-fixtures.test.ts
+++ b/frontend/tests/tours/support/pinned-fixtures.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import {
+  ALL_FIXTURE_MARKERS,
+  OVERDUE_CAPTURE_CAP,
+  assertOverdueFitsCapture,
+  resolveFixture,
+} from './pinned-fixtures'
+import { DEFAULT_ARRAY_CAP } from './normalize'
+import type { APIRequestContext } from '@playwright/test'
+
+// The tour-side fixture machinery is a set of fail-loud gates, and a gate nobody
+// has watched fail is indistinguishable from one that always passes. These are the
+// bad inputs each gate exists to reject.
+
+const FIXTURES_GO = path.join(
+  import.meta.dirname ?? __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'backend',
+  'internal',
+  'synthetic',
+  'fixtures.go'
+)
+
+// A stub standing in for Playwright's APIRequestContext: only `get` is reached,
+// and only its JSON body matters here.
+function stubApiCtx(rows: Array<{ id: string; full_name: string }>): APIRequestContext {
+  return {
+    get: async () => ({ json: async () => ({ data: rows }) }),
+  } as unknown as APIRequestContext
+}
+
+describe('assertOverdueFitsCapture', () => {
+  it('throws above the cap, naming the tour and the count', () => {
+    expect(() => assertOverdueFitsCapture(OVERDUE_CAPTURE_CAP + 1, 'dashboard')).toThrow(
+      /dashboard tour: 65 overdue contacts exceed the capture cap of 64/
+    )
+  })
+
+  it('accepts a population exactly at the cap', () => {
+    expect(() => assertOverdueFitsCapture(OVERDUE_CAPTURE_CAP, 'dashboard')).not.toThrow()
+  })
+
+  it('accepts the population the seed actually ships', () => {
+    // 50 catalog overdue slots + the 2 designated fixtures, measured on a
+    // prod-shaped world. The guard must not fire on the shipping seed — a cap that
+    // rejects the intended population is as broken as one that never fires.
+    expect(() => assertOverdueFitsCapture(52, 'relationship-loop')).not.toThrow()
+  })
+
+  it('leaves headroom over the default array cap', () => {
+    // The whole point of the explicit cap: at DEFAULT_ARRAY_CAP the shipping
+    // population truncates.
+    expect(OVERDUE_CAPTURE_CAP).toBeGreaterThan(DEFAULT_ARRAY_CAP)
+  })
+})
+
+describe('resolveFixture', () => {
+  const row = (id: string, full_name: string) => ({ id, full_name })
+
+  it('returns the single marker-bearing row', async () => {
+    const ctx = stubApiCtx([row('a', 'synth-ns-Zeta Testwell fxsearchsubject')])
+    await expect(resolveFixture(ctx, 'fxsearchsubject', 'label')).resolves.toMatchObject({
+      id: 'a',
+    })
+  })
+
+  it('throws when nothing carries the marker', async () => {
+    const ctx = stubApiCtx([])
+    await expect(resolveFixture(ctx, 'fxsearchsubject', 'CON-065')).rejects.toThrow(
+      /must resolve to exactly one contact, got 0/
+    )
+  })
+
+  it('throws when two contacts carry the marker', async () => {
+    const ctx = stubApiCtx([
+      row('a', 'synth-ns-Zeta Testwell fxsearchsubject'),
+      row('b', 'synth-ns-Vex Mockford fxsearchsubject'),
+    ])
+    await expect(resolveFixture(ctx, 'fxsearchsubject', 'CON-065')).rejects.toThrow(
+      /must resolve to exactly one contact, got 2/
+    )
+  })
+
+  it('ignores search hits that do not carry the marker', async () => {
+    // Full-text search ranks and returns neighbours; only the marker decides.
+    const ctx = stubApiCtx([
+      row('a', 'synth-ns-Zeta Testwell'),
+      row('b', 'synth-ns-Vex Mockford fxsearchsubject'),
+    ])
+    await expect(resolveFixture(ctx, 'fxsearchsubject', 'CON-065')).resolves.toMatchObject({
+      id: 'b',
+    })
+  })
+})
+
+describe('marker parity with the Go seed', () => {
+  // The markers here are hand-copied across the language boundary. A Go-side
+  // rename passes lint, unit, integration and E2E, and fails only as a
+  // resolveFixture throw on the nightly staging sweep — this pulls that into the
+  // deterministic lane.
+  const goMarkers = (): string[] => {
+    const src = fs.readFileSync(FIXTURES_GO, 'utf8')
+    return [...src.matchAll(/^\tFixtureMarker\w+\s*=\s*"([a-z0-9]+)"$/gm)].map(m => m[1])
+  }
+
+  it('finds the Go constants at all (the regex is load-bearing)', () => {
+    expect(goMarkers().length).toBeGreaterThan(0)
+  })
+
+  it('declares exactly the markers the seed declares', () => {
+    expect([...ALL_FIXTURE_MARKERS].sort()).toEqual([...goMarkers()].sort())
+  })
+})

--- a/frontend/tests/tours/support/pinned-fixtures.ts
+++ b/frontend/tests/tours/support/pinned-fixtures.ts
@@ -9,7 +9,9 @@
 //
 // Fixtures that a tour never resolves (the designated overdue contacts) are
 // deliberately absent: those are population guarantees, and the tours that consume
-// them select positionally because the selection is the behavior under test.
+// them select positionally because the selection is the behavior under test. What
+// those tours DO need from here is the capture cap below, which is what carries a
+// population guarantee through to the judge intact.
 
 import type { APIRequestContext } from '@playwright/test'
 
@@ -22,6 +24,29 @@ export const FIXTURE_MERGE_SOURCE = 'fxmergesource'
 export const FIXTURE_SEARCH = 'fxsearchsubject'
 export const FIXTURE_DELETE = 'fxdeletevictim'
 export const FIXTURE_BIRTHDAY = 'fxbirthday'
+
+// The overdue set is EVIDENCE, not a sample: the judge grades urgency ordering and
+// tier separation across the WHOLE list, and the seed guarantees two designated
+// overdue contacts are in it. A capture array longer than its cap is sliced
+// head-first, so the tail is dropped — and under the name and last-contacted sorts
+// that tail has nothing to do with urgency, which is how a designated fixture can
+// end up in it. The prod-shaped overdue population measures 52, above the 50-row
+// default, so the overdue-bearing captures carry this EXPLICIT cap instead.
+export const OVERDUE_CAPTURE_CAP = 64
+
+// Refuse to tour a world whose overdue population has outgrown the capture cap.
+// Truncation is recorded in the capture but the dropped rows are not, so a judge
+// grading a partial list cannot tell which contacts it never saw — the loud
+// failure is the only outcome that stays honest.
+export function assertOverdueFitsCapture(count: number, tourName: string): void {
+  if (count > OVERDUE_CAPTURE_CAP) {
+    throw new Error(
+      `${tourName} tour: ${count} overdue contacts exceed the capture cap of ${OVERDUE_CAPTURE_CAP} — ` +
+        'the captured overdue list would be truncated and the judge would grade a partial set. ' +
+        'Bring the seeded overdue population back under the cap, or raise the cap deliberately.'
+    )
+  }
+}
 
 interface MarkedContact {
   id: string

--- a/frontend/tests/tours/support/pinned-fixtures.ts
+++ b/frontend/tests/tours/support/pinned-fixtures.ts
@@ -7,11 +7,16 @@
 // backend/internal/synthetic/fixtures.go. Do not restate it here; the literals
 // below are the interface between the two, nothing more.
 //
-// Fixtures that a tour never resolves (the designated overdue contacts) are
-// deliberately absent: those are population guarantees, and the tours that consume
-// them select positionally because the selection is the behavior under test. What
-// those tours DO need from here is the capture cap below, which is what carries a
-// population guarantee through to the judge intact.
+// No tour resolves the designated overdue contacts: those are population
+// guarantees, and the tours that consume them select positionally because the
+// selection is the behavior under test. What those tours DO need from here is the
+// capture cap below, which is what carries a population guarantee through to the
+// judge intact.
+//
+// These literals are hand-copied from Go constants, so pinned-fixtures.test.ts
+// reads fixtures.go and fails on drift — a renamed marker would otherwise pass
+// every per-PR gate and surface only as a resolveFixture throw on the nightly
+// staging sweep, out-of-band and post-merge.
 
 import type { APIRequestContext } from '@playwright/test'
 
@@ -24,6 +29,28 @@ export const FIXTURE_MERGE_SOURCE = 'fxmergesource'
 export const FIXTURE_SEARCH = 'fxsearchsubject'
 export const FIXTURE_DELETE = 'fxdeletevictim'
 export const FIXTURE_BIRTHDAY = 'fxbirthday'
+
+// The two designated overdue markers. Exported ONLY so the drift check covers the
+// seed's full marker set — no tour resolves them, and none should: see above.
+export const FIXTURE_OVERDUE_A = 'fxoverduea'
+export const FIXTURE_OVERDUE_B = 'fxoverdueb'
+
+// Every marker the seed declares, in no meaningful order. The drift check compares
+// this against the Go constants as a SET, so a marker added on one side only is a
+// failure rather than a silent divergence.
+export const ALL_FIXTURE_MARKERS = [
+  FIXTURE_NO_ACTIVITY,
+  FIXTURE_OUTREACH,
+  FIXTURE_RESPONSE,
+  FIXTURE_PENDING,
+  FIXTURE_MERGE_TARGET,
+  FIXTURE_MERGE_SOURCE,
+  FIXTURE_SEARCH,
+  FIXTURE_DELETE,
+  FIXTURE_BIRTHDAY,
+  FIXTURE_OVERDUE_A,
+  FIXTURE_OVERDUE_B,
+]
 
 // The overdue set is EVIDENCE, not a sample: the judge grades urgency ordering and
 // tier separation across the WHOLE list, and the seed guarantees two designated

--- a/frontend/tests/tours/support/pinned-fixtures.ts
+++ b/frontend/tests/tours/support/pinned-fixtures.ts
@@ -1,0 +1,52 @@
+// pinned-fixtures.ts — resolving the seed's hand-authored tour fixtures.
+//
+// Every world state a tour depends on is pinned by the seed to a named contact
+// carrying a MARKER inside its full_name. THE CONVENTION ITSELF — why a marker is
+// a single lowercase alphanumeric token, why resolution must be exactly-one, and
+// what each fixture guarantees — is documented once, at the seeding site:
+// backend/internal/synthetic/fixtures.go. Do not restate it here; the literals
+// below are the interface between the two, nothing more.
+//
+// Fixtures that a tour never resolves (the designated overdue contacts) are
+// deliberately absent: those are population guarantees, and the tours that consume
+// them select positionally because the selection is the behavior under test.
+
+import type { APIRequestContext } from '@playwright/test'
+
+export const FIXTURE_NO_ACTIVITY = 'fxnoactivity'
+export const FIXTURE_OUTREACH = 'fxoutreach'
+export const FIXTURE_RESPONSE = 'fxresponse'
+export const FIXTURE_PENDING = 'fxpending'
+export const FIXTURE_MERGE_TARGET = 'fxmergetarget'
+export const FIXTURE_MERGE_SOURCE = 'fxmergesource'
+export const FIXTURE_SEARCH = 'fxsearchsubject'
+export const FIXTURE_DELETE = 'fxdeletevictim'
+export const FIXTURE_BIRTHDAY = 'fxbirthday'
+
+interface MarkedContact {
+  id: string
+  full_name: string
+}
+
+// resolveFixture returns the ONE contact carrying `marker`, via the same search
+// endpoint a user's search box drives. Anything other than exactly one match is a
+// seed problem, thrown loudly and named: touring on a mis-resolved subject
+// produces evidence about the wrong contact, which reads as a real regression to
+// anything grading it. Callers still verify the returned row's STATE before using
+// it — a search that returned something is not proof it returned the right thing.
+export async function resolveFixture<T extends MarkedContact>(
+  apiCtx: APIRequestContext,
+  marker: string,
+  label: string
+): Promise<T> {
+  const resp = await apiCtx.get(`/api/v1/contacts?limit=200&search=${encodeURIComponent(marker)}`)
+  const rows = ((await resp.json())?.data ?? []) as T[]
+  const matches = rows.filter(c => c.full_name.includes(marker))
+  if (matches.length !== 1) {
+    throw new Error(
+      `tour: pinned fixture "${marker}" (${label}) must resolve to exactly one contact, got ${matches.length} — ` +
+        'the seed did not establish it, or a second contact carries the marker. Reseed before touring.'
+    )
+  }
+  return matches[0]
+}


### PR DESCRIPTION
PR4 of the seed-realism archetype arc (#747). PR1 (#744), PR2 (#745) and PR3 (#746) are merged; PR5 is planned and follows.

## What this does

Turns the ten hard-throw tour dependencies A1–A10 into named, reseed-reproducible fixtures. Each fixture contact carries a marker token appended to `full_name`, and a tour resolves it with one `GET /contacts?search=<marker>` and then **verifies the row it got back** carries the expected marker and the expected state — resolution is verified, never inferred from the search having returned something.

Because that search path is Postgres full-text search over `full_name` plus method values rather than a substring match, a marker must be a single lowercase alphanumeric token: a hyphenated marker stems into shared lexemes and mis-resolves, which is the exact failure the pinning exists to remove. The single authority for the convention is the comment block at the top of `backend/internal/synthetic/fixtures.go`.

Eight fixtures are **subject-binding**. Two are deliberately **state guarantees only** — A5 (≥1 overdue contact) and A6 (≥5 contacts, ≥3 unique-named) — because those tours' positional selection is itself the behavior under test, and binding an identity there would destroy the evidence.

## Acceptance: the fixture-absence sweep

The criterion for this PR is that every coverage assertion fails **loudly** when the state it guards is absent — established by deliberately breaking each one, not by reading the assertion and finding it convincing.

**15 probes, 15 produced a loud non-zero exit, 1 exposed a defect.** Every failure trace landed inside `assertPinnedTourFixtures`, so each assertion demonstrably caught its own absence rather than being intercepted by an earlier gate.

The enumeration is 15 rather than the estimated 13: the positional-non-degeneracy group is two independent assertions (neither dominates the other), and there is a harness-recording-completeness gate that the original list did not name. A9 was unlabelled in the code because the delete victim carries no state of its own — it is discharged entirely by the four generic resolution rules — and now carries a comment saying so.

Both known vacuity species were defended against explicitly: each injection was confirmed to have landed by re-reading the changed line from disk (the driver rejected one early attempt whose proof logic would have passed on a no-op edit), and every exit code was read directly from the test process rather than through a pipe.

## The defect it found

`require.NotNil(t, searchSubject.Cadence)` carried no message, so losing the A8 state produced `Expected value not to be nil.` and nothing else — loud enough to fail, not loud enough to diagnose. Eight further message-less requires in the same function had the same shape. All now name their fixture and their property; re-verified by re-running the probe against the fixed tree.

Two assertions were found to be **unable to fail** under the current fixture set. They are reported rather than shrugged off, and **kept rather than deleted** — each states a requirement its consuming tour genuinely has — now commented as documentation rather than as independent gates.

## Keeping the overdue set inside the capture cap

Review raised that this branch pushes the overdue population past `DEFAULT_ARRAY_CAP = 50`. Confirmed by measurement under **production** cadence durations (the suite's compressed test durations make everything trivially overdue, so a count taken there would prove nothing): **50 overdue at the merge base, 52 on this branch**. The base sat exactly at the cap, so this branch is precisely what starts truncation.

Truncation is `slice(0, cap)` — head kept, tail dropped, with a marker that records *that* rows are missing but never *which*. Under the urgency sort both pinned fixtures happen to survive, but the dashboard captures the same list under name and last-contacted sorts too, where a fixture's position has nothing to do with its urgency. So "the fixtures survive" was true of one capture in three, by luck, with 8 rows of margin.

Fixed with an explicit `OVERDUE_CAPTURE_CAP = 64` on the overdue-bearing captures plus `assertOverdueFitsCapture`: the tours now refuse to run above the cap rather than shipping a partial list. The guarantee is a two-part chain with a failing assertion on each half — the Go gate proves both fixtures are genuinely overdue under production durations, and the tour guard proves that response is never truncated on its way into a capture.

Alternatives considered and rejected: riding contacts the catalog already makes overdue would falsify the diversity-gap test by construction (the pair exists to supply an age and cadence the frozen catalog cannot); reducing the catalog's contribution means editing `catalogOptionsFor`, which the arc freezes; raising the global default changes evidence policy for every tour to fix a problem local to two. A marker-presence check inside the overdue tours was deliberately **not** added — it would put fixture identity into tours whose selection is positional by design, converting a state guarantee into a subject binding.

## Capture-sequence stability

The judge's capture cap is re-derived statically rather than assumed. `contacts.tour.ts` is the only tour tagging any member of the relevant intent; its 17 bound captures truncate at 10 to exactly the retained set the catalog comment pins. The ordered behaviour-tag sequence of both edited tours is byte-identical between the merge base and this head, and capture counts are unchanged in every touched tour — so this branch cannot have moved the binding.

## Verification

`make lint`, `make test` (unit + integration + frontend), the full pre-push gate including E2E, and all 46 `TestSynthetic*` long tests pass, including both call sites of the pinned-fixture gate.

One integration failure during an earlier run was investigated and attributed to a **pre-existing flake**, not this branch: `TestSyntheticBatchReplay_PromotionBarrier` reproduces failing 1-in-8 at the merge base with this branch not applied. It asserts a negative about a race while its own comment claims that failure is deterministic; that claim is false. Filed as #748 — this branch touches none of the code it exercises.

## Review gate

Codex quota is exhausted on both accounts until 2026-07-28 (`recover` returned `ALL_EXHAUSTED`, confirmed by a canary call), so the merge-gate verdict for this head is a `SOURCE: claude-fallback` review — the same path PR1–PR3 of this arc shipped on. Reviewer model is fable rather than opus deliberately: the author was opus, and with the Codex harness unavailable, model diversity is the only reviewer diversity left.

No migrations. New sqlc queries live in `db/queries/test.sql` with `repository/synthetic_support.go` wrappers.