### PR TITLE
fix(synthetic): gate the overdue band on the endpoint's own read

### DIFF
--- a/.ai/patterns/synthetic-seed-toolkit.md
+++ b/.ai/patterns/synthetic-seed-toolkit.md
@@ -111,6 +111,18 @@ result, _ := synthetic.RunProfile(ctx, h, params)           // counts-only Profi
 
 Some pending states have **no toolkit producer yet** (documented, asserted-absent by the coverage check, tracked for a follow-on): `conflict_pending` meeting_note, title-candidate review rows, `comms_message` without `interaction_id`. See the comment block on `runCatalogProfile` in `profiles.go`.
 
+## Asserting the seeded population's shape — read what the product reads
+
+A population-shape gate ("the seed leaves 12–22% of live contacts overdue") is a claim about what the application SHOWS. Assert it through the same read the application performs, not through a recomputation of the same concept from the underlying columns. The two are different quantities whenever a derived/cached column can lag its inputs, and a gate on the recomputation passes while the deployed world disagrees — silently, because both numbers look correct.
+
+The concrete case (gh #751): the overdue band was asserted by recomputing overdue-ness from `(cadence, last_contacted, created_at)` via `synthetic.OverdueAtProduction`, while `GET /contacts/overdue` filters on the persisted `contact_by` column. `contact_by` is written FORWARD-ONLY, so an archetype whose newest two-way interaction predates its contact's `created_at` moves `last_contacted` backwards past `created_at` and leaves `contact_by` at the creation-time value — the recompute says overdue, the endpoint does not return it. Deployed staging was nine contacts short of what the gate measured and the gate could not see it. The fix was to measure both, model both (`PredictedCatalogOverdue` vs `PredictedCatalogOverduePersisted`), and put the product-facing band on the endpoint's own predicate (`SyntheticSupportRepository.ListOverdueContactIdsByNamePrefix`, a deliberate namespace-scoped copy of the production query).
+
+Rules of thumb when adding one of these gates:
+
+- Prefer a test-only sqlc query that COPIES the production predicate (namespace-scoped and unbounded — the production `LIMIT` would let an accumulated shared test DB truncate the window) over re-deriving the concept in Go.
+- If a derived column is involved, assert its precondition rather than assuming it. `contact_by` holds `base + AMBIENT cadence period`, so `assertOverdueBand` requires `cadence.GetCadenceConfig() == cadence.ProductionCadenceConfig()` outright; under a compressed `CRM_ENV` that column is minutes wide and the band would be grading nonsense. (The Go integration suite runs with `CRM_ENV` unset — i.e. production durations — because no `make test-integration*` target sets it; only the frontend E2E lane sets `CRM_ENV=testing`.)
+- Keep the recomputation too, as a separate assertion. It is what the seed's assignment can actually steer, and the two measurements bracketing each other (endpoint set ⊆ recomputed set) is itself a regression detector.
+
 ## Entrypoints
 
 | Entrypoint | What it does |

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -309,9 +309,7 @@ const OverdueCeiling = 45
 //	  + SeededMerged            merge WINNERS — one live contact per pair, since the
 //	                            loser is tombstoned and the buckets query filters it
 //
-// dev: 5+4+1+8+1 = 19. prod-shaped: 15+4+1+8+3 = 31. The merge term is the one
-// that moved when the prod-shaped coverage test bounded its knobs, and leaving it
-// out of this list is how the number and its explanation came apart before.
+// dev: 5+4+1+8+1 = 19. prod-shaped: 15+4+1+8+3 = 31.
 //
 // Exported so the coverage tests derive that denominator from one authority
 // instead of freezing a measured total. How firmly each is held differs:
@@ -323,9 +321,7 @@ const OverdueCeiling = 45
 //     gh #751 (181 live against a 150-slot catalog) but pinned by no executing
 //     lane: the only prod-shaped coverage test bounds its volume knobs for CI and
 //     never seeds n=150. What that lane DOES pin is its own bounded cohort, which
-//     it derives from this constant and its own SeededMerged override — so the
-//     merge knob cannot drift unnoticed. The other knobs it bounds seed no contact
-//     rows at all, so no live-contact assertion moves with them either way.
+//     it derives from this constant and its own SeededMerged override.
 const (
 	DevNonCatalogLiveContacts        = 19
 	ProdShapedNonCatalogLiveContacts = 31
@@ -379,8 +375,8 @@ const overdueSharePercent = 23
 //     against this 22.0% ceiling and FAILS the band — 2.3 points of margin, with
 //     5.8 points still left above the legitimate 16.2% persisted share. It also
 //     fails the exact equality by three contacts. Two independent catches.
-//   - prod-shaped (n=9): the band branch is skipped (n < archetypeLadderFullAssignment)
-//     and the two models coincide, so NOTHING on that lane catches a revert. Pinned
+//   - prod-shaped (n=9): the band branch is skipped below n=12 and the two models
+//     coincide, so NOTHING on that lane catches a revert. Pinned
 //     as an explicit zero in TestArchetypeAssignmentOverdueBand so it stays visible.
 //   - n=150, the shipped prod-shaped size: a revert would measure 40/181 = 22.10%
 //     against 22.0%, a margin of a tenth of a point — but no gate runs there.
@@ -388,17 +384,6 @@ const overdueSharePercent = 23
 // So the band is not decorative; it is one of two catches at the only scope that
 // runs it. The reason not to LEAN on it is the n=150 row: at that size the margin
 // is a fifth of a contact, and any claim resting on it would be an overclaim.
-//
-// The corridor is worth recording because it is where a "just tighten the
-// ceiling" instinct goes wrong. Across the modelled sweep the persisted share
-// tops out at 21.11% (n=71) and the recomputed share bottoms at 22.10%, so the
-// ceiling can be anything in [21.12, 22.0) — 0.99 points wide. Moving to 21.2
-// would buy 0.90 points against a revert at n=150 while leaving 0.09 points above
-// a legitimate persisted population, which is the same knife-edge pointed the
-// other way. That tension is a property of the SWEEP, not of any executing lane:
-// at dev both margins are comfortable at 22.0 (2.3 and 5.8). The ceiling stays at
-// 22.0 because it buys variation headroom where the gate actually runs, and the
-// n=150 margin it gives up is one no gate was collecting.
 //
 // The guard that does not depend on any of this is the coverage gate's EXACT
 // equality against PredictedCatalogOverduePersisted, whose margin is the gap

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -328,15 +328,20 @@ const overdueSharePercent = 23
 //
 // It is deliberately wide enough that the calm quota, the ladder, or the
 // non-catalog cohort can move by a couple of contacts without flaking a gate —
-// at prod-shaped one contact is 0.55% of the share — and deliberately narrow
-// enough to exclude the RECOMPUTED share, which runs 22–26% over the same range.
-// A gate that quietly went back to recomputing overdue-ness instead of reading
-// the column therefore fails here rather than passing while staging disagrees,
-// which is the regression gh #751 recorded.
+// at prod-shaped one contact is 0.55% of the share.
 //
-// The band is the population-SHAPE statement and carries that slack on purpose.
-// The tight guard is the exact equality against PredictedCatalogOverduePersisted
-// in the coverage gate; this is not the place to catch a one-contact drift.
+// This is a COARSE SANITY BAND and nothing more. In particular it is NOT what
+// stops a gate from quietly reverting to recomputing overdue-ness: the recomputed
+// share at prod-shaped is 40/181 = 22.10% against a 22.0% ceiling, a margin of a
+// tenth of a point — under a fifth of one contact — and the band cannot be
+// tightened to buy more, because the persisted range tops out at 21.11% while the
+// recomputed range bottoms out at 22.10%. The ceiling is boxed in.
+//
+// The real anti-revert guard is the coverage gate's EXACT equality against
+// PredictedCatalogOverduePersisted, which a revert misses by nine contacts at
+// prod-shaped and three at dev — margins that are not close to anything. Read the
+// band as "the population still looks roughly like the one we designed", and read
+// the equality as the assertion that actually holds the line.
 const (
 	OverdueBandFloorPercent   = 12.0
 	OverdueBandCeilingPercent = 22.0

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -295,12 +295,36 @@ func archetypeScarcityOrder() []factory.Archetype {
 // the two, and therefore the conservative side to assert from.
 const OverdueCeiling = 45
 
-// catalogNonCatalogLiveContacts models the profile's non-catalog live contacts —
-// 19 at the dev knobs and 31 at prod-shaped's, so the midpoint is what one
-// formula has to pick when it must set a sensible target for both. It is a
-// TARGET-PICKING device inside the budget, never an assertion: the coverage test
-// measures the live population from the database.
-const catalogNonCatalogLiveContacts = 25
+// DevNonCatalogLiveContacts / ProdShapedNonCatalogLiveContacts are how many LIVE
+// contacts each profile seeds OUTSIDE the catalog: the per-source showcase
+// contacts, the direction cohort, the follow-up contact and the pinned tour
+// fixtures. Together with the catalog size they give a profile's live population,
+// which is the denominator every overdue share is taken over.
+//
+// Exported so the coverage tests derive that denominator from one authority
+// instead of freezing a measured total. How firmly each is held differs, and the
+// difference is worth knowing:
+//
+//   - Dev is PINNED against the database. TestSyntheticProfile_DevCoversCatalog
+//     seeds the profile at its natural knobs, so assertOverdueBand asserts the
+//     measured non-catalog count equals this constant on every run.
+//   - Prod-shaped is a MODEL. It is corroborated by the deployed-staging
+//     measurement in gh #751 (181 live against a 150-slot catalog), but no
+//     executing lane pins it: the only prod-shaped coverage test bounds its
+//     volume knobs for CI, which shrinks the cohort to
+//     prodShapedBoundedNonCatalogLive. That bounded number IS pinned, so the
+//     bounding cannot drift unnoticed either.
+const (
+	DevNonCatalogLiveContacts        = 19
+	ProdShapedNonCatalogLiveContacts = 31
+)
+
+// catalogNonCatalogLiveContacts is the midpoint of the two, which is what one
+// budget formula has to pick when it must set a sensible target for both
+// profiles. DERIVED rather than restated, so the two cohorts above stay the
+// single authority. It is a TARGET-PICKING device inside the budget, never an
+// assertion: the coverage test measures the live population from the database.
+const catalogNonCatalogLiveContacts = (DevNonCatalogLiveContacts + ProdShapedNonCatalogLiveContacts) / 2
 
 // overdueSharePercent is the percentage of the live population the budget lets
 // the assignment leave overdue. It bounds the RECOMPUTED quantity — the one
@@ -332,16 +356,32 @@ const overdueSharePercent = 23
 //
 // This is a COARSE SANITY BAND and nothing more. In particular it is NOT what
 // stops a gate from quietly reverting to recomputing overdue-ness: the recomputed
-// share at prod-shaped is 40/181 = 22.10% against a 22.0% ceiling, a margin of a
-// tenth of a point — under a fifth of one contact — and the band cannot be
-// tightened to buy more, because the persisted range tops out at 21.11% while the
-// recomputed range bottoms out at 22.10%. The ceiling is boxed in.
+// share at prod-shaped is 40/181 = 22.10% against a 22.0% ceiling — a tenth of a
+// point, under a fifth of one contact.
 //
-// The real anti-revert guard is the coverage gate's EXACT equality against
-// PredictedCatalogOverduePersisted, which a revert misses by nine contacts at
-// prod-shaped and three at dev — margins that are not close to anything. Read the
-// band as "the population still looks roughly like the one we designed", and read
-// the equality as the assertion that actually holds the line.
+// The ceiling COULD be lowered: the corridor between the persisted maximum
+// (21.11%, at n=71) and the recomputed minimum (22.10%) admits any value in
+// [21.12, 22.0), and 21.2 would buy 0.90 points against a revert. That is not
+// free, though — it is the same knife-edge pointed the other way, leaving only
+// 0.09 points of headroom above a legitimate persisted population. The corridor
+// is about one point wide in total, so every position in it trades anti-revert
+// margin against legitimate-variation margin, and there is no setting that has
+// both. 22.0 spends the corridor on variation headroom deliberately, because
+// legitimate variation is the thing this band exists to tolerate and the
+// anti-revert job belongs to an assertion that can do it properly.
+//
+// That assertion is the coverage gate's EXACT equality against
+// PredictedCatalogOverduePersisted. Its margin is the gap between the two models,
+// and the gap is SIZE-DEPENDENT: nine contacts at n=150, three at n=18, and ZERO
+// at n=9, where the two models coincide. Only the sizes a gate actually runs at
+// count, and that is n=18 (dev) and n=9 (prod-shaped, CI-bounded) — so the
+// enforced anti-revert margin is three contacts on the dev lane and nothing at
+// all on the prod-shaped one. n=9 is pinned as an explicit zero in
+// TestArchetypeAssignmentOverdueBand so the blind spot stays visible.
+//
+// Read the band as "the population still looks roughly like the one we
+// designed", and read the dev lane's equality as the assertion that holds the
+// line.
 const (
 	OverdueBandFloorPercent   = 12.0
 	OverdueBandCeilingPercent = 22.0

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -296,24 +296,36 @@ func archetypeScarcityOrder() []factory.Archetype {
 const OverdueCeiling = 45
 
 // DevNonCatalogLiveContacts / ProdShapedNonCatalogLiveContacts are how many LIVE
-// contacts each profile seeds OUTSIDE the catalog: the per-source showcase
-// contacts, the direction cohort, the follow-up contact and the pinned tour
-// fixtures. Together with the catalog size they give a profile's live population,
-// which is the denominator every overdue share is taken over.
+// contacts each profile seeds OUTSIDE the catalog. Together with the catalog size
+// they give a profile's live population, which is the denominator every overdue
+// share is taken over.
+//
+// The composition, which ADDS UP to both constants rather than gesturing at them:
+//
+//	5 × perSourceSettledCount   per-source settled showcase contacts (1 dev / 3 prod-shaped)
+//	  + 4                       message-direction cohort (3 outbound-only + 1 telegram mutual)
+//	  + 1                       follow-up-loop contact
+//	  + 8                       pinned tour-fixture contacts
+//	  + SeededMerged            merge WINNERS — one live contact per pair, since the
+//	                            loser is tombstoned and the buckets query filters it
+//
+// dev: 5+4+1+8+1 = 19. prod-shaped: 15+4+1+8+3 = 31. The merge term is the one
+// that moved when the prod-shaped coverage test bounded its knobs, and leaving it
+// out of this list is how the number and its explanation came apart before.
 //
 // Exported so the coverage tests derive that denominator from one authority
-// instead of freezing a measured total. How firmly each is held differs, and the
-// difference is worth knowing:
+// instead of freezing a measured total. How firmly each is held differs:
 //
 //   - Dev is PINNED against the database. TestSyntheticProfile_DevCoversCatalog
 //     seeds the profile at its natural knobs, so assertOverdueBand asserts the
 //     measured non-catalog count equals this constant on every run.
-//   - Prod-shaped is a MODEL. It is corroborated by the deployed-staging
-//     measurement in gh #751 (181 live against a 150-slot catalog), but no
-//     executing lane pins it: the only prod-shaped coverage test bounds its
-//     volume knobs for CI, which shrinks the cohort to
-//     prodShapedBoundedNonCatalogLive. That bounded number IS pinned, so the
-//     bounding cannot drift unnoticed either.
+//   - Prod-shaped is a MODEL, corroborated by the deployed-staging measurement in
+//     gh #751 (181 live against a 150-slot catalog) but pinned by no executing
+//     lane: the only prod-shaped coverage test bounds its volume knobs for CI and
+//     never seeds n=150. What that lane DOES pin is its own bounded cohort, which
+//     it derives from this constant and its own SeededMerged override — so the
+//     merge knob cannot drift unnoticed. The other knobs it bounds seed no contact
+//     rows at all, so no live-contact assertion moves with them either way.
 const (
 	DevNonCatalogLiveContacts        = 19
 	ProdShapedNonCatalogLiveContacts = 31
@@ -324,6 +336,11 @@ const (
 // profiles. DERIVED rather than restated, so the two cohorts above stay the
 // single authority. It is a TARGET-PICKING device inside the budget, never an
 // assertion: the coverage test measures the live population from the database.
+//
+// This is INTEGER division, so it is the true midpoint only while the two cohorts
+// sum to an even number — 19+31 = 50 today. A future cohort change making the sum
+// odd would silently round down by half a contact rather than fail, so the parity
+// is asserted in TestArchetypeAssignmentOverdueBand instead of left to chance.
 const catalogNonCatalogLiveContacts = (DevNonCatalogLiveContacts + ProdShapedNonCatalogLiveContacts) / 2
 
 // overdueSharePercent is the percentage of the live population the budget lets
@@ -354,34 +371,38 @@ const overdueSharePercent = 23
 // non-catalog cohort can move by a couple of contacts without flaking a gate —
 // at prod-shaped one contact is 0.55% of the share.
 //
-// This is a COARSE SANITY BAND and nothing more. In particular it is NOT what
-// stops a gate from quietly reverting to recomputing overdue-ness: the recomputed
-// share at prod-shaped is 40/181 = 22.10% against a 22.0% ceiling — a tenth of a
-// point, under a fifth of one contact.
+// How much protection it gives against a gate quietly reverting to RECOMPUTING
+// overdue-ness is LANE-DEPENDENT, and the honest answer is per-lane rather than
+// one sentence:
 //
-// The ceiling COULD be lowered: the corridor between the persisted maximum
-// (21.11%, at n=71) and the recomputed minimum (22.10%) admits any value in
-// [21.12, 22.0), and 21.2 would buy 0.90 points against a revert. That is not
-// free, though — it is the same knife-edge pointed the other way, leaving only
-// 0.09 points of headroom above a legitimate persisted population. The corridor
-// is about one point wide in total, so every position in it trades anti-revert
-// margin against legitimate-variation margin, and there is no setting that has
-// both. 22.0 spends the corridor on variation headroom deliberately, because
-// legitimate variation is the thing this band exists to tolerate and the
-// anti-revert job belongs to an assertion that can do it properly.
+//   - dev (n=18), where the band branch executes: a revert measures 9/37 = 24.3%
+//     against this 22.0% ceiling and FAILS the band — 2.3 points of margin, with
+//     5.8 points still left above the legitimate 16.2% persisted share. It also
+//     fails the exact equality by three contacts. Two independent catches.
+//   - prod-shaped (n=9): the band branch is skipped (n < archetypeLadderFullAssignment)
+//     and the two models coincide, so NOTHING on that lane catches a revert. Pinned
+//     as an explicit zero in TestArchetypeAssignmentOverdueBand so it stays visible.
+//   - n=150, the shipped prod-shaped size: a revert would measure 40/181 = 22.10%
+//     against 22.0%, a margin of a tenth of a point — but no gate runs there.
 //
-// That assertion is the coverage gate's EXACT equality against
-// PredictedCatalogOverduePersisted. Its margin is the gap between the two models,
-// and the gap is SIZE-DEPENDENT: nine contacts at n=150, three at n=18, and ZERO
-// at n=9, where the two models coincide. Only the sizes a gate actually runs at
-// count, and that is n=18 (dev) and n=9 (prod-shaped, CI-bounded) — so the
-// enforced anti-revert margin is three contacts on the dev lane and nothing at
-// all on the prod-shaped one. n=9 is pinned as an explicit zero in
-// TestArchetypeAssignmentOverdueBand so the blind spot stays visible.
+// So the band is not decorative; it is one of two catches at the only scope that
+// runs it. The reason not to LEAN on it is the n=150 row: at that size the margin
+// is a fifth of a contact, and any claim resting on it would be an overclaim.
 //
-// Read the band as "the population still looks roughly like the one we
-// designed", and read the dev lane's equality as the assertion that holds the
-// line.
+// The corridor is worth recording because it is where a "just tighten the
+// ceiling" instinct goes wrong. Across the modelled sweep the persisted share
+// tops out at 21.11% (n=71) and the recomputed share bottoms at 22.10%, so the
+// ceiling can be anything in [21.12, 22.0) — 0.99 points wide. Moving to 21.2
+// would buy 0.90 points against a revert at n=150 while leaving 0.09 points above
+// a legitimate persisted population, which is the same knife-edge pointed the
+// other way. That tension is a property of the SWEEP, not of any executing lane:
+// at dev both margins are comfortable at 22.0 (2.3 and 5.8). The ceiling stays at
+// 22.0 because it buys variation headroom where the gate actually runs, and the
+// n=150 margin it gives up is one no gate was collecting.
+//
+// The guard that does not depend on any of this is the coverage gate's EXACT
+// equality against PredictedCatalogOverduePersisted, whose margin is the gap
+// between the two models: three contacts at n=18, ZERO at n=9, nine at n=150.
 const (
 	OverdueBandFloorPercent   = 12.0
 	OverdueBandCeilingPercent = 22.0

--- a/backend/internal/synthetic/archetypes.go
+++ b/backend/internal/synthetic/archetypes.go
@@ -288,6 +288,11 @@ func archetypeScarcityOrder() []factory.Archetype {
 // array cap (50), and the overdue tours' own explicit cap, which they enforce by
 // REFUSING to run above it. Exported so the coverage tests assert the shipped
 // population against the same number the assignment is built to.
+//
+// The bound the tours actually feel is on the ENDPOINT-visible set, which is a
+// subset of the recomputed one (see archetypeLeavesSlotPersistedOverdue), so the
+// coverage gate holds this ceiling against the recomputed count — the larger of
+// the two, and therefore the conservative side to assert from.
 const OverdueCeiling = 45
 
 // catalogNonCatalogLiveContacts models the profile's non-catalog live contacts —
@@ -297,10 +302,45 @@ const OverdueCeiling = 45
 // measures the live population from the database.
 const catalogNonCatalogLiveContacts = 25
 
-// overdueSharePercent is the percentage of the live population the overdue set
-// aims at. The band the coverage gates assert is 20–27%; the budget aims at the
-// middle of it.
+// overdueSharePercent is the percentage of the live population the budget lets
+// the assignment leave overdue. It bounds the RECOMPUTED quantity — the one
+// archetypeLeavesSlotOverdue counts — because that is what the placement loop
+// can actually steer: whether a slot's contact_by ends up in the past is decided
+// afterwards, by the forward-only cadence write, not by the assignment.
+// 23% keeps the recomputed population in the 20–27% range across the assignable
+// sizes; the ENDPOINT-visible share that falls out of it is the lower band below.
 const overdueSharePercent = 23
+
+// OverdueBandFloorPercent / OverdueBandCeilingPercent bound the share of live
+// contacts the seeded world leaves overdue AS THE PRODUCT SHOWS IT — the count
+// GET /contacts/overdue returns, which is the persisted contact_by column.
+//
+// Derivation, not a golden number. The endpoint-visible set is the
+// natively-overdue (backdated) catalog slots that no calm archetype rescued,
+// plus the two pinned fixtures — see archetypeLeavesSlotPersistedOverdue for why
+// the endpoint's set is exactly that conjunction. Backdated slots are one
+// catalog index in three, so the numerator grows like n/3 less the calm quota
+// while the denominator grows like n plus a fixed non-catalog cohort, which puts
+// the share in the mid-to-high teens across the whole assignable range: sweeping
+// n over [12, 150] against the dev-knob denominator spans 12.9% to 21.1%, and the
+// two shipped worlds measure 16.2% (dev, n=18: 6 of 37) and 17.1% (prod-shaped,
+// n=150: 31 of 181). The band is that sweep rounded outward to whole points.
+//
+// It is deliberately wide enough that the calm quota, the ladder, or the
+// non-catalog cohort can move by a couple of contacts without flaking a gate —
+// at prod-shaped one contact is 0.55% of the share — and deliberately narrow
+// enough to exclude the RECOMPUTED share, which runs 22–26% over the same range.
+// A gate that quietly went back to recomputing overdue-ness instead of reading
+// the column therefore fails here rather than passing while staging disagrees,
+// which is the regression gh #751 recorded.
+//
+// The band is the population-SHAPE statement and carries that slack on purpose.
+// The tight guard is the exact equality against PredictedCatalogOverduePersisted
+// in the coverage gate; this is not the place to catch a one-contact drift.
+const (
+	OverdueBandFloorPercent   = 12.0
+	OverdueBandCeilingPercent = 22.0
+)
 
 // PinnedOverdueFixtureCount is how many overdue contacts the pinned-fixture block
 // adds. They sit OUTSIDE the catalog and are always overdue, so the catalog
@@ -632,10 +672,60 @@ func archetypeLeavesSlotOverdue(i, n int, a factory.Archetype) bool {
 // PredictedCatalogOverdue is how many CATALOG slots the assignment leaves
 // overdue at this catalog size. Exported so the coverage test can compare a
 // DB-measured count against the prediction rather than trusting either alone.
+//
+// This is the RECOMPUTED quantity — overdue derived from (cadence,
+// last_contacted, created_at). It is NOT what GET /contacts/overdue returns; see
+// PredictedCatalogOverduePersisted for that, and the comment there for why the
+// two legitimately differ.
 func PredictedCatalogOverdue(n int) int {
 	count := 0
 	for i, a := range archetypeAssignment(n) {
 		if archetypeLeavesSlotOverdue(i, n, a) {
+			count++
+		}
+	}
+	return count
+}
+
+// archetypeLeavesSlotPersistedOverdue predicts whether the slot ends up overdue
+// AS THE OVERDUE ENDPOINT SEES IT — with the persisted contact_by column in the
+// past — which is a strictly smaller set than archetypeLeavesSlotOverdue.
+//
+// The two differ because contact_by is written FORWARD-ONLY. Creation seeds it
+// at DateOnly(created_at + period) (repository.CreateContact); an interaction
+// then offers DateOnly(occurred_at + period) through the forward branch of
+// UpdateContactCadenceForward, which writes only when the incoming date is
+// strictly GREATER than the stored one. An archetype whose newest two-way entry
+// predates the contact's own created_at — which the catalog produces
+// deliberately, since a backfill routinely discovers correspondence older than
+// the row that records it — therefore moves last_contacted backwards past
+// created_at while leaving contact_by at the creation-time value. The recompute
+// bases on last_contacted and says overdue; the endpoint reads contact_by and
+// does not. Whether the APPLICATION should behave that way is tracked separately
+// as gh #753; the seed models what it does rather than assuming the reads agree.
+//
+// So the endpoint's answer is the CONJUNCTION: contact_by ends up at
+// max(created_at + period, last_contacted + period), and a maximum is in the
+// past only when both terms are. Hence natively-overdue AND recompute-overdue.
+//
+// The conjunction is exact rather than approximate because the two creation
+// shapes that are not natively overdue are not near the boundary: a slotRecent
+// is created within 48h against a 7d-or-longer period, and a slotFresh is
+// created at the anchor itself. No PRNG draw inside either window can push
+// created_at + period into the past, so this stays a pure function of (i, n, a).
+func archetypeLeavesSlotPersistedOverdue(i, n int, a factory.Archetype) bool {
+	return catalogSlotNativelyOverdue(i, n) && archetypeLeavesSlotOverdue(i, n, a)
+}
+
+// PredictedCatalogOverduePersisted is how many CATALOG slots the assignment
+// leaves overdue in the persisted contact_by column — i.e. how many the overdue
+// ENDPOINT returns, which is the number the arc's overdue band is about.
+// Exported for the same reason as PredictedCatalogOverdue: so the coverage gate
+// compares a DB measurement against a model instead of trusting either alone.
+func PredictedCatalogOverduePersisted(n int) int {
+	count := 0
+	for i, a := range archetypeAssignment(n) {
+		if archetypeLeavesSlotPersistedOverdue(i, n, a) {
 			count++
 		}
 	}
@@ -655,10 +745,17 @@ func PredictedCatalogOverdue(n int) int {
 // that the caller holds a nullable cadence STRING, and that an absent cadence
 // means no due date at all rather than a defaulted one.
 //
-// Exported for the coverage tests, which run under CRM_ENV=test where annual is
-// two hours and every contact is overdue — so a measurement taken through the
-// ambient config would prove nothing, and mutating the variable would change
+// Exported so the coverage tests can state a production-duration expectation
+// without DEPENDING on the ambient environment: under CRM_ENV=test annual is two
+// hours and every contact is trivially overdue, so a recomputation taken through
+// the ambient config would prove nothing, and mutating the variable would change
 // cadence semantics for every concurrently-running test.
+//
+// This is the RECOMPUTE, and it is not what the overdue endpoint answers. The
+// endpoint reads the persisted contact_by column, which the forward-only cadence
+// write can leave in the future on a contact this function calls overdue — see
+// archetypeLeavesSlotPersistedOverdue. Anything asserting what the PRODUCT shows
+// must read the column; this function is for reasoning about the seed's intent.
 func OverdueAtProduction(cadenceName string, lastContacted *time.Time, createdAt, ref time.Time) bool {
 	if cadenceName == "" {
 		// No cadence means the app computes no due date, so nothing can be overdue.

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -399,31 +399,14 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 	// than assumed.
 	require.Zero(t, (DevNonCatalogLiveContacts+ProdShapedNonCatalogLiveContacts)%2,
 		"the two non-catalog cohorts must sum to an EVEN number, or catalogNonCatalogLiveContacts (integer division) is not their midpoint")
-	require.Equal(t, (DevNonCatalogLiveContacts+ProdShapedNonCatalogLiveContacts)/2, catalogNonCatalogLiveContacts,
-		"the budget's non-catalog model must stay the midpoint of the two profiles' cohorts")
 
-	// Note on what is deliberately NOT asserted here: "the endpoint-visible set is a
-	// subset of the recomputed set". A count-comparing version of it used to live
-	// here and was removed rather than moved, for three reasons that are worth
-	// stating so this does not read as coverage quietly dropped.
-	//
-	// First, it compared SIZES, not membership, so it could not catch the failure
-	// the property is about: a set with the wrong members but the right cardinality
-	// passed it. The real form needs the two id SETS, which only exist against a
-	// seeded database — that version now lives in assertOverdueBand as
-	// require.Subset, in the LONG_TESTS lane.
-	//
-	// Second, the models it compared are not left unguarded in PR CI: the exact
-	// totals and the three exact gap pins below run here, and between them they pin
-	// both models at every size that matters, which subsumes any inequality between
-	// them.
-	//
-	// Third, at the MODEL level the inequality is not falsifiable at all —
-	// archetypeLeavesSlotPersistedOverdue is DEFINED as a conjunction with
-	// archetypeLeavesSlotOverdue, so no (i, n, archetype) exists at which it could
-	// fail. That is a narrow claim about this specific expression, not a general
-	// licence: an assertion that merely happens to pass today is worth keeping, and
-	// this one is different only because its failure set is provably empty.
+	// "The endpoint-visible set is a subset of the recomputed set" is NOT asserted
+	// here. At the model level archetypeLeavesSlotPersistedOverdue is DEFINED as a
+	// conjunction with archetypeLeavesSlotOverdue, so no (i, n, archetype) exists at
+	// which the inequality could fail — a narrow claim about this expression, not a
+	// general licence to drop assertions that merely pass. The falsifiable form
+	// needs the two id SETS against a seeded database, and lives in
+	// assertOverdueBand as require.Subset.
 	for n := 1; n <= 150; n++ {
 		total := PredictedCatalogOverdue(n) + PinnedOverdueFixtureCount
 		endpointTotal := PredictedCatalogOverduePersisted(n) + PinnedOverdueFixtureCount
@@ -444,11 +427,9 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 			"n=%d: endpoint-visible overdue share %.1f%% is above the product band", n, endpointShare)
 	}
 
-	// What stops a silent revert to recompute-based measurement is the coverage
-	// gate's EXACT equality against PredictedCatalogOverduePersisted, and what makes
-	// that guard real is the GAP it would be off by. The band cannot do that job:
-	// its ceiling clears the prod-shaped recomputed share by 0.10 percentage points
-	// (40/181 = 22.10% against 22.0%), under a fifth of one contact.
+	// The coverage gate's EXACT equality against PredictedCatalogOverduePersisted
+	// catches a silent revert to recompute-based measurement, and the GAP between
+	// the two models is the margin it catches it by.
 	//
 	// The gap is SIZE-DEPENDENT, and pinning it exactly — at the sizes that ship AND
 	// at the sizes gates actually run at — is the point of this block. Those are not
@@ -458,7 +439,7 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 	// the dev lane, and n=9's ZERO is pinned deliberately: at that size the two
 	// models coincide, so on the prod-shaped lane a revert to recompute-based
 	// measurement passes the equality, passes the subset check on identical sets, and
-	// skips the band branch (n < archetypeLadderFullAssignment) entirely. That lane
+	// skips the band branch (below n=12) entirely. That lane
 	// has no anti-revert power at all. Pinning the zero keeps the blind spot an
 	// asserted fact rather than something a later reader has to rediscover.
 	for _, c := range []struct {

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -366,24 +366,32 @@ func TestArchetypeAssignmentIsDeterministic(t *testing.T) {
 // strictly smaller — that gap is what shipped unnoticed to staging as gh #751.
 // The product-facing band is the endpoint one.
 //
-// Both bands' denominator is live(n) = n + 19, the DEV-knob non-catalog live
+// The SWEEP's denominator is live(n) = n + 19, the DEV-knob non-catalog live
 // count. It is exact at the small sizes the sweep spends most of its range on,
 // and it is strictly CONSERVATIVE at large ones: a smaller denominator inflates
 // the share, so the sweep tests against each ceiling rather than away from it.
 // The budget formula's own midpoint constant is a target-picking device for two
 // profiles at once and is deliberately NOT reused here — it puts n = 12 below the
-// band. Neither model is ever an assertion about the world: the coverage test
-// counts live and overdue contacts from the database.
+// band. The two SHIPPING sizes are held against their real measured live counts
+// instead, because a modelled denominator that flatters the number is exactly how
+// a margin gets overstated. Neither model is ever an assertion about the world:
+// the coverage test counts live and overdue contacts from the database.
 func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 	const devKnobNonCatalogLive = 19
+
+	// The live contact counts the two shipped worlds actually carry, MEASURED in
+	// the coverage tests (dev) and on deployed staging (prod-shaped) — not
+	// n + a modelled non-catalog cohort.
+	const (
+		devLiveContacts        = 37
+		prodShapedLiveContacts = 181
+	)
 
 	for n := 1; n <= 150; n++ {
 		total := PredictedCatalogOverdue(n) + PinnedOverdueFixtureCount
 		endpointTotal := PredictedCatalogOverduePersisted(n) + PinnedOverdueFixtureCount
 		require.LessOrEqual(t, total, OverdueCeiling,
 			"n=%d: the overdue population must stay under the ceiling (the overdue tours refuse to run above their own, higher, capture cap)", n)
-		require.LessOrEqual(t, endpointTotal, total,
-			"n=%d: the endpoint-visible set is contact_by in the past, which the forward-only write makes a SUBSET of the recomputed set", n)
 
 		if n < archetypeLadderFullAssignment {
 			continue
@@ -399,13 +407,30 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 			"n=%d: endpoint-visible overdue share %.1f%% is above the product band", n, endpointShare)
 	}
 
-	// The band's whole point is that it separates the two quantities: a gate that
-	// silently reverted to recomputing overdue-ness has to FAIL it, at both
-	// shipping sizes, or the band is decorative.
+	// What actually stops a silent revert to recompute-based measurement is the
+	// coverage gate's EXACT equality against PredictedCatalogOverduePersisted, and
+	// what makes that guard real is the size of the gap it would be off by. Pin the
+	// gap, not the band: the band's ceiling clears the prod-shaped recomputed share
+	// by 0.10 percentage points (40/181 = 22.10% against a 22.0% ceiling — under a
+	// fifth of one contact), which is far too little to carry an anti-revert claim.
 	for _, n := range []int{18, 150} {
-		recomputedShare := 100.0 * float64(PredictedCatalogOverdue(n)+PinnedOverdueFixtureCount) / float64(n+devKnobNonCatalogLive)
-		require.Greater(t, recomputedShare, OverdueBandCeilingPercent,
-			"n=%d: the recomputed share (%.1f%%) must sit ABOVE the endpoint band's ceiling — otherwise the band cannot tell the two reads apart", n, recomputedShare)
+		gap := PredictedCatalogOverdue(n) - PredictedCatalogOverduePersisted(n)
+		require.GreaterOrEqual(t, gap, 3,
+			"n=%d: the recomputed and endpoint-visible models must differ by enough contacts (%d) that measuring the wrong one fails the coverage gate's exact equality by an unmistakable margin", n, gap)
+	}
+
+	// The shipping shares, against the REAL live denominators. These are the numbers
+	// the deployed worlds produce, so this is where the band is held honest.
+	devShare := 100.0 * float64(PredictedCatalogOverduePersisted(18)+PinnedOverdueFixtureCount) / float64(devLiveContacts)
+	prodShare := 100.0 * float64(PredictedCatalogOverduePersisted(150)+PinnedOverdueFixtureCount) / float64(prodShapedLiveContacts)
+	for _, c := range []struct {
+		label string
+		share float64
+	}{{"dev (n=18)", devShare}, {"prod-shaped (n=150)", prodShare}} {
+		require.GreaterOrEqual(t, c.share, OverdueBandFloorPercent,
+			"%s: shipped endpoint-visible share %.2f%% is below the product band", c.label, c.share)
+		require.LessOrEqual(t, c.share, OverdueBandCeilingPercent,
+			"%s: shipped endpoint-visible share %.2f%% is above the product band", c.label, c.share)
 	}
 
 	// The two shipping sizes are pinned exactly, so a tuning change to the budget
@@ -458,6 +483,12 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 // the recent pool, would make the prediction quietly PRNG-dependent, and this is
 // where that fails.
 func TestPersistedOverduePredictionIsNotBoundarySensitive(t *testing.T) {
+	kindName := map[catalogSlotKind]string{
+		slotBackdated: "backdated",
+		slotRecent:    "recent",
+		slotFresh:     "fresh",
+	}
+
 	checked := 0
 	for n := 1; n <= 150; n++ {
 		for i := 0; i < n; i++ {
@@ -469,15 +500,8 @@ func TestPersistedOverduePredictionIsNotBoundarySensitive(t *testing.T) {
 			require.True(t, ok, "n=%d i=%d: slot cadence %q must be a recognized cadence", n, i, slot.Cadence)
 			require.Less(t, slot.CreatedAgeBound+calmMargin, period,
 				"n=%d i=%d: a %s slot may be created up to %s before the anchor on a %s cadence (period %s) — a draw at that bound puts created_at + period in the PAST, so the endpoint-overdue prediction stops being a pure function of the assignment",
-				n, i, slot.Cadence, slot.CreatedAgeBound, slot.Cadence, period)
+				n, i, kindName[slot.Kind], slot.CreatedAgeBound, slot.Cadence, period)
 			checked++
-
-			// The conjunction's consequence, stated as behaviour: whatever archetype
-			// lands here, the endpoint cannot see this slot as overdue.
-			for _, a := range archetypeTieBreak {
-				require.False(t, archetypeLeavesSlotPersistedOverdue(i, n, a),
-					"n=%d i=%d: a non-backdated slot carrying %s must not be predicted endpoint-overdue", n, i, a)
-			}
 		}
 	}
 	require.NotZero(t, checked, "the sweep must actually reach non-backdated slots, or it proves nothing")

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -393,17 +393,37 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 		prodShapedLiveContacts = prodShapedCatalog + ProdShapedNonCatalogLiveContacts
 	)
 
+	// catalogNonCatalogLiveContacts is their midpoint under INTEGER division, which
+	// is the true midpoint only while the sum is even. An odd sum would round down
+	// by half a contact silently rather than fail, so the parity is asserted rather
+	// than assumed.
+	require.Zero(t, (DevNonCatalogLiveContacts+ProdShapedNonCatalogLiveContacts)%2,
+		"the two non-catalog cohorts must sum to an EVEN number, or catalogNonCatalogLiveContacts (integer division) is not their midpoint")
+	require.Equal(t, (DevNonCatalogLiveContacts+ProdShapedNonCatalogLiveContacts)/2, catalogNonCatalogLiveContacts,
+		"the budget's non-catalog model must stay the midpoint of the two profiles' cohorts")
+
 	// Note on what is deliberately NOT asserted here: "the endpoint-visible set is a
-	// subset of the recomputed set". At the MODEL level that is a tautology —
+	// subset of the recomputed set". A count-comparing version of it used to live
+	// here and was removed rather than moved, for three reasons that are worth
+	// stating so this does not read as coverage quietly dropped.
+	//
+	// First, it compared SIZES, not membership, so it could not catch the failure
+	// the property is about: a set with the wrong members but the right cardinality
+	// passed it. The real form needs the two id SETS, which only exist against a
+	// seeded database — that version now lives in assertOverdueBand as
+	// require.Subset, in the LONG_TESTS lane.
+	//
+	// Second, the models it compared are not left unguarded in PR CI: the exact
+	// totals and the three exact gap pins below run here, and between them they pin
+	// both models at every size that matters, which subsumes any inequality between
+	// them.
+	//
+	// Third, at the MODEL level the inequality is not falsifiable at all —
 	// archetypeLeavesSlotPersistedOverdue is DEFINED as a conjunction with
 	// archetypeLeavesSlotOverdue, so no (i, n, archetype) exists at which it could
-	// fail, and asserting it would be an inert guard dressed as a real one. The
-	// property is only falsifiable against DATA, where contact_by is a column
-	// written by the cadence engine rather than a term in an expression, and that is
-	// where it lives: assertOverdueBand's require.Subset over the two id sets. That
-	// puts it in the LONG_TESTS lane (pre-push and the nightly slow workflow), not
-	// PR CI — which is a real coverage difference, but the alternative is not a
-	// cheaper guard, it is a fake one.
+	// fail. That is a narrow claim about this specific expression, not a general
+	// licence: an assertion that merely happens to pass today is worth keeping, and
+	// this one is different only because its failure set is provably empty.
 	for n := 1; n <= 150; n++ {
 		total := PredictedCatalogOverdue(n) + PinnedOverdueFixtureCount
 		endpointTotal := PredictedCatalogOverduePersisted(n) + PinnedOverdueFixtureCount

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -355,13 +355,21 @@ func TestArchetypeAssignmentIsDeterministic(t *testing.T) {
 }
 
 // TestArchetypeAssignmentOverdueBand pins the overdue population: the absolute
-// ceiling at every size, the target band on the full rung, both shipping
-// profiles' exact totals, and the structural floor.
+// ceiling at every size, both bands on the full rung, both shipping profiles'
+// exact totals, and the structural floor.
 //
-// The band's denominator is live(n) = n + 19, the DEV-knob non-catalog live
+// TWO quantities are pinned, because they are genuinely different numbers. The
+// RECOMPUTED population (PredictedCatalogOverdue) is what the assignment's budget
+// steers, and the budget's 23% midpoint holds it in 20–27%. The ENDPOINT-visible
+// population (PredictedCatalogOverduePersisted) is what GET /contacts/overdue
+// returns once the forward-only contact_by write has had its say, and it is
+// strictly smaller — that gap is what shipped unnoticed to staging as gh #751.
+// The product-facing band is the endpoint one.
+//
+// Both bands' denominator is live(n) = n + 19, the DEV-knob non-catalog live
 // count. It is exact at the small sizes the sweep spends most of its range on,
 // and it is strictly CONSERVATIVE at large ones: a smaller denominator inflates
-// the share, so the sweep tests against the 27% ceiling rather than away from it.
+// the share, so the sweep tests against each ceiling rather than away from it.
 // The budget formula's own midpoint constant is a target-picking device for two
 // profiles at once and is deliberately NOT reused here — it puts n = 12 below the
 // band. Neither model is ever an assertion about the world: the coverage test
@@ -371,21 +379,44 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 
 	for n := 1; n <= 150; n++ {
 		total := PredictedCatalogOverdue(n) + PinnedOverdueFixtureCount
+		endpointTotal := PredictedCatalogOverduePersisted(n) + PinnedOverdueFixtureCount
 		require.LessOrEqual(t, total, OverdueCeiling,
 			"n=%d: the overdue population must stay under the ceiling (the overdue tours refuse to run above their own, higher, capture cap)", n)
+		require.LessOrEqual(t, endpointTotal, total,
+			"n=%d: the endpoint-visible set is contact_by in the past, which the forward-only write makes a SUBSET of the recomputed set", n)
 
 		if n < archetypeLadderFullAssignment {
 			continue
 		}
 		share := 100.0 * float64(total) / float64(n+devKnobNonCatalogLive)
-		require.GreaterOrEqual(t, share, 20.0, "n=%d: overdue share %.1f%% is below the band", n, share)
-		require.LessOrEqual(t, share, 27.0, "n=%d: overdue share %.1f%% is above the band", n, share)
+		require.GreaterOrEqual(t, share, 20.0, "n=%d: recomputed overdue share %.1f%% is below the budget's band", n, share)
+		require.LessOrEqual(t, share, 27.0, "n=%d: recomputed overdue share %.1f%% is above the budget's band", n, share)
+
+		endpointShare := 100.0 * float64(endpointTotal) / float64(n+devKnobNonCatalogLive)
+		require.GreaterOrEqual(t, endpointShare, OverdueBandFloorPercent,
+			"n=%d: endpoint-visible overdue share %.1f%% is below the product band", n, endpointShare)
+		require.LessOrEqual(t, endpointShare, OverdueBandCeilingPercent,
+			"n=%d: endpoint-visible overdue share %.1f%% is above the product band", n, endpointShare)
+	}
+
+	// The band's whole point is that it separates the two quantities: a gate that
+	// silently reverted to recomputing overdue-ness has to FAIL it, at both
+	// shipping sizes, or the band is decorative.
+	for _, n := range []int{18, 150} {
+		recomputedShare := 100.0 * float64(PredictedCatalogOverdue(n)+PinnedOverdueFixtureCount) / float64(n+devKnobNonCatalogLive)
+		require.Greater(t, recomputedShare, OverdueBandCeilingPercent,
+			"n=%d: the recomputed share (%.1f%%) must sit ABOVE the endpoint band's ceiling — otherwise the band cannot tell the two reads apart", n, recomputedShare)
 	}
 
 	// The two shipping sizes are pinned exactly, so a tuning change to the budget
-	// or the placement ordering is a deliberate edit rather than a drift.
-	require.Equal(t, 9, PredictedCatalogOverdue(18)+PinnedOverdueFixtureCount, "dev (n=18) overdue total")
-	require.Equal(t, 40, PredictedCatalogOverdue(150)+PinnedOverdueFixtureCount, "prod-shaped (n=150) overdue total")
+	// or the placement ordering is a deliberate edit rather than a drift. The
+	// endpoint totals are the numbers measured on the seeded worlds: 6 of 37 live
+	// at dev and 31 of 181 at prod-shaped (the latter reproduces, to the contact,
+	// what deployed staging returned in gh #751).
+	require.Equal(t, 9, PredictedCatalogOverdue(18)+PinnedOverdueFixtureCount, "dev (n=18) recomputed overdue total")
+	require.Equal(t, 40, PredictedCatalogOverdue(150)+PinnedOverdueFixtureCount, "prod-shaped (n=150) recomputed overdue total")
+	require.Equal(t, 6, PredictedCatalogOverduePersisted(18)+PinnedOverdueFixtureCount, "dev (n=18) endpoint-visible overdue total")
+	require.Equal(t, 31, PredictedCatalogOverduePersisted(150)+PinnedOverdueFixtureCount, "prod-shaped (n=150) endpoint-visible overdue total")
 
 	// The structural FLOOR: backdated slots with no admissible calm archetype are
 	// overdue whatever they receive, the no-method slot is reserved and backdated,
@@ -410,6 +441,46 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 		require.LessOrEqual(t, floor, PredictedCatalogOverdue(n)+PinnedOverdueFixtureCount,
 			"n=%d: the predicted total can never be below the structural floor", n)
 	}
+}
+
+// TestPersistedOverduePredictionIsNotBoundarySensitive proves the one claim
+// PredictedCatalogOverduePersisted rests on that is not visible in its own body:
+// that a slot which is not NATIVELY overdue cannot become endpoint-overdue for
+// any PRNG draw inside its creation window.
+//
+// The prediction is a pure function of (i, n, archetype), but created_at is a
+// DRAW — slotRecent picks a real age anywhere inside catalogRecentWindow. That is
+// only sound while every possible draw leaves created_at + period in the future,
+// because contact_by is seeded at creation and the forward-only write never
+// lowers it. So assert the separation directly, with a margin, rather than
+// trusting that 48 hours is obviously less than a week: a future edit that
+// widened the recent window past a cadence period, or put a sub-window cadence in
+// the recent pool, would make the prediction quietly PRNG-dependent, and this is
+// where that fails.
+func TestPersistedOverduePredictionIsNotBoundarySensitive(t *testing.T) {
+	checked := 0
+	for n := 1; n <= 150; n++ {
+		for i := 0; i < n; i++ {
+			slot := catalogSlot(i, n)
+			if slot.Kind == slotBackdated {
+				continue
+			}
+			period, ok := productionCadencePeriod(slot.Cadence)
+			require.True(t, ok, "n=%d i=%d: slot cadence %q must be a recognized cadence", n, i, slot.Cadence)
+			require.Less(t, slot.CreatedAgeBound+calmMargin, period,
+				"n=%d i=%d: a %s slot may be created up to %s before the anchor on a %s cadence (period %s) — a draw at that bound puts created_at + period in the PAST, so the endpoint-overdue prediction stops being a pure function of the assignment",
+				n, i, slot.Cadence, slot.CreatedAgeBound, slot.Cadence, period)
+			checked++
+
+			// The conjunction's consequence, stated as behaviour: whatever archetype
+			// lands here, the endpoint cannot see this slot as overdue.
+			for _, a := range archetypeTieBreak {
+				require.False(t, archetypeLeavesSlotPersistedOverdue(i, n, a),
+					"n=%d i=%d: a non-backdated slot carrying %s must not be predicted endpoint-overdue", n, i, a)
+			}
+		}
+	}
+	require.NotZero(t, checked, "the sweep must actually reach non-backdated slots, or it proves nothing")
 }
 
 // TestArchetypeAssignmentPreservesC3Floors re-asserts the coherence floors the

--- a/backend/internal/synthetic/archetypes_test.go
+++ b/backend/internal/synthetic/archetypes_test.go
@@ -377,16 +377,33 @@ func TestArchetypeAssignmentIsDeterministic(t *testing.T) {
 // a margin gets overstated. Neither model is ever an assertion about the world:
 // the coverage test counts live and overdue contacts from the database.
 func TestArchetypeAssignmentOverdueBand(t *testing.T) {
-	const devKnobNonCatalogLive = 19
+	const devKnobNonCatalogLive = DevNonCatalogLiveContacts
 
-	// The live contact counts the two shipped worlds actually carry, MEASURED in
-	// the coverage tests (dev) and on deployed staging (prod-shaped) — not
-	// n + a modelled non-catalog cohort.
+	// The live populations the two shipped worlds carry, DERIVED from the
+	// per-profile non-catalog cohorts rather than frozen as measured totals — a
+	// literal 37 or 181 here would go stale silently the moment a profile knob
+	// changed. Dev's cohort is pinned against the database by assertOverdueBand;
+	// prod-shaped's is a model corroborated by the staging measurement in gh #751.
+	// See the constants' own doc for which is which and why.
 	const (
-		devLiveContacts        = 37
-		prodShapedLiveContacts = 181
+		devCatalog        = 18
+		prodShapedCatalog = 150
+
+		devLiveContacts        = devCatalog + DevNonCatalogLiveContacts
+		prodShapedLiveContacts = prodShapedCatalog + ProdShapedNonCatalogLiveContacts
 	)
 
+	// Note on what is deliberately NOT asserted here: "the endpoint-visible set is a
+	// subset of the recomputed set". At the MODEL level that is a tautology —
+	// archetypeLeavesSlotPersistedOverdue is DEFINED as a conjunction with
+	// archetypeLeavesSlotOverdue, so no (i, n, archetype) exists at which it could
+	// fail, and asserting it would be an inert guard dressed as a real one. The
+	// property is only falsifiable against DATA, where contact_by is a column
+	// written by the cadence engine rather than a term in an expression, and that is
+	// where it lives: assertOverdueBand's require.Subset over the two id sets. That
+	// puts it in the LONG_TESTS lane (pre-push and the nightly slow workflow), not
+	// PR CI — which is a real coverage difference, but the alternative is not a
+	// cheaper guard, it is a fake one.
 	for n := 1; n <= 150; n++ {
 		total := PredictedCatalogOverdue(n) + PinnedOverdueFixtureCount
 		endpointTotal := PredictedCatalogOverduePersisted(n) + PinnedOverdueFixtureCount
@@ -407,16 +424,35 @@ func TestArchetypeAssignmentOverdueBand(t *testing.T) {
 			"n=%d: endpoint-visible overdue share %.1f%% is above the product band", n, endpointShare)
 	}
 
-	// What actually stops a silent revert to recompute-based measurement is the
-	// coverage gate's EXACT equality against PredictedCatalogOverduePersisted, and
-	// what makes that guard real is the size of the gap it would be off by. Pin the
-	// gap, not the band: the band's ceiling clears the prod-shaped recomputed share
-	// by 0.10 percentage points (40/181 = 22.10% against a 22.0% ceiling — under a
-	// fifth of one contact), which is far too little to carry an anti-revert claim.
-	for _, n := range []int{18, 150} {
-		gap := PredictedCatalogOverdue(n) - PredictedCatalogOverduePersisted(n)
-		require.GreaterOrEqual(t, gap, 3,
-			"n=%d: the recomputed and endpoint-visible models must differ by enough contacts (%d) that measuring the wrong one fails the coverage gate's exact equality by an unmistakable margin", n, gap)
+	// What stops a silent revert to recompute-based measurement is the coverage
+	// gate's EXACT equality against PredictedCatalogOverduePersisted, and what makes
+	// that guard real is the GAP it would be off by. The band cannot do that job:
+	// its ceiling clears the prod-shaped recomputed share by 0.10 percentage points
+	// (40/181 = 22.10% against 22.0%), under a fifth of one contact.
+	//
+	// The gap is SIZE-DEPENDENT, and pinning it exactly — at the sizes that ship AND
+	// at the sizes gates actually run at — is the point of this block. Those are not
+	// the same set. assertOverdueBand has exactly two call sites, n=18 (dev) and n=9
+	// (prod-shaped, whose coverage test bounds its catalog for CI); n=150 ships but
+	// is executed by no gate. So the enforced anti-revert margin is three contacts on
+	// the dev lane, and n=9's ZERO is pinned deliberately: at that size the two
+	// models coincide, so on the prod-shaped lane a revert to recompute-based
+	// measurement passes the equality, passes the subset check on identical sets, and
+	// skips the band branch (n < archetypeLadderFullAssignment) entirely. That lane
+	// has no anti-revert power at all. Pinning the zero keeps the blind spot an
+	// asserted fact rather than something a later reader has to rediscover.
+	for _, c := range []struct {
+		n       int
+		wantGap int
+		note    string
+	}{
+		{n: 9, wantGap: 0, note: "prod-shaped coverage lane (CI-bounded catalog) — the models COINCIDE here, so this lane cannot detect a revert"},
+		{n: 18, wantGap: 3, note: "dev coverage lane — the only executing gate with anti-revert power"},
+		{n: 150, wantGap: 9, note: "shipped prod-shaped size — no gate executes it; this is the number staging would have caught"},
+	} {
+		gap := PredictedCatalogOverdue(c.n) - PredictedCatalogOverduePersisted(c.n)
+		require.Equal(t, c.wantGap, gap,
+			"n=%d: the gap between the recomputed and endpoint-visible models is the margin a revert to the wrong measurement is caught by — %s", c.n, c.note)
 	}
 
 	// The shipping shares, against the REAL live denominators. These are the numbers

--- a/backend/internal/synthetic/fixtures_test.go
+++ b/backend/internal/synthetic/fixtures_test.go
@@ -136,8 +136,16 @@ func TestPinnedOverdueFixturesCloseTheDiversityGap(t *testing.T) {
 		ct, err := cadence.ParseCadence(pair.cadence)
 		require.NoError(t, err)
 		period := cadence.GetCadenceDuration(ct)
-		require.Greater(t, pair.createdAge, period,
-			"fixture %s (%s, age %s) must be overdue under prod durations (age > period %s)", pair.marker, pair.cadence, pair.createdAge, period)
+		// Same bound the catalog ladder is held to (TestCatalogOverdueLadderWellFormed),
+		// and for the same two reasons: these fixtures are counted into the coverage
+		// gate's exact equalities through PinnedOverdueFixtureCount, which assumes
+		// every one of them is overdue in the PERSISTED contact_by column; and an
+		// entry overdue by less than a day makes whether DateOnly(created_at + period)
+		// has crossed today's date depend on where the anchor sits in the day. The
+		// margin removes both.
+		require.GreaterOrEqual(t, pair.createdAge, period+calmMargin,
+			"fixture %s (%s, age %s) must be overdue under prod durations by at least the calm margin (age >= period %s + %s) — PinnedOverdueFixtureCount counts it as endpoint-overdue, and a sub-day margin makes that wall-clock dependent",
+			pair.marker, pair.cadence, pair.createdAge, period, calmMargin)
 
 		// Backdated past the coherence gate's 14-day floor, so each fixture is a
 		// genuine backdated-overdue contact rather than a recent one that merely

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -164,8 +164,21 @@ func TestCatalogOverdueLadderWellFormed(t *testing.T) {
 
 		// Genuinely overdue under prod durations: created-age exceeds the cadence
 		// period, so the computed contact_by has elapsed.
-		require.Greater(t, pair.createdAge, period,
-			"ladder[%d] (%s, age %s) must be overdue under prod durations (age > period %s)", i, pair.cadence, pair.createdAge, period)
+		//
+		// The bound is period + calmMargin, not a bare `>`, because
+		// catalogSlotNativelyOverdue — which the endpoint-visible overdue prediction
+		// is built on — admits a slot only at that margin. A ladder entry landing in
+		// [period, period+calmMargin) would satisfy a bare `>` and still be predicted
+		// NOT natively overdue, which would silently drop it from
+		// PredictedCatalogOverduePersisted while the world still contains it. Worse,
+		// a created_age within a day of its period is overdue by less than a day, so
+		// whether DateOnly(created_at + period) has crossed today's date depends on
+		// where the anchor sits in the day — the exact-equality assertion in the
+		// coverage gate would become wall-clock dependent. Today's entries clear by
+		// four days or more; this keeps that a property rather than a coincidence.
+		require.GreaterOrEqual(t, pair.createdAge, period+calmMargin,
+			"ladder[%d] (%s, age %s) must be overdue under prod durations by at least the calm margin (age >= period %s + %s) — catalogSlotNativelyOverdue admits it only at that bound, and a sub-day margin makes the coverage gate's exact equality wall-clock dependent",
+			i, pair.cadence, pair.createdAge, period, calmMargin)
 
 		overdue := pair.createdAge - period
 		overdueMagnitudes[overdue] = true

--- a/backend/tests/synthetic_archetype_integration_test.go
+++ b/backend/tests/synthetic_archetype_integration_test.go
@@ -251,10 +251,18 @@ func assertArchetypeReplayOutcomes(t *testing.T, ctx context.Context, database *
 		assertCadenceShape(t, label, want.CadenceShape, ts, newest)
 
 		// --- 4. overdue preservation under PRODUCTION durations -----------------
-		// The suite runs under CRM_ENV=test, where annual is two hours and every
-		// contact is trivially overdue, so reading the ambient config would prove
-		// nothing. The durations are constructed explicitly and evaluated at the
-		// seeded world's own anchor.
+		// The durations are constructed explicitly rather than read from the ambient
+		// config, and evaluated at the seeded world's own anchor, so this states a
+		// production-duration expectation whatever CRM_ENV happens to be — under
+		// CRM_ENV=test annual is two hours and every contact would be trivially
+		// overdue.
+		//
+		// This is the RECOMPUTE, and it is the right read HERE: the claim is about
+		// what each archetype's history does to last_contacted, which is the
+		// archetype's own contract. It is NOT a claim about what
+		// GET /contacts/overdue returns — the persisted contact_by column can
+		// disagree with it (see archetypeLeavesSlotPersistedOverdue) — and the
+		// population gate that must answer for the endpoint is assertOverdueBand.
 		bucket, ok := bucketByID[sample.ContactID]
 		require.True(t, ok, "%s: the catalog contact must be live in the namespace", label)
 		require.NotNil(t, bucket.Cadence, "%s: every catalog slot is cadence-bearing", label)

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -1183,9 +1183,8 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 
 	params, err := synthetic.ProfileParams(synthetic.ProfileProdShaped)
 	require.NoError(t, err)
-	// Captured BEFORE the CI bounding below, so the live-population expectation can
-	// be derived from how far this test bounds the profile rather than restating a
-	// measured total. See the assertOverdueBand call at the end.
+	// Captured BEFORE the CI bounding below; the live-population expectation at the
+	// assertOverdueBand call is derived from the difference.
 	shippedSeededMerged := params.Counts.SeededMerged
 	params.Namespace = syntheticNS(t)
 	// Bound the prod-shaped volume for CI: the orchestration is the same at a
@@ -1606,19 +1605,12 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// assignment the seed applied is the one the pure function derives and that the
 	// two counters show the collapse.
 	assertArchetypeCohorts(t, ctx, h, res, params.Counts.SeededContacts)
-	// This test bounds its volume knobs for CI, so its non-catalog cohort is smaller
-	// than the shipped prod-shaped figure. Exactly ONE of those knobs moves a
-	// live-contact count: SeededMerged. Each merge pair creates two contacts and
-	// leaves one LIVE — the loser is tombstoned and the buckets query filters it —
-	// so bounding the pair count costs one live contact per pair dropped. (The other
-	// bounded knobs — UnmatchedExternal, StrandedTelegram, StrandedMessages,
-	// UnmatchedCalendar — replay MatchUnknown payloads and create no contact rows at
-	// all, so they cannot move this number in either direction.)
-	//
-	// DERIVED from the shipped constant and the override, not restated as a literal:
-	// a future change to either SeededMerged value moves this automatically, so the
-	// number and its explanation cannot come apart. That divergence is exactly how
-	// the previous version of this comment came to blame the wrong four knobs.
+	// This test bounds SeededMerged for CI, which shrinks its non-catalog cohort
+	// below the shipped prod-shaped figure: each merge pair creates two contacts and
+	// leaves one LIVE (MergeContacts soft-deletes the loser, and the buckets query
+	// filters deleted_at IS NULL), so every pair dropped costs one live contact.
+	// Derived from the shipped constant and the override rather than restated as a
+	// literal, so it tracks either value.
 	wantNonCatalogLive := synthetic.ProdShapedNonCatalogLiveContacts - (shippedSeededMerged - params.Counts.SeededMerged)
 	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts, wantNonCatalogLive)
 

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -938,21 +938,39 @@ func assertArchetypeSettleBudget(t *testing.T, res synthetic.ProfileResult) {
 		"settles must stay strictly below payloads — a per-payload replay loop settles once PER payload, so equality is the regression")
 }
 
-// assertOverdueBand measures the overdue population from the DATABASE and holds
-// it against the assignment's prediction, the absolute ceiling, and the target
-// share of the live world.
+// assertOverdueBand measures the overdue population from the DATABASE, TWICE —
+// once by recomputing overdue-ness from (cadence, last_contacted, created_at),
+// and once through the predicate GET /contacts/overdue actually runs — and holds
+// each against its own model, the absolute ceiling, and the target share.
 //
-// The measurement constructs PRODUCTION cadence durations explicitly and
-// evaluates them at the seeded world's own anchor. The suite runs under
-// CRM_ENV=test, where annual is two hours and every contact is trivially overdue,
-// so a count taken through the ambient config would be meaningless — and mutating
-// the variable would change cadence semantics for every concurrently-running
-// test.
+// Measuring twice is the point. The two quantities are not the same, and the
+// difference is not a rounding error: contact_by is written FORWARD-ONLY, so an
+// archetype whose newest two-way entry predates its contact's created_at moves
+// last_contacted backwards past created_at while leaving contact_by at the
+// creation-time value. The recompute calls that contact overdue; the endpoint
+// does not return it. Asserting the band on the recompute alone let a
+// nine-contact divergence ship silently to staging (gh #751), because the band
+// is a statement about what the PRODUCT shows and the recompute is not that.
 //
-// The prediction-versus-measurement equality is what keeps the assignment's
-// denominator MODEL honest: the model is never the assertion, the database is.
+// The recompute constructs PRODUCTION cadence durations explicitly rather than
+// reading the ambient config, so it states a production-duration expectation
+// whatever CRM_ENV happens to be. The persisted column cannot do that — it was
+// written by the seed through the ambient config — so the production-duration
+// precondition is asserted outright below instead of assumed.
+//
+// The prediction-versus-measurement equalities are what keep the assignment's
+// MODELS honest: a model is never the assertion, the database is.
 func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, n int) {
 	t.Helper()
+
+	// Precondition, not an assumption. The persisted contact_by column holds
+	// base + AMBIENT cadence period, so the endpoint-visible count below is the
+	// production quantity only while the ambient table IS the production one.
+	// Under CRM_ENV=test annual is two hours and every column would be minutes
+	// wide, which would make the band meaningless rather than merely wrong — so
+	// fail loudly and say why, rather than grading nonsense.
+	require.Equal(t, cadence.ProductionCadenceConfig(), cadence.GetCadenceConfig(),
+		"the overdue band is a production-duration statement and the persisted contact_by column is written through the AMBIENT cadence table; run this suite without a compressed CRM_ENV")
 
 	buckets, err := support.ListContactBucketsByNamePrefix(ctx, h.Generator().Prefix())
 	require.NoError(t, err)
@@ -968,12 +986,25 @@ func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.Sy
 		}
 	}
 
+	// The endpoint's own read: contact_by set and strictly before today's DATE,
+	// namespace-scoped and unbounded (the production query's global LIMIT would
+	// let an accumulated shared test DB truncate the window). Evaluated at the
+	// same anchor the recompute uses, so the two counts answer one question about
+	// one instant instead of straddling the seed's own duration.
+	endpointOverdueIDs, err := support.ListOverdueContactIdsByNamePrefix(ctx, h.Generator().Prefix(), cadence.Today(anchor))
+	require.NoError(t, err)
+	endpointOverdue := len(endpointOverdueIDs)
+
 	// The pinned overdue fixtures sit outside the catalog and are always overdue,
-	// so the assignment's catalog prediction accounts for them separately. The
+	// so the assignment's catalog predictions account for them separately. The
 	// count is READ from the seed rather than restated here, so a change to the
-	// fixture table cannot drift the budget and this assertion apart.
+	// fixture table cannot drift the budget and these assertions apart.
 	require.Equal(t, synthetic.PredictedCatalogOverdue(n)+synthetic.PinnedOverdueFixtureCount, overdue,
-		"the measured overdue population must equal what the assignment predicts — a drifting model has to fail here rather than be trusted")
+		"the recomputed overdue population must equal what the assignment predicts — a drifting model has to fail here rather than be trusted")
+	require.Equal(t, synthetic.PredictedCatalogOverduePersisted(n)+synthetic.PinnedOverdueFixtureCount, endpointOverdue,
+		"the ENDPOINT-visible overdue population must equal what the assignment predicts for the persisted contact_by column — this is the assertion gh #751 was missing")
+	require.LessOrEqual(t, endpointOverdue, overdue,
+		"the endpoint's overdue set is contact_by in the past, which the forward-only write makes a SUBSET of the recomputed set — the reverse is a cadence-write regression, not a modelling gap")
 	require.LessOrEqual(t, overdue, synthetic.OverdueCeiling,
 		"the overdue population must stay under the ceiling; the overdue tours refuse to run above their own, higher, capture cap")
 
@@ -982,9 +1013,11 @@ func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.Sy
 	}
 	live := len(buckets)
 	require.Positive(t, live)
-	share := 100.0 * float64(overdue) / float64(live)
-	require.GreaterOrEqual(t, share, 20.0, "overdue share %.1f%% of %d live contacts is below the target band", share, live)
-	require.LessOrEqual(t, share, 27.0, "overdue share %.1f%% of %d live contacts is above the target band", share, live)
+	share := 100.0 * float64(endpointOverdue) / float64(live)
+	require.GreaterOrEqual(t, share, synthetic.OverdueBandFloorPercent,
+		"endpoint-visible overdue share %.1f%% of %d live contacts is below the target band", share, live)
+	require.LessOrEqual(t, share, synthetic.OverdueBandCeilingPercent,
+		"endpoint-visible overdue share %.1f%% of %d live contacts is above the target band", share, live)
 }
 
 func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
@@ -1572,6 +1605,16 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	}
 	require.Equal(t, driftingID, contactedOverdue[0],
 		"the contacted-and-overdue contact must be the slot the assignment gave mutual-drifting to")
+
+	// …and the product has to AGREE that it is overdue. The state exists to put a
+	// contacted-and-overdue card on the dashboard, so recomputing overdue-ness is
+	// not enough: the same contact must come back from the predicate the overdue
+	// endpoint runs against the persisted contact_by column. Recompute-only was
+	// exactly how a nine-contact shortfall reached staging unnoticed (gh #751).
+	endpointOverdueIDs, err := support.ListOverdueContactIdsByNamePrefix(ctx, prefix, cadence.Today(anchor))
+	require.NoError(t, err)
+	require.Contains(t, endpointOverdueIDs, driftingID,
+		"the reserved rung's contacted-and-overdue contact must also be returned by the overdue ENDPOINT — a contact the product does not list as overdue does not supply the state")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -976,24 +976,36 @@ func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.Sy
 	require.NoError(t, err)
 	anchor := h.Generator().Anchor()
 
-	overdue := 0
+	recomputedIDs := make([]uuid.UUID, 0, len(buckets))
 	for _, b := range buckets {
 		if b.Cadence == nil || *b.Cadence == "" || b.CreatedAt == nil {
 			continue
 		}
 		if synthetic.OverdueAtProduction(*b.Cadence, b.LastContacted, *b.CreatedAt, anchor) {
-			overdue++
+			recomputedIDs = append(recomputedIDs, b.ID)
 		}
 	}
+	overdue := len(recomputedIDs)
 
 	// The endpoint's own read: contact_by set and strictly before today's DATE,
 	// namespace-scoped and unbounded (the production query's global LIMIT would
 	// let an accumulated shared test DB truncate the window). Evaluated at the
-	// same anchor the recompute uses, so the two counts answer one question about
+	// same anchor the recompute uses, so the two reads answer one question about
 	// one instant instead of straddling the seed's own duration.
 	endpointOverdueIDs, err := support.ListOverdueContactIdsByNamePrefix(ctx, h.Generator().Prefix(), cadence.Today(anchor))
 	require.NoError(t, err)
 	endpointOverdue := len(endpointOverdueIDs)
+
+	// MEMBERSHIP first, and over the id SETS rather than their sizes. The endpoint
+	// returns contact_by in the past, which the forward-only write can only ever
+	// make a subset of the recomputed set — a contact the endpoint lists as overdue
+	// while the recompute does not means the persisted column and the cadence
+	// formula have drifted apart, which is a different and worse failure than a
+	// count being off. Comparing counts would miss it entirely whenever the
+	// cardinalities happen to match, and the two exact equalities below would
+	// happily pass on a set with the wrong members in it.
+	require.Subset(t, recomputedIDs, endpointOverdueIDs,
+		"every contact the overdue ENDPOINT returns must also be overdue by the cadence formula — an endpoint-only overdue contact means contact_by no longer agrees with (cadence, last_contacted, created_at)")
 
 	// The pinned overdue fixtures sit outside the catalog and are always overdue,
 	// so the assignment's catalog predictions account for them separately. The
@@ -1002,9 +1014,7 @@ func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.Sy
 	require.Equal(t, synthetic.PredictedCatalogOverdue(n)+synthetic.PinnedOverdueFixtureCount, overdue,
 		"the recomputed overdue population must equal what the assignment predicts — a drifting model has to fail here rather than be trusted")
 	require.Equal(t, synthetic.PredictedCatalogOverduePersisted(n)+synthetic.PinnedOverdueFixtureCount, endpointOverdue,
-		"the ENDPOINT-visible overdue population must equal what the assignment predicts for the persisted contact_by column — this is the assertion gh #751 was missing")
-	require.LessOrEqual(t, endpointOverdue, overdue,
-		"the endpoint's overdue set is contact_by in the past, which the forward-only write makes a SUBSET of the recomputed set — the reverse is a cadence-write regression, not a modelling gap")
+		"the ENDPOINT-visible overdue population must equal what the assignment predicts for the persisted contact_by column — this is the assertion gh #751 was missing, and the one a silent revert to recompute-based measurement fails by nine contacts at prod-shaped")
 	require.LessOrEqual(t, overdue, synthetic.OverdueCeiling,
 		"the overdue population must stay under the ceiling; the overdue tours refuse to run above their own, higher, capture cap")
 

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -1183,6 +1183,10 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 
 	params, err := synthetic.ProfileParams(synthetic.ProfileProdShaped)
 	require.NoError(t, err)
+	// Captured BEFORE the CI bounding below, so the live-population expectation can
+	// be derived from how far this test bounds the profile rather than restating a
+	// measured total. See the assertOverdueBand call at the end.
+	shippedSeededMerged := params.Counts.SeededMerged
 	params.Namespace = syntheticNS(t)
 	// Bound the prod-shaped volume for CI: the orchestration is the same at a
 	// smaller scale, and the coverage buckets each still get ≥1 representative.
@@ -1602,14 +1606,21 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// assignment the seed applied is the one the pure function derives and that the
 	// two counters show the collapse.
 	assertArchetypeCohorts(t, ctx, h, res, params.Counts.SeededContacts)
-	// This test bounds its volume knobs for CI (UnmatchedExternal, StrandedTelegram,
-	// StrandedMessages, UnmatchedCalendar above), which shrinks the non-catalog
-	// cohort below the shipped prod-shaped figure. So the number pinned here is the
-	// BOUNDED cohort, not synthetic.ProdShapedNonCatalogLiveContacts — pinning it
-	// anyway is what keeps the bounding itself from drifting unnoticed, since no
-	// lane measures the shipped prod-shaped world at all.
-	const prodShapedBoundedNonCatalogLive = 29
-	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts, prodShapedBoundedNonCatalogLive)
+	// This test bounds its volume knobs for CI, so its non-catalog cohort is smaller
+	// than the shipped prod-shaped figure. Exactly ONE of those knobs moves a
+	// live-contact count: SeededMerged. Each merge pair creates two contacts and
+	// leaves one LIVE — the loser is tombstoned and the buckets query filters it —
+	// so bounding the pair count costs one live contact per pair dropped. (The other
+	// bounded knobs — UnmatchedExternal, StrandedTelegram, StrandedMessages,
+	// UnmatchedCalendar — replay MatchUnknown payloads and create no contact rows at
+	// all, so they cannot move this number in either direction.)
+	//
+	// DERIVED from the shipped constant and the override, not restated as a literal:
+	// a future change to either SeededMerged value moves this automatically, so the
+	// number and its explanation cannot come apart. That divergence is exactly how
+	// the previous version of this comment came to blame the wrong four knobs.
+	wantNonCatalogLive := synthetic.ProdShapedNonCatalogLiveContacts - (shippedSeededMerged - params.Counts.SeededMerged)
+	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts, wantNonCatalogLive)
 
 	// The reserved rung's whole point: exactly one CONTACTED-AND-OVERDUE contact —
 	// a state the seed produces nowhere else — and it is the slot the assignment

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -960,7 +960,13 @@ func assertArchetypeSettleBudget(t *testing.T, res synthetic.ProfileResult) {
 //
 // The prediction-versus-measurement equalities are what keep the assignment's
 // MODELS honest: a model is never the assertion, the database is.
-func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, n int) {
+//
+// wantNonCatalogLive is how many LIVE contacts the profile seeds outside the
+// catalog, so the live denominator is pinned rather than merely read. Without it
+// the share assertions accept any denominator that keeps the ratio in band — at
+// dev that is a 23-contact window — and a profile knob change would move the world
+// without moving a single assertion.
+func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, n, wantNonCatalogLive int) {
 	t.Helper()
 
 	// Precondition, not an assumption. The persisted contact_by column holds
@@ -975,6 +981,10 @@ func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.Sy
 	buckets, err := support.ListContactBucketsByNamePrefix(ctx, h.Generator().Prefix())
 	require.NoError(t, err)
 	anchor := h.Generator().Anchor()
+
+	require.Equal(t, n+wantNonCatalogLive, len(buckets),
+		"the live population must be the catalog (%d) plus this profile's non-catalog cohort (%d) — the overdue share's denominator is pinned, not merely read, so a knob change that moves the world cannot leave every assertion still passing",
+		n, wantNonCatalogLive)
 
 	recomputedIDs := make([]uuid.UUID, 0, len(buckets))
 	for _, b := range buckets {
@@ -1014,7 +1024,7 @@ func assertOverdueBand(t *testing.T, ctx context.Context, support *repository.Sy
 	require.Equal(t, synthetic.PredictedCatalogOverdue(n)+synthetic.PinnedOverdueFixtureCount, overdue,
 		"the recomputed overdue population must equal what the assignment predicts — a drifting model has to fail here rather than be trusted")
 	require.Equal(t, synthetic.PredictedCatalogOverduePersisted(n)+synthetic.PinnedOverdueFixtureCount, endpointOverdue,
-		"the ENDPOINT-visible overdue population must equal what the assignment predicts for the persisted contact_by column — this is the assertion gh #751 was missing, and the one a silent revert to recompute-based measurement fails by nine contacts at prod-shaped")
+		"the ENDPOINT-visible overdue population must equal what the assignment predicts for the persisted contact_by column — this is the assertion gh #751 was missing. Its anti-revert margin is the gap between the two models AT THIS n: three contacts at n=18, and ZERO at n=9, where they coincide and this assertion cannot detect a revert at all (pinned in TestArchetypeAssignmentOverdueBand)")
 	require.LessOrEqual(t, overdue, synthetic.OverdueCeiling,
 		"the overdue population must stay under the ceiling; the overdue tours refuse to run above their own, higher, capture cap")
 
@@ -1141,7 +1151,9 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// Archetype cohorts: the catalog's interaction state now EMERGES from replayed
 	// source payloads, so assert the cohorts exist, vary, and collapse as intended.
 	assertArchetypeCohorts(t, ctx, h, res, params.Counts.SeededContacts)
-	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts)
+	// Dev seeds at its natural knobs, so its non-catalog cohort is the shipped one
+	// and this call PINS synthetic.DevNonCatalogLiveContacts against the database.
+	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts, synthetic.DevNonCatalogLiveContacts)
 }
 
 // assertNotesCoverage runs the F6 notes gate: the profile seeds a note on a
@@ -1590,7 +1602,14 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// assignment the seed applied is the one the pure function derives and that the
 	// two counters show the collapse.
 	assertArchetypeCohorts(t, ctx, h, res, params.Counts.SeededContacts)
-	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts)
+	// This test bounds its volume knobs for CI (UnmatchedExternal, StrandedTelegram,
+	// StrandedMessages, UnmatchedCalendar above), which shrinks the non-catalog
+	// cohort below the shipped prod-shaped figure. So the number pinned here is the
+	// BOUNDED cohort, not synthetic.ProdShapedNonCatalogLiveContacts — pinning it
+	// anyway is what keeps the bounding itself from drifting unnoticed, since no
+	// lane measures the shipped prod-shaped world at all.
+	const prodShapedBoundedNonCatalogLive = 29
+	assertOverdueBand(t, ctx, support, h, params.Counts.SeededContacts, prodShapedBoundedNonCatalogLive)
 
 	// The reserved rung's whole point: exactly one CONTACTED-AND-OVERDUE contact —
 	// a state the seed produces nowhere else — and it is the slot the assignment


### PR DESCRIPTION
Closes #751.

## The divergence, and why the gate could not see it

The seed's overdue band was asserted by **recomputing** overdue-ness from `(cadence, last_contacted, created_at)` through `synthetic.OverdueAtProduction`, while `GET /contacts/overdue` establishes it by reading the persisted **`contact_by`** column. Those are different quantities. On deployed staging they differed by nine contacts (40 recomputed, 31 endpoint-visible) and the coherence gate measured only the first one, so it stayed green.

## Root cause — established, reproduced locally, not fixed here

`contact_by` is written **forward-only**. `CreateContact` seeds it at `DateOnly(created_at + period)`; the interaction-driven write (`UpdateContactCadenceForward`) then only ever *raises* it — `AND (contact_by IS NULL OR incoming > contact_by)`. `last_contacted` is forward-only too, but it starts NULL, so it *does* advance. So whenever an archetype's newest two-way entry predates its contact's own `created_at`, `last_contacted` moves backwards past `created_at` while `contact_by` keeps the creation-time value. The recompute (which bases on `last_contacted`) says overdue; the endpoint (which reads `contact_by`) does not return the contact.

History predating `created_at` is the normal shape of a backfill and something the catalog produces deliberately, so this is a designed-for shape, not a corner case.

**Reproduced locally**, no staging access needed — `TestSyntheticProfile_DevCoversCatalog`, dev profile, n=18, 37 live contacts:

| Overdue count | Value |
|---|---|
| recomputed | 9 |
| endpoint predicate (`contact_by < today`) | 6 |

All three divergent rows carried a `last_contacted` several months before an almost-new `created_at`, with `contact_by` a week or two in the *future*. The issue's lead about 16 rows with `last_contacted` and a NULL `contact_by` was a red herring: those are the cadence-less cohort, and both reads agree they are not overdue.

The pure model this PR adds predicts **31** endpoint-visible at n=150 against **40** recomputed — which is, to the contact, what deployed staging returned. The root cause is fully accounted for without a staging measurement.

Whether the *application* should behave this way is filed separately as **#753** and deliberately not touched here. A real user hits it as: contact created today, Gmail sync discovers a four-month-old thread, detail page says "last contacted 4 months ago", overdue list and dashboard never show them.

## What changed

1. **`assertOverdueBand` measures both quantities** and models both. New `synthetic.PredictedCatalogOverduePersisted` predicts the endpoint-visible set as the conjunction `natively-overdue AND recompute-overdue` — which is exact, because `contact_by` ends up at `max(created_at + period, last_contacted + period)` and a maximum is in the past only when both terms are. The product-facing band now sits on the endpoint's own predicate (`ListOverdueContactIdsByNamePrefix`, the existing namespace-scoped copy of the production query). The recompute assertion stays: it is what the assignment's budget can actually steer.
2. **`endpoint ⊆ recomputed` is asserted over the id SETS**, via `require.Subset`, ordered *before* the two exact-count equalities. Comparing counts would have been inert — a real membership violation with matching cardinality passes every count assertion. An endpoint-only overdue contact means `contact_by` and the cadence formula have drifted apart, which is a different and worse failure than a count being off, and it now reports as such.
3. **The production-duration precondition is asserted, not assumed.** The persisted column holds `base + AMBIENT cadence period`, so the gate requires `cadence.GetCadenceConfig() == cadence.ProductionCadenceConfig()`. Relatedly, the comment claiming "the suite runs under CRM_ENV=test" was simply false — no `make test-integration*` target sets `CRM_ENV`, so the Go integration suite has always run on production durations. That false premise is what made a recompute look mandatory. Corrected in all three places it appeared (`assertOverdueBand`, `OverdueAtProduction`, and `synthetic_archetype_integration_test.go`); remaining `CRM_ENV=test` mentions in the tree are true conditionals and are left alone.
4. **The reserved rung's contacted-and-overdue contact** must now also come back from the endpoint, not merely recompute as overdue. A contact the product does not list as overdue does not supply that state.
5. **The overdue ladder's and the pinned fixtures' well-formedness guards are tightened** from `createdAge > period` to `createdAge >= period + calmMargin`, matching what `catalogSlotNativelyOverdue` actually admits. An entry landing in `[period, period + 24h)` would have passed the old guard while being predicted *not* natively overdue — and, being overdue by less than a day, would have made the coverage gate's exact equality depend on where the anchor sits in the day. Both tables feed the same equalities (`pinnedOverdueFixtures` via `PinnedOverdueFixtureCount`), so both get the bound. Latent today — the ladder's minimum clearance is exactly 4.00 days.

6. **Docs**: a new section in `.ai/patterns/synthetic-seed-toolkit.md` on asserting population shape through the read the product performs. No `spec/*.yaml` behavior states the seed's band (the spec covers product behavior; `CAD-007`/`CAD-008` already describe the forward-only mechanism), so no spec change.

## The restated band: 12–22% of live contacts

Derivation, not a golden number. The endpoint-visible set is the natively-overdue (backdated) catalog slots that no calm archetype rescued, plus the two pinned fixtures. Backdated slots are one catalog index in three, so the numerator grows like `n/3` less the calm quota while the denominator grows like `n` plus a fixed non-catalog cohort — a share in the mid-to-high teens across the whole assignable range. Sweeping `n` over `[12, 150]` against the dev-knob denominator spans **12.9%–21.1%**; the two shipped worlds measure **16.2%** (dev, 6 of 37) and **17.1%** (prod-shaped, 31 of 181). The band is that sweep rounded outward to whole points.

It is wide enough that the calm quota, the ladder, or the non-catalog cohort can move by a couple of contacts without flaking — at prod-shaped one contact is 0.55% of the share.

**How much it protects against a revert to recompute-based measurement is lane-dependent**, so it is stated per lane rather than as one sentence:

| lane | band branch | a revert is caught by |
|---|---|---|
| dev, n=18 | executes | **the band** (9/37 = 24.3% vs the 22.0% ceiling, 2.3 points of margin) **and** the exact equality (by 3 contacts) |
| prod-shaped, n=9 | skipped (`n < archetypeLadderFullAssignment`) | **nothing** — the two models coincide, gap 0 |
| n=150 (shipped) | — | would be 22.10% vs 22.0%, but no gate runs there |

So the band is not decorative: at the only scope that executes it, it is one of two independent catches, with 5.8 points still left above the legitimate 16.2% persisted share. The reason not to *lean* on it is the n=150 row, where the margin is a fifth of a contact.

The reason not to *lean* on it is the n=150 row, where the margin is a fifth of a contact — which is why the exact equality, not the band, is what the anti-revert claim rests on.

### What the anti-revert guarantee actually is

That assertion is the coverage gate's **exact equality** against `PredictedCatalogOverduePersisted`. Its margin is the gap between the two models, and the gap is **size-dependent** — which matters, because the sizes that ship and the sizes gates run at are not the same set:

| n | model gap | executed by |
|---|---|---|
| 9 | **0** | `TestSyntheticProfile_ProdShapedCoverageCheck` (catalog bounded for CI) |
| 18 | 3 | `TestSyntheticProfile_DevCoversCatalog` |
| 150 | 9 | nothing — the shipped prod-shaped size |

At n=9 the two models coincide, so on the prod-shaped lane a revert passes the equality, passes the `Subset` check on identical sets, and skips the band branch (`n < archetypeLadderFullAssignment`) entirely. **That lane has no anti-revert power at all.** The enforced margin is **three contacts, on the dev lane**, in the LONG_TESTS lane — pre-push and the nightly `backend-slow-tests.yml`, not PR CI (`ci-test` runs `test-integration-fast`, which skips it).

The earlier draft of this PR claimed nine, which is the n=150 gap no gate runs. The unit test now pins all three gaps **exactly**, each labelled with whether a gate executes it, so the n=9 zero is an asserted fact rather than an omission a later reader has to rediscover.

### Denominators are derived and pinned, not frozen

`19` and `31` previously existed only as prose inside `catalogNonCatalogLiveContacts`. They are now `synthetic.DevNonCatalogLiveContacts` / `ProdShapedNonCatalogLiveContacts`, the midpoint constant is *derived* from them, and the unit test builds `37 = 18 + 19` and `181 = 150 + 31` instead of restating measurements.

`assertOverdueBand` now takes the expected cohort and **pins the live denominator against the database**, which closes the dev lane's 23-contact staleness window (with the numerator fixed at 6, the band alone accepted live ∈ [28, 50]). Held honestly per lane:

- **Dev** seeds at its natural knobs, so its call pins the shipped cohort, 19.
- **Prod-shaped's** coverage test bounds its volume knobs for CI, which shrinks the cohort to **29**. That number is no longer a literal with a prose cause — it is *derived* as `ProdShapedNonCatalogLiveContacts - (shippedSeededMerged - params.Counts.SeededMerged)`, read from the profile before the override, so it self-corrects and cannot diverge from its explanation. The shipped 31 remains a *model*, corroborated only by the deployed-staging measurement in #751, because no lane seeds prod-shaped at n=150.

An earlier draft of this comment blamed the shrink on four bounded knobs (`UnmatchedExternal`, `StrandedTelegram`, `StrandedMessages`, `UnmatchedCalendar`). That was wrong: all four replay `MatchUnknown` payloads and create no contact rows, so none can move a live-contact count. **Measured**: `SeededMerged` 1 → 3 moves the live population 38 → 40, so each merge pair contributes exactly **one** live contact — the winner, with the loser tombstoned and filtered by the buckets query.

The constants' composition now adds up rather than gesturing: `5 × perSourceSettledCount + 4 direction cohort + 1 follow-up + 8 pinned fixtures + SeededMerged winners` gives dev `5+4+1+8+1 = 19` and prod-shaped `15+4+1+8+3 = 31`. The midpoint constant derived from them uses integer division, so its parity is asserted rather than assumed.

The arc's original intent — 20–27% of live contacts overdue *as the product shows it* — is not met by the seed as built; the reality is ~17%. That is the "less realistic than intended" consequence #751 recorded, and it is now stated where the numbers are rather than contradicted by a passing gate.

## Proof the gate can fail

**Failing-first.** With the new endpoint measurement wired up but the band still at the old 20–27%, `TestSyntheticProfile_DevCoversCatalog` fails: `endpoint-visible overdue share 16.2% of 37 live contacts is below the target band`, exit code 1 (read directly, not through a pipe).

**Injection probe.** Injected a one-line defect into the write path the gate is supposed to observe — `applyContactBy = false` in `CadenceUpdater.buildInteractionWrite`, i.e. `contact_by` never rescheduled by an interaction — confirmed the injection landed by re-reading the line from disk, and re-ran. Exit code 1, failing on:

```
expected: 6
actual  : 8
Messages: the ENDPOINT-visible overdue population must equal what the assignment predicts for the persisted contact_by column
```

The recompute equality, which runs *first*, passed — so the pre-change gate would not have caught this defect at all, which is the whole point.

**Subset probe (added in the review round).** Injected a formula drift into `cadence.CalculateContactBy` (`duration -= 10d`), so `contact_by` disagrees with the overdue formula and weekly recently-created slots become endpoint-overdue without being recompute-overdue. Exit code 1, failing on the new `require.Subset` — "every contact the overdue ENDPOINT returns must also be overdue by the cadence formula" — and failing there *first*, ahead of the count equalities, which is the ordering the guard depends on.

**Ladder-margin probe (added in the review round).** Added a ladder entry at `monthly, 30d + 12h`, inside `[period, period + calmMargin)`. The old guard (`createdAge > period`) would have accepted it; the new one fails: `"732h0m0s" is not greater than or equal to "744h0m0s"`. Exit code 1.

**Denominator probe.** Set `DevNonCatalogLiveContacts` to 20 — the exact staleness the pin exists to catch. Exit 1: `expected: 38, actual: 37`.

**Pinned-fixture margin probe.** Set `fxoverdueb` to `biweekly, 14d + 12h`. Exit 1: `"348h0m0s" is not greater than or equal to "360h0m0s"`. The old guard would have accepted it.

**Gap-pin probe.** Changed the n=9 expectation from 0 to 1. Exit 1: `expected: 1, actual: 0` — the pinned zero is an exact equality, so it cannot be vacuous.

**Parity probe.** Set `DevNonCatalogLiveContacts` to 20 (sum 51, odd). Exit 1: "the two non-catalog cohorts must sum to an EVEN number".

**Derivation probe (positive).** Set the prod-shaped test's `SeededMerged` override to 2. The derived cohort became 30 and the test **passed** at live = 39 — proving the formula tracks the knob rather than restating a frozen total.

All injections reverted, tree verified clean by `git status` after each, full suite re-run green (`make lint`, `make test-unit`, and the three affected integration tests).

Rebased onto `origin/develop` after #754 and #755 landed.
