### PR TITLE
perf(hooks): run the fast integration set in pre-push

### DIFF
--- a/.ai/pre-push.json
+++ b/.ai/pre-push.json
@@ -25,7 +25,7 @@
       { "name": "Pre-push filter unit tests", "command": "bash scripts/hooks/test/test-pre-push-filters.sh" },
       { "name": "Deploy script tests", "command": "make test-deploy-scripts" },
       { "name": "Unit tests", "command": "make test-unit" },
-      { "name": "Integration tests", "command": "make test-integration" },
+      { "name": "Integration tests", "command": "make test-integration-fast" },
       { "name": "Frontend tests", "command": "make test-frontend" },
       { "name": "E2E tests", "command": "make test-e2e-diff" }
     ]

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -323,7 +323,7 @@ classify_command() {
 # FRONTEND, FILTER, E2E) so every .test.commands[] entry in a lane runs and its
 # `optional` flag is honored — matching the prior hook, which ran every command.
 # For today's two required GO commands this reduces to
-# `make test-unit && make test-integration`.
+# `make test-unit && make test-integration-fast`.
 run_lane() {
   # $@ alternates: cmd optional cmd optional ...
   local cmd optional

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -20,6 +20,7 @@ assert_eq "test-pre-push-filters -> CONCURRENT"         "CONCURRENT" "$(classify
 assert_eq "test-deploy-scripts -> CONCURRENT"           "CONCURRENT" "$(classify_command 'make test-deploy-scripts')"
 assert_eq "test-unit -> GO"                             "GO"         "$(classify_command 'make test-unit')"
 assert_eq "test-integration -> GO"                      "GO"         "$(classify_command 'make test-integration')"
+assert_eq "test-integration-fast -> GO"                 "GO"         "$(classify_command 'make test-integration-fast')"
 # Unrecognized command defaults to the GO (serial, DB-owning) lane — never concurrent.
 assert_eq "unrecognized command -> GO (safe default)"   "GO"         "$(classify_command 'make some-future-db-command')"
 


### PR DESCRIPTION
Pre-push ran `make test-integration` (`LONG_TESTS=1`) — a strictly larger suite than CI's PR gate, which runs `test-integration-fast`. This makes the local gate match CI.

## Measurements

Both dev machines, `bash -c 'TIMEFORMAT="real %3R user %3U sys %3S"; time make …'`:

| | `test-integration` | `test-integration-fast` | delta |
|---|---|---|---|
| macOS (12 cores, `-p 9`) | 337.0s real / 38.6s CPU | **29.2s** real / 23.4s CPU | **−307.8s (−91%)** |
| Linux sandbox (6-CPU quota, `-p 4`) | 344.2s real / 73.1s CPU | **39.6s** real / 50.9s CPU | **−304.6s (−88%)** |

The long tests add ~15–22s of **CPU** but ~305s of **wall clock** — a ~20:1 wait-to-work ratio. They sit on River's real-time maintenance loops (rescuer interval, periodic scheduler tick), not on computation. Wall clock came out within 2% across two machines with 2× different CPU budgets and different `-p` values, confirming the phase was idle rather than saturated.

For scale: the whole CI pipeline is ~4m41s. The pre-push integration phase alone was longer than that.

## Changes

- `.ai/pre-push.json` — `make test-integration` → `make test-integration-fast`
- `scripts/hooks/test/test-pre-push-phases.sh` — explicit lane assertion for the new command
- `scripts/hooks/pre-push` — refreshed the `run_lane` comment that named the old command

`classify_command` globs on `*test-integration*`, so the new command still lands in the serial DB-owning `GO` lane (and the unrecognized-command default is `GO` regardless) — no lane reclassification, no concurrency change.

## Coverage trade-off — please confirm this is what you want

The long tests (`TestSyncWorker_LoadNoDuplicateConcurrentSyncs`, `TestPeriodicTick_FiresOnStart`, `TestSyncWorker_RescueOnCrash`, `TestSynthetic`, `TestTestdb`) keep their coverage via `backend-slow-tests.yml` — but that workflow triggers on `schedule` (08:00 UTC) and `workflow_dispatch` **only**. It does not run per-PR.

So this trades push-time feedback for nightly feedback on that set, not "still gated in CI". If per-PR coverage is wanted, the follow-up is adding that job to `ci.yml`, which costs no local wall clock but would stretch CI from ~4m41s to ~6m since it becomes the long pole.

## Verification

Static and unit-level only — this environment has no Docker or Postgres, so the suites themselves were not run here, and the pre-push hook did not execute on the push (`core.hooksPath` unset, no `.git/hooks/pre-push`). The first real push from a dev machine is the true verification.

What was checked:
- `scripts/hooks/test/test-pre-push-phases.sh` — all 20 assertions pass, including the new one
- `.ai/pre-push.json` parses and the hook reads the new command
- `test-integration-fast` exists as a Makefile target

## Follow-ups

From the same audit, filed separately: #759 (seed architecture), #760 (spec citation keys), #761 (Langfuse model prices). Independent of this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmT85NaZbSK6kY5kJcnRxY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmT85NaZbSK6kY5kJcnRxY)_