### PR TITLE
test(synthetic): assert no-barrier path is unreliable, not impossible

### DIFF
--- a/backend/tests/synthetic_batch_replay_integration_test.go
+++ b/backend/tests/synthetic_batch_replay_integration_test.go
@@ -656,18 +656,38 @@ func TestSyntheticBatchReplay_PromotionBarrier(t *testing.T) {
 		assert.Equal(t, 1, withBarrier(t), "run %d: the barrier must be reliable, not lucky", i)
 	}
 
-	// The no-barrier variant turns out to fail DETERMINISTICALLY rather than
-	// intermittently, which is a stronger result than the design assumed: the
-	// inbound does not merely sometimes lose the race, it cannot win it. Its
-	// outbound's claimed rows are excluded from the aggregation read for a
-	// five-minute TTL, and the outbound's interaction does not exist yet, so the
-	// inbound has nothing to promote against and lands its own row. Asserting it
-	// keeps the barrier from being quietly deleted as ceremony.
-	for i := 0; i < repetitions; i++ {
-		assert.NotEqual(t, 1, withoutBarrier(t),
-			"run %d: forcing both halves into one generation must NOT collapse to a single mutual — "+
-				"if it does, the barrier's justification has changed and needs re-deriving, not deleting", i)
+	// The no-barrier variant is UNRELIABLE, not impossible. The outbound's
+	// claimed rows are excluded from the inbound's aggregation read for a
+	// five-minute TTL, and the outbound's INTERACTION is written later by a River
+	// consumer, so the inbound usually has nothing to promote against and lands
+	// its own row — but when the consumer wins the race the pair does collapse to
+	// one mutual. Measured: 60 collapses in 400 executions (15.0%) over eight
+	// 50-execution batches spanning idle to heavily loaded, worst single batch 13
+	// of 50 (26%); and 4 collapses in the 60 executions of twenty full runs of
+	// this test, which failed 4 times out of 20 on a strict "never collapses".
+	//
+	// What is true, and what the barrier's justification actually rests on, is
+	// that the un-barriered path cannot be RELIED on to promote: over
+	// noBarrierRepetitions runs at least one must decline to. That is wrong only
+	// if EVERY run collapses — p^10, i.e. 5.8e-9 at the measured 15%, 1.4e-6 at
+	// the worst observed 26%, and still 1.0e-4 at a 40% rate no batch approached.
+	// Collapses are near-independent (12 adjacent pairs observed against 8.8
+	// expected under independence; longest streak 3 in 400). Keeping the
+	// assertion is what stops the barrier being deleted as ceremony: if the
+	// engine ever made the un-barriered path reliable, every run here would
+	// promote and the barrier's justification would need re-deriving.
+	const noBarrierRepetitions = 10
+	collapsed := 0
+	for i := 0; i < noBarrierRepetitions; i++ {
+		if withoutBarrier(t) == 1 {
+			collapsed++
+		}
 	}
+	t.Logf("no-barrier: %d of %d runs collapsed to a single mutual", collapsed, noBarrierRepetitions)
+	assert.Less(t, collapsed, noBarrierRepetitions,
+		"every one of %d runs forcing both halves into one generation collapsed to a single mutual — "+
+			"the un-barriered path has become reliable, so the barrier's justification has changed "+
+			"and needs re-deriving, not deleting", noBarrierRepetitions)
 }
 
 // TestSyntheticBatchReplay_TelegramOrderPromotesMutual proves the TIMING

--- a/backend/tests/synthetic_batch_replay_integration_test.go
+++ b/backend/tests/synthetic_batch_replay_integration_test.go
@@ -660,6 +660,11 @@ func TestSyntheticBatchReplay_PromotionBarrier(t *testing.T) {
 			return true
 		}
 		require.Len(t, rows, 2, "the un-promoted outcome is exactly the two one-sided rows")
+		require.ElementsMatch(t, []string{"outbound", "inbound"},
+			[]string{rows[0].Direction, rows[1].Direction},
+			"the two rows must be one outbound and one inbound — direction admits only these three "+
+				"values, so any other pair (a promoted row left beside a duplicate inbound above all) "+
+				"is a regression, not the race")
 		return false
 	}
 
@@ -680,8 +685,8 @@ func TestSyntheticBatchReplay_PromotionBarrier(t *testing.T) {
 	// and a re-measurement should say which it took. A tight loop of 50
 	// consecutive executions inside one warm process collapsed 60 times in 400
 	// (15.0%) over eight batches spanning idle to heavily loaded, worst batch 13
-	// of 50 (26%). The 3-execution shape this test actually runs, across twenty
-	// fresh processes, collapsed 4 times in 60 (6.7%) — enough to fail a strict
+	// of 50 (26%). A colder shape — twenty fresh processes, three executions each
+	// — collapsed 4 times in 60 (6.7%), which was already enough to fail a strict
 	// "never collapses" on 4 of those 20 runs. The loop below is the warm shape
 	// and is sized against the higher 15%.
 	//

--- a/backend/tests/synthetic_batch_replay_integration_test.go
+++ b/backend/tests/synthetic_batch_replay_integration_test.go
@@ -626,7 +626,14 @@ func TestSyntheticBatchReplay_PromotionBarrier(t *testing.T) {
 		return len(rows)
 	}
 
-	withoutBarrier := func(t *testing.T) int {
+	// withoutBarrier reports whether the pair COLLAPSED to a single promoted
+	// mutual. Row count alone would not distinguish that from a regression that
+	// drops the inbound outright, which also leaves one row; counting the two as
+	// one would corrupt the very rate the repetition count below is sized
+	// against. Only two outcomes are legitimate — the collapse, or the two
+	// one-sided rows the race normally leaves — so any other shape fails here
+	// rather than being silently bucketed into either.
+	withoutBarrier := func(t *testing.T) bool {
 		h := batchTestHarness(t, ctx, database)
 		gen := h.Generator()
 		spec := gen.Contact(factory.WithTelegram())
@@ -647,7 +654,13 @@ func TestSyntheticBatchReplay_PromotionBarrier(t *testing.T) {
 
 		rows, err := h.InteractionRepo().ListContactInteractions(ctx, contact.ID, 100, 0)
 		require.NoError(t, err)
-		return len(rows)
+		if len(rows) == 1 {
+			require.Equal(t, "mutual", rows[0].Direction,
+				"a lone row must be the promoted mutual — a one-sided one means a half was dropped, not promoted")
+			return true
+		}
+		require.Len(t, rows, 2, "the un-promoted outcome is exactly the two one-sided rows")
+		return false
 	}
 
 	// Both variants are repeated: the failure mode is a timing window, so one
@@ -661,25 +674,45 @@ func TestSyntheticBatchReplay_PromotionBarrier(t *testing.T) {
 	// five-minute TTL, and the outbound's INTERACTION is written later by a River
 	// consumer, so the inbound usually has nothing to promote against and lands
 	// its own row — but when the consumer wins the race the pair does collapse to
-	// one mutual. Measured: 60 collapses in 400 executions (15.0%) over eight
-	// 50-execution batches spanning idle to heavily loaded, worst single batch 13
-	// of 50 (26%); and 4 collapses in the 60 executions of twenty full runs of
-	// this test, which failed 4 times out of 20 on a strict "never collapses".
+	// one mutual.
 	//
-	// What is true, and what the barrier's justification actually rests on, is
-	// that the un-barriered path cannot be RELIED on to promote: over
-	// noBarrierRepetitions runs at least one must decline to. That is wrong only
-	// if EVERY run collapses — p^10, i.e. 5.8e-9 at the measured 15%, 1.4e-6 at
-	// the worst observed 26%, and still 1.0e-4 at a 40% rate no batch approached.
-	// Collapses are near-independent (12 adjacent pairs observed against 8.8
-	// expected under independence; longest streak 3 in 400). Keeping the
-	// assertion is what stops the barrier being deleted as ceremony: if the
-	// engine ever made the un-barriered path reliable, every run here would
-	// promote and the barrier's justification would need re-deriving.
+	// Two measurements exist, of DIFFERENT shapes; they are not interchangeable
+	// and a re-measurement should say which it took. A tight loop of 50
+	// consecutive executions inside one warm process collapsed 60 times in 400
+	// (15.0%) over eight batches spanning idle to heavily loaded, worst batch 13
+	// of 50 (26%). The 3-execution shape this test actually runs, across twenty
+	// fresh processes, collapsed 4 times in 60 (6.7%) — enough to fail a strict
+	// "never collapses" on 4 of those 20 runs. The loop below is the warm shape
+	// and is sized against the higher 15%.
+	//
+	// What is true, and what the barrier's justification rests on, is that the
+	// un-barriered path cannot be RELIED on to promote: over noBarrierRepetitions
+	// runs at least one must decline to. That is wrong only if EVERY run
+	// collapses. Under independence that is p^10 — 5.8e-9 at 15%, 1.4e-6 at the
+	// worst batch's 26%. Independence is ASSUMED, not established: 12 adjacent
+	// collapse pairs against 8.8 expected is 1.1 sigma, which fails to refute
+	// independence rather than evidencing it, and only the longest streak (3
+	// observed, ~3 expected) genuinely matches it. Taken as real clustering the
+	// conditional rate is 12/58 = 0.21, a 1.38x lift; carrying that lift onto the
+	// worst batch's marginal gives the pessimistic figure, 0.26 * 0.359^9 =
+	// 2.6e-5. A second assumption rides underneath: the ten runs share one
+	// process, one database and one load state, so the honest quantity is E[p^10]
+	// across environments, dominated by the worst one. The batches above bound
+	// that on a developer machine; they cannot bound an arbitrary CI runner.
+	// Even the pessimistic 2.6e-5 is four orders of magnitude below the ~19% at
+	// which the strict form false-positived, which is what makes 10 the count.
+	//
+	// The guard is deliberately weak against PARTIAL reliability shifts: it fires
+	// only 10.7% of the time if the collapse rate reached 80%, 34.9% at 90%. That
+	// band was never usefully covered — the strict form false-positived on a
+	// healthy engine roughly one run in five — and the shift worth catching is
+	// the total one: an engine change that makes the un-barriered path reliable
+	// promotes every run here, and the barrier's justification then needs
+	// re-deriving, not deleting.
 	const noBarrierRepetitions = 10
 	collapsed := 0
 	for i := 0; i < noBarrierRepetitions; i++ {
-		if withoutBarrier(t) == 1 {
+		if withoutBarrier(t) {
 			collapsed++
 		}
 	}


### PR DESCRIPTION
Closes #748.

`TestSyntheticBatchReplay_PromotionBarrier` asserted a negative about a race — that forcing both halves of a promotion pair into one dependency generation can NEVER collapse to a single mutual — and a comment above it claimed the un-barriered path "fails DETERMINISTICALLY rather than intermittently". Both are false. Aggregation only claims rows and publishes an envelope; the outbound's interaction is written later by a River consumer, so an inbound driven in the same generation does sometimes find it already written and promote against it.

## Proof of failure

Ran the committed test 20 times, unchanged: **4 failures in 20 runs**. Every failure was the `withoutBarrier` `assert.NotEqual(t, 1, ...)` (4 collapse events across the 60 executions those runs performed, 6.7%). The `withBarrier` half failed **0 of 60** executions — the asymmetry the issue describes, confirmed.

## Measured collapse rate

Instrumented the `withoutBarrier` construction directly, 50 executions per batch, 8 batches:

| Batch | Condition | Collapses / 50 |
|---|---|---|
| A, B | idle | 6, 7 |
| C | 16 busy-loop CPU hogs (10 cores) | 13 |
| D | 40 busy-loop CPU hogs | 10 |
| E–H | concurrent with a full `make test-integration` | 8, 5, 5, 6 |

**Pooled: 60 / 400 = 15.0%**, worst single batch 13/50 = 26%. Load raises the rate rather than lowering it, matching the issue's account of the flake surfacing under pre-push gate load.

**These two rates are not commensurable and the comment now says so.** 15.0% is a tight loop of 50 consecutive executions inside one warm process; 6.7% is the committed test's 3-execution shape across twenty fresh processes. The repetition count is sized against the higher figure.

## The fix (issue's option 1)

Assert the un-barriered path is *unreliable*, not *impossible*: over `noBarrierRepetitions` runs, at least one must decline to promote. This keeps the assertion's real purpose — stopping the barrier being deleted as ceremony — without asserting something untrue.

**Choosing N = 10.** The assertion is wrong only if EVERY run collapses:

| Model | Figure |
|---|---|
| Independent, measured 15% | 5.8e-9 |
| Independent, worst batch 26% | 1.4e-6 |
| Markov at the measured rate (conditional 12/58 = 0.21) | 1.0e-7 |
| **Markov lift carried onto the worst batch (0.26 × 0.359^9)** | **2.6e-5** |

Both assumptions are named in the comment rather than glossed:

- **Independence is assumed, not established.** 12 adjacent collapse pairs against 8.8 expected is 1.1σ against a binomial sd of 2.94 — that *fails to refute* independence; it is not evidence *for* it. Only the longest-streak figure (3 observed, ~3 expected) genuinely matches independence. Read literally the adjacency implies mild positive clustering, which is why the pessimistic Markov row above is quoted as the operative bound.
- **Environment homogeneity is assumed.** The ten runs share one process, one database and one load state, so the honest quantity is `E[p_env^10]`, dominated by the worst environment. The idle-to-loaded batches bound that on this machine; they cannot bound an arbitrary CI runner.

The conclusion survives honestly: even the pessimistic 2.6e-5 is four orders of magnitude below the ~19% at which the strict form false-positived.

**Power curve, recorded deliberately.** The guard is weak against *partial* reliability shifts — it fires only 10.7% of the time at an 80% collapse rate, 34.9% at 90%. That band was never usefully covered, since the strict form false-positived on a healthy engine roughly one run in five. What it does catch is the total shift: an engine change making the un-barriered path reliable promotes every run.

**Counter correctness.** `withoutBarrier` now returns whether the pair collapsed to a single *mutual*, not merely to a single row. Scoring on row count alone would have counted a regression that drops the inbound outright as a promotion — inflating the very rate the margin depends on.

The two-row branch is checked just as strictly. `interaction.direction` is `NOT NULL` with a three-value CHECK (migration 031, unaltered since), so five of the six possible two-row multisets are illegitimate and previously scored as the healthy non-collapse — `(mutual, inbound)`, a promote-and-duplicate regression, above all. That could only deflate `collapsed`, never inflate it, so the sizing margin was never at risk; the cost was diagnosis. The branch now asserts the multiset is exactly `{outbound, inbound}`.

`withBarrier` is untouched: still `assert.Equal(t, 1, ...)` over 3 repetitions, byte-identical to develop.

## Verification

- **20 / 20 green** on the final test (20 separate `make test-integration` invocations, re-run after each counter change). Latest: 20 collapses across 200 executions (10.0%), per-run max **3 of 10** — never within 7 of the 10 needed to fail. The new direction-multiset guard tripped **0 times** across the ~180 two-row outcomes those runs produced, while injection D proves it is live rather than vacuous.
- **Injection A — barrier deleted.** Forced `partitionGenerations` to return a single generation. Exit **2**; `withBarrier` fails four assertions including `require.Len(rows, 1)` reporting two one-sided rows.
- **Injection B — un-barriered path made reliable.** Added a per-ITEM settle inside the generation loop of `ReplayTelegramBatch`, leaving `SettleCalls` untouched so it is the engine that changed, not the batch shape. Exit **2**, `no-barrier: 10 of 10 runs collapsed`, new assertion fires with its message. `withBarrier` passed, confirming the new assertion does independent work.
- **Injection D — pair misdirected.** Forced both un-barriered halves inbound (gated on `PairKey == 0` so the barriered variant, which runs first and Goexits on `require`, still reaches the loop). Exit **2**, `elements differ` naming `outbound` as the missing element — the actual multiset was `(inbound, inbound)`. `withBarrier` recorded 0 failures, confirming the trip is the new guard.
- **Injection C — inbound dropped outright.** Skipped the inbound item in `ReplayTelegramBatch`. Exit **2** with `a lone row must be the promoted mutual — a one-sided one means a half was dropped, not promoted`. Under the previous row-count counter this run would have scored 10/10 "collapses" and produced a misdiagnosing "the un-barriered path has become reliable" message.
- Every injection re-read from disk to confirm it landed, then reverted; `grep -c "INJECTED DEFECT"` returns 0 in both touched files and the clean tree passes.
- `make lint` 0 issues; full pre-push gate (LINT/GO/FRONTEND/FILTER/E2E) green on both commits.

Test-only change; no production code touched.
