### PR TITLE
feat(synthetic): populate dev and prod-shaped with archetype histories

### DIFF
--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -905,11 +905,19 @@ func writeSeedSummary(w io.Writer, res synthetic.ProfileResult, partial bool) er
 		"  stranded_telegram:    %d\n"+
 		"  stranded_messages:    %d\n"+
 		"  unmatched_calendar:   %d\n"+
-		"  orphan_meeting_notes: %d\n",
+		"  orphan_meeting_notes: %d\n"+
+		// The two archetype counters are reported SEPARATELY because they measure
+		// different units: payloads driven versus interaction rows landed. The
+		// second is deliberately smaller — aggregation collapses a promotion pair
+		// into one mutual row and a burst into one session — so a reader comparing
+		// them is seeing the collapse, not a shortfall.
+		"  archetype_payloads:   %d\n"+
+		"  archetype_interactions: %d\n",
 		res.Profile, res.Namespace, res.Seed, marker,
 		res.Contacts, res.GmailSettled, res.TelegramSettled, res.GCalSettled, res.GChatSettled,
 		res.IMessageSettled, res.UnmatchedExternal, res.StrandedTelegram, res.StrandedMessages,
-		res.UnmatchedCalendar, res.OrphanMeetingNote); err != nil {
+		res.UnmatchedCalendar, res.OrphanMeetingNote,
+		res.ArchetypePayloads, res.ArchetypeInteractions); err != nil {
 		return fmt.Errorf("write seed summary: %w", err)
 	}
 	if err := writeSeedTimings(w, res.Timings); err != nil {

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -906,18 +906,19 @@ func writeSeedSummary(w io.Writer, res synthetic.ProfileResult, partial bool) er
 		"  stranded_messages:    %d\n"+
 		"  unmatched_calendar:   %d\n"+
 		"  orphan_meeting_notes: %d\n"+
-		// The two archetype counters are reported SEPARATELY because they measure
-		// different units: payloads driven versus interaction rows landed. The
-		// second is deliberately smaller — aggregation collapses a promotion pair
-		// into one mutual row and a burst into one session — so a reader comparing
-		// them is seeing the collapse, not a shortfall.
+		// Three archetype figures in three different UNITS, which is why they are
+		// reported separately rather than reconciled: payloads driven, interaction
+		// rows landed (smaller by design — aggregation collapses a promotion pair
+		// into one mutual and a burst into one session), and settle gates waited on
+		// (one per dependency generation, not per payload — the phase's real cost).
 		"  archetype_payloads:   %d\n"+
-		"  archetype_interactions: %d\n",
+		"  archetype_rows:       %d\n"+
+		"  archetype_settles:    %d\n",
 		res.Profile, res.Namespace, res.Seed, marker,
 		res.Contacts, res.GmailSettled, res.TelegramSettled, res.GCalSettled, res.GChatSettled,
 		res.IMessageSettled, res.UnmatchedExternal, res.StrandedTelegram, res.StrandedMessages,
 		res.UnmatchedCalendar, res.OrphanMeetingNote,
-		res.ArchetypePayloads, res.ArchetypeInteractions); err != nil {
+		res.ArchetypePayloads, res.ArchetypeInteractions, res.ArchetypeSettleCalls); err != nil {
 		return fmt.Errorf("write seed summary: %w", err)
 	}
 	if err := writeSeedTimings(w, res.Timings); err != nil {

--- a/backend/cmd/crm-admin/seed_summary_test.go
+++ b/backend/cmd/crm-admin/seed_summary_test.go
@@ -26,6 +26,10 @@ func timingFixture() synthetic.ProfileResult {
 		Namespace: "prodshaped",
 		Seed:      42,
 		Contacts:  179,
+		// Distinct from each other and from every other count in the fixture, so a
+		// rendering that printed the wrong field cannot coincidentally match.
+		ArchetypePayloads:     943,
+		ArchetypeInteractions: 771,
 		Timings: synthetic.SeedTimings{
 			Total: 100 * time.Second,
 			Phases: []synthetic.PhaseTiming{
@@ -65,6 +69,11 @@ func TestWriteSeedSummaryRendersTimingBlock(t *testing.T) {
 	// 100s total − (40+18+9)s of gate wait.
 	require.Contains(t, out, "  outside_gates:        33.00s")
 	require.Contains(t, out, "NOT a hypothesis test", "the residual is labelled as bookkeeping")
+	// The archetype block reports payloads driven and interaction ROWS landed as
+	// two separate figures: they measure different units, and the second is
+	// smaller by design because aggregation collapses.
+	require.Contains(t, out, "  archetype_payloads:   943")
+	require.Contains(t, out, "  archetype_interactions: 771")
 }
 
 func TestWriteSeedSummaryRendersEveryPhaseWithPayloadVolume(t *testing.T) {

--- a/backend/cmd/crm-admin/seed_summary_test.go
+++ b/backend/cmd/crm-admin/seed_summary_test.go
@@ -30,6 +30,7 @@ func timingFixture() synthetic.ProfileResult {
 		// rendering that printed the wrong field cannot coincidentally match.
 		ArchetypePayloads:     943,
 		ArchetypeInteractions: 771,
+		ArchetypeSettleCalls:  7,
 		Timings: synthetic.SeedTimings{
 			Total: 100 * time.Second,
 			Phases: []synthetic.PhaseTiming{
@@ -73,7 +74,8 @@ func TestWriteSeedSummaryRendersTimingBlock(t *testing.T) {
 	// two separate figures: they measure different units, and the second is
 	// smaller by design because aggregation collapses.
 	require.Contains(t, out, "  archetype_payloads:   943")
-	require.Contains(t, out, "  archetype_interactions: 771")
+	require.Contains(t, out, "  archetype_rows:       771")
+	require.Contains(t, out, "  archetype_settles:    7")
 }
 
 func TestWriteSeedSummaryRendersEveryPhaseWithPayloadVolume(t *testing.T) {

--- a/backend/cmd/crm-api/wire_aggregation.go
+++ b/backend/cmd/crm-api/wire_aggregation.go
@@ -84,15 +84,14 @@ func buildAggregationEngines(
 	// GChat aggregation engine over comms_message. LIVE but INERT: the
 	// engine/worker/sweeper/reenqueuer for gchat run on every tick, but every
 	// query is source='gchat'-scoped and returns zero rows until a provider +
-	// enablement write comms_message(source='gchat') rows. Burst/reply windows
-	// are hard-coded here (matching how messages hard-codes its constants);
-	// env-var overrides are out of scope for now.
+	// enablement write comms_message(source='gchat') rows. The burst/reply windows
+	// are constants on the engine's own package, so a caller that sizes its input
+	// to them reads the same values this wiring passes; env-var overrides are out
+	// of scope for now.
 	gchatEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
-	const gchatBurstWindowHours = 2
-	const gchatReplyBridgeHours = 48
 	gchatEngine := google.NewGChatAggregationEngine(
-		gchatBurstWindowHours,
-		gchatReplyBridgeHours,
+		google.GChatBurstWindowHours,
+		google.GChatReplyBridgeHours,
 		commsMessageRepo,
 		interactionRepo,
 		contactService,

--- a/backend/internal/cadence/cadence_config.go
+++ b/backend/internal/cadence/cadence_config.go
@@ -75,8 +75,23 @@ func GetCadenceConfig() CadenceConfig {
 
 // GetCadenceDuration returns the duration for a given cadence type
 func GetCadenceDuration(cadenceType CadenceType) time.Duration {
-	config := GetCadenceConfig()
+	return durationFor(GetCadenceConfig(), cadenceType)
+}
 
+// GetProductionCadenceDuration is GetCadenceDuration against the PRODUCTION
+// table rather than the ambient environment's. It exists so a caller that must
+// reason in real-world durations — a seed asserting an overdue expectation under
+// CRM_ENV=test, where annual is two hours — resolves the duration through the
+// SAME lookup, including its unrecognized-cadence fallback, instead of
+// hand-copying it.
+func GetProductionCadenceDuration(cadenceType CadenceType) time.Duration {
+	return durationFor(ProductionCadenceConfig(), cadenceType)
+}
+
+// durationFor is the single cadence-type → duration lookup. Both accessors above
+// route through it, so an unrecognized cadence cannot resolve one way in one
+// caller and another way in the next.
+func durationFor(config CadenceConfig, cadenceType CadenceType) time.Duration {
 	switch cadenceType {
 	case CadenceWeekly:
 		return config.Weekly
@@ -111,17 +126,31 @@ func CalculateNextDueDateWithConfig(cadenceType CadenceType, lastContacted *time
 
 // IsOverdueWithConfig checks if contact is overdue using environment-specific cadences
 func IsOverdueWithConfig(cadenceType CadenceType, lastContacted *time.Time, createdAt time.Time, checkTime time.Time) bool {
-	duration := GetCadenceDuration(cadenceType)
+	return isOverdue(GetCadenceDuration(cadenceType), lastContacted, createdAt, checkTime)
+}
 
-	var lastContactTime time.Time
+// IsOverdueWithProductionConfig is IsOverdueWithConfig evaluated against the
+// PRODUCTION cadence table, whatever the ambient environment is. It shares the
+// formula rather than restating it, so the two answers cannot diverge — which
+// they would, silently, if a caller needing production semantics kept its own
+// copy: under CRM_ENV=test annual is two hours and every contact is overdue, so
+// such a caller cannot simply use the env-derived helper either.
+//
+// checkTime is the caller's reference instant, so a prediction and a measurement
+// can be made to answer the same question about the same moment.
+func IsOverdueWithProductionConfig(cadenceType CadenceType, lastContacted *time.Time, createdAt time.Time, checkTime time.Time) bool {
+	return isOverdue(GetProductionCadenceDuration(cadenceType), lastContacted, createdAt, checkTime)
+}
+
+// isOverdue is the overdue formula itself: a contact is overdue once checkTime
+// has passed its base instant plus the cadence period, where the base is
+// last_contacted when set and created_at otherwise.
+func isOverdue(duration time.Duration, lastContacted *time.Time, createdAt time.Time, checkTime time.Time) bool {
+	lastContactTime := createdAt
 	if lastContacted != nil {
 		lastContactTime = *lastContacted
-	} else {
-		lastContactTime = createdAt
 	}
-
-	nextContactDue := lastContactTime.Add(duration)
-	return checkTime.After(nextContactDue)
+	return checkTime.After(lastContactTime.Add(duration))
 }
 
 // GetOverdueDaysWithConfig returns how many "days" overdue

--- a/backend/internal/cadence/cadence_config.go
+++ b/backend/internal/cadence/cadence_config.go
@@ -16,6 +16,24 @@ type CadenceConfig struct {
 	Annual    time.Duration
 }
 
+// ProductionCadenceConfig is the real-world cadence table — the durations
+// production and staging run on. It is exported so a caller can state a
+// production-duration expectation WITHOUT reading (or mutating) CRM_ENV: under
+// CRM_ENV=test annual is two hours and every contact is trivially overdue, so a
+// test that reads the ambient environment proves nothing about these semantics,
+// and setting the variable would change cadence behaviour for every
+// concurrently-running test in the process.
+func ProductionCadenceConfig() CadenceConfig {
+	return CadenceConfig{
+		Weekly:    7 * 24 * time.Hour,   // 1 week
+		Biweekly:  14 * 24 * time.Hour,  // 2 weeks
+		Monthly:   30 * 24 * time.Hour,  // ~1 month
+		Quarterly: 90 * 24 * time.Hour,  // ~3 months
+		Biannual:  180 * 24 * time.Hour, // ~6 months
+		Annual:    365 * 24 * time.Hour, // 1 year
+	}
+}
+
 // GetCadenceConfig returns appropriate cadence configuration based on environment
 func GetCadenceConfig() CadenceConfig {
 	env := os.Getenv("CRM_ENV")
@@ -48,24 +66,10 @@ func GetCadenceConfig() CadenceConfig {
 	case "staging", "production", "prod", "":
 		// Production semantics: real-world cadences. Staging shares them —
 		// its QA world is prod-shaped by construction, not by compressed time.
-		return CadenceConfig{
-			Weekly:    7 * 24 * time.Hour,   // 1 week
-			Biweekly:  14 * 24 * time.Hour,  // 2 weeks
-			Monthly:   30 * 24 * time.Hour,  // ~1 month
-			Quarterly: 90 * 24 * time.Hour,  // ~3 months
-			Biannual:  180 * 24 * time.Hour, // ~6 months
-			Annual:    365 * 24 * time.Hour, // 1 year
-		}
+		return ProductionCadenceConfig()
 	default:
 		// Default to production for safety
-		return CadenceConfig{
-			Weekly:    7 * 24 * time.Hour,   // 1 week
-			Biweekly:  14 * 24 * time.Hour,  // 2 weeks
-			Monthly:   30 * 24 * time.Hour,  // ~1 month
-			Quarterly: 90 * 24 * time.Hour,  // ~3 months
-			Biannual:  180 * 24 * time.Hour, // ~6 months
-			Annual:    365 * 24 * time.Hour, // 1 year
-		}
+		return ProductionCadenceConfig()
 	}
 }
 

--- a/backend/internal/cadence/cadence_config_test.go
+++ b/backend/internal/cadence/cadence_config_test.go
@@ -1,0 +1,62 @@
+package cadence
+
+import (
+	"testing"
+	"time"
+)
+
+// TestProductionCadenceConfigMatchesEnvironmentBranches proves the exported
+// production table IS what GetCadenceConfig returns on every branch that runs
+// production semantics — staging, production, prod, the empty env, and any
+// unrecognized value (which defaults to production for safety).
+//
+// Without it the extraction could silently drift from the branch it replaced,
+// and the drift would only show up as a wrong overdue classification in a caller
+// that deliberately does not read the environment.
+func TestProductionCadenceConfigMatchesEnvironmentBranches(t *testing.T) {
+	want := ProductionCadenceConfig()
+
+	for _, env := range []string{"staging", "production", "prod", "", "some-unrecognized-env"} {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv("CRM_ENV", env)
+			if got := GetCadenceConfig(); got != want {
+				t.Fatalf("GetCadenceConfig() with CRM_ENV=%q = %+v, want the production table %+v", env, got, want)
+			}
+		})
+	}
+}
+
+// TestProductionCadenceConfigCarriesRealWorldDurations pins the actual values.
+// The accessor exists so a caller can assert an overdue expectation in real
+// durations; a table that quietly became the compressed test one would make
+// every such assertion vacuous while still "matching GetCadenceConfig".
+func TestProductionCadenceConfigCarriesRealWorldDurations(t *testing.T) {
+	got := ProductionCadenceConfig()
+	want := CadenceConfig{
+		Weekly:    7 * 24 * time.Hour,
+		Biweekly:  14 * 24 * time.Hour,
+		Monthly:   30 * 24 * time.Hour,
+		Quarterly: 90 * 24 * time.Hour,
+		Biannual:  180 * 24 * time.Hour,
+		Annual:    365 * 24 * time.Hour,
+	}
+	if got != want {
+		t.Fatalf("ProductionCadenceConfig() = %+v, want %+v", got, want)
+	}
+}
+
+// TestGetCadenceConfigKeepsCompressedEnvironments guards the other direction:
+// the extraction must not have collapsed the compressed branches onto the
+// production table. A test/accelerated environment that started returning real
+// durations would make the whole cadence suite run in real weeks.
+func TestGetCadenceConfigKeepsCompressedEnvironments(t *testing.T) {
+	production := ProductionCadenceConfig()
+	for _, env := range []string{"test", "testing", "accelerated"} {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv("CRM_ENV", env)
+			if got := GetCadenceConfig(); got == production {
+				t.Fatalf("CRM_ENV=%q must keep its compressed durations, got the production table %+v", env, got)
+			}
+		})
+	}
+}

--- a/backend/internal/cadence/cadence_config_test.go
+++ b/backend/internal/cadence/cadence_config_test.go
@@ -60,3 +60,57 @@ func TestGetCadenceConfigKeepsCompressedEnvironments(t *testing.T) {
 		})
 	}
 }
+
+// TestIsOverdueWithProductionConfigAgreesWithTheEnvHelper pins the production
+// overdue helper against its environment-driven sibling: under a production-alias
+// CRM_ENV the two must agree for EVERY cadence type, including an unrecognized
+// one (which both resolve through the same Monthly fallback).
+//
+// The agreement is what makes it safe for a caller to reach for the production
+// variant. A hand-copied formula in another package would pass a spot check and
+// then drift on exactly this edge — an unrecognized cadence resolving to Monthly
+// on one side and to "never overdue" on the other.
+func TestIsOverdueWithProductionConfigAgreesWithTheEnvHelper(t *testing.T) {
+	t.Setenv("CRM_ENV", "production")
+
+	ref := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	types := []CadenceType{
+		CadenceWeekly, CadenceBiweekly, CadenceMonthly,
+		CadenceQuarterly, CadenceBiannual, CadenceAnnual,
+		CadenceType("not-a-cadence"), CadenceType(""),
+	}
+	// Ages that straddle every period boundary in the table, plus both bases.
+	ages := []time.Duration{
+		0, 6 * 24 * time.Hour, 8 * 24 * time.Hour, 15 * 24 * time.Hour,
+		31 * 24 * time.Hour, 91 * 24 * time.Hour, 181 * 24 * time.Hour, 366 * 24 * time.Hour,
+	}
+
+	for _, cadenceType := range types {
+		for _, age := range ages {
+			at := ref.Add(-age)
+			if got, want := IsOverdueWithProductionConfig(cadenceType, nil, at, ref), IsOverdueWithConfig(cadenceType, nil, at, ref); got != want {
+				t.Fatalf("cadence %q at created age %s: production helper = %t, env helper = %t", cadenceType, age, got, want)
+			}
+			if got, want := IsOverdueWithProductionConfig(cadenceType, &at, ref.Add(-400*24*time.Hour), ref), IsOverdueWithConfig(cadenceType, &at, ref.Add(-400*24*time.Hour), ref); got != want {
+				t.Fatalf("cadence %q at last-contacted age %s: production helper = %t, env helper = %t", cadenceType, age, got, want)
+			}
+		}
+	}
+}
+
+// TestIsOverdueWithProductionConfigIgnoresTheAmbientEnvironment is the other
+// half: under the COMPRESSED test durations, where a two-day-old annual contact
+// is long overdue, the production helper must still say it is not.
+func TestIsOverdueWithProductionConfigIgnoresTheAmbientEnvironment(t *testing.T) {
+	t.Setenv("CRM_ENV", "test")
+
+	ref := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	createdAt := ref.Add(-2 * 24 * time.Hour)
+
+	if !IsOverdueWithConfig(CadenceAnnual, nil, createdAt, ref) {
+		t.Fatal("precondition: under CRM_ENV=test an annual cadence is two hours, so a two-day-old contact is overdue")
+	}
+	if IsOverdueWithProductionConfig(CadenceAnnual, nil, createdAt, ref) {
+		t.Fatal("the production helper must read the production table, not the ambient environment")
+	}
+}

--- a/backend/internal/google/gchat_aggregation.go
+++ b/backend/internal/google/gchat_aggregation.go
@@ -30,6 +30,22 @@ const GChatSourceName = repository.InteractionSourceGChat
 // here means a later explicit-reply provider need not touch the adapter.
 const replyTargetMetadataKey = "reply_target_external_id"
 
+// GChatBurstWindowHours / GChatReplyBridgeHours are the aggregation windows the
+// GChat engine runs on: consecutive same-direction messages inside the burst
+// window form one session, and an inbound session that follows an outbound one
+// inside the reply-bridge window merges into it and turns it mutual.
+//
+// They are declared HERE, beside the constructor, because they are not free
+// parameters in practice: every caller passes the same pair, and a caller that
+// SIZES ITS INPUT to them — the synthetic seed spaces a burst's opening messages
+// to fall inside the burst window, and predicts how many rows a conversation
+// collapses into — is silently wrong the moment a wiring literal moves. Read
+// them; do not re-declare them.
+const (
+	GChatBurstWindowHours = 2
+	GChatReplyBridgeHours = 48
+)
+
 // NewGChatAggregationEngine constructs a shared aggregator engine configured
 // for the Google Chat source over the comms_message table. Mirror of
 // messages.NewAggregationEngine — same nil-safety conventions. Returns the

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/cadence"
+	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/synthetic/factory"
 	"personal-crm/backend/internal/synthetic/replay"
 
@@ -50,11 +51,16 @@ const (
 type catalogSlotSpec struct {
 	Kind    catalogSlotKind
 	Cadence string
-	// CreatedAge is how far before the anchor the contact is created. Exact for
-	// slotBackdated; for slotRecent it is the WINDOW (the true age is a PRNG draw
-	// inside it), which is the conservative bound for an overdue prediction since a
-	// larger age can only make a contact more overdue. Zero for slotFresh.
-	CreatedAge time.Duration
+	// CreatedAgeBound is an UPPER BOUND on how far before the anchor the contact is
+	// created: exact for slotBackdated (the frozen ladder pins it), the WINDOW for
+	// slotRecent (the true age is a PRNG draw inside it), zero for slotFresh.
+	//
+	// A bound rather than a value is enough because the only consumer is the
+	// overdue prediction, and a larger created age can only make a contact MORE
+	// overdue — so a slot whose bound is not overdue cannot be overdue. The one
+	// place the prediction concludes overdue (slotBackdated) is the one place the
+	// bound is exact.
+	CreatedAgeBound time.Duration
 	// NoMethods marks the no-method slot, which owns no identifier and can
 	// therefore match no source payload at all.
 	NoMethods bool
@@ -67,18 +73,18 @@ func catalogSlot(i, n int) catalogSlotSpec {
 	// differ.
 	if i == 3 && n > 3 {
 		pair := catalogOverdueLadder[(i/3)%len(catalogOverdueLadder)]
-		return catalogSlotSpec{Kind: slotBackdated, Cadence: pair.cadence, CreatedAge: pair.createdAge, NoMethods: true}
+		return catalogSlotSpec{Kind: slotBackdated, Cadence: pair.cadence, CreatedAgeBound: pair.createdAge, NoMethods: true}
 	}
 
 	switch i % 3 {
 	case 0:
 		pair := catalogOverdueLadder[(i/3)%len(catalogOverdueLadder)]
-		return catalogSlotSpec{Kind: slotBackdated, Cadence: pair.cadence, CreatedAge: pair.createdAge}
+		return catalogSlotSpec{Kind: slotBackdated, Cadence: pair.cadence, CreatedAgeBound: pair.createdAge}
 	case 1:
 		return catalogSlotSpec{
-			Kind:       slotRecent,
-			Cadence:    catalogRecentCadences[(i/3)%len(catalogRecentCadences)],
-			CreatedAge: catalogRecentWindow,
+			Kind:            slotRecent,
+			Cadence:         catalogRecentCadences[(i/3)%len(catalogRecentCadences)],
+			CreatedAgeBound: catalogRecentWindow,
 		}
 	default:
 		return catalogSlotSpec{
@@ -123,27 +129,38 @@ const calmMargin = 24 * time.Hour
 type archetypeIntent int
 
 const (
+	// intentNeutral never writes last_contacted at all (an outbound touches only
+	// last_outreach_at; an empty timeline touches nothing), so the slot keeps
+	// whatever overdue-ness its created_at gives it — on every cadence. It is
+	// FIRST so that it is the zero value: an archetype missing from the table
+	// then degrades to "changes nothing", which is the only safe default for a
+	// predicate that decides overdue-ness.
+	intentNeutral archetypeIntent = iota
 	// intentOverdue writes last_contacted from a deliberately OLD newest entry, so
 	// the contact stays overdue and carries real history behind it.
-	intentOverdue archetypeIntent = iota
+	intentOverdue
 	// intentCalm writes last_contacted from a RECENT newest entry, taking the
 	// contact out of the overdue set.
 	intentCalm
-	// intentNeutral never writes last_contacted at all (an outbound touches only
-	// last_outreach_at; an empty timeline touches nothing), so the slot keeps
-	// whatever overdue-ness its created_at gives it — on every cadence.
-	intentNeutral
 )
 
 // archetypeShape is one archetype's compatibility input: what it does to
-// overdue-ness, and the inclusive bounds of the age it dates its NEWEST entry at.
+// overdue-ness, and — for the archetypes whose intent makes that question
+// answerable — the inclusive bounds of the age it dates its newest
+// LAST-CONTACTED-WRITING entry at.
 //
-// The bounds RESTATE the generator's per-archetype table, because that table is
-// unexported and lives a package below this one. They are not trusted: a unit
-// test samples TimelineFor across thousands of namespaces and requires the
-// observed newest ages to sit inside these bounds AND to reach within one
-// calmMargin of each end, so a generator bound that moved by more than the margin
-// fails there rather than silently widening what this rule admits.
+// Both fields RESTATE facts that live a package below, in an unexported
+// generator table, and neither is trusted. A unit test samples TimelineFor
+// across thousands of namespaces and requires (a) that an archetype is neutral
+// exactly when its timelines never contain an entry that writes last_contacted,
+// and (b) that the observed newest such age sits inside these bounds AND reaches
+// within one calmMargin of each end. So a generator change that moved a bound by
+// more than the margin, or that gave a neutral archetype a two-way entry, fails
+// there rather than silently widening what this rule admits.
+//
+// A NEUTRAL archetype declares no bounds. It cannot move last_contacted at all,
+// so archetypeAdmissible never reads them, and carrying decorative values would
+// put an unguarded restatement back into the table.
 type archetypeShape struct {
 	Intent    archetypeIntent
 	NewestMin time.Duration
@@ -152,17 +169,24 @@ type archetypeShape struct {
 
 const archetypeDay = 24 * time.Hour
 
-// archetypeShapes is the closed catalog's compatibility table. never-contacted
-// carries no bounds because it emits no entry to date; a neutral intent is
-// admissible on every cadence without reading them.
+// archetypeShapes is the closed catalog's compatibility table.
 var archetypeShapes = map[factory.Archetype]archetypeShape{
 	factory.ArchetypeMutualRegular:  {Intent: intentCalm, NewestMin: 3 * archetypeDay, NewestMax: 14 * archetypeDay},
 	factory.ArchetypeMutualDrifting: {Intent: intentOverdue, NewestMin: 70 * archetypeDay, NewestMax: 112 * archetypeDay},
 	factory.ArchetypeDormant:        {Intent: intentOverdue, NewestMin: 120 * archetypeDay, NewestMax: 150 * archetypeDay},
 	factory.ArchetypeInboundOnly:    {Intent: intentCalm, NewestMin: 1 * archetypeDay, NewestMax: 15 * archetypeDay},
 	factory.ArchetypeBurstThenQuiet: {Intent: intentCalm, NewestMin: 30 * archetypeDay, NewestMax: 90 * archetypeDay},
-	factory.ArchetypeOutboundHeavy:  {Intent: intentNeutral, NewestMin: 2 * archetypeDay, NewestMax: 20 * archetypeDay},
+	factory.ArchetypeOutboundHeavy:  {Intent: intentNeutral},
 	factory.ArchetypeNeverContacted: {Intent: intentNeutral},
+}
+
+// archetypeWritesLastContacted reports whether a timeline entry is one the
+// pipeline classifies as inbound or mutual — the only kind that moves
+// last_contacted, and therefore the only kind the compatibility rule reasons
+// about. A matched calendar event is always mutual; a message writes it when it
+// arrives rather than when it is sent.
+func archetypeWritesLastContacted(e factory.TimelineEntry) bool {
+	return e.Source == factory.SourceGCal || !e.Outbound
 }
 
 // historyArchetypes are the six that emit a timeline, in the FIXED order every
@@ -186,29 +210,21 @@ var archetypeTieBreak = append(append([]factory.Archetype{}, historyArchetypes..
 // Compatibility breadth is counted over it.
 var archetypeCadences = []string{"weekly", "biweekly", "monthly", "quarterly", "biannual", "annual"}
 
-// productionCadencePeriod is a cadence name's PRODUCTION period.
+// productionCadencePeriod is a cadence name's PRODUCTION period, and whether the
+// name is one this table recognizes at all.
+//
+// The duration comes from the cadence package's own lookup, so the two cannot
+// disagree. What is deliberately NOT shared is the fallback: that lookup resolves
+// an unrecognized cadence to Monthly, which is the right answer when computing a
+// due date for a row that already exists, and the wrong one here — the
+// compatibility rule decides what MAY be placed, and defaulting would silently
+// admit archetypes onto a cadence nobody reasoned about.
 func productionCadencePeriod(name string) (time.Duration, bool) {
 	cadenceType, err := cadence.ParseCadence(name)
 	if err != nil {
 		return 0, false
 	}
-	cfg := cadence.ProductionCadenceConfig()
-	switch cadenceType {
-	case cadence.CadenceWeekly:
-		return cfg.Weekly, true
-	case cadence.CadenceBiweekly:
-		return cfg.Biweekly, true
-	case cadence.CadenceMonthly:
-		return cfg.Monthly, true
-	case cadence.CadenceQuarterly:
-		return cfg.Quarterly, true
-	case cadence.CadenceBiannual:
-		return cfg.Biannual, true
-	case cadence.CadenceAnnual:
-		return cfg.Annual, true
-	default:
-		return 0, false
-	}
+	return cadence.GetProductionCadenceDuration(cadenceType), true
 }
 
 // archetypeAdmissible reports whether the archetype may be placed on a slot
@@ -286,10 +302,12 @@ const catalogNonCatalogLiveContacts = 25
 // middle of it.
 const overdueSharePercent = 23
 
-// pinnedOverdueFixtureCount is how many overdue contacts the pinned-fixture block
+// PinnedOverdueFixtureCount is how many overdue contacts the pinned-fixture block
 // adds. They sit OUTSIDE the catalog and are always overdue, so the catalog
-// budget subtracts them rather than counting them twice.
-const pinnedOverdueFixtureCount = 2
+// budget subtracts them rather than counting them twice. Exported so the coverage
+// tests add the same number back rather than restating it, and pinned against
+// pinnedOverdueFixtures by a unit test (a slice literal cannot be a const).
+const PinnedOverdueFixtureCount = 2
 
 // catalogOverdueBudget is how many CATALOG slots the assignment may leave
 // overdue at this catalog size.
@@ -298,7 +316,7 @@ func catalogOverdueBudget(n int) int {
 	if target > OverdueCeiling {
 		target = OverdueCeiling
 	}
-	return target - pinnedOverdueFixtureCount
+	return target - PinnedOverdueFixtureCount
 }
 
 // archetypeQuota is how many samples of each history archetype the quota phase
@@ -337,7 +355,11 @@ const noMethodCatalogIndex = 3
 func ArchetypeForIndex(i, n int) factory.Archetype {
 	assignment := archetypeAssignment(n)
 	if i < 0 || i >= len(assignment) {
-		return factory.ArchetypeNeverContacted
+		// The EMPTY archetype, deliberately not a real one. This function's whole
+		// justification is that it is an INDEPENDENT oracle: an out-of-range answer
+		// that happened to be a valid archetype would let a comparison against a
+		// mis-derived index agree by coincidence instead of failing loudly.
+		return factory.Archetype("")
 	}
 	return assignment[i]
 }
@@ -466,7 +488,11 @@ func archetypeAssignment(n int) []factory.Archetype {
 			discretionary = append(discretionary, i)
 		}
 	}
-	for _, i := range append(forced, discretionary...) {
+	// Copied rather than appended in place: `forced` was grown by append above and
+	// can carry spare capacity, so appending onto it would write into its own
+	// backing array.
+	order := append(append([]int{}, forced...), discretionary...)
+	for _, i := range order {
 		slot := catalogSlot(i, n)
 		if overdue+1 <= budget {
 			// Under budget: keep the slot never-connected AND overdue, which is the
@@ -581,7 +607,7 @@ func catalogSlotNativelyOverdue(i, n int) bool {
 	if !ok {
 		return false
 	}
-	return slot.CreatedAge >= period+calmMargin
+	return slot.CreatedAgeBound >= period+calmMargin
 }
 
 // archetypeLeavesSlotOverdue predicts whether a slot ends up overdue once its
@@ -616,25 +642,29 @@ func PredictedCatalogOverdue(n int) int {
 	return count
 }
 
-// OverdueAtProduction reports whether a contact is overdue under PRODUCTION
-// cadence durations, evaluated at ref — normally the seeded world's own generator
-// anchor, so a prediction and a measurement answer the same question about the
-// same instant instead of racing the wall clock between them.
+// OverdueAtProduction reports whether a contact carrying this cadence NAME is
+// overdue under production durations, evaluated at ref — normally the seeded
+// world's own generator anchor, so a prediction and a measurement answer the same
+// question about the same instant instead of racing the wall clock between them.
 //
-// Same formula as cadence.IsOverdueWithConfig, with the env-derived duration
-// replaced by the production one. Exported for the coverage tests: the suite runs
-// under CRM_ENV=test, where annual is two hours and every contact is overdue, so
-// a measurement taken through the ambient config would prove nothing.
+// It DELEGATES the formula rather than restating it: the cadence package owns
+// both the table and the overdue arithmetic, and a second copy here would be free
+// to drift on exactly the edge a copy always drifts on (this one previously did —
+// an unrecognized cadence resolved to Monthly there and to "never overdue"
+// here). What is local is only the two things the cadence package cannot know:
+// that the caller holds a nullable cadence STRING, and that an absent cadence
+// means no due date at all rather than a defaulted one.
+//
+// Exported for the coverage tests, which run under CRM_ENV=test where annual is
+// two hours and every contact is overdue — so a measurement taken through the
+// ambient config would prove nothing, and mutating the variable would change
+// cadence semantics for every concurrently-running test.
 func OverdueAtProduction(cadenceName string, lastContacted *time.Time, createdAt, ref time.Time) bool {
-	period, ok := productionCadencePeriod(cadenceName)
-	if !ok {
+	if cadenceName == "" {
+		// No cadence means the app computes no due date, so nothing can be overdue.
 		return false
 	}
-	base := createdAt
-	if lastContacted != nil {
-		base = *lastContacted
-	}
-	return ref.After(base.Add(period))
+	return cadence.IsOverdueWithProductionConfig(cadence.CadenceType(cadenceName), lastContacted, createdAt, ref)
 }
 
 // --- timeline → batch payloads ----------------------------------------------
@@ -657,6 +687,22 @@ var (
 	// errArchetypePairMalformed — a promotion pair that is not exactly two entries
 	// with differing directions, or whose timing breaks the source-specific rule.
 	errArchetypePairMalformed = errors.New("synthetic archetypes: promotion pair is malformed")
+	// errArchetypeChatCloneUnresolved — a chat conversation whose membership does
+	// not yield BOTH the connected account and a peer, so a clone cannot be given a
+	// sender. Left unchecked this is the mapper's one silent failure: the clone
+	// would carry an empty sender, the provider would read it as INBOUND with an
+	// empty peer address, and the batch ownership preflight skips empty-addressed
+	// items by design — so an intended outbound would strand and time out a gate
+	// blaming the wrong thing. Every other failure here is named and immediate.
+	errArchetypeChatCloneUnresolved = errors.New("synthetic archetypes: chat conversation membership does not resolve both sender roles")
+	// errArchetypeSlotOutOfRange — a slot whose frozen index is not in the catalog
+	// the assignment was derived for. The two must be the same catalog or the
+	// overlay is being applied to a world it was not computed against.
+	errArchetypeSlotOutOfRange = errors.New("synthetic archetypes: slot index is outside the assigned catalog")
+	// errArchetypeSettleBudget — the block settled more times than one Settle per
+	// dependency generation allows, which is what a regression from batch replay
+	// back to per-payload replay looks like from the outside.
+	errArchetypeSettleBudget = errors.New("synthetic archetypes: replay exceeded its settle budget")
 )
 
 const (
@@ -672,13 +718,16 @@ const (
 	// can never straddle two buckets.
 	gmailAgeBucketWidth = 120 * 24 * time.Hour
 
-	// chatBurstWindow / chatReplyBridgeWindow mirror the harness's GChat
-	// aggregation engine wiring. They are used only to PREDICT how many interaction
-	// rows a chat conversation collapses into; the prediction is compared against
-	// the database row for row, so a drift here fails the collapse assertion rather
-	// than passing quietly.
-	chatBurstWindow       = 2 * time.Hour
-	chatReplyBridgeWindow = 48 * time.Hour
+	// chatBurstWindow / chatReplyBridgeWindow are the GChat aggregation engine's
+	// OWN windows, read from the package that declares them rather than mirrored as
+	// local literals — a mirrored literal cannot fail when the real window moves,
+	// which is precisely the drift this arc's other budget accessors exist to stop.
+	//
+	// They are load-bearing twice over: the collapse prediction below counts
+	// sessions by the burst window, and the opening burst's forty-minute stride is
+	// only INSIDE one session while that window stays above it.
+	chatBurstWindow       = time.Duration(google.GChatBurstWindowHours) * time.Hour
+	chatReplyBridgeWindow = time.Duration(google.GChatReplyBridgeHours) * time.Hour
 )
 
 // archetypeSlot is one catalog slot the archetype block gives history to: which
@@ -693,12 +742,50 @@ type archetypeSlot struct {
 // archetypeBatches is the block's whole payload plan, ready to drive. Gmail is
 // pre-bucketed (oldest bucket first, each bucket oldest-entry first); the other
 // two are single batches in oldest-first order.
+//
+// It carries no payload total on purpose: the seeding block counts what the
+// adapters actually DROVE, and a second counter for the same quantity would be
+// two numbers kept in step by nothing but a cross-check.
 type archetypeBatches struct {
 	GCal         []replay.GCalBatchItem
 	GmailBuckets [][]replay.GmailBatchItem
 	GChat        []replay.GChatBatchItem
 	Samples      []replay.ArchetypeSample
-	Payloads     int
+}
+
+// empty reports whether the plan would drive nothing at all — the case the
+// adapters reject by preflight and the caller must therefore skip.
+func (b archetypeBatches) empty() bool {
+	return len(b.GCal) == 0 && len(b.GmailBuckets) == 0 && len(b.GChat) == 0
+}
+
+// archetypeTimelineSource resolves one slot's archetype and the timeline that
+// archetype produces for it. It is a seam, not indirection for its own sake: the
+// mapper's guard branches are reachable only from timeline SHAPES the generator
+// does not currently emit (a calendar entry carrying a pair key, a pair spanning
+// two sources), and a guard nothing can exercise is indistinguishable from one
+// that always passes.
+type archetypeTimelineSource func(slot archetypeSlot) (factory.Archetype, factory.Timeline, error)
+
+// buildArchetypeBatches turns each slot's assigned archetype into source
+// payloads.
+//
+// TimelineFor is called for EVERY slot, including the ones that end up with no
+// history at all: its draw cost is fixed, so calling it unconditionally makes the
+// block's PRNG consumption a function of the catalog size alone and never of
+// which archetype landed where.
+func buildArchetypeBatches(gen *factory.Generator, slots []archetypeSlot, n int) (archetypeBatches, error) {
+	// Derived ONCE for the whole catalog: the assignment is a whole-catalog
+	// computation, so resolving it per slot would run it n times per seed.
+	assignment := archetypeAssignment(n)
+	return buildArchetypeBatchesFrom(gen, slots, func(slot archetypeSlot) (factory.Archetype, factory.Timeline, error) {
+		if slot.Index < 0 || slot.Index >= len(assignment) {
+			return "", factory.Timeline{}, fmt.Errorf("slot %d against a %d-slot catalog: %w",
+				slot.Index, len(assignment), errArchetypeSlotOutOfRange)
+		}
+		archetype := assignment[slot.Index]
+		return archetype, gen.TimelineFor(archetype, archetypeMethodSet(slot.Spec)), nil
+	})
 }
 
 // archetypeMethodSet reports what identifiers a seeded catalog contact actually
@@ -714,13 +801,9 @@ func archetypeMethodSet(spec factory.ContactSpec) factory.MethodSet {
 	}
 }
 
-// buildArchetypeBatches turns each slot's archetype into source payloads.
-//
-// TimelineFor is called for EVERY slot, including the ones that end up with no
-// history at all: its draw cost is fixed, so calling it unconditionally makes the
-// block's PRNG consumption a function of the catalog size alone and never of
-// which archetype landed where.
-func buildArchetypeBatches(gen *factory.Generator, slots []archetypeSlot, n int) (archetypeBatches, error) {
+// buildArchetypeBatchesFrom is buildArchetypeBatches over a caller-supplied
+// timeline source.
+func buildArchetypeBatchesFrom(gen *factory.Generator, slots []archetypeSlot, timelineFor archetypeTimelineSource) (archetypeBatches, error) {
 	var out archetypeBatches
 
 	// Every batch is collected with its entries' ages, so the whole block can be
@@ -748,8 +831,10 @@ func buildArchetypeBatches(gen *factory.Generator, slots []archetypeSlot, n int)
 	nextPairKey := 0
 
 	for _, slot := range slots {
-		archetype := ArchetypeForIndex(slot.Index, n)
-		timeline := gen.TimelineFor(archetype, archetypeMethodSet(slot.Spec))
+		archetype, timeline, err := timelineFor(slot)
+		if err != nil {
+			return out, err
+		}
 
 		// A conversation is a PLAN-level statement; at replay time the payloads must
 		// also share the source's conversation identifier, and the factories mint a
@@ -805,12 +890,16 @@ func buildArchetypeBatches(gen *factory.Generator, slots []archetypeSlot, n int)
 				var spec factory.GChatMessageSpec
 				if base, ok := spaces[entry.ConversationKey]; entry.ConversationKey != 0 && ok {
 					spaceClones[entry.ConversationKey]++
-					spec = cloneArchetypeGChatMessage(
+					clone, cloneErr := cloneArchetypeGChatMessage(
 						base,
 						fmt.Sprintf("arch-%d", spaceClones[entry.ConversationKey]),
 						entry.Outbound,
 						gen.Anchor().Add(-gchatMessageDefaultOffset-entry.Age),
 					)
+					if cloneErr != nil {
+						return out, fmt.Errorf("slot %d (%s): %w", slot.Index, archetype, cloneErr)
+					}
+					spec = clone
 				} else {
 					spec = gen.GChatMessage(slot.Spec, factory.MatchSeeded, archetypeMessageOptions(entry)...)
 					if entry.ConversationKey != 0 {
@@ -838,7 +927,6 @@ func buildArchetypeBatches(gen *factory.Generator, slots []archetypeSlot, n int)
 			Payloads:             len(timeline.Entries),
 			ExpectedInteractions: expectedArchetypeInteractions(timeline),
 		})
-		out.Payloads += len(timeline.Entries)
 	}
 
 	sort.SliceStable(calendar, func(i, j int) bool { return calendar[i].age > calendar[j].age })
@@ -941,7 +1029,7 @@ func validateArchetypePairs(slotIndex int, archetype factory.Archetype, pairs ma
 // Deliberately not shared with the batch tests' equivalent: that one is a fixture
 // for hand-authored batches, and coupling seed orchestration to a test helper
 // would make either one hard to change. Both are covered by their own assertions.
-func cloneArchetypeGChatMessage(base factory.GChatMessageSpec, suffix string, outbound bool, createTime time.Time) factory.GChatMessageSpec {
+func cloneArchetypeGChatMessage(base factory.GChatMessageSpec, suffix string, outbound bool, createTime time.Time) (factory.GChatMessageSpec, error) {
 	// Pick the sender by MEMBERSHIP order rather than by ranging EmailByUser: Go
 	// randomizes map iteration, so a space with more than two members would
 	// otherwise clone a nondeterministic sender.
@@ -961,6 +1049,13 @@ func cloneArchetypeGChatMessage(base factory.GChatMessageSpec, suffix string, ou
 			sender = user
 		}
 	}
+	// Both roles must resolve. A missing one would produce an empty sender, which
+	// the provider reads as an inbound from an empty address — a direction flip and
+	// an unmatchable payload, neither of which any downstream check would name.
+	if me == "" || sender == "" {
+		return factory.GChatMessageSpec{}, fmt.Errorf("space %q resolves me=%q peer=%q: %w",
+			base.SpaceName, me, sender, errArchetypeChatCloneUnresolved)
+	}
 	from := sender
 	if outbound {
 		from = me
@@ -974,7 +1069,7 @@ func cloneArchetypeGChatMessage(base factory.GChatMessageSpec, suffix string, ou
 		CreateTime: createTime.UTC().Format(time.RFC3339Nano),
 	}
 	clone.ExternalID = name
-	return clone
+	return clone, nil
 }
 
 // --- the expected payload → interaction collapse -----------------------------
@@ -1116,12 +1211,21 @@ func seedArchetypeHistories(
 	// Recorded for EVERY slot, including the history-free ones, so a coverage
 	// assertion can prove absence as well as presence.
 	h.SetArchetypeSamples(batches.Samples)
+	if batches.empty() {
+		return nil
+	}
 
+	batchCalls := 0
 	record := func(result replay.BatchResult) {
+		batchCalls++
 		res.ArchetypePayloads += result.Payloads
 		// Each batch snapshots the touched contacts' interaction ids before it
 		// drives, so summing across batches cannot double-count.
 		res.ArchetypeInteractions += result.Interactions
+		// Settle is O(all harness contacts) and rebuilds the whole event-id union
+		// on every call, so the phase's cost is its SETTLE count, not its payload
+		// count. One per dependency generation, at most two per batch.
+		res.ArchetypeSettleCalls += result.SettleCalls
 	}
 
 	if len(batches.GCal) > 0 {
@@ -1148,5 +1252,22 @@ func seedArchetypeHistories(
 		}
 		record(result)
 	}
+
+	// The settle budget is the whole reason this block batches at all: the same
+	// history through per-payload single replays would cost one Settle per payload
+	// — roughly a hundred at dev and a thousand at prod-shaped — each of them
+	// O(all harness contacts). A batch settles once per dependency GENERATION, and
+	// a generation split exists only where a promotion pair does, so two per call
+	// is the ceiling. Exceeding it means the batching has been undone somewhere,
+	// which every other assertion in this arc would happily pass.
+	if max := batchCalls * archetypeMaxSettlesPerBatch; res.ArchetypeSettleCalls > max {
+		return fmt.Errorf("profile %s: archetype replay settled %d times across %d batches (max %d): %w",
+			profile, res.ArchetypeSettleCalls, batchCalls, max, errArchetypeSettleBudget)
+	}
 	return nil
 }
+
+// archetypeMaxSettlesPerBatch is how many Settles one batch call may cost: one
+// per dependency generation, and a batch has at most two (the inbound half of
+// each promotion pair is deferred to the second).
+const archetypeMaxSettlesPerBatch = 2

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -1,7 +1,11 @@
 package synthetic
 
 import (
+	"sort"
 	"time"
+
+	"personal-crm/backend/internal/cadence"
+	"personal-crm/backend/internal/synthetic/factory"
 )
 
 // --- the frozen catalog slot model ------------------------------------------
@@ -75,4 +79,552 @@ func catalogSlot(i, n int) catalogSlotSpec {
 			Cadence: catalogNeverContactedCadences[(i/3)%len(catalogNeverContactedCadences)],
 		}
 	}
+}
+
+// --- archetype ↔ cadence compatibility ---------------------------------------
+//
+// Which archetype may land on which cadence is a statement about PRODUCTION
+// durations (weekly 7d … annual 365d) and nothing here may be checked by reading
+// the ambient environment: under CRM_ENV=test annual is two hours and every
+// contact is trivially overdue.
+//
+// The rule is STRICT, with a margin, and both halves are load-bearing:
+//
+//   - An archetype whose point is to stay OVERDUE (mutual-drifting, dormant) is
+//     admitted on a cadence only when its whole newest-age range clears the
+//     period: newestMin >= period + calmMargin.
+//   - An archetype meant to stay CALM (mutual-regular, inbound-only,
+//     burst-then-quiet) is admitted only when the period clears its whole newest-
+//     age range: period >= newestMax + calmMargin.
+//
+// A naive >= at the boundary is wrong for two compounding reasons. The newest-age
+// maxima are INCLUSIVE draws, so mutual-regular can draw exactly biweekly's
+// period and burst-then-quiet exactly quarterly's; and every source stamps its
+// payload at anchor − defaultOffset − age with an offset of one or two hours, so
+// at a boundary draw the contact is already overdue AT THE ANCHOR. Pinning the
+// reference instant therefore does not fix it — it converts a rare wall-clock
+// flake into an equally rare deterministic-when-drawn failure. The margin removes
+// the boundary entirely, and it buys something the boundary never could: a calm
+// sample stays calm for at least fourteen days after the reseed, so a tour round
+// running the morning after grades the population the seed produced. (The
+// tightest admitted pair is inbound-only on monthly: 30d − 15d − 2h = 14d 22h.)
+// Do not relax this back to >=.
+const calmMargin = 24 * time.Hour
+
+// archetypeIntent classifies what an archetype does to a contact's overdue-ness,
+// which is the only property the compatibility rule cares about.
+type archetypeIntent int
+
+const (
+	// intentOverdue writes last_contacted from a deliberately OLD newest entry, so
+	// the contact stays overdue and carries real history behind it.
+	intentOverdue archetypeIntent = iota
+	// intentCalm writes last_contacted from a RECENT newest entry, taking the
+	// contact out of the overdue set.
+	intentCalm
+	// intentNeutral never writes last_contacted at all (an outbound touches only
+	// last_outreach_at; an empty timeline touches nothing), so the slot keeps
+	// whatever overdue-ness its created_at gives it — on every cadence.
+	intentNeutral
+)
+
+// archetypeShape is one archetype's compatibility input: what it does to
+// overdue-ness, and the inclusive bounds of the age it dates its NEWEST entry at.
+//
+// The bounds RESTATE the generator's per-archetype table, because that table is
+// unexported and lives a package below this one. They are not trusted: a unit
+// test samples TimelineFor across thousands of namespaces and requires the
+// observed newest ages to sit inside these bounds AND to reach within one
+// calmMargin of each end, so a generator bound that moved by more than the margin
+// fails there rather than silently widening what this rule admits.
+type archetypeShape struct {
+	Intent     archetypeIntent
+	NewestMin  time.Duration
+	NewestMax  time.Duration
+	HasHistory bool
+}
+
+const archetypeDay = 24 * time.Hour
+
+// archetypeShapes is the closed catalog's compatibility table.
+var archetypeShapes = map[factory.Archetype]archetypeShape{
+	factory.ArchetypeMutualRegular:  {Intent: intentCalm, NewestMin: 3 * archetypeDay, NewestMax: 14 * archetypeDay, HasHistory: true},
+	factory.ArchetypeMutualDrifting: {Intent: intentOverdue, NewestMin: 70 * archetypeDay, NewestMax: 112 * archetypeDay, HasHistory: true},
+	factory.ArchetypeDormant:        {Intent: intentOverdue, NewestMin: 120 * archetypeDay, NewestMax: 150 * archetypeDay, HasHistory: true},
+	factory.ArchetypeInboundOnly:    {Intent: intentCalm, NewestMin: 1 * archetypeDay, NewestMax: 15 * archetypeDay, HasHistory: true},
+	factory.ArchetypeBurstThenQuiet: {Intent: intentCalm, NewestMin: 30 * archetypeDay, NewestMax: 90 * archetypeDay, HasHistory: true},
+	factory.ArchetypeOutboundHeavy:  {Intent: intentNeutral, NewestMin: 2 * archetypeDay, NewestMax: 20 * archetypeDay, HasHistory: true},
+	factory.ArchetypeNeverContacted: {Intent: intentNeutral, HasHistory: false},
+}
+
+// historyArchetypes are the six that emit a timeline, in the FIXED order every
+// "least-used" tie-break resolves by. never-contacted is appended for the same
+// tie-break, but is never quota-placed: it is what an unassigned slot falls back
+// to, not a cohort to fill.
+var historyArchetypes = []factory.Archetype{
+	factory.ArchetypeMutualDrifting,
+	factory.ArchetypeDormant,
+	factory.ArchetypeMutualRegular,
+	factory.ArchetypeInboundOnly,
+	factory.ArchetypeBurstThenQuiet,
+	factory.ArchetypeOutboundHeavy,
+}
+
+// archetypeTieBreak is the total order "least-used" ties resolve by, so the whole
+// assignment is deterministic with no map iteration anywhere in it.
+var archetypeTieBreak = append(append([]factory.Archetype{}, historyArchetypes...), factory.ArchetypeNeverContacted)
+
+// archetypeCadences is every cadence a catalog slot can carry, in a fixed order.
+// Compatibility breadth is counted over it.
+var archetypeCadences = []string{"weekly", "biweekly", "monthly", "quarterly", "biannual", "annual"}
+
+// productionCadencePeriod is a cadence name's PRODUCTION period.
+func productionCadencePeriod(name string) (time.Duration, bool) {
+	cadenceType, err := cadence.ParseCadence(name)
+	if err != nil {
+		return 0, false
+	}
+	cfg := cadence.ProductionCadenceConfig()
+	switch cadenceType {
+	case cadence.CadenceWeekly:
+		return cfg.Weekly, true
+	case cadence.CadenceBiweekly:
+		return cfg.Biweekly, true
+	case cadence.CadenceMonthly:
+		return cfg.Monthly, true
+	case cadence.CadenceQuarterly:
+		return cfg.Quarterly, true
+	case cadence.CadenceBiannual:
+		return cfg.Biannual, true
+	case cadence.CadenceAnnual:
+		return cfg.Annual, true
+	default:
+		return 0, false
+	}
+}
+
+// archetypeAdmissible reports whether the archetype may be placed on a slot
+// carrying this cadence, under the strict production-duration rule above.
+func archetypeAdmissible(a factory.Archetype, cadenceName string) bool {
+	shape, ok := archetypeShapes[a]
+	if !ok {
+		return false
+	}
+	if shape.Intent == intentNeutral {
+		// Touches neither last_contacted nor contact_by, so it cannot contradict any
+		// cadence.
+		return true
+	}
+	period, ok := productionCadencePeriod(cadenceName)
+	if !ok {
+		return false
+	}
+	if shape.Intent == intentOverdue {
+		return shape.NewestMin >= period+calmMargin
+	}
+	return period >= shape.NewestMax+calmMargin
+}
+
+// archetypeCadenceBreadth counts how many cadences admit this archetype. It is
+// the SCARCITY measure the quota phase places in ascending order of.
+func archetypeCadenceBreadth(a factory.Archetype) int {
+	n := 0
+	for _, c := range archetypeCadences {
+		if archetypeAdmissible(a, c) {
+			n++
+		}
+	}
+	return n
+}
+
+// archetypeScarcityOrder is historyArchetypes ordered by ascending compatibility
+// breadth, ties by the fixed order. Placing the most-constrained archetype first
+// is necessary but NOT sufficient — see the specificity ordering in the quota
+// phase for the other half.
+func archetypeScarcityOrder() []factory.Archetype {
+	out := append([]factory.Archetype{}, historyArchetypes...)
+	index := map[factory.Archetype]int{}
+	for i, a := range historyArchetypes {
+		index[a] = i
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		bi, bj := archetypeCadenceBreadth(out[i]), archetypeCadenceBreadth(out[j])
+		if bi != bj {
+			return bi < bj
+		}
+		return index[out[i]] < index[out[j]]
+	})
+	return out
+}
+
+// --- the overdue budget ------------------------------------------------------
+
+// OverdueCeiling is the absolute cap on how many contacts a seeded world may
+// leave overdue. Two capture bounds sit above it: the tour normalizer's default
+// array cap (50), and the overdue tours' own explicit cap, which they enforce by
+// REFUSING to run above it. Exported so the coverage tests assert the shipped
+// population against the same number the assignment is built to.
+const OverdueCeiling = 45
+
+// catalogNonCatalogLiveContacts models the profile's non-catalog live contacts —
+// 19 at the dev knobs and 31 at prod-shaped's, so the midpoint is what one
+// formula has to pick when it must set a sensible target for both. It is a
+// TARGET-PICKING device inside the budget, never an assertion: the coverage test
+// measures the live population from the database.
+const catalogNonCatalogLiveContacts = 25
+
+// overdueSharePercent is the percentage of the live population the overdue set
+// aims at. The band the coverage gates assert is 20–27%; the budget aims at the
+// middle of it.
+const overdueSharePercent = 23
+
+// pinnedOverdueFixtureCount is how many overdue contacts the pinned-fixture block
+// adds. They sit OUTSIDE the catalog and are always overdue, so the catalog
+// budget subtracts them rather than counting them twice.
+const pinnedOverdueFixtureCount = 2
+
+// catalogOverdueBudget is how many CATALOG slots the assignment may leave
+// overdue at this catalog size.
+func catalogOverdueBudget(n int) int {
+	target := overdueSharePercent * (n + catalogNonCatalogLiveContacts) / 100
+	if target > OverdueCeiling {
+		target = OverdueCeiling
+	}
+	return target - pinnedOverdueFixtureCount
+}
+
+// archetypeQuota is how many samples of each history archetype the quota phase
+// places. Two is the floor because the arc's commitment is multi-SAMPLE
+// variation: one sample of an archetype demonstrates presence and no jitter at
+// all.
+func archetypeQuota(n int) int {
+	if q := n / 24; q > 2 {
+		return q
+	}
+	return 2
+}
+
+// --- the assignment ----------------------------------------------------------
+
+// archetypeLadderFullAssignment / archetypeLadderReservedOnly are the catalog
+// sizes at which the degradation ladder changes rung. Below the reserved-only
+// floor the no-method bucket is structurally unreachable (it needs n > 3) and the
+// coherence floors cannot be satisfied, so the whole overlay is a no-op and the
+// world is byte-identical to one seeded without archetypes at all.
+const (
+	archetypeLadderFullAssignment = 12
+	archetypeLadderReservedOnly   = 5
+)
+
+// noMethodCatalogIndex is the frozen index of the no-method slot. It is reserved
+// for never-contacted mechanically, not by preference: a contact owning no
+// identifier can match no source payload, so any other archetype would give it an
+// empty timeline anyway while claiming a cohort membership it does not have.
+const noMethodCatalogIndex = 3
+
+// ArchetypeForIndex is the archetype catalog slot i of n carries. Exported
+// because the coverage tests re-derive the assignment independently and compare
+// it against what the seed actually recorded — an assertion that reads the
+// recorded value back out of the harness would be circular.
+func ArchetypeForIndex(i, n int) factory.Archetype {
+	assignment := archetypeAssignment(n)
+	if i < 0 || i >= len(assignment) {
+		return factory.ArchetypeNeverContacted
+	}
+	return assignment[i]
+}
+
+// archetypeAssignment maps every frozen catalog index of an n-contact catalog
+// onto an archetype. Pure, deterministic and PRNG-free: it reads the frozen slot
+// table and nothing else, so it can be re-derived by a test without a generator,
+// and reassigning archetypes cannot shift the shared PRNG stream (TimelineFor's
+// draw cost is fixed).
+//
+// Three rungs:
+//
+//   - n < 5 — every slot never-contacted. The overlay drives no payload and the
+//     world is byte-identical to one seeded without it.
+//   - 5 <= n < 12 — reserved slots only: the no-method slot, one contacted-and-
+//     overdue supplier, one outbound-heavy on a fresh slot, the rest
+//     never-contacted. The percentage target does not apply on this rung.
+//   - n >= 12 — the full assignment: quota, then the backdated remainder, then
+//     everything else.
+func archetypeAssignment(n int) []factory.Archetype {
+	if n < 0 {
+		n = 0
+	}
+	out := make([]factory.Archetype, n)
+	if n < archetypeLadderReservedOnly {
+		for i := range out {
+			out[i] = factory.ArchetypeNeverContacted
+		}
+		return out
+	}
+
+	assigned := make([]bool, n)
+	used := map[factory.Archetype]int{}
+	overdue := 0
+	budget := catalogOverdueBudget(n)
+
+	place := func(i int, a factory.Archetype) {
+		out[i] = a
+		assigned[i] = true
+		used[a]++
+		if archetypeLeavesSlotOverdue(i, n, a) {
+			overdue++
+		}
+	}
+
+	// Phase 0 — the no-method slot. It is backdated, so it costs the budget one.
+	if n > noMethodCatalogIndex {
+		place(noMethodCatalogIndex, factory.ArchetypeNeverContacted)
+	}
+
+	if n < archetypeLadderFullAssignment {
+		assignReservedSlots(out, assigned, place, n)
+		for i := range out {
+			if !assigned[i] {
+				out[i] = factory.ArchetypeNeverContacted
+			}
+		}
+		return out
+	}
+
+	quota := archetypeQuota(n)
+	scarcity := archetypeScarcityOrder()
+
+	// Phase Q — fill each history archetype's quota, most-constrained archetype
+	// first, and within an archetype spend its LEAST-CONTESTED slot first.
+	//
+	// Scarcity order alone is not enough, and the failure is concrete: dormant is
+	// admissible on quarterly, and filling it from the earliest compatible slot
+	// spends a quarterly slot that mutual-regular and inbound-only need, leaving
+	// mutual-regular at a single sample at n = 13. Specificity ordering — fewest
+	// OTHER still-unfilled history archetypes admissible on that slot's cadence,
+	// then index — spends a weekly slot (which only drifting and dormant can use)
+	// before a quarterly one (which three archetypes want), and with it every
+	// history archetype reaches its quota at every n >= 13.
+	for _, a := range scarcity {
+		contenders := make([]factory.Archetype, 0, len(scarcity))
+		for _, other := range scarcity {
+			if other != a && used[other] < quota {
+				contenders = append(contenders, other)
+			}
+		}
+		for used[a] < quota {
+			best := -1
+			bestContested := 0
+			for i := 0; i < n; i++ {
+				if assigned[i] {
+					continue
+				}
+				slot := catalogSlot(i, n)
+				if !archetypeAdmissible(a, slot.Cadence) {
+					continue
+				}
+				if archetypeLeavesSlotOverdue(i, n, a) && overdue+1 > budget {
+					continue
+				}
+				contested := 0
+				for _, other := range contenders {
+					if archetypeAdmissible(other, slot.Cadence) {
+						contested++
+					}
+				}
+				if best == -1 || contested < bestContested {
+					best, bestContested = i, contested
+				}
+			}
+			if best == -1 {
+				break
+			}
+			place(best, a)
+		}
+	}
+
+	// Phase B — the backdated remainder. These slots are overdue whatever they
+	// receive unless a CALM archetype takes them, so they are the only ones that
+	// interact with the budget, and the ones with NO admissible calm archetype
+	// (weekly and biweekly: none exists under the strict rule) are processed FIRST
+	// so they consume the budget before any discretionary spend.
+	var forced, discretionary []int
+	for i := 0; i < n; i++ {
+		if assigned[i] || catalogSlot(i, n).Kind != slotBackdated {
+			continue
+		}
+		if len(admissibleArchetypes(intentCalm, catalogSlot(i, n).Cadence)) == 0 {
+			forced = append(forced, i)
+		} else {
+			discretionary = append(discretionary, i)
+		}
+	}
+	for _, i := range append(forced, discretionary...) {
+		slot := catalogSlot(i, n)
+		if overdue+1 <= budget {
+			// Under budget: keep the slot never-connected AND overdue, which is the
+			// shape the overdue-diversity gate reads.
+			place(i, leastUsed(used, []factory.Archetype{factory.ArchetypeOutboundHeavy, factory.ArchetypeNeverContacted}))
+			continue
+		}
+		if calm := admissibleArchetypes(intentCalm, slot.Cadence); len(calm) > 0 {
+			// Budget spent: a calm archetype takes the slot OUT of the overdue set.
+			place(i, leastUsed(used, calm))
+			continue
+		}
+		// Budget spent and nothing calm is admissible here. The slot takes a neutral
+		// archetype and the budget is exceeded — a documented floor, not a silent
+		// one: the unit test asserts the structural floor itself never exceeds the
+		// ceiling.
+		place(i, leastUsed(used, []factory.Archetype{factory.ArchetypeOutboundHeavy, factory.ArchetypeNeverContacted}))
+	}
+
+	// Phase C — the recent / fresh remainder. Neither is ever overdue while
+	// last_contacted is NULL and neither can be made overdue by a calm archetype,
+	// so there is no budget interaction here.
+	for i := 0; i < n; i++ {
+		if assigned[i] {
+			continue
+		}
+		slot := catalogSlot(i, n)
+		pool := admissibleArchetypes(intentCalm, slot.Cadence)
+		pool = append(pool, factory.ArchetypeOutboundHeavy, factory.ArchetypeNeverContacted)
+		place(i, leastUsed(used, pool))
+	}
+
+	return out
+}
+
+// assignReservedSlots is the 5 <= n < 12 rung: the smallest world that still
+// carries the states the coherence gates read.
+func assignReservedSlots(out []factory.Archetype, assigned []bool, place func(int, factory.Archetype), n int) {
+	// The sole supplier of CONTACTED-AND-OVERDUE, a state the seed produces
+	// nowhere else. mutual-drifting is preferred and dormant is the fallback; under
+	// today's frozen ladder index 0 is weekly and always admits drifting, so the
+	// fallback is unreachable — it is kept because the ladder is data, and a future
+	// edit that made index 0 quarterly should degrade rather than silently drop the
+	// state.
+	for _, a := range []factory.Archetype{factory.ArchetypeMutualDrifting, factory.ArchetypeDormant} {
+		placed := false
+		for i := 0; i < n; i++ {
+			slot := catalogSlot(i, n)
+			if assigned[i] || slot.Kind != slotBackdated || !archetypeAdmissible(a, slot.Cadence) {
+				continue
+			}
+			place(i, a)
+			placed = true
+			break
+		}
+		if placed {
+			break
+		}
+	}
+
+	// One outbound-heavy on a FRESH slot, so it exercises last_outreach_at without
+	// last_contacted while staying out of the overdue set.
+	for i := 0; i < n; i++ {
+		if assigned[i] || catalogSlot(i, n).Kind != slotFresh {
+			continue
+		}
+		place(i, factory.ArchetypeOutboundHeavy)
+		break
+	}
+}
+
+// admissibleArchetypes returns the history archetypes of the given intent that
+// this cadence admits, in the fixed tie-break order.
+func admissibleArchetypes(intent archetypeIntent, cadenceName string) []factory.Archetype {
+	var out []factory.Archetype
+	for _, a := range historyArchetypes {
+		if archetypeShapes[a].Intent == intent && archetypeAdmissible(a, cadenceName) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// leastUsed picks the pool member placed fewest times so far, ties by the fixed
+// archetype order — never by map iteration, which Go randomizes.
+func leastUsed(used map[factory.Archetype]int, pool []factory.Archetype) factory.Archetype {
+	rank := map[factory.Archetype]int{}
+	for i, a := range archetypeTieBreak {
+		rank[a] = i
+	}
+	best := pool[0]
+	for _, a := range pool[1:] {
+		if used[a] < used[best] || (used[a] == used[best] && rank[a] < rank[best]) {
+			best = a
+		}
+	}
+	return best
+}
+
+// --- overdue prediction ------------------------------------------------------
+
+// catalogSlotNativelyOverdue reports whether the slot is overdue on its own —
+// backdated past its cadence period with an empty timeline. Only a backdated slot
+// can be, and every entry in the frozen ladder is (that is what the ladder is
+// for), so this is a derivation rather than an assumption.
+func catalogSlotNativelyOverdue(i, n int) bool {
+	slot := catalogSlot(i, n)
+	if slot.Kind != slotBackdated {
+		return false
+	}
+	period, ok := productionCadencePeriod(slot.Cadence)
+	if !ok {
+		return false
+	}
+	return slot.CreatedAge >= period+calmMargin
+}
+
+// archetypeLeavesSlotOverdue predicts whether a slot ends up overdue once its
+// archetype's history has landed:
+//
+//   - an overdue-intent archetype is overdue by construction (its newest two-way
+//     entry is older than the period, which the compatibility rule guarantees);
+//   - a calm one writes a recent last_contacted and is not;
+//   - a neutral one never writes last_contacted, so the slot keeps whatever its
+//     created_at gives it.
+func archetypeLeavesSlotOverdue(i, n int, a factory.Archetype) bool {
+	switch archetypeShapes[a].Intent {
+	case intentOverdue:
+		return true
+	case intentCalm:
+		return false
+	default:
+		return catalogSlotNativelyOverdue(i, n)
+	}
+}
+
+// PredictedCatalogOverdue is how many CATALOG slots the assignment leaves
+// overdue at this catalog size. Exported so the coverage test can compare a
+// DB-measured count against the prediction rather than trusting either alone.
+func PredictedCatalogOverdue(n int) int {
+	count := 0
+	for i, a := range archetypeAssignment(n) {
+		if archetypeLeavesSlotOverdue(i, n, a) {
+			count++
+		}
+	}
+	return count
+}
+
+// OverdueAtProduction reports whether a contact is overdue under PRODUCTION
+// cadence durations, evaluated at ref — normally the seeded world's own generator
+// anchor, so a prediction and a measurement answer the same question about the
+// same instant instead of racing the wall clock between them.
+//
+// Same formula as cadence.IsOverdueWithConfig, with the env-derived duration
+// replaced by the production one. Exported for the coverage tests: the suite runs
+// under CRM_ENV=test, where annual is two hours and every contact is overdue, so
+// a measurement taken through the ambient config would prove nothing.
+func OverdueAtProduction(cadenceName string, lastContacted *time.Time, createdAt, ref time.Time) bool {
+	period, ok := productionCadencePeriod(cadenceName)
+	if !ok {
+		return false
+	}
+	base := createdAt
+	if lastContacted != nil {
+		base = *lastContacted
+	}
+	return ref.After(base.Add(period))
 }

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -1,6 +1,7 @@
 package synthetic
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -1074,4 +1075,77 @@ func chatSessionCount(entries []factory.TimelineEntry) int {
 	}
 	flush()
 	return len(sessions)
+}
+
+// --- the seeding block -------------------------------------------------------
+
+// seedArchetypeHistories gives every catalog slot the interaction history its
+// archetype describes, by replaying the timeline's payloads through the batch
+// adapters.
+//
+// It runs at the VERY END of the catalog profile, after every other
+// generator-drawing block: TimelineFor draws the shared PRNG, and inserting it
+// anywhere earlier would shift every later allocation — a shifted numeric
+// identifier can land on an id another contact already owns, which surfaces as a
+// cross-match and a settle timeout far from the edit that caused it.
+//
+// The three sources are driven in a fixed order — calendar, then mail bucket by
+// bucket, then chat — so the phase's settle count is reproducible. Cross-source
+// ordering is otherwise free: the consumers' occurred_at guard is forward-only,
+// so an older calendar batch replayed after a newer mail batch cannot move
+// last_contacted backwards, and promotion is per-thread or per-space, never
+// across sources.
+//
+// A source with no payloads is SKIPPED rather than driven: the adapters reject a
+// zero-item batch by preflight, and on the reserved rung the chat batch is
+// guaranteed empty.
+func seedArchetypeHistories(
+	ctx context.Context,
+	h *Harness,
+	gen *factory.Generator,
+	profile Profile,
+	slots []archetypeSlot,
+	n int,
+	res *ProfileResult,
+) error {
+	batches, err := buildArchetypeBatches(gen, slots, n)
+	if err != nil {
+		return fmt.Errorf("profile %s: build archetype payloads: %w", profile, err)
+	}
+	// Recorded for EVERY slot, including the history-free ones, so a coverage
+	// assertion can prove absence as well as presence.
+	h.SetArchetypeSamples(batches.Samples)
+
+	record := func(result replay.BatchResult) {
+		res.ArchetypePayloads += result.Payloads
+		// Each batch snapshots the touched contacts' interaction ids before it
+		// drives, so summing across batches cannot double-count.
+		res.ArchetypeInteractions += result.Interactions
+	}
+
+	if len(batches.GCal) > 0 {
+		result, err := h.ReplayGCalBatch(ctx, batches.GCal)
+		if err != nil {
+			return fmt.Errorf("profile %s: replay archetype calendar batch: %w", profile, err)
+		}
+		record(result)
+	}
+	for i, bucket := range batches.GmailBuckets {
+		if len(bucket) == 0 {
+			continue
+		}
+		result, err := h.ReplayGmailBatch(ctx, bucket)
+		if err != nil {
+			return fmt.Errorf("profile %s: replay archetype mail bucket %d: %w", profile, i, err)
+		}
+		record(result)
+	}
+	if len(batches.GChat) > 0 {
+		result, err := h.ReplayGChatBatch(ctx, batches.GChat)
+		if err != nil {
+			return fmt.Errorf("profile %s: replay archetype chat batch: %w", profile, err)
+		}
+		record(result)
+	}
+	return nil
 }

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -1,0 +1,78 @@
+package synthetic
+
+import (
+	"time"
+)
+
+// --- the frozen catalog slot model ------------------------------------------
+//
+// The catalog's creation ORDER and per-index spec are frozen: committed
+// assertions hard-code catalog indices, and the archetype assignment below is an
+// index-keyed OVERLAY over them, never a reshuffle. catalogOptionsFor is the
+// single authority for what a slot is, but it returns builder OPTIONS — the only
+// way to learn a slot's cadence or created-age from it is to run it through the
+// generator, which draws PRNG.
+//
+// catalogSlot reports the same per-index spec as a pure function, derived from
+// the SAME three tables catalogOptionsFor reads (catalogOverdueLadder,
+// catalogRecentCadences / catalogNeverContactedCadences, and the no-method
+// branch). It is a second reader of those tables, not a second copy of them, and
+// a unit test builds every slot through catalogOptionsFor and requires the two
+// to agree — so a future edit to either side fails immediately rather than
+// silently drifting the assignment away from the world it is assigning over.
+
+// catalogSlotKind classifies a catalog index by its CREATED-AGE shape, which is
+// what decides whether the slot is overdue on its own.
+type catalogSlotKind int
+
+const (
+	// slotBackdated is created far in the past (the overdue ladder). It is the
+	// only kind that is overdue with an empty timeline.
+	slotBackdated catalogSlotKind = iota
+	// slotRecent is created within the last catalogRecentWindow.
+	slotRecent
+	// slotFresh is created at the anchor (no created-age option at all).
+	slotFresh
+)
+
+// catalogSlotSpec is one frozen catalog index's shape.
+type catalogSlotSpec struct {
+	Kind    catalogSlotKind
+	Cadence string
+	// CreatedAge is how far before the anchor the contact is created. Exact for
+	// slotBackdated; for slotRecent it is the WINDOW (the true age is a PRNG draw
+	// inside it), which is the conservative bound for an overdue prediction since a
+	// larger age can only make a contact more overdue. Zero for slotFresh.
+	CreatedAge time.Duration
+	// NoMethods marks the no-method slot, which owns no identifier and can
+	// therefore match no source payload at all.
+	NoMethods bool
+}
+
+// catalogSlot reports the frozen spec of catalog index i in a catalog of n.
+func catalogSlot(i, n int) catalogSlotSpec {
+	// The no-method bucket draws its (cadence, created-age) from the overdue
+	// ladder by the same rotation as any other i%3==0 slot; only the methods
+	// differ.
+	if i == 3 && n > 3 {
+		pair := catalogOverdueLadder[(i/3)%len(catalogOverdueLadder)]
+		return catalogSlotSpec{Kind: slotBackdated, Cadence: pair.cadence, CreatedAge: pair.createdAge, NoMethods: true}
+	}
+
+	switch i % 3 {
+	case 0:
+		pair := catalogOverdueLadder[(i/3)%len(catalogOverdueLadder)]
+		return catalogSlotSpec{Kind: slotBackdated, Cadence: pair.cadence, CreatedAge: pair.createdAge}
+	case 1:
+		return catalogSlotSpec{
+			Kind:       slotRecent,
+			Cadence:    catalogRecentCadences[(i/3)%len(catalogRecentCadences)],
+			CreatedAge: catalogRecentWindow,
+		}
+	default:
+		return catalogSlotSpec{
+			Kind:    slotFresh,
+			Cadence: catalogNeverContactedCadences[(i/3)%len(catalogNeverContactedCadences)],
+		}
+	}
+}

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -145,23 +145,24 @@ const (
 // calmMargin of each end, so a generator bound that moved by more than the margin
 // fails there rather than silently widening what this rule admits.
 type archetypeShape struct {
-	Intent     archetypeIntent
-	NewestMin  time.Duration
-	NewestMax  time.Duration
-	HasHistory bool
+	Intent    archetypeIntent
+	NewestMin time.Duration
+	NewestMax time.Duration
 }
 
 const archetypeDay = 24 * time.Hour
 
-// archetypeShapes is the closed catalog's compatibility table.
+// archetypeShapes is the closed catalog's compatibility table. never-contacted
+// carries no bounds because it emits no entry to date; a neutral intent is
+// admissible on every cadence without reading them.
 var archetypeShapes = map[factory.Archetype]archetypeShape{
-	factory.ArchetypeMutualRegular:  {Intent: intentCalm, NewestMin: 3 * archetypeDay, NewestMax: 14 * archetypeDay, HasHistory: true},
-	factory.ArchetypeMutualDrifting: {Intent: intentOverdue, NewestMin: 70 * archetypeDay, NewestMax: 112 * archetypeDay, HasHistory: true},
-	factory.ArchetypeDormant:        {Intent: intentOverdue, NewestMin: 120 * archetypeDay, NewestMax: 150 * archetypeDay, HasHistory: true},
-	factory.ArchetypeInboundOnly:    {Intent: intentCalm, NewestMin: 1 * archetypeDay, NewestMax: 15 * archetypeDay, HasHistory: true},
-	factory.ArchetypeBurstThenQuiet: {Intent: intentCalm, NewestMin: 30 * archetypeDay, NewestMax: 90 * archetypeDay, HasHistory: true},
-	factory.ArchetypeOutboundHeavy:  {Intent: intentNeutral, NewestMin: 2 * archetypeDay, NewestMax: 20 * archetypeDay, HasHistory: true},
-	factory.ArchetypeNeverContacted: {Intent: intentNeutral, HasHistory: false},
+	factory.ArchetypeMutualRegular:  {Intent: intentCalm, NewestMin: 3 * archetypeDay, NewestMax: 14 * archetypeDay},
+	factory.ArchetypeMutualDrifting: {Intent: intentOverdue, NewestMin: 70 * archetypeDay, NewestMax: 112 * archetypeDay},
+	factory.ArchetypeDormant:        {Intent: intentOverdue, NewestMin: 120 * archetypeDay, NewestMax: 150 * archetypeDay},
+	factory.ArchetypeInboundOnly:    {Intent: intentCalm, NewestMin: 1 * archetypeDay, NewestMax: 15 * archetypeDay},
+	factory.ArchetypeBurstThenQuiet: {Intent: intentCalm, NewestMin: 30 * archetypeDay, NewestMax: 90 * archetypeDay},
+	factory.ArchetypeOutboundHeavy:  {Intent: intentNeutral, NewestMin: 2 * archetypeDay, NewestMax: 20 * archetypeDay},
+	factory.ArchetypeNeverContacted: {Intent: intentNeutral},
 }
 
 // historyArchetypes are the six that emit a timeline, in the FIXED order every

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -1,11 +1,17 @@
 package synthetic
 
 import (
+	"errors"
+	"fmt"
 	"sort"
 	"time"
 
 	"personal-crm/backend/internal/cadence"
 	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/synthetic/replay"
+
+	"github.com/google/uuid"
+	chat "google.golang.org/api/chat/v1"
 )
 
 // --- the frozen catalog slot model ------------------------------------------
@@ -627,4 +633,445 @@ func OverdueAtProduction(cadenceName string, lastContacted *time.Time, createdAt
 		base = *lastContacted
 	}
 	return ref.After(base.Add(period))
+}
+
+// --- timeline → batch payloads ----------------------------------------------
+
+// Batch-composition failures. Each is named so a mapper bug is an immediate,
+// self-describing error instead of a stranded row and a settle timeout blaming
+// the wrong thing.
+var (
+	// errArchetypeUnsupportedSource — a timeline emitted a source the catalog
+	// cannot carry. Catalog contacts are email-only, so the generator resolves them
+	// to exactly {gcal, email, gchat}; telegram and iMessage would need dedicated
+	// contacts, and archetypes add history rather than contacts. Failing loudly is
+	// the point: a future method-set change must be a deliberate edit here, not a
+	// silent strand.
+	errArchetypeUnsupportedSource = errors.New("synthetic archetypes: timeline emitted a source the catalog cannot match")
+	// errArchetypeCalendarPairKey — a calendar entry carried a pair key. A matched
+	// calendar event is always mutual, so the batch item type has no field to carry
+	// one; dropping it silently would lose a stated intent.
+	errArchetypeCalendarPairKey = errors.New("synthetic archetypes: calendar entry carries a promotion pair key")
+	// errArchetypePairMalformed — a promotion pair that is not exactly two entries
+	// with differing directions, or whose timing breaks the source-specific rule.
+	errArchetypePairMalformed = errors.New("synthetic archetypes: promotion pair is malformed")
+)
+
+const (
+	// gmailAgeBucketWidth buckets the block's mail by age before it is replayed.
+	// Mail pooled across archetypes spans up to 179 days — mutual-drifting's second
+	// correspondence pair at the far end of the second meeting gap against
+	// inbound-only at its newest bound — while one Gmail batch may span at most 150
+	// days, and the adapter REJECTS a wider batch rather than auto-splitting it
+	// (only the caller knows whether splitting a contact's history across two syncs
+	// is semantically fine). A fixed 120-day window makes the bound hold by
+	// construction whatever the draws are: every bucket spans strictly less than
+	// 120 days. Both halves of a Gmail promotion pair carry the SAME age, so a pair
+	// can never straddle two buckets.
+	gmailAgeBucketWidth = 120 * 24 * time.Hour
+
+	// chatBurstWindow / chatReplyBridgeWindow mirror the harness's GChat
+	// aggregation engine wiring. They are used only to PREDICT how many interaction
+	// rows a chat conversation collapses into; the prediction is compared against
+	// the database row for row, so a drift here fails the collapse assertion rather
+	// than passing quietly.
+	chatBurstWindow       = 2 * time.Hour
+	chatReplyBridgeWindow = 48 * time.Hour
+)
+
+// archetypeSlot is one catalog slot the archetype block gives history to: which
+// frozen index it is, which contact it became, and the spec the source payloads
+// must address so the replay actually matches it.
+type archetypeSlot struct {
+	Index     int
+	ContactID uuid.UUID
+	Spec      factory.ContactSpec
+}
+
+// archetypeBatches is the block's whole payload plan, ready to drive. Gmail is
+// pre-bucketed (oldest bucket first, each bucket oldest-entry first); the other
+// two are single batches in oldest-first order.
+type archetypeBatches struct {
+	GCal         []replay.GCalBatchItem
+	GmailBuckets [][]replay.GmailBatchItem
+	GChat        []replay.GChatBatchItem
+	Samples      []replay.ArchetypeSample
+	Payloads     int
+}
+
+// archetypeMethodSet reports what identifiers a seeded catalog contact actually
+// owns, so the generator can only ever emit sources it can match. Read off the
+// spec rather than assumed, so a catalog slot that gained a method would produce
+// an honest timeline — and one that produced an unmatchable source would fail at
+// the mapper rather than strand a row.
+func archetypeMethodSet(spec factory.ContactSpec) factory.MethodSet {
+	return factory.MethodSet{
+		Email:    spec.Email != "",
+		Telegram: spec.TelegramHandle != "",
+		Phone:    spec.Phone != "",
+	}
+}
+
+// buildArchetypeBatches turns each slot's archetype into source payloads.
+//
+// TimelineFor is called for EVERY slot, including the ones that end up with no
+// history at all: its draw cost is fixed, so calling it unconditionally makes the
+// block's PRNG consumption a function of the catalog size alone and never of
+// which archetype landed where.
+func buildArchetypeBatches(gen *factory.Generator, slots []archetypeSlot, n int) (archetypeBatches, error) {
+	var out archetypeBatches
+
+	// Every batch is collected with its entries' ages, so the whole block can be
+	// put into one chronological order at the end rather than per contact — and so
+	// the mail can be bucketed by age band across every contact at once.
+	type agedGCalItem struct {
+		item replay.GCalBatchItem
+		age  time.Duration
+	}
+	type agedGmailItem struct {
+		item replay.GmailBatchItem
+		age  time.Duration
+	}
+	type agedGChatItem struct {
+		item replay.GChatBatchItem
+		age  time.Duration
+	}
+	var calendar []agedGCalItem
+	var mail []agedGmailItem
+	var messages []agedGChatItem
+
+	// PairKey groups are validated across the WHOLE batch by the adapter, so two
+	// contacts each carrying the timeline-local key 1 would form a four-member
+	// group and be rejected. Re-key every pair against one block-global counter.
+	nextPairKey := 0
+
+	for _, slot := range slots {
+		archetype := ArchetypeForIndex(slot.Index, n)
+		timeline := gen.TimelineFor(archetype, archetypeMethodSet(slot.Spec))
+
+		// A conversation is a PLAN-level statement; at replay time the payloads must
+		// also share the source's conversation identifier, and the factories mint a
+		// fresh one per call. So the first entry of a conversation mints it and every
+		// later entry is cloned onto it.
+		threads := map[int]string{}
+		spaces := map[int]factory.GChatMessageSpec{}
+		spaceClones := map[int]int{}
+		batchPairKeys := map[int]int{}
+		pairMembers := map[int][]factory.TimelineEntry{}
+
+		for _, entry := range timeline.Entries {
+			pairKey := 0
+			if entry.PairKey != 0 {
+				key, ok := batchPairKeys[entry.PairKey]
+				if !ok {
+					nextPairKey++
+					key = nextPairKey
+					batchPairKeys[entry.PairKey] = key
+				}
+				pairKey = key
+				pairMembers[entry.PairKey] = append(pairMembers[entry.PairKey], entry)
+			}
+
+			switch entry.Source {
+			case factory.SourceGCal:
+				if entry.PairKey != 0 {
+					return out, fmt.Errorf("slot %d (%s): %w", slot.Index, archetype, errArchetypeCalendarPairKey)
+				}
+				calendar = append(calendar, agedGCalItem{
+					item: replay.GCalBatchItem{
+						ContactID: slot.ContactID,
+						Spec:      gen.GCalEvent(slot.Spec, factory.MatchSeeded, factory.WithMessageAge(entry.Age)),
+					},
+					age: entry.Age,
+				})
+
+			case factory.SourceEmail:
+				spec := gen.GmailMessage(slot.Spec, factory.MatchSeeded, archetypeMessageOptions(entry)...)
+				if entry.ConversationKey != 0 {
+					if threadID, ok := threads[entry.ConversationKey]; ok {
+						spec.Message.ThreadId = threadID
+					} else {
+						threads[entry.ConversationKey] = spec.Message.ThreadId
+					}
+				}
+				mail = append(mail, agedGmailItem{
+					item: replay.GmailBatchItem{ContactID: slot.ContactID, Spec: spec, PairKey: pairKey},
+					age:  entry.Age,
+				})
+
+			case factory.SourceGChat:
+				var spec factory.GChatMessageSpec
+				if base, ok := spaces[entry.ConversationKey]; entry.ConversationKey != 0 && ok {
+					spaceClones[entry.ConversationKey]++
+					spec = cloneArchetypeGChatMessage(
+						base,
+						fmt.Sprintf("arch-%d", spaceClones[entry.ConversationKey]),
+						entry.Outbound,
+						gen.Anchor().Add(-gchatMessageDefaultOffset-entry.Age),
+					)
+				} else {
+					spec = gen.GChatMessage(slot.Spec, factory.MatchSeeded, archetypeMessageOptions(entry)...)
+					if entry.ConversationKey != 0 {
+						spaces[entry.ConversationKey] = spec
+					}
+				}
+				messages = append(messages, agedGChatItem{
+					item: replay.GChatBatchItem{ContactID: slot.ContactID, Spec: spec, PairKey: pairKey},
+					age:  entry.Age,
+				})
+
+			default:
+				return out, fmt.Errorf("slot %d (%s): source %q: %w", slot.Index, archetype, entry.Source, errArchetypeUnsupportedSource)
+			}
+		}
+
+		if err := validateArchetypePairs(slot.Index, archetype, pairMembers); err != nil {
+			return out, err
+		}
+
+		out.Samples = append(out.Samples, replay.ArchetypeSample{
+			ContactID:            slot.ContactID,
+			SlotIndex:            slot.Index,
+			Archetype:            archetype,
+			Payloads:             len(timeline.Entries),
+			ExpectedInteractions: expectedArchetypeInteractions(timeline),
+		})
+		out.Payloads += len(timeline.Entries)
+	}
+
+	sort.SliceStable(calendar, func(i, j int) bool { return calendar[i].age > calendar[j].age })
+	for _, c := range calendar {
+		out.GCal = append(out.GCal, c.item)
+	}
+	sort.SliceStable(messages, func(i, j int) bool { return messages[i].age > messages[j].age })
+	for _, m := range messages {
+		out.GChat = append(out.GChat, m.item)
+	}
+
+	// Bucket the mail by age band and emit the OLDEST bucket first, each bucket
+	// oldest-entry first — the chronological replay order the adapters require.
+	byBucket := map[int][]replay.GmailBatchItem{}
+	buckets := []int{}
+	sort.SliceStable(mail, func(i, j int) bool { return mail[i].age > mail[j].age })
+	for _, m := range mail {
+		bucket := int(m.age / gmailAgeBucketWidth)
+		if _, ok := byBucket[bucket]; !ok {
+			buckets = append(buckets, bucket)
+		}
+		byBucket[bucket] = append(byBucket[bucket], m.item)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(buckets)))
+	for _, bucket := range buckets {
+		out.GmailBuckets = append(out.GmailBuckets, byBucket[bucket])
+	}
+
+	return out, nil
+}
+
+// gchatMessageDefaultOffset is the small backward offset the GChat factory adds
+// on top of a message's age. A cloned message has to reproduce it exactly, or the
+// clone's instant would not be the instant its timeline entry asked for.
+const gchatMessageDefaultOffset = time.Hour
+
+// archetypeMessageOptions maps a timeline entry onto the factory's message
+// options. Age is passed THROUGH: promotion-pair timing is decided by the
+// generator (a mail pair at the same instant, a chat pair six hours apart with
+// the outbound older), and a caller that recomputed or "improved" a gap would
+// reintroduce exactly the tie-break the construction exists to remove.
+func archetypeMessageOptions(entry factory.TimelineEntry) []factory.MessageOption {
+	opts := []factory.MessageOption{factory.WithMessageAge(entry.Age)}
+	if entry.Outbound {
+		opts = append(opts, factory.WithOutbound())
+	}
+	return opts
+}
+
+// validateArchetypePairs checks the promotion-pair contract structurally, per
+// source, so a future generator change trips a named error here rather than a
+// local-midnight flake or a nondeterministic session split in the pipeline.
+func validateArchetypePairs(slotIndex int, archetype factory.Archetype, pairs map[int][]factory.TimelineEntry) error {
+	keys := make([]int, 0, len(pairs))
+	for k := range pairs {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		members := pairs[k]
+		if len(members) != 2 {
+			return fmt.Errorf("slot %d (%s): pair %d has %d members (want 2): %w",
+				slotIndex, archetype, k, len(members), errArchetypePairMalformed)
+		}
+		older, newer := members[0], members[1]
+		if older.Outbound == newer.Outbound {
+			return fmt.Errorf("slot %d (%s): pair %d members share a direction: %w",
+				slotIndex, archetype, k, errArchetypePairMalformed)
+		}
+		if older.Source != newer.Source {
+			return fmt.Errorf("slot %d (%s): pair %d spans two sources (%q and %q): %w",
+				slotIndex, archetype, k, older.Source, newer.Source, errArchetypePairMalformed)
+		}
+		if older.Source == factory.SourceEmail {
+			// The mail aggregation key includes a LOCAL day, so any nonzero gap can
+			// straddle local midnight depending on where the moving anchor lands. The
+			// same instant is the same local day, unconditionally.
+			if older.Age != newer.Age {
+				return fmt.Errorf("slot %d (%s): mail pair %d halves are %s apart but must share an instant: %w",
+					slotIndex, archetype, k, older.Age-newer.Age, errArchetypePairMalformed)
+			}
+			continue
+		}
+		// The chat path orders eligible rows only by sent time and promotion requires
+		// the outbound to precede the inbound, so equal timestamps could
+		// nondeterministically become one mutual or two one-sided sessions.
+		if !older.Outbound || older.Age <= newer.Age {
+			return fmt.Errorf("slot %d (%s): chat pair %d must place its OUTBOUND half strictly older: %w",
+				slotIndex, archetype, k, errArchetypePairMalformed)
+		}
+	}
+	return nil
+}
+
+// cloneArchetypeGChatMessage builds another message in the SAME space as base —
+// the clone discipline that makes a group of items one conversation. Independent
+// factory calls mint a fresh space each, which can never bridge and costs the
+// provider's shared page budget three fresh pages.
+//
+// Deliberately not shared with the batch tests' equivalent: that one is a fixture
+// for hand-authored batches, and coupling seed orchestration to a test helper
+// would make either one hard to change. Both are covered by their own assertions.
+func cloneArchetypeGChatMessage(base factory.GChatMessageSpec, suffix string, outbound bool, createTime time.Time) factory.GChatMessageSpec {
+	// Pick the sender by MEMBERSHIP order rather than by ranging EmailByUser: Go
+	// randomizes map iteration, so a space with more than two members would
+	// otherwise clone a nondeterministic sender.
+	sender, me := "", ""
+	for _, member := range base.Members {
+		if member == nil || member.Member == nil {
+			continue
+		}
+		user := member.Member.Name
+		if base.EmailByUser[user] == base.AccountID {
+			if me == "" {
+				me = user
+			}
+			continue
+		}
+		if sender == "" {
+			sender = user
+		}
+	}
+	from := sender
+	if outbound {
+		from = me
+	}
+	name := base.SpaceName + "/messages/" + suffix
+	clone := base
+	clone.Message = &chat.Message{
+		Name:       name,
+		Sender:     &chat.User{Name: from, Type: "HUMAN"},
+		Text:       "synthetic chat message",
+		CreateTime: createTime.UTC().Format(time.RFC3339Nano),
+	}
+	clone.ExternalID = name
+	return clone
+}
+
+// --- the expected payload → interaction collapse -----------------------------
+
+// expectedArchetypeInteractions is how many interaction ROWS a timeline's
+// payloads are expected to land once the pipeline has aggregated them. It is
+// deliberately smaller than the payload count: a mail promotion pair collapses
+// into one mutual row, and a chat burst collapses into one session per idle gap.
+//
+// It is derived from the timeline's STRUCTURE and from the pipeline's stated
+// aggregation semantics — not measured — so comparing it against the database is
+// a real test rather than a tautology. When the two disagree the derivation is
+// wrong and must be re-derived; it is never relaxed to an inequality.
+func expectedArchetypeInteractions(tl factory.Timeline) int {
+	rows := 0
+	mailThreads := map[int]bool{}
+	chatConversations := map[int][]factory.TimelineEntry{}
+	soloChat := 0
+
+	for _, entry := range tl.Entries {
+		switch entry.Source {
+		case factory.SourceGCal:
+			// A matched calendar event is one mutual interaction, and the archetypes
+			// space meetings weeks apart, so no two collapse.
+			rows++
+		case factory.SourceEmail:
+			// Mail promotion keys on (contact, thread, local day). Every conversation
+			// this catalog emits is one thread at one instant, so a thread is one row;
+			// an unthreaded message is its own.
+			if entry.ConversationKey == 0 {
+				rows++
+				continue
+			}
+			mailThreads[entry.ConversationKey] = true
+		default:
+			if entry.ConversationKey == 0 {
+				soloChat++
+				continue
+			}
+			chatConversations[entry.ConversationKey] = append(chatConversations[entry.ConversationKey], entry)
+		}
+	}
+	rows += len(mailThreads) + soloChat
+
+	keys := make([]int, 0, len(chatConversations))
+	for k := range chatConversations {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		rows += chatSessionCount(chatConversations[k])
+	}
+	return rows
+}
+
+// chatSessionCount is how many interaction rows one chat conversation's messages
+// aggregate into, following the engine's own two steps: consecutive same-
+// direction messages inside the burst window form a burst, and an inbound burst
+// that follows an outbound SESSION within the reply-bridge window merges into it
+// and turns it mutual (so a second inbound cannot bridge into the same session).
+//
+// entries arrive oldest-first, which is the order the engine reads them in.
+func chatSessionCount(entries []factory.TimelineEntry) int {
+	if len(entries) == 0 {
+		return 0
+	}
+	type session struct {
+		outbound bool
+		mutual   bool
+		lastAge  time.Duration
+	}
+	var sessions []session
+	burstOutbound := entries[0].Outbound
+	burstFirstAge, burstLastAge := entries[0].Age, entries[0].Age
+
+	flush := func() {
+		if len(sessions) > 0 && !burstOutbound {
+			prev := &sessions[len(sessions)-1]
+			// The engine bridges by INSTANT gap, and ages run backwards, so the gap
+			// from the previous session's newest message to this burst's oldest is
+			// prev.lastAge − burstFirstAge.
+			if prev.outbound && !prev.mutual && prev.lastAge-burstFirstAge <= chatReplyBridgeWindow {
+				prev.mutual = true
+				prev.lastAge = burstLastAge
+				return
+			}
+		}
+		sessions = append(sessions, session{outbound: burstOutbound, lastAge: burstLastAge})
+	}
+
+	for _, entry := range entries[1:] {
+		gap := burstLastAge - entry.Age
+		if entry.Outbound != burstOutbound || gap > chatBurstWindow {
+			flush()
+			burstOutbound, burstFirstAge, burstLastAge = entry.Outbound, entry.Age, entry.Age
+			continue
+		}
+		burstLastAge = entry.Age
+	}
+	flush()
+	return len(sessions)
 }

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	chat "google.golang.org/api/chat/v1"
 )
 
 // catalogSlotSizes are the catalog sizes the slot/assignment tests sweep: the
@@ -40,18 +41,18 @@ func TestCatalogSlotMatchesFrozenOptions(t *testing.T) {
 			switch slot.Kind {
 			case slotBackdated:
 				require.NotNil(t, spec.CreatedAt, "n=%d i=%d: a backdated slot stamps created_at", n, i)
-				require.True(t, spec.CreatedAt.Equal(anchor.Add(-slot.CreatedAge)),
-					"n=%d i=%d: backdated created_at must be exactly anchor − CreatedAge (got %s, want %s)",
-					n, i, spec.CreatedAt, anchor.Add(-slot.CreatedAge))
+				require.True(t, spec.CreatedAt.Equal(anchor.Add(-slot.CreatedAgeBound)),
+					"n=%d i=%d: backdated created_at must be exactly anchor − CreatedAgeBound (got %s, want %s)",
+					n, i, spec.CreatedAt, anchor.Add(-slot.CreatedAgeBound))
 			case slotRecent:
 				require.NotNil(t, spec.CreatedAt, "n=%d i=%d: a recent slot stamps created_at", n, i)
 				age := anchor.Sub(*spec.CreatedAt)
 				require.GreaterOrEqual(t, age, time.Duration(0), "n=%d i=%d: a recent slot is not created in the future", n, i)
-				require.Less(t, age, slot.CreatedAge,
+				require.Less(t, age, slot.CreatedAgeBound,
 					"n=%d i=%d: a recent slot lands inside the window catalogSlot reports as its bound", n, i)
 			case slotFresh:
 				require.Nil(t, spec.CreatedAt, "n=%d i=%d: a fresh slot carries no created-age option", n, i)
-				require.Zero(t, slot.CreatedAge, "n=%d i=%d: a fresh slot reports no created age", n, i)
+				require.Zero(t, slot.CreatedAgeBound, "n=%d i=%d: a fresh slot reports no created age", n, i)
 			}
 		}
 	}
@@ -71,39 +72,75 @@ func TestCatalogSlotIsPure(t *testing.T) {
 
 // --- compatibility -----------------------------------------------------------
 
-// TestArchetypeNewestAgeRangesMatchTheGenerator is the anti-drift guard for the
-// one table this package RESTATES rather than reads: the generator's
-// per-archetype newest-entry bounds live in an unexported table a package below,
-// so the compatibility rule declares its own copy.
+// TestArchetypeShapesMatchTheGenerator is the anti-drift guard for the table
+// this package RESTATES rather than reads: the generator's per-archetype
+// parameters are unexported and live a package below, so the compatibility rule
+// declares its own copy of the two facts it consumes.
 //
-// The guard samples real timelines across many namespaces and requires the
-// observed newest ages to (a) stay inside the declared bounds and (b) reach
-// within one calmMargin of each end. (a) catches a generator that widened its
-// range past what the rule was reasoned about; (b) catches one that narrowed or
-// shifted it. A drift smaller than the margin survives, which is the honest limit
-// of a sampling guard — but a drift smaller than the margin also cannot flip an
-// admissibility verdict on its own, which is what the margin is for.
+// It guards BOTH of them, over real sampled timelines:
+//
+//   - Intent — the field that selects WHICH inequality applies, and therefore
+//     the more load-bearing half. An archetype is neutral exactly when its
+//     timelines can never move last_contacted; a generator change that gave a
+//     neutral archetype an inbound or a calendar entry would silently make the
+//     "admissible on every cadence" shortcut false, and fails here instead.
+//     (Overdue-versus-calm is a DESIGN statement about which side of the period
+//     the archetype should sit on, not a generator fact, so it is pinned by the
+//     margin test below rather than derived here.)
+//   - NewestMin/NewestMax — measured over the newest entry that WRITES
+//     last_contacted, which is the quantity the rule reasons about. Measuring the
+//     newest entry of any kind would coincide today only because no archetype
+//     emits a one-sided entry newer than its newest two-way one.
+//
+// The bounds must sit inside the declared range AND reach within one calmMargin
+// of each end: (a) catches a generator that widened past what the rule was
+// reasoned about, (b) catches one that narrowed or shifted. A drift smaller than
+// the margin survives, which is the honest limit of a sampling guard — and a
+// drift smaller than the margin cannot flip an admissibility verdict on its own,
+// which is what the margin is for.
 //
 // The sample size makes (b) non-flaky rather than merely likely: the narrowest
 // declared range is 265 whole-hour draws and the margin is 25 of them, so the
 // probability of no sample landing in an end band is about e^-283.
-func TestArchetypeNewestAgeRangesMatchTheGenerator(t *testing.T) {
+func TestArchetypeShapesMatchTheGenerator(t *testing.T) {
 	const namespaces = 3000
 	caps := factory.MethodSet{Email: true}
 
 	observedMin := map[factory.Archetype]time.Duration{}
 	observedMax := map[factory.Archetype]time.Duration{}
+	writesLastContacted := map[factory.Archetype]bool{}
+
 	for s := 0; s < namespaces; s++ {
-		g := factory.NewGenerator(factory.DefaultSeed, "rangeunit"+strconv.Itoa(s))
-		for _, a := range historyArchetypes {
+		g := factory.NewGenerator(factory.DefaultSeed, "shapeunit"+strconv.Itoa(s))
+		for _, a := range archetypeTieBreak {
 			tl := g.TimelineFor(a, caps)
+			if a == factory.ArchetypeNeverContacted {
+				require.Empty(t, tl.Entries, "never-contacted must stay history-free")
+				continue
+			}
 			require.NotEmpty(t, tl.Entries, "%s must emit a timeline for an email-bearing contact", a)
-			newest := tl.Entries[0].Age
+
+			var newest time.Duration
+			found := false
 			for _, e := range tl.Entries {
-				if e.Age < newest {
-					newest = e.Age
+				// Calendar carries no promotion mechanic — a matched event is always
+				// mutual — so the generator must never ask for a pair key on one. The
+				// calendar batch item has no field to carry it, and the mapper refuses
+				// rather than dropping it (TestArchetypeCalendarPairKeyIsRejected).
+				if e.Source == factory.SourceGCal {
+					require.Zero(t, e.PairKey, "%s: a calendar entry must carry no promotion pair key", a)
+				}
+				if !archetypeWritesLastContacted(e) {
+					continue
+				}
+				if !found || e.Age < newest {
+					newest, found = e.Age, true
 				}
 			}
+			if !found {
+				continue
+			}
+			writesLastContacted[a] = true
 			if prev, ok := observedMin[a]; !ok || newest < prev {
 				observedMin[a] = newest
 			}
@@ -113,13 +150,27 @@ func TestArchetypeNewestAgeRangesMatchTheGenerator(t *testing.T) {
 		}
 	}
 
-	for _, a := range historyArchetypes {
+	for _, a := range archetypeTieBreak {
 		shape := archetypeShapes[a]
+
+		// The intent half: neutral EXACTLY when nothing the archetype emits can move
+		// last_contacted.
+		if shape.Intent == intentNeutral {
+			require.False(t, writesLastContacted[a],
+				"%s is declared NEUTRAL — admissible on every cadence without reading its bounds — but its timelines carry an entry that writes last_contacted", a)
+			require.Zero(t, shape.NewestMin, "%s is neutral, so it must declare no bounds to keep unread values out of the table", a)
+			require.Zero(t, shape.NewestMax, "%s is neutral, so it must declare no bounds to keep unread values out of the table", a)
+			continue
+		}
+		require.True(t, writesLastContacted[a],
+			"%s is declared with an overdue/calm intent, so its timelines must contain an entry that writes last_contacted", a)
+
+		// The bounds half, measured over that entry.
 		require.GreaterOrEqual(t, observedMin[a], shape.NewestMin,
-			"%s drew a newest age of %s, below the declared floor %s — the compatibility rule was reasoned about the declared range",
+			"%s dated its newest two-way entry %s back, below the declared floor %s — the compatibility rule was reasoned about the declared range",
 			a, observedMin[a], shape.NewestMin)
 		require.LessOrEqual(t, observedMax[a], shape.NewestMax,
-			"%s drew a newest age of %s, above the declared ceiling %s — the compatibility rule was reasoned about the declared range",
+			"%s dated its newest two-way entry %s back, above the declared ceiling %s — the compatibility rule was reasoned about the declared range",
 			a, observedMax[a], shape.NewestMax)
 		require.LessOrEqual(t, observedMin[a]-shape.NewestMin, calmMargin,
 			"%s never drew within one margin of its declared floor %s (closest %s) — the generator's floor has moved",
@@ -128,6 +179,15 @@ func TestArchetypeNewestAgeRangesMatchTheGenerator(t *testing.T) {
 			"%s never drew within one margin of its declared ceiling %s (closest %s) — the generator's ceiling has moved",
 			a, shape.NewestMax, observedMax[a])
 	}
+}
+
+// TestPinnedOverdueFixtureCountMatchesTheTable keeps the exported constant — a
+// const because the coverage tests add it back to a catalog prediction — in step
+// with the fixture table it counts. A slice literal cannot be a const, so this is
+// what makes the number a derivation rather than a restatement.
+func TestPinnedOverdueFixtureCountMatchesTheTable(t *testing.T) {
+	require.Equal(t, len(pinnedOverdueFixtures), PinnedOverdueFixtureCount,
+		"the exported pinned-overdue count must equal the number of pinned overdue fixtures")
 }
 
 // TestArchetypeCompatibilityHasAMargin proves the rule is STRICT WITH A MARGIN,
@@ -310,7 +370,7 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 	const devKnobNonCatalogLive = 19
 
 	for n := 1; n <= 150; n++ {
-		total := PredictedCatalogOverdue(n) + pinnedOverdueFixtureCount
+		total := PredictedCatalogOverdue(n) + PinnedOverdueFixtureCount
 		require.LessOrEqual(t, total, OverdueCeiling,
 			"n=%d: the overdue population must stay under the ceiling (the overdue tours refuse to run above their own, higher, capture cap)", n)
 
@@ -324,15 +384,15 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 
 	// The two shipping sizes are pinned exactly, so a tuning change to the budget
 	// or the placement ordering is a deliberate edit rather than a drift.
-	require.Equal(t, 9, PredictedCatalogOverdue(18)+pinnedOverdueFixtureCount, "dev (n=18) overdue total")
-	require.Equal(t, 40, PredictedCatalogOverdue(150)+pinnedOverdueFixtureCount, "prod-shaped (n=150) overdue total")
+	require.Equal(t, 9, PredictedCatalogOverdue(18)+PinnedOverdueFixtureCount, "dev (n=18) overdue total")
+	require.Equal(t, 40, PredictedCatalogOverdue(150)+PinnedOverdueFixtureCount, "prod-shaped (n=150) overdue total")
 
 	// The structural FLOOR: backdated slots with no admissible calm archetype are
 	// overdue whatever they receive, the no-method slot is reserved and backdated,
 	// and the two pinned fixtures are always overdue. The budget cannot push below
 	// this, so it must itself fit under the ceiling.
 	for n := 1; n <= 150; n++ {
-		floor := pinnedOverdueFixtureCount
+		floor := PinnedOverdueFixtureCount
 		for i := 0; i < n; i++ {
 			slot := catalogSlot(i, n)
 			if i == noMethodCatalogIndex && n > noMethodCatalogIndex {
@@ -347,7 +407,7 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 		}
 		require.LessOrEqual(t, floor, OverdueCeiling,
 			"n=%d: the structural overdue floor (%d) must fit under the ceiling — no budget can lower it", n, floor)
-		require.LessOrEqual(t, floor, PredictedCatalogOverdue(n)+pinnedOverdueFixtureCount,
+		require.LessOrEqual(t, floor, PredictedCatalogOverdue(n)+PinnedOverdueFixtureCount,
 			"n=%d: the predicted total can never be below the structural floor", n)
 	}
 }
@@ -377,10 +437,10 @@ func TestArchetypeAssignmentPreservesC3Floors(t *testing.T) {
 		}
 		for i, a := range assignment {
 			slot := catalogSlot(i, n)
-			if archetypeShapes[a].Intent != intentNeutral || slot.Kind != slotBackdated || slot.CreatedAge <= diversityFloorAge {
+			if archetypeShapes[a].Intent != intentNeutral || slot.Kind != slotBackdated || slot.CreatedAgeBound <= diversityFloorAge {
 				continue
 			}
-			ages[slot.CreatedAge] = true
+			ages[slot.CreatedAgeBound] = true
 			cadences[slot.Cadence] = true
 		}
 		require.GreaterOrEqual(t, len(ages), 3, "n=%d: the never-connected backdated set spans >=3 distinct created-ages", n)
@@ -483,7 +543,12 @@ func TestArchetypePayloadsAreAdapterLegal(t *testing.T) {
 			for _, bucket := range batches.GmailBuckets {
 				total += len(bucket)
 			}
-			require.Equal(t, batches.Payloads, total, "n=%d ns=%d: the payload count must be the batches' size", n, s)
+			perSlot := 0
+			for _, sample := range batches.Samples {
+				perSlot += sample.Payloads
+			}
+			require.Equal(t, perSlot, total,
+				"n=%d ns=%d: every timeline entry must reach exactly one batch item", n, s)
 
 			identifiers := map[string]bool{}
 			requireUnique := func(id string) {
@@ -610,7 +675,7 @@ func TestArchetypePayloadsSkipEmptySources(t *testing.T) {
 		gen := factory.NewGenerator(factory.DefaultSeed, "emptyunitlow"+strconv.Itoa(n))
 		batches, err := buildArchetypeBatches(gen, archetypeUnitSlots(gen, n), n)
 		require.NoError(t, err)
-		require.Zero(t, batches.Payloads, "n=%d: below the floor the overlay drives nothing", n)
+		require.True(t, batches.empty(), "n=%d: below the floor the overlay drives nothing", n)
 		require.Empty(t, batches.GCal)
 		require.Empty(t, batches.GmailBuckets)
 		require.Empty(t, batches.GChat)
@@ -667,6 +732,10 @@ func TestArchetypePairValidationRejectsMalformedPairs(t *testing.T) {
 		"mail_gap":           {mail(10*24*time.Hour+time.Hour, true), mail(10*24*time.Hour, false)},
 		"chat_equal_age":     {chatEntry(10*24*time.Hour, true), chatEntry(10*24*time.Hour, false)},
 		"chat_inbound_older": {chatEntry(10*24*time.Hour, false), chatEntry(10*24*time.Hour+6*time.Hour, true)},
+		// A pair whose halves live on different sources has no coherent timing rule
+		// at all — mail promotes on a shared thread and one local day, chat on the
+		// reply bridge in one space — so neither half can promote the other.
+		"two_sources": {mail(10*24*time.Hour, true), chatEntry(10*24*time.Hour, false)},
 	}
 	for name, members := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -755,4 +824,94 @@ func TestExpectedInteractionsMatchesArchetypeShape(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestArchetypeCalendarPairKeyIsRejected watches the guard the calendar batch
+// item type explicitly asks callers to write. GCalBatchItem has NO PairKey field
+// — a matched calendar event is always mutual, so calendar carries no promotion
+// mechanic — and its own comment says a caller mapping a plan that CAN carry a
+// pair key must ASSERT it is unset rather than drop it silently.
+//
+// The generator emits no such timeline today, which is exactly why the branch
+// needs a hand-authored one: a guard nothing can exercise is indistinguishable
+// from one that always passes.
+func TestArchetypeCalendarPairKeyIsRejected(t *testing.T) {
+	gen := factory.NewGenerator(factory.DefaultSeed, "gcalpairunit")
+	spec := gen.Contact(factory.WithEmail(), factory.WithCadence("weekly"))
+	slots := []archetypeSlot{{Index: 0, ContactID: uuid.New(), Spec: spec}}
+
+	timeline := factory.Timeline{
+		Archetype: factory.ArchetypeMutualRegular,
+		Entries: []factory.TimelineEntry{
+			{Source: factory.SourceGCal, Age: 30 * 24 * time.Hour, PairKey: 1},
+			{Source: factory.SourceGCal, Age: 10 * 24 * time.Hour, PairKey: 1},
+		},
+	}
+	_, err := buildArchetypeBatchesFrom(gen, slots, func(archetypeSlot) (factory.Archetype, factory.Timeline, error) {
+		return factory.ArchetypeMutualRegular, timeline, nil
+	})
+	require.ErrorIs(t, err, errArchetypeCalendarPairKey,
+		"a stated promotion intent must be refused by name, not dropped because the item type has nowhere to put it")
+}
+
+// TestArchetypeChatCloneRejectsUnresolvedMembership watches the mapper's one
+// otherwise-SILENT failure. A cloned chat message whose space membership does not
+// yield both the connected account and a peer would be built with an empty
+// sender; the provider reads that as an INBOUND from an empty address, and the
+// batch ownership preflight skips empty-addressed items by design — so an
+// intended outbound would strand and time out a gate blaming the wrong thing.
+//
+// burst-then-quiet's opening and filler clones carry no PairKey, so the
+// malformed-pair check would not catch them either.
+func TestArchetypeChatCloneRejectsUnresolvedMembership(t *testing.T) {
+	gen := factory.NewGenerator(factory.DefaultSeed, "cloneunit")
+	spec := gen.Contact(factory.WithEmail(), factory.WithCadence("annual"))
+	base := gen.GChatMessage(spec, factory.MatchSeeded, factory.WithMessageAge(20*24*time.Hour))
+
+	t.Run("resolved_membership_clones", func(t *testing.T) {
+		clone, err := cloneArchetypeGChatMessage(base, "arch-1", true, gen.Anchor().Add(-30*24*time.Hour))
+		require.NoError(t, err)
+		require.Equal(t, base.SpaceName, clone.SpaceName)
+		require.Equal(t, base.AccountID, clone.EmailByUser[clone.Message.Sender.Name],
+			"an outbound clone must be sent BY the connected account")
+	})
+
+	t.Run("missing_peer", func(t *testing.T) {
+		broken := base
+		broken.EmailByUser = map[string]string{}
+		for user := range base.EmailByUser {
+			broken.EmailByUser[user] = base.AccountID // every member resolves to "me"
+		}
+		_, err := cloneArchetypeGChatMessage(broken, "arch-1", true, gen.Anchor())
+		require.ErrorIs(t, err, errArchetypeChatCloneUnresolved)
+	})
+
+	t.Run("missing_me", func(t *testing.T) {
+		broken := base
+		broken.AccountID = "someone-else@synthetic.example"
+		_, err := cloneArchetypeGChatMessage(broken, "arch-1", false, gen.Anchor())
+		require.ErrorIs(t, err, errArchetypeChatCloneUnresolved)
+	})
+
+	t.Run("nil_member_entries", func(t *testing.T) {
+		broken := base
+		broken.Members = []*chat.Membership{nil, {State: "JOINED"}}
+		_, err := cloneArchetypeGChatMessage(broken, "arch-1", false, gen.Anchor())
+		require.ErrorIs(t, err, errArchetypeChatCloneUnresolved)
+	})
+}
+
+// TestArchetypeSlotOutOfRangeIsRejected pins the other half of the oracle
+// contract: the assignment is a WHOLE-CATALOG computation, so applying it to a
+// slot that is not in that catalog is a caller error, not something to paper over
+// with a default archetype.
+func TestArchetypeSlotOutOfRangeIsRejected(t *testing.T) {
+	gen := factory.NewGenerator(factory.DefaultSeed, "rangeslotunit")
+	spec := gen.Contact(factory.WithEmail(), factory.WithCadence("weekly"))
+	_, err := buildArchetypeBatches(gen, []archetypeSlot{{Index: 18, ContactID: uuid.New(), Spec: spec}}, 18)
+	require.ErrorIs(t, err, errArchetypeSlotOutOfRange)
+
+	require.Empty(t, ArchetypeForIndex(18, 18),
+		"the oracle must not answer with a valid archetype outside the catalog — a mis-derived index has to disagree loudly")
+	require.Empty(t, ArchetypeForIndex(-1, 18))
 }

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/synthetic/replay"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -420,6 +422,337 @@ func TestArchetypeAssignmentPreservesC3Floors(t *testing.T) {
 		if n == 12 || n == 13 {
 			require.Zero(t, catalogSupplied,
 				"n=%d: at this size the catalog cannot supply the floor and fxnoactivity is the sole supplier — if this changes, the note above is stale", n)
+		}
+	}
+}
+
+// --- payload construction ----------------------------------------------------
+
+// archetypeUnitSlots builds the catalog slots for an n-contact catalog without a
+// database: the same frozen options the profile uses, with a synthetic contact id
+// standing in for the seeded row.
+func archetypeUnitSlots(gen *factory.Generator, n int) []archetypeSlot {
+	slots := make([]archetypeSlot, 0, n)
+	for i := 0; i < n; i++ {
+		spec := gen.Contact(catalogOptionsFor(i, n, gen.Anchor(), gen.Prefix())...)
+		slots = append(slots, archetypeSlot{Index: i, ContactID: uuid.New(), Spec: spec})
+	}
+	return slots
+}
+
+func gmailItemOutbound(it replay.GmailBatchItem) bool {
+	for _, label := range it.Spec.Message.LabelIds {
+		if label == "SENT" {
+			return true
+		}
+	}
+	return false
+}
+
+func gchatItemOutbound(it replay.GChatBatchItem) bool {
+	return it.Spec.EmailByUser[it.Spec.Message.Sender.Name] == it.Spec.AccountID
+}
+
+func gchatItemCreatedAt(t *testing.T, it replay.GChatBatchItem) time.Time {
+	t.Helper()
+	at, err := time.Parse(time.RFC3339Nano, it.Spec.Message.CreateTime)
+	require.NoError(t, err)
+	return at
+}
+
+// TestArchetypePayloadsAreAdapterLegal builds the whole block's payloads across
+// many namespaces and asserts the shape the batch adapters' preflight demands.
+// Every rejection those adapters raise is a named error raised BEFORE anything is
+// driven, so a mapper that produced an illegal batch would fail the seed rather
+// than corrupt it — but it would fail it in the slow lane, at reseed time, on a
+// draw that happened to hit the bad case. This is the fast-lane equivalent.
+func TestArchetypePayloadsAreAdapterLegal(t *testing.T) {
+	const namespaces = 60
+	// The determinism run, the prod coverage run, the ladder rung, the multi-sample
+	// threshold and the dev profile. 150 is covered by the coverage sweep rather
+	// than here: it multiplies the cost without reaching a new shape.
+	sizes := []int{5, 9, 12, 13, 18}
+
+	for _, n := range sizes {
+		for s := 0; s < namespaces; s++ {
+			gen := factory.NewGenerator(factory.DefaultSeed, "payloadunit"+strconv.Itoa(n)+"x"+strconv.Itoa(s))
+			batches, err := buildArchetypeBatches(gen, archetypeUnitSlots(gen, n), n)
+			require.NoError(t, err, "n=%d ns=%d", n, s)
+
+			total := len(batches.GCal) + len(batches.GChat)
+			for _, bucket := range batches.GmailBuckets {
+				total += len(bucket)
+			}
+			require.Equal(t, batches.Payloads, total, "n=%d ns=%d: the payload count must be the batches' size", n, s)
+
+			identifiers := map[string]bool{}
+			requireUnique := func(id string) {
+				require.False(t, identifiers[id], "n=%d ns=%d: duplicate source identifier %q — the adapters reject a batch carrying one", n, s, id)
+				identifiers[id] = true
+			}
+
+			// --- calendar -----------------------------------------------------------
+			var prevStart time.Time
+			for i, it := range batches.GCal {
+				require.Equal(t, factory.MatchSeeded, it.Spec.Intent, "calendar items must be MatchSeeded")
+				requireUnique(it.Spec.GcalEventID)
+				start, err := time.Parse(time.RFC3339, it.Spec.Event.Start.DateTime)
+				require.NoError(t, err)
+				if i > 0 {
+					require.False(t, start.Before(prevStart), "n=%d ns=%d: calendar items must be oldest-first", n, s)
+				}
+				prevStart = start
+			}
+
+			// --- mail ---------------------------------------------------------------
+			mailPairs := map[int][]replay.GmailBatchItem{}
+			for _, bucket := range batches.GmailBuckets {
+				require.NotEmpty(t, bucket, "an empty bucket must never be driven — the adapters reject a zero-item batch")
+				var oldest, newest time.Time
+				var prev time.Time
+				for i, it := range bucket {
+					require.Equal(t, factory.MatchSeeded, it.Spec.Intent, "mail items must be MatchSeeded")
+					requireUnique(it.Spec.ExternalID)
+					sentAt := time.UnixMilli(it.Spec.Message.InternalDate).UTC()
+					if i == 0 || sentAt.Before(oldest) {
+						oldest = sentAt
+					}
+					if i == 0 || sentAt.After(newest) {
+						newest = sentAt
+					}
+					if i > 0 {
+						require.False(t, sentAt.Before(prev), "n=%d ns=%d: mail must be oldest-first inside a bucket", n, s)
+					}
+					prev = sentAt
+					if it.PairKey != 0 {
+						mailPairs[it.PairKey] = append(mailPairs[it.PairKey], it)
+					}
+				}
+				require.Less(t, newest.Sub(oldest), 150*24*time.Hour,
+					"n=%d ns=%d: a mail bucket must stay inside one sync's reach — the adapter rejects a wider batch by design", n, s)
+			}
+			for key, members := range mailPairs {
+				require.Len(t, members, 2, "mail pair %d must have exactly two members", key)
+				require.NotEqual(t, gmailItemOutbound(members[0]), gmailItemOutbound(members[1]),
+					"mail pair %d members must differ in direction", key)
+				require.Equal(t, members[0].Spec.Message.InternalDate, members[1].Spec.Message.InternalDate,
+					"mail pair %d must share an INSTANT: the aggregation key includes a local day, so any nonzero gap can straddle local midnight", key)
+				require.Equal(t, members[0].Spec.Message.ThreadId, members[1].Spec.Message.ThreadId,
+					"mail pair %d must share a thread — the factory mints a fresh one per call, so the caller clones", key)
+			}
+
+			// --- chat ---------------------------------------------------------------
+			chatPairs := map[int][]replay.GChatBatchItem{}
+			spaceOf := map[uuid.UUID]map[string]bool{}
+			var prevCreated time.Time
+			for i, it := range batches.GChat {
+				require.Equal(t, factory.MatchSeeded, it.Spec.Intent, "chat items must be MatchSeeded")
+				requireUnique(it.Spec.ExternalID)
+				createdAt := gchatItemCreatedAt(t, it)
+				if i > 0 {
+					require.False(t, createdAt.Before(prevCreated), "n=%d ns=%d: chat items must be oldest-first", n, s)
+				}
+				prevCreated = createdAt
+				if spaceOf[it.ContactID] == nil {
+					spaceOf[it.ContactID] = map[string]bool{}
+				}
+				spaceOf[it.ContactID][it.Spec.SpaceName] = true
+				if it.PairKey != 0 {
+					chatPairs[it.PairKey] = append(chatPairs[it.PairKey], it)
+				}
+			}
+			for key, members := range chatPairs {
+				require.Len(t, members, 2, "chat pair %d must have exactly two members", key)
+				outboundFirst := gchatItemOutbound(members[0])
+				require.True(t, outboundFirst && !gchatItemOutbound(members[1]),
+					"chat pair %d must be an OUTBOUND then an inbound: this path orders eligible rows only by sent time, so the ordering has to be decided by construction", key)
+				require.True(t, gchatItemCreatedAt(t, members[0]).Before(gchatItemCreatedAt(t, members[1])),
+					"chat pair %d outbound half must be strictly older", key)
+				require.Equal(t, members[0].Spec.SpaceName, members[1].Spec.SpaceName,
+					"chat pair %d must share a space — a pair across two spaces can never bridge", key)
+			}
+			// A contact's chat history is ONE conversation: the archetypes that use chat
+			// hold a single space for the whole timeline, which is also what keeps a
+			// burst inside the provider's page budget.
+			for contactID, spaces := range spaceOf {
+				require.Len(t, spaces, 1, "n=%d ns=%d: contact %s must carry exactly one chat space", n, s, contactID)
+			}
+
+			// Pair keys are BLOCK-global: the adapters group by pair key across the
+			// whole batch, so two contacts each carrying the timeline-local key 1 would
+			// form a four-member group and be rejected.
+			for key := range mailPairs {
+				require.NotContains(t, chatPairs, key, "pair key %d is reused across two sources", key)
+			}
+		}
+	}
+}
+
+// TestArchetypePayloadsSkipEmptySources pins the skip-empty rule at the size it
+// actually bites. On the reserved rung the assignment is mutual-drifting plus
+// outbound-heavy plus never-contacted, none of which emits a chat entry for an
+// email-only contact, so the chat batch is EMPTY at every 5 <= n < 12 — which is
+// exactly the configuration the determinism run (5) and the prod coverage run (9)
+// use. The adapters reject a zero-item batch by preflight, so driving one would
+// fail the seed.
+func TestArchetypePayloadsSkipEmptySources(t *testing.T) {
+	for n := archetypeLadderReservedOnly; n < archetypeLadderFullAssignment; n++ {
+		gen := factory.NewGenerator(factory.DefaultSeed, "emptyunit"+strconv.Itoa(n))
+		batches, err := buildArchetypeBatches(gen, archetypeUnitSlots(gen, n), n)
+		require.NoError(t, err)
+		require.Empty(t, batches.GChat, "n=%d: the reserved rung emits no chat payload at all", n)
+		require.NotEmpty(t, batches.GCal, "n=%d: the reserved rung's contacted-and-overdue supplier emits meetings", n)
+		require.NotEmpty(t, batches.GmailBuckets, "n=%d: the reserved rung's outbound-heavy slot emits mail", n)
+	}
+
+	// Below the reserved rung the whole overlay is a no-op.
+	for n := 1; n < archetypeLadderReservedOnly; n++ {
+		gen := factory.NewGenerator(factory.DefaultSeed, "emptyunitlow"+strconv.Itoa(n))
+		batches, err := buildArchetypeBatches(gen, archetypeUnitSlots(gen, n), n)
+		require.NoError(t, err)
+		require.Zero(t, batches.Payloads, "n=%d: below the floor the overlay drives nothing", n)
+		require.Empty(t, batches.GCal)
+		require.Empty(t, batches.GmailBuckets)
+		require.Empty(t, batches.GChat)
+	}
+}
+
+// TestArchetypePayloadsRejectUnmatchableSource proves the method-awareness guard
+// fires rather than stranding a row. A contact the frozen catalog cannot produce
+// today — one owning a telegram handle — resolves the chat role to telegram,
+// which no catalog replay path carries. The mapper must refuse it by NAME rather
+// than build a payload nothing in the block will drive, because an unmatchable
+// source surfaces thirty seconds later as a settle timeout blaming the wrong
+// thing.
+func TestArchetypePayloadsRejectUnmatchableSource(t *testing.T) {
+	const n = 18
+	gen := factory.NewGenerator(factory.DefaultSeed, "unmatchableunit")
+	spec := gen.Contact(factory.WithEmail(), factory.WithTelegram(), factory.WithCadence("weekly"))
+
+	chatBearing := -1
+	for i := 0; i < n; i++ {
+		switch ArchetypeForIndex(i, n) {
+		case factory.ArchetypeDormant, factory.ArchetypeBurstThenQuiet:
+			chatBearing = i
+		}
+		if chatBearing >= 0 {
+			break
+		}
+	}
+	require.GreaterOrEqual(t, chatBearing, 0, "n=%d must place a chat-bearing archetype somewhere", n)
+
+	_, err := buildArchetypeBatches(gen, []archetypeSlot{{Index: chatBearing, ContactID: uuid.New(), Spec: spec}}, n)
+	require.ErrorIs(t, err, errArchetypeUnsupportedSource,
+		"a telegram-bearing contact resolves the chat role to telegram, which the catalog replay block does not drive")
+}
+
+// TestArchetypePairValidationRejectsMalformedPairs watches the pair contract
+// fail. Each case is a shape a future generator change could produce, and each
+// one silently breaks a different thing downstream: a mis-sized group has no
+// defined generation split, a same-direction group promotes nothing, a mail pair
+// with a gap can straddle local midnight, and a chat pair in the wrong order
+// becomes two one-sided sessions instead of one mutual.
+func TestArchetypePairValidationRejectsMalformedPairs(t *testing.T) {
+	mail := func(age time.Duration, outbound bool) factory.TimelineEntry {
+		return factory.TimelineEntry{Source: factory.SourceEmail, Age: age, Outbound: outbound, PairKey: 1}
+	}
+	chatEntry := func(age time.Duration, outbound bool) factory.TimelineEntry {
+		return factory.TimelineEntry{Source: factory.SourceGChat, Age: age, Outbound: outbound, PairKey: 1}
+	}
+
+	cases := map[string][]factory.TimelineEntry{
+		"one_member":         {mail(10*24*time.Hour, true)},
+		"three_members":      {mail(10*24*time.Hour, true), mail(10*24*time.Hour, false), mail(10*24*time.Hour, false)},
+		"same_direction":     {mail(10*24*time.Hour, true), mail(10*24*time.Hour, true)},
+		"mail_gap":           {mail(10*24*time.Hour+time.Hour, true), mail(10*24*time.Hour, false)},
+		"chat_equal_age":     {chatEntry(10*24*time.Hour, true), chatEntry(10*24*time.Hour, false)},
+		"chat_inbound_older": {chatEntry(10*24*time.Hour, false), chatEntry(10*24*time.Hour+6*time.Hour, true)},
+	}
+	for name, members := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := validateArchetypePairs(0, factory.ArchetypeDormant, map[int][]factory.TimelineEntry{1: members})
+			require.ErrorIs(t, err, errArchetypePairMalformed)
+		})
+	}
+
+	// The two legal shapes must pass, or the rejections above are vacuous.
+	require.NoError(t, validateArchetypePairs(0, factory.ArchetypeMutualRegular,
+		map[int][]factory.TimelineEntry{1: {mail(10*24*time.Hour, true), mail(10*24*time.Hour, false)}}))
+	require.NoError(t, validateArchetypePairs(0, factory.ArchetypeDormant,
+		map[int][]factory.TimelineEntry{1: {chatEntry(10*24*time.Hour+6*time.Hour, true), chatEntry(10*24*time.Hour, false)}}))
+}
+
+// TestExpectedInteractionsMatchesArchetypeShape pins the payload → interaction
+// collapse formula against each archetype's actual timeline structure, across
+// many namespaces. The formula is what the seed records as its expectation and
+// what the end-to-end test compares the database against, so a generator change
+// that altered the collapse must fail in this fast lane rather than only in the
+// slow one.
+func TestExpectedInteractionsMatchesArchetypeShape(t *testing.T) {
+	const namespaces = 400
+	caps := factory.MethodSet{Email: true}
+
+	for s := 0; s < namespaces; s++ {
+		gen := factory.NewGenerator(factory.DefaultSeed, "collapseunit"+strconv.Itoa(s))
+		for _, a := range archetypeTieBreak {
+			tl := gen.TimelineFor(a, caps)
+			var gcal, mail, chatMsgs int
+			pairs := map[int]bool{}
+			for _, e := range tl.Entries {
+				switch e.Source {
+				case factory.SourceGCal:
+					gcal++
+				case factory.SourceEmail:
+					mail++
+				default:
+					chatMsgs++
+				}
+				if e.PairKey != 0 {
+					pairs[e.PairKey] = true
+				}
+			}
+			got := expectedArchetypeInteractions(tl)
+
+			switch a {
+			case factory.ArchetypeMutualRegular:
+				// M meetings 21–35 days apart, each its own row, plus ONE correspondence
+				// pair collapsing to a single mutual.
+				require.Equal(t, 2, mail)
+				require.Len(t, pairs, 1)
+				require.Equal(t, gcal+1, got)
+			case factory.ArchetypeMutualDrifting:
+				// The same series, stopped, with one or two correspondence pairs.
+				require.Equal(t, 2*len(pairs), mail)
+				require.Equal(t, gcal+len(pairs), got)
+			case factory.ArchetypeDormant:
+				// M meetings plus a closing chat exchange six hours apart in one space,
+				// which the reply bridge promotes into a single mutual.
+				require.Equal(t, 2, chatMsgs)
+				require.Len(t, pairs, 1)
+				require.Equal(t, gcal+1, got)
+			case factory.ArchetypeOutboundHeavy, factory.ArchetypeInboundOnly:
+				// Distinct threads five or more days apart: nothing collapses.
+				require.Empty(t, pairs)
+				require.Zero(t, gcal)
+				require.Equal(t, mail, got)
+			case factory.ArchetypeBurstThenQuiet:
+				// K messages in ONE space: the opening three inside one burst window
+				// become one session (−2), and the closing pair promotes into one (−1).
+				require.Zero(t, gcal)
+				require.Zero(t, mail)
+				require.Len(t, pairs, 1)
+				require.Equal(t, chatMsgs-3, got,
+					"a burst of %d messages must collapse to %d rows — the assertion that proves the burst window is exercised rather than K unrelated messages seeded",
+					chatMsgs, chatMsgs-3)
+			case factory.ArchetypeNeverContacted:
+				require.Empty(t, tl.Entries)
+				require.Zero(t, got)
+			}
+
+			if a != factory.ArchetypeNeverContacted {
+				require.LessOrEqual(t, got, len(tl.Entries), "%s: the collapse can never produce MORE rows than payloads", a)
+				require.Positive(t, got, "%s must land at least one row", a)
+			}
 		}
 	}
 }

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -1,6 +1,7 @@
 package synthetic
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -62,6 +63,363 @@ func TestCatalogSlotIsPure(t *testing.T) {
 	for _, n := range catalogSlotSizes {
 		for i := 0; i < n; i++ {
 			require.Equal(t, catalogSlot(i, n), catalogSlot(i, n), "catalogSlot(%d, %d) must be pure", i, n)
+		}
+	}
+}
+
+// --- compatibility -----------------------------------------------------------
+
+// TestArchetypeNewestAgeRangesMatchTheGenerator is the anti-drift guard for the
+// one table this package RESTATES rather than reads: the generator's
+// per-archetype newest-entry bounds live in an unexported table a package below,
+// so the compatibility rule declares its own copy.
+//
+// The guard samples real timelines across many namespaces and requires the
+// observed newest ages to (a) stay inside the declared bounds and (b) reach
+// within one calmMargin of each end. (a) catches a generator that widened its
+// range past what the rule was reasoned about; (b) catches one that narrowed or
+// shifted it. A drift smaller than the margin survives, which is the honest limit
+// of a sampling guard — but a drift smaller than the margin also cannot flip an
+// admissibility verdict on its own, which is what the margin is for.
+//
+// The sample size makes (b) non-flaky rather than merely likely: the narrowest
+// declared range is 265 whole-hour draws and the margin is 25 of them, so the
+// probability of no sample landing in an end band is about e^-283.
+func TestArchetypeNewestAgeRangesMatchTheGenerator(t *testing.T) {
+	const namespaces = 3000
+	caps := factory.MethodSet{Email: true}
+
+	observedMin := map[factory.Archetype]time.Duration{}
+	observedMax := map[factory.Archetype]time.Duration{}
+	for s := 0; s < namespaces; s++ {
+		g := factory.NewGenerator(factory.DefaultSeed, "rangeunit"+strconv.Itoa(s))
+		for _, a := range historyArchetypes {
+			tl := g.TimelineFor(a, caps)
+			require.NotEmpty(t, tl.Entries, "%s must emit a timeline for an email-bearing contact", a)
+			newest := tl.Entries[0].Age
+			for _, e := range tl.Entries {
+				if e.Age < newest {
+					newest = e.Age
+				}
+			}
+			if prev, ok := observedMin[a]; !ok || newest < prev {
+				observedMin[a] = newest
+			}
+			if prev, ok := observedMax[a]; !ok || newest > prev {
+				observedMax[a] = newest
+			}
+		}
+	}
+
+	for _, a := range historyArchetypes {
+		shape := archetypeShapes[a]
+		require.GreaterOrEqual(t, observedMin[a], shape.NewestMin,
+			"%s drew a newest age of %s, below the declared floor %s — the compatibility rule was reasoned about the declared range",
+			a, observedMin[a], shape.NewestMin)
+		require.LessOrEqual(t, observedMax[a], shape.NewestMax,
+			"%s drew a newest age of %s, above the declared ceiling %s — the compatibility rule was reasoned about the declared range",
+			a, observedMax[a], shape.NewestMax)
+		require.LessOrEqual(t, observedMin[a]-shape.NewestMin, calmMargin,
+			"%s never drew within one margin of its declared floor %s (closest %s) — the generator's floor has moved",
+			a, shape.NewestMin, observedMin[a])
+		require.LessOrEqual(t, shape.NewestMax-observedMax[a], calmMargin,
+			"%s never drew within one margin of its declared ceiling %s (closest %s) — the generator's ceiling has moved",
+			a, shape.NewestMax, observedMax[a])
+	}
+}
+
+// TestArchetypeCompatibilityHasAMargin proves the rule is STRICT WITH A MARGIN,
+// in both directions, and that the two pairs a naive >= would have admitted are
+// rejected.
+func TestArchetypeCompatibilityHasAMargin(t *testing.T) {
+	for _, a := range historyArchetypes {
+		shape := archetypeShapes[a]
+		for _, cadenceName := range archetypeCadences {
+			period, ok := productionCadencePeriod(cadenceName)
+			require.True(t, ok, "%q must be a production cadence", cadenceName)
+			if !archetypeAdmissible(a, cadenceName) {
+				continue
+			}
+			switch shape.Intent {
+			case intentOverdue:
+				require.GreaterOrEqual(t, shape.NewestMin, period+calmMargin,
+					"%s is admitted on %s, so its WHOLE newest-age range must clear the period by the margin", a, cadenceName)
+			case intentCalm:
+				require.GreaterOrEqual(t, period, shape.NewestMax+calmMargin,
+					"%s is admitted on %s, so the period must clear its WHOLE newest-age range by the margin", a, cadenceName)
+			case intentNeutral:
+				// Touches last_contacted on no cadence, so every cadence admits it.
+			}
+		}
+	}
+
+	// The two boundary pairs. Both are draws AT the period, and every source stamps
+	// its payload one to two hours before the drawn age, so at that draw the
+	// contact is already overdue at the anchor — a ~1/265 and ~1/1441 designed-in
+	// failure, not a wall-clock flake a pinned reference instant could remove.
+	require.False(t, archetypeAdmissible(factory.ArchetypeMutualRegular, "biweekly"),
+		"mutual-regular's newest age is an INCLUSIVE draw that reaches exactly biweekly's 14d period, and the source offset puts it over — do not relax this to >=")
+	require.False(t, archetypeAdmissible(factory.ArchetypeBurstThenQuiet, "quarterly"),
+		"burst-then-quiet's newest age is an INCLUSIVE draw that reaches exactly quarterly's 90d period, and the source offset puts it over — do not relax this to >=")
+
+	// mutual-drifting straddles quarterly (70–112d against 90d), so its overdue-ness
+	// there is INDETERMINATE rather than merely wrong-intent. Either way it is out.
+	require.False(t, archetypeAdmissible(factory.ArchetypeMutualDrifting, "quarterly"),
+		"mutual-drifting's 70–112d range straddles quarterly's 90d period, so its overdue-ness would be a coin flip per draw")
+
+	// Non-vacuity: the rule must still admit something on every cadence, or the
+	// assignment would silently degrade to never-contacted everywhere.
+	for _, cadenceName := range archetypeCadences {
+		var admitted int
+		for _, a := range historyArchetypes {
+			if archetypeAdmissible(a, cadenceName) {
+				admitted++
+			}
+		}
+		require.GreaterOrEqual(t, admitted, 2, "cadence %q must admit >=2 history archetypes", cadenceName)
+	}
+}
+
+// --- the assignment ----------------------------------------------------------
+
+// TestArchetypeAssignmentRungs walks the degradation ladder.
+func TestArchetypeAssignmentRungs(t *testing.T) {
+	t.Run("below_five_is_a_no_op", func(t *testing.T) {
+		for n := 0; n < archetypeLadderReservedOnly; n++ {
+			assignment := archetypeAssignment(n)
+			require.Len(t, assignment, n)
+			for i, a := range assignment {
+				require.Equal(t, factory.ArchetypeNeverContacted, a,
+					"n=%d i=%d: below the floor every slot is never-contacted, so the overlay drives no payload at all", n, i)
+			}
+		}
+	})
+
+	t.Run("reserved_only", func(t *testing.T) {
+		for n := archetypeLadderReservedOnly; n < archetypeLadderFullAssignment; n++ {
+			assignment := archetypeAssignment(n)
+			counts := map[factory.Archetype]int{}
+			for _, a := range assignment {
+				counts[a]++
+			}
+			contactedOverdue := counts[factory.ArchetypeMutualDrifting] + counts[factory.ArchetypeDormant]
+			require.Equal(t, 1, contactedOverdue,
+				"n=%d: the reserved rung places exactly one contacted-and-overdue supplier", n)
+			require.Equal(t, 1, counts[factory.ArchetypeOutboundHeavy],
+				"n=%d: the reserved rung places exactly one outbound-heavy", n)
+			require.Equal(t, n-2, counts[factory.ArchetypeNeverContacted],
+				"n=%d: every other slot stays never-contacted", n)
+			require.Equal(t, factory.ArchetypeNeverContacted, assignment[noMethodCatalogIndex],
+				"n=%d: the no-method slot is reserved on every rung", n)
+		}
+	})
+
+	t.Run("full_assignment", func(t *testing.T) {
+		for _, n := range []int{archetypeLadderFullAssignment, 13, 18, 150} {
+			assignment := archetypeAssignment(n)
+			require.Len(t, assignment, n)
+			present := map[factory.Archetype]int{}
+			for i, a := range assignment {
+				require.NotEmpty(t, a, "n=%d i=%d: every slot is assigned on the full rung", n, i)
+				present[a]++
+			}
+			for _, a := range archetypeTieBreak {
+				require.GreaterOrEqual(t, present[a], 1, "n=%d: every archetype has a cohort on the full rung (%s)", n, a)
+			}
+		}
+	})
+}
+
+// TestArchetypeAssignmentRespectsCompatibility is the gate that keeps an
+// indeterminate or wrong-intent placement from ever shipping: at EVERY catalog
+// size, every slot's archetype must be admissible on that slot's cadence.
+func TestArchetypeAssignmentRespectsCompatibility(t *testing.T) {
+	for n := 1; n <= 150; n++ {
+		for i, a := range archetypeAssignment(n) {
+			slot := catalogSlot(i, n)
+			require.True(t, archetypeAdmissible(a, slot.Cadence),
+				"n=%d i=%d: %s is not admissible on a %s slot", n, i, a, slot.Cadence)
+		}
+	}
+}
+
+// TestArchetypeAssignmentReservesIndexThree pins the mechanical reservation: the
+// no-method slot owns no identifier, so it can match no source payload and any
+// other archetype would claim a cohort membership it cannot have.
+func TestArchetypeAssignmentReservesIndexThree(t *testing.T) {
+	for n := noMethodCatalogIndex + 1; n <= 150; n++ {
+		require.True(t, catalogSlot(noMethodCatalogIndex, n).NoMethods,
+			"n=%d: index %d is the frozen no-method slot", n, noMethodCatalogIndex)
+		require.Equal(t, factory.ArchetypeNeverContacted, archetypeAssignment(n)[noMethodCatalogIndex],
+			"n=%d: the no-method slot must be never-contacted", n)
+	}
+}
+
+// TestArchetypeAssignmentMultiSample pins the arc's commitment that every
+// history archetype carries at least TWO samples, so the population demonstrates
+// jitter rather than mere presence.
+//
+// The floor is asserted from n >= 13, not from the ladder rung at 12, and the
+// derivation is arithmetic rather than a preference: the no-method slot is
+// structurally history-free whatever archetype it is given, leaving n − 1 usable
+// slots, and six history archetypes at two samples each need twelve of them. At
+// n = 12 exactly the floor is unsatisfiable over the frozen catalog, and
+// archetypes add history rather than contacts, so it cannot be fixed by seeding
+// another slot. Both shipping profiles (18 and 150) are above the threshold and
+// no suite run uses 12. Do not "fix" this to 12.
+func TestArchetypeAssignmentMultiSample(t *testing.T) {
+	for n := 13; n <= 150; n++ {
+		counts := map[factory.Archetype]int{}
+		for _, a := range archetypeAssignment(n) {
+			counts[a]++
+		}
+		for _, a := range historyArchetypes {
+			require.GreaterOrEqual(t, counts[a], 2,
+				"n=%d: %s must carry >=2 samples (six history archetypes x 2 need 12 of the n-1 usable slots)", n, a)
+		}
+	}
+}
+
+// TestArchetypeAssignmentIsDeterministic pins the whole overlay as a pure
+// function of n. Every "least-used" tie-break resolves by a fixed archetype
+// order, so no map iteration can leak into the result.
+func TestArchetypeAssignmentIsDeterministic(t *testing.T) {
+	for _, n := range catalogSlotSizes {
+		first := archetypeAssignment(n)
+		for run := 0; run < 5; run++ {
+			require.Equal(t, first, archetypeAssignment(n), "n=%d: the assignment must be identical on every call", n)
+		}
+	}
+}
+
+// TestArchetypeAssignmentOverdueBand pins the overdue population: the absolute
+// ceiling at every size, the target band on the full rung, both shipping
+// profiles' exact totals, and the structural floor.
+//
+// The band's denominator is live(n) = n + 19, the DEV-knob non-catalog live
+// count. It is exact at the small sizes the sweep spends most of its range on,
+// and it is strictly CONSERVATIVE at large ones: a smaller denominator inflates
+// the share, so the sweep tests against the 27% ceiling rather than away from it.
+// The budget formula's own midpoint constant is a target-picking device for two
+// profiles at once and is deliberately NOT reused here — it puts n = 12 below the
+// band. Neither model is ever an assertion about the world: the coverage test
+// counts live and overdue contacts from the database.
+func TestArchetypeAssignmentOverdueBand(t *testing.T) {
+	const devKnobNonCatalogLive = 19
+
+	for n := 1; n <= 150; n++ {
+		total := PredictedCatalogOverdue(n) + pinnedOverdueFixtureCount
+		require.LessOrEqual(t, total, OverdueCeiling,
+			"n=%d: the overdue population must stay under the ceiling (the overdue tours refuse to run above their own, higher, capture cap)", n)
+
+		if n < archetypeLadderFullAssignment {
+			continue
+		}
+		share := 100.0 * float64(total) / float64(n+devKnobNonCatalogLive)
+		require.GreaterOrEqual(t, share, 20.0, "n=%d: overdue share %.1f%% is below the band", n, share)
+		require.LessOrEqual(t, share, 27.0, "n=%d: overdue share %.1f%% is above the band", n, share)
+	}
+
+	// The two shipping sizes are pinned exactly, so a tuning change to the budget
+	// or the placement ordering is a deliberate edit rather than a drift.
+	require.Equal(t, 9, PredictedCatalogOverdue(18)+pinnedOverdueFixtureCount, "dev (n=18) overdue total")
+	require.Equal(t, 40, PredictedCatalogOverdue(150)+pinnedOverdueFixtureCount, "prod-shaped (n=150) overdue total")
+
+	// The structural FLOOR: backdated slots with no admissible calm archetype are
+	// overdue whatever they receive, the no-method slot is reserved and backdated,
+	// and the two pinned fixtures are always overdue. The budget cannot push below
+	// this, so it must itself fit under the ceiling.
+	for n := 1; n <= 150; n++ {
+		floor := pinnedOverdueFixtureCount
+		for i := 0; i < n; i++ {
+			slot := catalogSlot(i, n)
+			if i == noMethodCatalogIndex && n > noMethodCatalogIndex {
+				if catalogSlotNativelyOverdue(i, n) {
+					floor++
+				}
+				continue
+			}
+			if slot.Kind == slotBackdated && len(admissibleArchetypes(intentCalm, slot.Cadence)) == 0 && catalogSlotNativelyOverdue(i, n) {
+				floor++
+			}
+		}
+		require.LessOrEqual(t, floor, OverdueCeiling,
+			"n=%d: the structural overdue floor (%d) must fit under the ceiling — no budget can lower it", n, floor)
+		require.LessOrEqual(t, floor, PredictedCatalogOverdue(n)+pinnedOverdueFixtureCount,
+			"n=%d: the predicted total can never be below the structural floor", n)
+	}
+}
+
+// TestArchetypeAssignmentPreservesC3Floors re-asserts the coherence floors the
+// catalog carried BEFORE archetypes, over the population the overlay produces.
+//
+// The floors are read over the union of catalog slots and the pinned tour
+// fixtures, because two of them are not catalog-supplied at every size — see the
+// zero-visible-task case below.
+func TestArchetypeAssignmentPreservesC3Floors(t *testing.T) {
+	const diversityFloorAge = 7 * 24 * time.Hour
+
+	for _, n := range []int{9, 12, 13, 18, 150} {
+		assignment := archetypeAssignment(n)
+
+		// Overdue-cohort diversity (the dashboard's urgency tiers): among rows with a
+		// cadence, a NULL last_contacted and a created_at older than the floor, >=3
+		// distinct created-ages and >=2 distinct cadences. Only a NEUTRAL archetype
+		// leaves last_contacted NULL, so a slot that took a contacting archetype has
+		// left this set.
+		ages := map[time.Duration]bool{}
+		cadences := map[string]bool{}
+		for _, fixture := range pinnedOverdueFixtures {
+			ages[fixture.createdAge] = true
+			cadences[fixture.cadence] = true
+		}
+		for i, a := range assignment {
+			slot := catalogSlot(i, n)
+			if archetypeShapes[a].Intent != intentNeutral || slot.Kind != slotBackdated || slot.CreatedAge <= diversityFloorAge {
+				continue
+			}
+			ages[slot.CreatedAge] = true
+			cadences[slot.Cadence] = true
+		}
+		require.GreaterOrEqual(t, len(ages), 3, "n=%d: the never-connected backdated set spans >=3 distinct created-ages", n)
+		require.GreaterOrEqual(t, len(cadences), 2, "n=%d: the never-connected backdated set spans >=2 distinct cadences", n)
+
+		// >=1 never-connected contact on a RECENT-creation slot, a cohort distinct
+		// from the backdated one. The pinned no-activity fixture supplies it
+		// independently at every size, but the catalog must not lose it either.
+		if n >= archetypeLadderFullAssignment {
+			recentNeverConnected := 0
+			for i, a := range assignment {
+				if catalogSlot(i, n).Kind == slotRecent && archetypeShapes[a].Intent == intentNeutral {
+					recentNeverConnected++
+				}
+			}
+			require.GreaterOrEqual(t, recentNeverConnected, 1,
+				"n=%d: >=1 recent-creation slot must stay never-connected (both neutral archetypes leave last_contacted NULL)", n)
+		}
+
+		// >=1 never-contacted contact OUTSIDE the visible-task-spread cohort
+		// (creation indices 1-3) carrying zero product-visible tasks. At n = 12 and
+		// n = 13 EXACTLY, every usable slot takes a history archetype and the only
+		// catalog never-contacted is the no-method slot — which is inside that
+		// cohort — so at those two sizes the pinned fxnoactivity fixture is the SOLE
+		// supplier. Asserting the union is what keeps a future fixture edit from
+		// silently stranding the floor.
+		catalogSupplied := 0
+		for i, a := range assignment {
+			if i >= 1 && i <= 3 {
+				continue
+			}
+			if a == factory.ArchetypeNeverContacted {
+				catalogSupplied++
+			}
+		}
+		fixtureSupplied := 1 // fxnoactivity: never-connected, recent, zero visible tasks
+		require.GreaterOrEqual(t, catalogSupplied+fixtureSupplied, 1,
+			"n=%d: the zero-visible-task floor must be supplied by the catalog or by fxnoactivity", n)
+		if n == 12 || n == 13 {
+			require.Zero(t, catalogSupplied,
+				"n=%d: at this size the catalog cannot supply the floor and fxnoactivity is the sole supplier — if this changes, the note above is stale", n)
 		}
 	}
 }

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -1,0 +1,67 @@
+package synthetic
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/synthetic/factory"
+
+	"github.com/stretchr/testify/require"
+)
+
+// catalogSlotSizes are the catalog sizes the slot/assignment tests sweep: the
+// determinism run (5), the prod coverage run (9), the ladder rung boundary (12)
+// and the multi-sample threshold (13), plus both shipping profiles (18, 150).
+var catalogSlotSizes = []int{5, 9, 12, 13, 18, 150}
+
+// TestCatalogSlotMatchesFrozenOptions is the anti-drift guard for the slot
+// model: catalogSlot must report exactly the spec catalogOptionsFor BUILDS, for
+// every index of every size the suite runs. The comparison goes through the real
+// factory rather than through a restatement of the tables, so a change to either
+// reader fails here instead of silently teaching the archetype assignment a
+// world that no longer exists.
+func TestCatalogSlotMatchesFrozenOptions(t *testing.T) {
+	for _, n := range catalogSlotSizes {
+		g := factory.NewGenerator(factory.DefaultSeed, "slotunit")
+		anchor := g.Anchor()
+		for i := 0; i < n; i++ {
+			spec := g.Contact(catalogOptionsFor(i, n, anchor, g.Prefix())...)
+			slot := catalogSlot(i, n)
+
+			require.NotNil(t, spec.Cadence, "n=%d i=%d: every catalog slot is cadence-bearing", n, i)
+			require.Equal(t, slot.Cadence, *spec.Cadence, "n=%d i=%d: catalogSlot cadence must match the built spec", n, i)
+
+			hasMethods := len(spec.Methods) > 0
+			require.Equal(t, slot.NoMethods, !hasMethods, "n=%d i=%d: catalogSlot no-methods must match the built spec", n, i)
+
+			switch slot.Kind {
+			case slotBackdated:
+				require.NotNil(t, spec.CreatedAt, "n=%d i=%d: a backdated slot stamps created_at", n, i)
+				require.True(t, spec.CreatedAt.Equal(anchor.Add(-slot.CreatedAge)),
+					"n=%d i=%d: backdated created_at must be exactly anchor − CreatedAge (got %s, want %s)",
+					n, i, spec.CreatedAt, anchor.Add(-slot.CreatedAge))
+			case slotRecent:
+				require.NotNil(t, spec.CreatedAt, "n=%d i=%d: a recent slot stamps created_at", n, i)
+				age := anchor.Sub(*spec.CreatedAt)
+				require.GreaterOrEqual(t, age, time.Duration(0), "n=%d i=%d: a recent slot is not created in the future", n, i)
+				require.Less(t, age, slot.CreatedAge,
+					"n=%d i=%d: a recent slot lands inside the window catalogSlot reports as its bound", n, i)
+			case slotFresh:
+				require.Nil(t, spec.CreatedAt, "n=%d i=%d: a fresh slot carries no created-age option", n, i)
+				require.Zero(t, slot.CreatedAge, "n=%d i=%d: a fresh slot reports no created age", n, i)
+			}
+		}
+	}
+}
+
+// TestCatalogSlotIsPure pins the slot model as a pure function of (i, n): the
+// assignment built on top of it must be reproducible without a generator, and a
+// map iteration or clock read leaking in would make the whole overlay
+// non-deterministic.
+func TestCatalogSlotIsPure(t *testing.T) {
+	for _, n := range catalogSlotSizes {
+		for i := 0; i < n; i++ {
+			require.Equal(t, catalogSlot(i, n), catalogSlot(i, n), "catalogSlot(%d, %d) must be pure", i, n)
+		}
+	}
+}

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -435,12 +435,17 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 
 	// --- Contact edge-case catalog (deterministic spread across n) ---------
 	// These contacts carry the cadence / recency / birthday / name / no-method
-	// edge-case shapes the UI + QA tour exercise. They are seeded here with NO
-	// interaction history: their history arrives at the very END of this profile,
-	// from the archetype block, which replays a per-slot relationship shape through
-	// the batch adapters. Seeding it here instead would clobber the cadence states
-	// the later blocks are built on — the settle order is what makes the states
-	// survive, not an absence of history.
+	// edge-case shapes the UI + QA tour exercise. No interaction history is seeded
+	// HERE: it arrives at the very END of this profile, from the archetype block,
+	// which replays a per-slot relationship shape through the batch adapters.
+	//
+	// That placement is not tidiness. A replayed inbound or mutual moves
+	// last_contacted and contact_by, so which history a slot may receive has to be
+	// decided against its cadence — otherwise a shape lands that silently
+	// un-overdues the slot — and the no-method slot can match no payload at all.
+	// The archetype assignment makes both decisions; an ad-hoc settling replay in
+	// this loop would make neither, and would run BEFORE the blocks that read the
+	// catalog's cadence state.
 	catalogContactIDs := make([]uuid.UUID, 0, n)
 	// archetypeSlots retains each slot's index + spec alongside its id so the
 	// archetype block can address the contact with source payloads it can actually

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -165,6 +165,13 @@ type ProfileResult struct {
 	// and is extended explicitly rather than relaxed — folding a collapsing count
 	// into a call-vs-row invariant would muddy both. Counts-only / no PII.
 	ArchetypeInteractions int
+	// ArchetypeSettleCalls is how many settle gates the archetype block waited on:
+	// one per dependency GENERATION of each batch, not one per payload. It is the
+	// phase's real cost model — a settle is O(all harness contacts) and rebuilds
+	// the full event-id union every call — so it is reported separately from the
+	// payload volume, and the block refuses to finish if it exceeds one settle per
+	// generation. Counts-only / no PII.
+	ArchetypeSettleCalls int
 	// Timings is the run's wall-clock measurement. It is EXCLUDED from every
 	// equality assertion (durations are wall-clock and never equal across runs) —
 	// the determinism test zeroes it on both sides before comparing, deliberately

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -154,6 +154,17 @@ type ProfileResult struct {
 	// it into a call-vs-row count would muddy that invariant. Counts-only / no PII.
 	OutboundOnlyContacts  int
 	MutualMessageContacts int
+	// ArchetypePayloads is the number of SOURCE PAYLOADS the archetype block drove
+	// onto the catalog — the calendar events, mail messages and chat messages the
+	// assigned relationship shapes describe. Counts-only / no PII.
+	ArchetypePayloads int
+	// ArchetypeInteractions is the number of interaction ROWS those payloads
+	// LANDED. It is deliberately smaller than ArchetypePayloads: aggregation
+	// collapses, so a mail promotion pair becomes one mutual row and a chat burst
+	// becomes one session. Kept OUT of SettledInteractions, whose equality is exact
+	// and is extended explicitly rather than relaxed — folding a collapsing count
+	// into a call-vs-row invariant would muddy both. Counts-only / no PII.
+	ArchetypeInteractions int
 	// Timings is the run's wall-clock measurement. It is EXCLUDED from every
 	// equality assertion (durations are wall-clock and never equal across runs) —
 	// the determinism test zeroes it on both sides before comparing, deliberately
@@ -424,13 +435,18 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 
 	// --- Contact edge-case catalog (deterministic spread across n) ---------
 	// These contacts carry the cadence / recency / birthday / name / no-method
-	// edge-case shapes the UI + QA tour exercise. They are seeded WITHOUT a
-	// settling MatchSeeded replay ON PURPOSE: a settled inbound interaction would
-	// make the cadence updater overwrite last_contacted (destroying the overdue /
-	// never-contacted intent), and every contact would carry a method (no
-	// no-method bucket). The settled per-source interactions live on the
-	// dedicated contacts below instead.
+	// edge-case shapes the UI + QA tour exercise. They are seeded here with NO
+	// interaction history: their history arrives at the very END of this profile,
+	// from the archetype block, which replays a per-slot relationship shape through
+	// the batch adapters. Seeding it here instead would clobber the cadence states
+	// the later blocks are built on — the settle order is what makes the states
+	// survive, not an absence of history.
 	catalogContactIDs := make([]uuid.UUID, 0, n)
+	// archetypeSlots retains each slot's index + spec alongside its id so the
+	// archetype block can address the contact with source payloads it can actually
+	// match. Memory only: no PRNG draw, no id allocation, so it cannot shift the
+	// deterministic sequence the source replays depend on.
+	archetypeSlots := make([]archetypeSlot, 0, n)
 	// cadenceBearingCatalogIDs is the subset whose spec carries a cadence —
 	// CreateContact auto-computes contact_by from cadence, making them eligible for
 	// ReplayTodoist's reconcile (which seeds one `managed` cadence task per such
@@ -465,6 +481,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			res.ContactsWithLocation++
 		}
 		catalogContactIDs = append(catalogContactIDs, contact.ID)
+		archetypeSlots = append(archetypeSlots, archetypeSlot{Index: i, ContactID: contact.ID, Spec: spec})
 		if spec.Cadence != nil && *spec.Cadence != "" {
 			cadenceBearingCatalogIDs = append(cadenceBearingCatalogIDs, contact.ID)
 		}
@@ -1202,6 +1219,25 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	}
 	stop(0)
 
+	// --- Archetype interaction histories (replayed LAST of all) -----------------
+	//
+	// Every catalog slot carries a relationship SHAPE — a recurring meeting series,
+	// one-sided outreach, a burst that went quiet — and this block is where that
+	// shape becomes interaction state, by replaying its source payloads through the
+	// batch adapters. Nothing here writes a contact column directly: the state
+	// EMERGES from the payloads exactly as it does in production, which is what
+	// makes it impossible for the seed to express a state the app cannot produce.
+	//
+	// It runs after every other generator-drawing block because TimelineFor draws
+	// the shared PRNG, and it adds HISTORY rather than contacts — the tour evidence
+	// caps bound the population's shape, so a richer world has to come from deeper
+	// histories, not more rows.
+	stop = phase("archetype-replay")
+	if err := seedArchetypeHistories(ctx, h, gen, params.Profile, archetypeSlots, n, &res); err != nil {
+		return res, err
+	}
+	stop(res.ArchetypePayloads)
+
 	return res, nil
 }
 
@@ -1361,9 +1397,12 @@ var catalogLocationStems = []string{
 // n, deterministically spreading the edge-case shapes across the population:
 // cadence states (overdue / recent / never-contacted), the 1900 birthday
 // sentinel, a unicode name, a descender name, a no-method contact, plus a
-// fraction carrying real-year birthdays and how_met bio facts. Catalog contacts
-// get NO settling replay, so these last_contacted states survive (a MatchSeeded
-// inbound would otherwise let the cadence updater overwrite them).
+// fraction carrying real-year birthdays and how_met bio facts.
+//
+// These options are the slot's IDENTITY. Its interaction state comes from the
+// archetype block at the end of the profile, and which archetypes a slot may
+// receive is decided from this spec — see catalogSlot, which reads the same three
+// tables this function does and is pinned against it.
 //
 // anchor is the generator's clock (real-year birthdays are anchor-relative, so
 // no time.Now()); prefix is the namespace prefix the how_met value carries so it

--- a/backend/internal/synthetic/replay/batch_test.go
+++ b/backend/internal/synthetic/replay/batch_test.go
@@ -259,6 +259,23 @@ func TestGmailBatchEntriesRejectsNilMessage(t *testing.T) {
 	require.Contains(t, err.Error(), "item 0")
 }
 
+// TestGCalBatchEntriesRejectsNilEvent / TestGChatBatchEntriesRejectsNilMessage
+// are the symmetric guards. They matter now that a caller builds these items
+// programmatically from a generated plan rather than by hand: without them a
+// mapper bug becomes a nil dereference deep inside a provider instead of a named
+// preflight error at the batch boundary.
+func TestGCalBatchEntriesRejectsNilEvent(t *testing.T) {
+	_, err := gcalBatchEntries([]GCalBatchItem{{ContactID: uuid.New(), Spec: factory.GCalEventSpec{Intent: factory.MatchSeeded}}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "item 0")
+}
+
+func TestGChatBatchEntriesRejectsNilMessage(t *testing.T) {
+	_, err := gchatBatchEntries([]GChatBatchItem{{ContactID: uuid.New(), Spec: factory.GChatMessageSpec{Intent: factory.MatchSeeded}}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "item 0")
+}
+
 // --- drive loops -------------------------------------------------------------
 
 func TestDriveUntilCountStopsOnCompletion(t *testing.T) {
@@ -515,7 +532,7 @@ func TestGCalBatchAccountRejectsMixedAccounts(t *testing.T) {
 	require.Contains(t, err.Error(), "item 1")
 }
 
-// --- INV-13a: why a Gmail promotion pair must share an Age -------------------
+// --- why a Gmail promotion pair must share an Age ----------------------------
 
 // TestGmailPairSameAgeSharesLocalDayAcrossAnchors is the clock-anchored-fixture
 // discipline applied to the Gmail promotion rule. The consumer's aggregation key

--- a/backend/internal/synthetic/replay/gcal.go
+++ b/backend/internal/synthetic/replay/gcal.go
@@ -176,7 +176,10 @@ func (h *Harness) ReplayGCalBatch(ctx context.Context, items []GCalBatchItem, op
 
 	options := applyBatchOptions(opts)
 
-	entries := gcalBatchEntries(items)
+	entries, err := gcalBatchEntries(items)
+	if err != nil {
+		return BatchResult{}, err
+	}
 	if err := validateBatchStructure(source, entries); err != nil {
 		return BatchResult{}, err
 	}
@@ -291,9 +294,12 @@ func gcalBatchGateKeys(items []GCalBatchItem) ([]string, []uuid.UUID) {
 // is no direction (a matched event is always mutual) and no PairKey; the
 // addressed identifier is the non-self attendee, the address that decides
 // whether the contact matches.
-func gcalBatchEntries(items []GCalBatchItem) []batchEntry {
+func gcalBatchEntries(items []GCalBatchItem) ([]batchEntry, error) {
 	out := make([]batchEntry, 0, len(items))
-	for _, it := range items {
+	for i, it := range items {
+		if it.Spec.Event == nil {
+			return nil, fmt.Errorf("gcal: item %d has a nil event", i)
+		}
 		out = append(out, batchEntry{
 			contactID:     it.ContactID,
 			identifier:    it.Spec.GcalEventID,
@@ -302,7 +308,7 @@ func gcalBatchEntries(items []GCalBatchItem) []batchEntry {
 			addressedType: identity.IdentifierTypeEmail,
 		})
 	}
-	return out
+	return out, nil
 }
 
 // gcalSpecPeerAttendee returns the first non-self attendee address on an event

--- a/backend/internal/synthetic/replay/gchat.go
+++ b/backend/internal/synthetic/replay/gchat.go
@@ -135,7 +135,10 @@ func (h *Harness) ReplayGChatBatch(ctx context.Context, items []GChatBatchItem, 
 
 	options := applyBatchOptions(opts)
 
-	entries := gchatBatchEntries(items)
+	entries, err := gchatBatchEntries(items)
+	if err != nil {
+		return BatchResult{}, err
+	}
 	if err := validateBatchStructure(source, entries); err != nil {
 		return BatchResult{}, err
 	}
@@ -298,9 +301,12 @@ func (h *Harness) gchatBatchSettled(externalIDs []string) gateA {
 // Direction is whether the sender resolves to the connected account, which is
 // exactly what the provider reads; the addressed identifier is the peer's chat
 // address (an email, normalized the same way).
-func gchatBatchEntries(items []GChatBatchItem) []batchEntry {
+func gchatBatchEntries(items []GChatBatchItem) ([]batchEntry, error) {
 	out := make([]batchEntry, 0, len(items))
-	for _, it := range items {
+	for i, it := range items {
+		if it.Spec.Message == nil {
+			return nil, fmt.Errorf("gchat: item %d has a nil message", i)
+		}
 		peer, outbound := gchatSpecPeer(it.Spec)
 		out = append(out, batchEntry{
 			contactID:     it.ContactID,
@@ -312,7 +318,7 @@ func gchatBatchEntries(items []GChatBatchItem) []batchEntry {
 			addressedType: identity.IdentifierTypeGChat,
 		})
 	}
-	return out
+	return out, nil
 }
 
 // gchatSpecPeer returns the peer's chat address and whether the message is

--- a/backend/internal/synthetic/replay/harness_setup.go
+++ b/backend/internal/synthetic/replay/harness_setup.go
@@ -290,7 +290,8 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 	)
 	gchatEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(client)
 	gchatEngine := google.NewGChatAggregationEngine(
-		2, 48, commsRepo, interactionRepo, contactService, contactService, bus, database.Pool, gchatEnqueuer,
+		google.GChatBurstWindowHours, google.GChatReplyBridgeHours,
+		commsRepo, interactionRepo, contactService, contactService, bus, database.Pool, gchatEnqueuer,
 	)
 	chatListerRegistry := scheduler.NewPerSourceChatListerRegistry(
 		map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -329,6 +329,16 @@ type Harness struct {
 	// result struct.
 	pinnedFixtureIDs map[string]uuid.UUID
 
+	// archetypeSamples is the per-catalog-slot record of which archetype the
+	// profile gave it, how many payloads its timeline drove, and how many
+	// interaction rows that timeline is EXPECTED to land after aggregation
+	// collapse. Recorded for EVERY slot including the history-free ones, so an
+	// assertion can prove absence as well as presence. Like the ids above it is NOT
+	// a ProfileResult field: it carries contact ids, which come from
+	// uuid_generate_v4() (non-deterministic), so it stays off the counts-only,
+	// determinism-compared result struct.
+	archetypeSamples []ArchetypeSample
+
 	created   *created
 	createdMu sync.Mutex
 
@@ -945,6 +955,41 @@ func (h *Harness) PinnedFixtureIDs() map[string]uuid.UUID {
 		out[marker] = id
 	}
 	return out
+}
+
+// ArchetypeSample is one archetype-assigned catalog contact: which frozen slot
+// it occupies, which relationship shape it was given, how many source payloads
+// that shape drove, and how many interaction ROWS those payloads are expected to
+// land once the pipeline has aggregated them.
+//
+// The expectation is derived from the timeline's structure and the pipeline's
+// aggregation semantics, never measured, so comparing it against the database is
+// a real test rather than a tautology.
+type ArchetypeSample struct {
+	ContactID            uuid.UUID
+	SlotIndex            int
+	Archetype            factory.Archetype
+	Payloads             int
+	ExpectedInteractions int
+}
+
+// SetArchetypeSamples records the archetype assignment the profile actually
+// seeded, one entry per catalog slot. Called by the seeding block (package
+// synthetic) — hence exported. Guarded by the ledger mutex for parity with the
+// other tracked ids.
+func (h *Harness) SetArchetypeSamples(samples []ArchetypeSample) {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	h.archetypeSamples = append([]ArchetypeSample(nil), samples...)
+}
+
+// ArchetypeSamples returns the per-slot archetype record (nil if the block did
+// not run). Read by the coverage checks to scope each archetype assertion to its
+// exact subject without putting contact ids in ProfileResult.
+func (h *Harness) ArchetypeSamples() []ArchetypeSample {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]ArchetypeSample(nil), h.archetypeSamples...)
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/tests/synthetic_archetype_integration_test.go
+++ b/backend/tests/synthetic_archetype_integration_test.go
@@ -299,6 +299,7 @@ func assertArchetypeReplayOutcomes(t *testing.T, ctx context.Context, database *
 		"the block's landed-row counter must equal the sum of the per-contact expectations")
 	require.Greater(t, res.ArchetypePayloads, res.ArchetypeInteractions,
 		"payloads must exceed rows: a mail promotion pair collapses to one mutual and a chat burst to one session")
+	assertArchetypeSettleBudget(t, res)
 	burstCohort := cohorts[factory.ArchetypeBurstThenQuiet]
 	require.NotEmpty(t, burstCohort, "the burst archetype must have a cohort")
 	for _, sample := range samples {

--- a/backend/tests/synthetic_archetype_integration_test.go
+++ b/backend/tests/synthetic_archetype_integration_test.go
@@ -1,0 +1,384 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic"
+	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/tests/testsupport"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file covers the seam nothing else reaches: archetype assignment →
+// timeline → payload construction → batch adapter → matching and aggregation →
+// the interaction rows and cadence columns a user actually sees. The batch tests
+// a package below drive HAND-AUTHORED batches; the generator tests stop at
+// abstract timelines. Only a real profile run crosses all of it at once.
+//
+// It uses newIsolatedRiverTestDB for the same reason the batch suite does: the
+// harness starts a live River client, and namespace scoping does not isolate
+// river_job CONSUMPTION. The clone additionally makes the calendar drain
+// meaningful — its past-event read takes a DB-wide LIMIT with the namespace
+// filter applied after it, so on a shared database another namespace owning the
+// oldest page is deterministic starvation rather than a flake.
+//
+// It does not call t.Parallel(): one clone costs about seven connections, the
+// subtests share it, and running them serially keeps concurrent clones near one.
+
+// archetypeExpectation is what one archetype's landed rows must look like: the
+// sources they may come from, the directions they may carry, and — where the
+// archetype earns exactly one promotion — how many must be mutual.
+type archetypeExpectation struct {
+	Sources      []string
+	Directions   []string
+	MutualRows   int // -1 when every row is mutual and the count is not fixed
+	CadenceShape string
+}
+
+const (
+	// cadenceShapeAllFour — a contacting archetype whose newest row is MUTUAL, so
+	// the direction→column table writes all four cadence columns together.
+	cadenceShapeAllFour = "all-four"
+	// cadenceShapeInbound — inbound writes last_contacted / last_interaction_at /
+	// last_response_at but NOT last_outreach_at: it is the response, not the
+	// outreach.
+	cadenceShapeInbound = "inbound"
+	// cadenceShapeOutreachOnly — outbound writes last_outreach_at and nothing else.
+	cadenceShapeOutreachOnly = "outreach-only"
+	// cadenceShapeNone — no history, so no column moves.
+	cadenceShapeNone = "none"
+)
+
+// archetypeExpectations is the per-archetype contract the pipeline must produce.
+// It is the direction→column table observed end to end rather than restated:
+// nothing here writes a contact column, so every one of these values is the
+// result of a source payload having been classified.
+var archetypeExpectations = map[factory.Archetype]archetypeExpectation{
+	factory.ArchetypeMutualRegular: {
+		Sources:      []string{repository.InteractionSourceGCal, repository.InteractionSourceEmail},
+		Directions:   []string{repository.InteractionDirectionMutual},
+		MutualRows:   -1,
+		CadenceShape: cadenceShapeAllFour,
+	},
+	factory.ArchetypeMutualDrifting: {
+		Sources:      []string{repository.InteractionSourceGCal, repository.InteractionSourceEmail},
+		Directions:   []string{repository.InteractionDirectionMutual},
+		MutualRows:   -1,
+		CadenceShape: cadenceShapeAllFour,
+	},
+	factory.ArchetypeDormant: {
+		Sources:      []string{repository.InteractionSourceGCal, repository.InteractionSourceGChat},
+		Directions:   []string{repository.InteractionDirectionMutual},
+		MutualRows:   -1,
+		CadenceShape: cadenceShapeAllFour,
+	},
+	factory.ArchetypeOutboundHeavy: {
+		Sources:      []string{repository.InteractionSourceEmail},
+		Directions:   []string{repository.InteractionDirectionOutbound},
+		MutualRows:   0,
+		CadenceShape: cadenceShapeOutreachOnly,
+	},
+	factory.ArchetypeInboundOnly: {
+		Sources:      []string{repository.InteractionSourceEmail},
+		Directions:   []string{repository.InteractionDirectionInbound},
+		MutualRows:   0,
+		CadenceShape: cadenceShapeInbound,
+	},
+	factory.ArchetypeBurstThenQuiet: {
+		Sources:      []string{repository.InteractionSourceGChat},
+		Directions:   []string{repository.InteractionDirectionOutbound, repository.InteractionDirectionMutual},
+		MutualRows:   1,
+		CadenceShape: cadenceShapeAllFour,
+	},
+	factory.ArchetypeNeverContacted: {
+		CadenceShape: cadenceShapeNone,
+	},
+}
+
+// TestSyntheticProfile_ArchetypeReplayOutcomes runs both catalog profiles and
+// asserts the whole archetype seam from the database side.
+func TestSyntheticProfile_ArchetypeReplayOutcomes(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	ctx := context.Background()
+	database, _ := newIsolatedRiverTestDB(t, ctx)
+
+	t.Run("dev", func(t *testing.T) {
+		params, err := synthetic.ProfileParams(synthetic.ProfileDev)
+		require.NoError(t, err)
+		params.Namespace = syntheticNS(t)
+		assertArchetypeReplayOutcomes(t, ctx, database, params)
+	})
+
+	t.Run("prod_shaped", func(t *testing.T) {
+		params, err := synthetic.ProfileParams(synthetic.ProfileProdShaped)
+		require.NoError(t, err)
+		params.Namespace = syntheticNS(t)
+		// The CI-safe knobs the prod-shaped coverage test uses, at the SMALLEST
+		// catalog on the full assignment rung that still satisfies the multi-sample
+		// floor. That exercises the prod-shaped orchestration without a second
+		// full-scale run: the assignment is the same algorithm at every size, and
+		// the 150-contact evidence is the staging reseed.
+		params.Counts.SeededContacts = 13
+		params.Counts.UnmatchedExternal = 2
+		params.Counts.StrandedTelegram = 1
+		params.Counts.StrandedMessages = 1
+		params.Counts.UnmatchedCalendar = 1
+		params.Counts.OrphanMeetingNote = 1
+		params.Counts.SeededAssertions = 5
+		params.Counts.SeededBoolFacts = 3
+		params.Counts.SeededRelationships = 3
+		params.Counts.SeededTasks = 1
+		params.Counts.SeededEntities = 3
+		params.Counts.SeededEntityEdges = 3
+		params.Counts.SeededSignals = 3
+		params.Counts.MessagesPerContact = 2
+		params.Counts.SeededSoftDeleted = 1
+		params.Counts.SeededMerged = 1
+		params.Counts.ImportCandidatesPerSource = 1
+		assertArchetypeReplayOutcomes(t, ctx, database, params)
+	})
+}
+
+func assertArchetypeReplayOutcomes(t *testing.T, ctx context.Context, database *db.Database, params synthetic.SeedParams) {
+	t.Helper()
+
+	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
+	res, err := synthetic.RunProfile(ctx, h, params)
+	require.NoError(t, err)
+
+	n := params.Counts.SeededContacts
+	support := repository.NewSyntheticSupportRepository(database.Queries)
+	// The reference instant for every overdue question below: the seeded world's
+	// OWN anchor, so the prediction and the measurement answer the same question
+	// about the same moment instead of racing the wall clock between them.
+	anchor := h.Generator().Anchor()
+
+	// --- 1. the assignment the seed actually applied ---------------------------
+	samples := h.ArchetypeSamples()
+	require.Len(t, samples, n, "one sample per catalog slot, including the history-free ones")
+	cohorts := map[factory.Archetype][]uuid.UUID{}
+	for i, sample := range samples {
+		require.Equal(t, i, sample.SlotIndex, "samples are recorded in frozen catalog order")
+		require.Equal(t, synthetic.ArchetypeForIndex(i, n), sample.Archetype,
+			"slot %d must carry the archetype the assignment independently derives", i)
+		cohorts[sample.Archetype] = append(cohorts[sample.Archetype], sample.ContactID)
+	}
+	for archetype := range archetypeExpectations {
+		require.NotEmpty(t, cohorts[archetype], "every archetype must have a cohort at n=%d", n)
+	}
+
+	// --- the world, read once --------------------------------------------------
+	buckets, err := support.ListContactBucketsByNamePrefix(ctx, h.Generator().Prefix())
+	require.NoError(t, err)
+	bucketByID := map[uuid.UUID]repository.ContactBucket{}
+	for _, b := range buckets {
+		bucketByID[b.ID] = b
+	}
+
+	occurredAtByContact := map[uuid.UUID][]time.Time{}
+	totalExpected := 0
+
+	for _, sample := range samples {
+		want := archetypeExpectations[sample.Archetype]
+		rows, err := h.InteractionRepo().ListContactInteractions(ctx, sample.ContactID, 500, 0)
+		require.NoError(t, err)
+
+		label := fmt.Sprintf("slot %d (%s)", sample.SlotIndex, sample.Archetype)
+
+		// --- 6. the payload → interaction collapse -----------------------------
+		// The expectation is derived from the timeline the seed built and from the
+		// pipeline's aggregation semantics; the measurement comes from the pipeline
+		// itself. They must agree EXACTLY — a disagreement means the derivation is
+		// wrong and has to be re-derived, never relaxed to an inequality.
+		require.Len(t, rows, sample.ExpectedInteractions,
+			"%s: %d payloads must land exactly %d interaction rows", label, sample.Payloads, sample.ExpectedInteractions)
+		totalExpected += sample.ExpectedInteractions
+
+		occurred := make([]time.Time, 0, len(rows))
+		sources := map[string]bool{}
+		directions := map[string]bool{}
+		mutualRows := 0
+		var newest repository.Interaction
+		for i, row := range rows {
+			occurred = append(occurred, row.OccurredAt)
+			sources[row.Source] = true
+			directions[row.Direction] = true
+			if row.Direction == repository.InteractionDirectionMutual {
+				mutualRows++
+			}
+			if i == 0 || row.OccurredAt.After(newest.OccurredAt) {
+				newest = row
+			}
+		}
+		sort.Slice(occurred, func(i, j int) bool { return occurred[i].Before(occurred[j]) })
+		occurredAtByContact[sample.ContactID] = occurred
+
+		if sample.Archetype == factory.ArchetypeNeverContacted {
+			require.Empty(t, rows, "%s: the empty timeline IS the archetype", label)
+		} else {
+			require.NotEmpty(t, rows, "%s: a history archetype must land rows", label)
+		}
+
+		// --- 2. source + direction per archetype --------------------------------
+		for source := range sources {
+			require.Contains(t, want.Sources, source, "%s: unexpected interaction source %q", label, source)
+		}
+		for direction := range directions {
+			require.Contains(t, want.Directions, direction, "%s: unexpected interaction direction %q", label, direction)
+		}
+		for _, source := range want.Sources {
+			require.True(t, sources[source], "%s: expected at least one %q interaction", label, source)
+		}
+		if want.MutualRows >= 0 {
+			require.Equal(t, want.MutualRows, mutualRows,
+				"%s: mutuality is EARNED — exactly %d row(s) may be promoted", label, want.MutualRows)
+		} else {
+			require.Equal(t, len(rows), mutualRows, "%s: every row must be mutual", label)
+		}
+
+		// --- 3. the four-column cadence signature -------------------------------
+		ts, err := support.ContactCadenceTimestampsForContact(ctx, sample.ContactID)
+		require.NoError(t, err)
+		assertCadenceShape(t, label, want.CadenceShape, ts, newest)
+
+		// --- 4. overdue preservation under PRODUCTION durations -----------------
+		// The suite runs under CRM_ENV=test, where annual is two hours and every
+		// contact is trivially overdue, so reading the ambient config would prove
+		// nothing. The durations are constructed explicitly and evaluated at the
+		// seeded world's own anchor.
+		bucket, ok := bucketByID[sample.ContactID]
+		require.True(t, ok, "%s: the catalog contact must be live in the namespace", label)
+		require.NotNil(t, bucket.Cadence, "%s: every catalog slot is cadence-bearing", label)
+		require.NotNil(t, bucket.CreatedAt, "%s: every catalog slot carries created_at", label)
+		overdue := synthetic.OverdueAtProduction(*bucket.Cadence, bucket.LastContacted, *bucket.CreatedAt, anchor)
+		switch sample.Archetype {
+		case factory.ArchetypeMutualDrifting, factory.ArchetypeDormant:
+			require.True(t, overdue,
+				"%s: this archetype exists to supply CONTACTED-AND-OVERDUE — its newest two-way entry must stay older than the %s period", label, *bucket.Cadence)
+		case factory.ArchetypeMutualRegular, factory.ArchetypeInboundOnly, factory.ArchetypeBurstThenQuiet:
+			require.False(t, overdue,
+				"%s: this archetype is deliberately NOT overdue on a %s cadence, and the compatibility margin is what keeps that true for days after the reseed", label, *bucket.Cadence)
+		}
+	}
+
+	// --- 5. multi-sample variation ---------------------------------------------
+	// Presence is not the commitment: every ranged archetype must carry at least
+	// two samples whose timelines DIFFER. The distinguisher is the full per-contact
+	// occurred_at multiset rather than a (row count, newest age) projection — two
+	// legitimately jittered samples collide on that projection often enough to be a
+	// designed-in flake, and the multiset is strictly stronger, needs no extra read,
+	// and collides only if two independent jitter vectors produce identical
+	// timelines.
+	if n >= 13 {
+		for archetype, contactIDs := range cohorts {
+			if archetype == factory.ArchetypeNeverContacted {
+				continue
+			}
+			require.GreaterOrEqual(t, len(contactIDs), 2,
+				"%s must carry >=2 samples at n=%d", archetype, n)
+			distinct := map[string]bool{}
+			for _, id := range contactIDs {
+				distinct[occurredAtFingerprint(occurredAtByContact[id])] = true
+			}
+			require.GreaterOrEqual(t, len(distinct), 2,
+				"%s must carry >=2 samples with DIFFERENT interaction timelines — jitter has to be observable, not merely drawn", archetype)
+		}
+	}
+
+	// --- 6 (aggregate). the two counters and the collapse between them ---------
+	require.Equal(t, totalExpected, res.ArchetypeInteractions,
+		"the block's landed-row counter must equal the sum of the per-contact expectations")
+	require.Greater(t, res.ArchetypePayloads, res.ArchetypeInteractions,
+		"payloads must exceed rows: a mail promotion pair collapses to one mutual and a chat burst to one session")
+	burstCohort := cohorts[factory.ArchetypeBurstThenQuiet]
+	require.NotEmpty(t, burstCohort, "the burst archetype must have a cohort")
+	for _, sample := range samples {
+		if sample.Archetype != factory.ArchetypeBurstThenQuiet {
+			continue
+		}
+		require.Equal(t, sample.Payloads-3, sample.ExpectedInteractions,
+			"slot %d: K messages in ONE space must collapse to K-3 rows — one opening burst, K-5 fillers, one closing mutual", sample.SlotIndex)
+	}
+
+	// --- 7. isolation ----------------------------------------------------------
+	// The archetype rows get their OWN counters and are never folded into the
+	// settled-interaction accounting, whose equality is exact.
+	settledContacts := res.GmailSettled + res.TelegramSettled + res.GCalSettled + res.GChatSettled + res.IMessageSettled
+	require.Equal(t, settledContacts*params.Counts.MessagesPerContact+res.SeededPendingFollowUps, res.SettledInteractions,
+		"the archetype block must not touch the per-source settled accounting")
+
+	// No pinned fixture may pick up archetype history: the fixtures are seeded
+	// outside the catalog and the block addresses catalog contacts only.
+	noActivityID, ok := h.PinnedFixtureIDs()[synthetic.FixtureMarkerNoActivity]
+	require.True(t, ok, "the no-activity fixture must be recorded")
+	noActivityRows, err := h.InteractionRepo().ListContactInteractions(ctx, noActivityID, 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, noActivityRows, "the no-activity fixture must carry no interaction at all")
+	noActivityTS, err := support.ContactCadenceTimestampsForContact(ctx, noActivityID)
+	require.NoError(t, err)
+	assert.Nil(t, noActivityTS.LastContacted, "no-activity fixture: last_contacted")
+	assert.Nil(t, noActivityTS.LastOutreachAt, "no-activity fixture: last_outreach_at")
+	assert.Nil(t, noActivityTS.LastResponseAt, "no-activity fixture: last_response_at")
+	assert.Nil(t, noActivityTS.LastInteractionAt, "no-activity fixture: last_interaction_at")
+}
+
+// assertCadenceShape checks the four cadence columns against the
+// direction→column table, observed rather than restated: outbound writes only
+// last_outreach_at, inbound writes the other three, mutual writes all four.
+func assertCadenceShape(t *testing.T, label, shape string, ts *repository.ContactCadenceTimestamps, newest repository.Interaction) {
+	t.Helper()
+	switch shape {
+	case cadenceShapeAllFour:
+		require.Equal(t, repository.InteractionDirectionMutual, newest.Direction,
+			"%s: the NEWEST row must be the mutual one — it is what writes all four columns", label)
+		require.NotNil(t, ts.LastContacted, "%s: last_contacted", label)
+		require.NotNil(t, ts.LastInteractionAt, "%s: last_interaction_at", label)
+		require.NotNil(t, ts.LastOutreachAt, "%s: last_outreach_at", label)
+		require.NotNil(t, ts.LastResponseAt, "%s: last_response_at", label)
+		require.True(t, ts.LastContacted.Equal(newest.OccurredAt), "%s: last_contacted == the newest mutual's occurred_at", label)
+		require.True(t, ts.LastInteractionAt.Equal(newest.OccurredAt), "%s: last_interaction_at == the newest mutual's occurred_at", label)
+		require.True(t, ts.LastOutreachAt.Equal(newest.OccurredAt), "%s: last_outreach_at == the newest mutual's occurred_at", label)
+		require.True(t, ts.LastResponseAt.Equal(newest.OccurredAt), "%s: last_response_at == the newest mutual's occurred_at", label)
+	case cadenceShapeInbound:
+		require.NotNil(t, ts.LastContacted, "%s: last_contacted", label)
+		require.NotNil(t, ts.LastInteractionAt, "%s: last_interaction_at", label)
+		require.NotNil(t, ts.LastResponseAt, "%s: last_response_at", label)
+		require.Nil(t, ts.LastOutreachAt,
+			"%s: an inbound is the RESPONSE, not the outreach — last_outreach_at must stay unset", label)
+		require.True(t, ts.LastContacted.Equal(newest.OccurredAt), "%s: last_contacted == the newest inbound's occurred_at", label)
+		require.True(t, ts.LastInteractionAt.Equal(newest.OccurredAt), "%s: last_interaction_at == the newest inbound's occurred_at", label)
+		require.True(t, ts.LastResponseAt.Equal(newest.OccurredAt), "%s: last_response_at == the newest inbound's occurred_at", label)
+	case cadenceShapeOutreachOnly:
+		require.NotNil(t, ts.LastOutreachAt, "%s: last_outreach_at", label)
+		require.True(t, ts.LastOutreachAt.Equal(newest.OccurredAt), "%s: last_outreach_at == the newest outbound's occurred_at", label)
+		require.Nil(t, ts.LastContacted, "%s: an outbound is not a connection — last_contacted must stay unset", label)
+		require.Nil(t, ts.LastInteractionAt, "%s: last_interaction_at must stay unset", label)
+		require.Nil(t, ts.LastResponseAt, "%s: last_response_at must stay unset", label)
+	case cadenceShapeNone:
+		require.Nil(t, ts.LastContacted, "%s: last_contacted", label)
+		require.Nil(t, ts.LastInteractionAt, "%s: last_interaction_at", label)
+		require.Nil(t, ts.LastOutreachAt, "%s: last_outreach_at", label)
+		require.Nil(t, ts.LastResponseAt, "%s: last_response_at", label)
+	}
+}
+
+// occurredAtFingerprint renders a contact's full interaction-instant MULTISET as
+// a comparable string. It is the multi-sample distinguisher: strictly stronger
+// than a (count, newest) projection, which two legitimately jittered samples
+// collide on often enough to ship a designed-in flake.
+func occurredAtFingerprint(occurred []time.Time) string {
+	parts := make([]string, 0, len(occurred))
+	for _, at := range occurred {
+		parts = append(parts, at.UTC().Format(time.RFC3339Nano))
+	}
+	return fmt.Sprint(parts)
+}

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -867,6 +867,7 @@ func assertArchetypeCohorts(t *testing.T, ctx context.Context, h *synthetic.Harn
 		require.Greater(t, res.ArchetypePayloads, res.ArchetypeInteractions,
 			"payloads must exceed landed rows — that difference IS the aggregation collapse")
 	}
+	assertArchetypeSettleBudget(t, res)
 
 	if n < 12 {
 		return
@@ -910,6 +911,33 @@ func assertArchetypeCohorts(t *testing.T, ctx context.Context, h *synthetic.Harn
 	}
 }
 
+// assertArchetypeSettleBudget pins the reason this phase batches at all.
+//
+// Settle is O(all harness contacts) and rebuilds the whole event-id union on
+// every call, so the phase's cost is its SETTLE count, not its payload count.
+// Batching collapses that to one Settle per dependency GENERATION — a handful for
+// the whole catalog — where the same history through per-payload single replays
+// would cost one per payload: roughly a hundred at dev and a thousand at
+// prod-shaped. A regression from batch replay back to single replay would leave
+// every other assertion in this suite passing while the reseed's gate wait
+// regressed by about two orders of magnitude, which is precisely what this bound
+// exists to catch.
+func assertArchetypeSettleBudget(t *testing.T, res synthetic.ProfileResult) {
+	t.Helper()
+	if res.ArchetypePayloads == 0 {
+		require.Zero(t, res.ArchetypeSettleCalls, "no payloads means no settles")
+		return
+	}
+	require.Positive(t, res.ArchetypeSettleCalls, "driving payloads must settle at least once")
+	// Calendar, up to two mail buckets and chat, each at most two generations.
+	const maxArchetypeSettles = 8
+	require.LessOrEqual(t, res.ArchetypeSettleCalls, maxArchetypeSettles,
+		"the archetype phase settled %d times for %d payloads — a per-payload replay loop looks exactly like this",
+		res.ArchetypeSettleCalls, res.ArchetypePayloads)
+	require.Less(t, res.ArchetypeSettleCalls, res.ArchetypePayloads,
+		"settles must stay strictly below payloads — a per-payload replay loop settles once PER payload, so equality is the regression")
+}
+
 // assertOverdueBand measures the overdue population from the DATABASE and holds
 // it against the assignment's prediction, the absolute ceiling, and the target
 // share of the live world.
@@ -940,10 +968,11 @@ func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.Sy
 		}
 	}
 
-	// The two pinned overdue fixtures sit outside the catalog and are always
-	// overdue, so the assignment's catalog prediction accounts for them separately.
-	const pinnedOverdue = 2
-	require.Equal(t, synthetic.PredictedCatalogOverdue(n)+pinnedOverdue, overdue,
+	// The pinned overdue fixtures sit outside the catalog and are always overdue,
+	// so the assignment's catalog prediction accounts for them separately. The
+	// count is READ from the seed rather than restated here, so a change to the
+	// fixture table cannot drift the budget and this assertion apart.
+	require.Equal(t, synthetic.PredictedCatalogOverdue(n)+synthetic.PinnedOverdueFixtureCount, overdue,
 		"the measured overdue population must equal what the assignment predicts — a drifting model has to fail here rather than be trusted")
 	require.LessOrEqual(t, overdue, synthetic.OverdueCeiling,
 		"the overdue population must stay under the ceiling; the overdue tours refuse to run above their own, higher, capture cap")

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/synthetic"
 	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/synthetic/replay"
 	"personal-crm/backend/tests/testsupport"
 
 	"github.com/google/uuid"
@@ -826,6 +827,137 @@ func assertMessageDirectionCoverage(t *testing.T, ctx context.Context, support *
 	require.True(t, ts.LastContacted.Equal(*ts.LastResponseAt), "mutual last_contacted == last_response_at")
 }
 
+// assertArchetypeCohorts is the archetype coverage gate both catalog profiles
+// run: the assignment the seed applied must be the one the pure function
+// derives, the cohorts the ladder promises must exist, their samples must
+// actually DIFFER, and the two archetype counters must show the collapse rather
+// than agree.
+//
+// The cohort and multi-sample floors are gated by catalog size, and the two
+// thresholds are deliberately different. Per-archetype PRESENCE is asserted from
+// n >= 12, where the ladder switches to the full assignment. The >=2-samples
+// floor is asserted from n >= 13, and the derivation is arithmetic: the no-method
+// slot is structurally history-free whatever archetype it is given, leaving n - 1
+// usable slots, and six history archetypes at two samples each need twelve of
+// them. At n = 12 exactly the floor is unsatisfiable over the frozen catalog, and
+// archetypes add history rather than contacts, so it cannot be fixed by seeding
+// another slot.
+func assertArchetypeCohorts(t *testing.T, ctx context.Context, h *synthetic.Harness, res synthetic.ProfileResult, n int) {
+	t.Helper()
+
+	samples := h.ArchetypeSamples()
+	require.Len(t, samples, n, "the archetype block records one sample per catalog slot, including the history-free ones")
+
+	cohorts := map[factory.Archetype][]replay.ArchetypeSample{}
+	totalExpected := 0
+	for i, sample := range samples {
+		require.Equal(t, i, sample.SlotIndex, "samples are recorded in frozen catalog order")
+		require.Equal(t, synthetic.ArchetypeForIndex(i, n), sample.Archetype,
+			"slot %d must carry the archetype the assignment independently derives", i)
+		cohorts[sample.Archetype] = append(cohorts[sample.Archetype], sample)
+		totalExpected += sample.ExpectedInteractions
+	}
+
+	// The collapse relation between the two counters, never an equality: a mail
+	// promotion pair lands one mutual row and a chat burst lands one session, so
+	// rows are strictly fewer than payloads wherever any history exists.
+	require.Equal(t, totalExpected, res.ArchetypeInteractions,
+		"the landed-row counter must equal the sum of the per-contact expectations")
+	if res.ArchetypePayloads > 0 {
+		require.Greater(t, res.ArchetypePayloads, res.ArchetypeInteractions,
+			"payloads must exceed landed rows — that difference IS the aggregation collapse")
+	}
+
+	if n < 12 {
+		return
+	}
+	for _, archetype := range []factory.Archetype{
+		factory.ArchetypeMutualRegular,
+		factory.ArchetypeMutualDrifting,
+		factory.ArchetypeDormant,
+		factory.ArchetypeOutboundHeavy,
+		factory.ArchetypeInboundOnly,
+		factory.ArchetypeBurstThenQuiet,
+		factory.ArchetypeNeverContacted,
+	} {
+		require.NotEmpty(t, cohorts[archetype], "n=%d: every archetype must have a cohort on the full assignment rung (%s)", n, archetype)
+	}
+
+	if n < 13 {
+		return
+	}
+	for archetype, cohort := range cohorts {
+		if archetype == factory.ArchetypeNeverContacted {
+			continue
+		}
+		require.GreaterOrEqual(t, len(cohort), 2, "n=%d: %s must carry >=2 samples", n, archetype)
+		// The distinguisher is the full per-contact occurred_at MULTISET, not a
+		// (row count, newest age) projection: two legitimately jittered samples
+		// collide on that projection often enough to be a designed-in flake.
+		distinct := map[string]bool{}
+		for _, sample := range cohort {
+			rows, err := h.InteractionRepo().ListContactInteractions(ctx, sample.ContactID, 500, 0)
+			require.NoError(t, err)
+			instants := make([]string, 0, len(rows))
+			for _, row := range rows {
+				instants = append(instants, row.OccurredAt.UTC().Format(time.RFC3339Nano))
+			}
+			sort.Strings(instants)
+			distinct[strings.Join(instants, "|")] = true
+		}
+		require.GreaterOrEqual(t, len(distinct), 2,
+			"n=%d: %s must carry >=2 samples with DIFFERENT interaction timelines — jitter has to be observable, not merely drawn", n, archetype)
+	}
+}
+
+// assertOverdueBand measures the overdue population from the DATABASE and holds
+// it against the assignment's prediction, the absolute ceiling, and the target
+// share of the live world.
+//
+// The measurement constructs PRODUCTION cadence durations explicitly and
+// evaluates them at the seeded world's own anchor. The suite runs under
+// CRM_ENV=test, where annual is two hours and every contact is trivially overdue,
+// so a count taken through the ambient config would be meaningless — and mutating
+// the variable would change cadence semantics for every concurrently-running
+// test.
+//
+// The prediction-versus-measurement equality is what keeps the assignment's
+// denominator MODEL honest: the model is never the assertion, the database is.
+func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, n int) {
+	t.Helper()
+
+	buckets, err := support.ListContactBucketsByNamePrefix(ctx, h.Generator().Prefix())
+	require.NoError(t, err)
+	anchor := h.Generator().Anchor()
+
+	overdue := 0
+	for _, b := range buckets {
+		if b.Cadence == nil || *b.Cadence == "" || b.CreatedAt == nil {
+			continue
+		}
+		if synthetic.OverdueAtProduction(*b.Cadence, b.LastContacted, *b.CreatedAt, anchor) {
+			overdue++
+		}
+	}
+
+	// The two pinned overdue fixtures sit outside the catalog and are always
+	// overdue, so the assignment's catalog prediction accounts for them separately.
+	const pinnedOverdue = 2
+	require.Equal(t, synthetic.PredictedCatalogOverdue(n)+pinnedOverdue, overdue,
+		"the measured overdue population must equal what the assignment predicts — a drifting model has to fail here rather than be trusted")
+	require.LessOrEqual(t, overdue, synthetic.OverdueCeiling,
+		"the overdue population must stay under the ceiling; the overdue tours refuse to run above their own, higher, capture cap")
+
+	if n < 12 {
+		return
+	}
+	live := len(buckets)
+	require.Positive(t, live)
+	share := 100.0 * float64(overdue) / float64(live)
+	require.GreaterOrEqual(t, share, 20.0, "overdue share %.1f%% of %d live contacts is below the target band", share, live)
+	require.LessOrEqual(t, share, 27.0, "overdue share %.1f%% of %d live contacts is above the target band", share, live)
+}
+
 func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -934,6 +1066,10 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// Pinned tour fixtures: every state the QA tours depend on resolves to exactly
 	// one named contact carrying that state.
 	assertPinnedTourFixtures(t, ctx, support, repository.NewContactRepository(database.Queries), h, h.Generator().Prefix(), h.Generator().Anchor())
+	// Archetype cohorts: the catalog's interaction state now EMERGES from replayed
+	// source payloads, so assert the cohorts exist, vary, and collapse as intended.
+	assertArchetypeCohorts(t, ctx, h, res, params.Counts.SeededContacts)
+	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts)
 }
 
 // assertNotesCoverage runs the F6 notes gate: the profile seeds a note on a
@@ -1376,6 +1512,37 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	tgDiscovery, err := support.CountUnmatchedTelegramDiscoveryInBand(ctx, h.Generator().PeerBandStart(), h.Generator().PeerBandEnd())
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, tgDiscovery, int64(1), "≥1 unmatched telegram discovery candidate present")
+
+	// Archetype cohorts. At this catalog size (9) the ladder is on its RESERVED
+	// rung, so per-archetype presence is not asserted; what is asserted is that the
+	// assignment the seed applied is the one the pure function derives and that the
+	// two counters show the collapse.
+	assertArchetypeCohorts(t, ctx, h, res, params.Counts.SeededContacts)
+	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts)
+
+	// The reserved rung's whole point: exactly one CONTACTED-AND-OVERDUE contact —
+	// a state the seed produces nowhere else — and it is the slot the assignment
+	// gave the drifting archetype to. Every other overdue contact in the world is
+	// never-connected, which is a different state and a different card.
+	anchor := h.Generator().Anchor()
+	var contactedOverdue []uuid.UUID
+	for _, b := range buckets {
+		if b.Cadence == nil || *b.Cadence == "" || b.CreatedAt == nil || b.LastContacted == nil {
+			continue
+		}
+		if synthetic.OverdueAtProduction(*b.Cadence, b.LastContacted, *b.CreatedAt, anchor) {
+			contactedOverdue = append(contactedOverdue, b.ID)
+		}
+	}
+	require.Len(t, contactedOverdue, 1, "the reserved rung supplies exactly one contacted-and-overdue contact")
+	var driftingID uuid.UUID
+	for _, sample := range h.ArchetypeSamples() {
+		if sample.Archetype == factory.ArchetypeMutualDrifting {
+			driftingID = sample.ContactID
+		}
+	}
+	require.Equal(t, driftingID, contactedOverdue[0],
+		"the contacted-and-overdue contact must be the slot the assignment gave mutual-drifting to")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -1386,7 +1386,7 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 // runCatalogProfile brackets with a phase timer. It is pinned so a block added
 // (or a stop() call lost) without a phase is caught here rather than silently
 // dropping a row from the reseed summary.
-const catalogProfilePhaseCount = 23
+const catalogProfilePhaseCount = 24
 
 // phaseShape projects phase timings onto their DETERMINISTIC components — name
 // and payload volume — dropping the wall-clock duration, so a run-to-run


### PR DESCRIPTION
Final PR of the seed-realism archetype arc (#747). PR1 (#744), PR2 (#745), PR3 (#746) and PR4 (#749) are merged.

## What this does

Assigns the seven-archetype catalog over the frozen catalog indices and replays each contact's generated timeline through the batch adapters, so `dev` and `prod-shaped` seed worlds carry realistic interaction *history* rather than only endpoint state. `minimal-scoped` is untouched and byte-identical.

The arc's motivating gap is now closed: prod-shaped produces **12 contacted-and-overdue contacts**, a state the seed produced *nowhere* before. Archetypes add history, never contacts.

## Measured outcomes — predicted vs actual

| Measure | Plan predicted | Measured |
|---|---|---|
| Overdue @ prod-shaped (n=150) | 40 | **40** of 181 live = 22.1% |
| Overdue @ dev (n=18) | 9 | **9** of 37 live = 24.3% |
| Overdue @ prod coverage run (n=9) | reserved rung | 5 of 38; exactly one contacted-and-overdue, on the `mutual-drifting` slot |
| Assignment tables | plan's D3 | reproduced exactly at n = 5/9/12/13/18/150 |

Overdue comes **down** from 52 (post-PR4) to 40 — five under this plan's ceiling of 45 and 24 under PR4's `OVERDUE_CAPTURE_CAP = 64`. A full sweep of n ∈ [1,150] shows no ceiling, band, compatibility, diversity, multi-sample or recent-never-connected violation.

Archetype counters keep their own accounting and are never folded into `SettledInteractions`; the expected *collapse* between payloads and landed rows is asserted per archetype rather than equality:

| Profile | `ArchetypePayloads` | `ArchetypeInteractions` |
|---|---|---|
| dev (18) | 99 | 84 |
| prod-shaped (13) | 76 | 63 |
| prod-shaped (150) | 736 | 627 |

Per-contact row counts equal the expected value exactly for all seven archetypes in both profiles.

## Reseed cost, measured rather than extrapolated

A real `crm-admin --reset-and-seed --profile prod-shaped --yes` at n=150 under `CRM_ENV=staging`, on a throwaway DB: **124.86 s wall, 93.1% gate wait** (gate_a 38.88 s / gate_b 76.97 s / capture 0.35 s), 113 settle calls, 24 phases.

Against PR1's measured baseline of 71.4 s at 94.7% gate wait: **+53.5 s**, of which the new `archetype-replay` phase accounts for **54.11 s across 736 payloads**. Growth is entirely the new phase and the gate-wait share is unchanged — consistent with the arc's finding that replay volume dominates and contact volume is cheap.

## Two commitments the plan would not let soften

**Multi-sample variation, not mere presence.** Every ranged archetype carries ≥2 samples whose timelines must genuinely differ, distinguished by the full per-contact interaction `occurred_at` **multiset**. The weaker `(row count, newest age)` projection was rejected during plan review: two legitimately jittered samples collide on it at roughly 1-in-530, which would have shipped a designed-in flake into the arc's most important test.

**The compatibility rule is strict, with a 24 h margin.** Plan review initially recommended the cheaper fix — pin overdue evaluation to the generator anchor. That was rejected with evidence and the rejection was independently upheld: every source stamps its payload at `anchor − offset − age` with a 1–2 h offset, so a boundary draw is *already* overdue at the anchor, and anchor-pinning would have converted a ~1-in-265 wall-clock flake into a deterministic-when-drawn failure at the same rate. Anchor-pinning is adopted anyway as reference-instant hygiene, explicitly labelled as not-the-fix.

## Tests

`TestSyntheticProfile_ArchetypeReplayOutcomes` is the arc's most important single test and did not exist before: no wave-1 test reaches the full seam, since PR2's tests use hand-authored batches and PR3's test abstract timelines. It exercises `ArchetypeForIndex → TimelineFor → payload construction → batch adapter → matching/aggregation → final interaction rows and cadence columns` on an isolated River clone, covering all seven archetypes across both profiles, per-archetype `source` + `direction`, the four-column timestamp signature, multi-sample variation, the payload→interaction collapse (including a chat burst in one space collapsing to the intended session count), and overdue *preservation* under **explicitly constructed production cadence durations** — the ambient test env makes everything trivially overdue, so reading it would prove nothing.

Three load-bearing assertions were proven able to fail, by injecting the defect at source, confirming the injection landed, reading the exit code directly, and reverting clean: disabling the chat reply bridge in the collapse formula; making the overdue helper read the ambient env; and reusing one timeline across an archetype cohort.

`TestArchetypeNewestAgeRangesMatchTheGenerator` is an addition beyond the plan's test list, for a specific reason: the newest-age bounds are the one table this package **restates** rather than reads, because the generator's copy is unexported a package below — a standing drift hazard. It samples 3000 namespaces of real timelines and requires observed newest ages to sit inside the declared bounds and reach within one margin of each end. Proven to fail by moving a declared ceiling from 90 d to 100 d.

## Deviations from the plan's letter

Three, all deliberate: `catalogSlot` returns a small struct rather than a 4-tuple; `ArchetypeForIndex` / `OverdueAtProduction` / `PredictedCatalogOverdue` / `OverdueCeiling` are **exported**, because the required named test lives in package `tests` and must re-derive the assignment independently — an unexported helper would make its first assertion circular; and `ArchetypeSample` plus its recorder landed in the mapper commit rather than the seeding commit, since the mapper is what produces them.

Two of PR2's deferred P3s are folded in here (nil-`Event`/nil-`Message` guards on the GCal/GChat batch entry builders, and the stale plan-label comment in `batch_test.go`); the other two remain deferred with reasons recorded in the plan.

## Review gate

Codex quota is exhausted on both accounts until 2026-07-28 (`recover` → `ALL_EXHAUSTED`, confirmed by canary), so the merge-gate verdict is a `SOURCE: claude-fallback` review — the same path PR1–PR4 of this arc shipped on. Reviewer model is fable rather than opus deliberately: the author was opus, and with the Codex harness unavailable, model diversity is the only reviewer diversity left.

One pre-push run was blocked by the known `TestSyntheticBatchReplay_PromotionBarrier` flake (#748, ~1-in-6, reproduced independently of this arc); the failing half is the negative-space `withoutBarrier` assertion, while the `withBarrier` half that carries INV-11's weight has never failed. Re-pushed clean.

No migrations. No frontend changes.