### PR TITLE
feat(spec): accept keyed then-item citations (PR1/3, #760)

### DIFF
--- a/backend/cmd/spec-coverage/main_test.go
+++ b/backend/cmd/spec-coverage/main_test.go
@@ -142,6 +142,83 @@ func TestSettledLabel(t *testing.T) {
 	}
 }
 
+// TestRunKeyedCitationsClean pins the keyed form at the CLI boundary: a corpus
+// whose items are cited by key (with a keyed waiver and a reserved-token
+// statement waiver alongside) is fully covered and exits 0.
+func TestRunKeyedCitationsClean(t *testing.T) {
+	code, stdout, stderr := runCLI(t, fixtures+"/coverage-keys")
+	if code != 0 {
+		t.Fatalf("want exit 0, got %d (stderr: %s)\n%s", code, stderr, stdout)
+	}
+	if !hasLine(stdout, "spec-coverage: all ui- and api-surface then-items covered or waived") {
+		t.Errorf("clean summary line missing from stdout:\n%s", stdout)
+	}
+	// Waived lines render by key, and a statement behavior's implicit item
+	// still renders as the bare ID.
+	for _, line := range []string{
+		"  waived ALP-001.waived-outcome: not deterministically provable in the browser",
+		"  waived ALP-003: structural, enforced by the query layer rather than observable",
+	} {
+		if !hasLine(stdout, line) {
+			t.Errorf("stdout missing golden line %q; got:\n%s", line, stdout)
+		}
+	}
+}
+
+// TestSpecCoverage_KeyedCorpusInsertionStable is acceptance criterion 2 at the
+// CLI boundary: the same corpus with one item inserted at position 1 keeps
+// every keyed citation's verdict, while the indexed citations in the same
+// fixture re-point and orphan the assertion they used to name.
+func TestSpecCoverage_KeyedCorpusInsertionStable(t *testing.T) {
+	_, before, _ := runCLI(t, fixtures+"/coverage-keys")
+	code, after, _ := runCLI(t, fixtures+"/coverage-keys-inserted")
+	if code != 0 {
+		t.Fatalf("want exit 0 (alpha is unsettled, so orphans warn), got %d:\n%s", code, after)
+	}
+
+	// Keyed: the waived item is still addressed by the same reference and still
+	// waived, though an item was inserted above it.
+	const waived = "  waived ALP-001.waived-outcome: not deterministically provable in the browser"
+	if !hasLine(before, waived) || !hasLine(after, waived) {
+		t.Errorf("keyed waiver line did not survive the insertion:\nBEFORE:\n%s\nAFTER:\n%s", before, after)
+	}
+	// No keyed item that was covered before became an orphan.
+	for _, line := range []string{
+		"  ORPHAN ALP-001.first-outcome: the first outcome holds",
+		"  ORPHAN ALP-001.second-outcome: the second outcome holds",
+	} {
+		if hasLine(after, line) {
+			t.Errorf("a keyed citation lost its item across the insertion: %q\n%s", line, after)
+		}
+	}
+	// Indexed, same insertion: the assertion the citation used to name is now
+	// an orphan. If this stops holding, the fixture pair has stopped
+	// discriminating and the keyed-stability claim above proves nothing.
+	const shifted = "  ORPHAN ALP-002[2]: the indexed second outcome holds"
+	if hasLine(before, shifted) {
+		t.Fatalf("precondition: the indexed item must be covered before the insertion:\n%s", before)
+	}
+	if !hasLine(after, shifted) {
+		t.Errorf("indexed citation should have re-pointed, orphaning %q:\n%s", shifted, after)
+	}
+}
+
+// TestSpecCoverage_DanglingKeyExitsOne is acceptance criterion 3 at the CLI
+// boundary: a citation naming a key the corpus no longer carries is a hard
+// failure that names the citing site.
+func TestSpecCoverage_DanglingKeyExitsOne(t *testing.T) {
+	code, stdout, _ := runCLI(t, fixtures+"/coverage-dangling-key")
+	if code != 1 {
+		t.Fatalf("want exit 1 on a dangling keyed citation, got %d:\n%s", code, stdout)
+	}
+	if !strings.Contains(stdout, "citation ALP-001.renamed-key names an unknown then-item key (behavior has: alpha, beta)") {
+		t.Errorf("stdout missing the dangling-key problem:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "alpha_test.go:3") {
+		t.Errorf("stdout must name the citing site:\n%s", stdout)
+	}
+}
+
 func TestRunLintDirtyCorpus(t *testing.T) {
 	// A repo root whose spec/ does not lint clean is an operational error —
 	// point spec/ at a fixture with violations by faking the layout.

--- a/backend/cmd/spec-coverage/main_test.go
+++ b/backend/cmd/spec-coverage/main_test.go
@@ -192,12 +192,26 @@ func TestSpecCoverage_KeyedCorpusInsertionStable(t *testing.T) {
 		}
 	}
 	// Indexed, same insertion: the assertion the citation used to name is now
-	// an orphan. If this stops holding, the fixture pair has stopped
-	// discriminating and the keyed-stability claim above proves nothing.
-	const shifted = "  ORPHAN ALP-002[2]: the indexed second outcome holds"
-	if hasLine(before, shifted) {
-		t.Fatalf("precondition: the indexed item must be covered before the insertion:\n%s", before)
+	// an orphan. The precondition is asserted POSITIVELY — report() prints
+	// nothing for a covered item, so "no ORPHAN ALP-002[2] before" would be
+	// unfalsifiable (the fixture gives ALP-002 two items, so index 2 cannot
+	// exist before the insertion) and would prove nothing about coverage.
+	// Instead: the base corpus reports everything covered-or-waived, and
+	// ALP-002 carries no waiver, so both of its indexed items are covered —
+	// and if either were not, the clean summary would be replaced by the
+	// corresponding ORPHAN line. Both halves are checked.
+	if !hasLine(before, "spec-coverage: all ui- and api-surface then-items covered or waived") {
+		t.Fatalf("precondition: the base corpus must be fully covered-or-waived:\n%s", before)
 	}
+	for _, line := range []string{
+		"  ORPHAN ALP-002[0]: the indexed first outcome holds",
+		"  ORPHAN ALP-002[1]: the indexed second outcome holds",
+	} {
+		if hasLine(before, line) {
+			t.Fatalf("precondition: ALP-002's items must both be covered before the insertion, saw %q:\n%s", line, before)
+		}
+	}
+	const shifted = "  ORPHAN ALP-002[2]: the indexed second outcome holds"
 	if !hasLine(after, shifted) {
 		t.Errorf("indexed citation should have re-pointed, orphaning %q:\n%s", shifted, after)
 	}

--- a/backend/internal/spec/coverage.go
+++ b/backend/internal/spec/coverage.go
@@ -17,13 +17,19 @@ import (
 // coverage keyed on surface — ui behaviors via E2E citations, api behaviors
 // via Go-test citations. The CLI wrapper lives in cmd/spec-coverage.
 
-// refString renders an (ID, then-index) reference as written in a marker:
-// the bare ID for then < 0, else ID[n].
-func refString(id string, then int) string {
-	if then < 0 {
+// refString renders a reference as written in a marker: ID.key when the item
+// carries a key, the bare ID for then < 0, else ID[n]. The key wins because it
+// is the stable handle — the index is only how the same item was addressed
+// before it had one.
+func refString(id string, then int, key string) string {
+	switch {
+	case key != "":
+		return id + "." + key
+	case then < 0:
 		return id
+	default:
+		return fmt.Sprintf("%s[%d]", id, then)
 	}
-	return fmt.Sprintf("%s[%d]", id, then)
 }
 
 // Citation is one parsed reference from a // spec: marker line in a test file.
@@ -31,12 +37,13 @@ type Citation struct {
 	Path string
 	Line int
 	ID   string
-	Then int  // 0-based then-item index; -1 = bare (whole-behavior) citation
-	E2E  bool // from a Playwright E2E spec; E2E cites credit ui, Go cites credit api
+	Key  string // then-item key; empty for a bare or indexed citation
+	Then int    // 0-based then-item index; -1 = bare (whole-behavior) or keyed citation
+	E2E  bool   // from a Playwright E2E spec; E2E cites credit ui, Go cites credit api
 }
 
-// Ref renders the citation reference as written (ID or ID[n]).
-func (c Citation) Ref() string { return refString(c.ID, c.Then) }
+// Ref renders the citation reference as written (ID, ID.key, or ID[n]).
+func (c Citation) Ref() string { return refString(c.ID, c.Then, c.Key) }
 
 // Item coverage states.
 const (
@@ -50,6 +57,7 @@ const (
 // single implicit item with Then = -1.
 type ItemCoverage struct {
 	ID      string
+	Key     string // the item's then-item key; empty when it carries none
 	Then    int
 	Text    string // the then-item text (or the statement)
 	State   string // covered | waived | orphan
@@ -57,8 +65,11 @@ type ItemCoverage struct {
 	Surface string // the owning behavior's surface: ui | api
 }
 
-// Ref renders the item as ID[n] (or the bare ID for a statement behavior).
-func (ic ItemCoverage) Ref() string { return refString(ic.ID, ic.Then) }
+// Ref renders the item as ID.key when it has a key, ID[n] when it does not, and
+// the bare ID for a statement behavior's implicit item. An uncited item
+// legitimately has no key, so orphan lines keep reading ID[n] — the author mints
+// the key when they write the citing test.
+func (ic ItemCoverage) Ref() string { return refString(ic.ID, ic.Then, ic.Key) }
 
 // DomainCoverage is one domain's slice of the coverage report.
 type DomainCoverage struct {
@@ -121,8 +132,10 @@ type Coverage struct {
 // match prose that merely mentions a marker (e.g. "(see `// spec: CON-038`)").
 var citationLine = regexp.MustCompile(`^\s*// spec: (.+?)\s*$`)
 
-// citationRef parses one comma-separated reference: <ID> or <ID>[<then-index>].
-var citationRef = regexp.MustCompile(`^([A-Z][A-Z0-9]*-\d+)(?:\[(\d+)\])?$`)
+// citationRef parses one comma-separated reference: <ID>, <ID>.<then-item-key>,
+// or the legacy <ID>[<then-index>]. The key alternative must stay in lockstep
+// with validate.go's thenKeyRegex.
+var citationRef = regexp.MustCompile(`^([A-Z][A-Z0-9]*-\d+)(?:\[(\d+)\]|\.([a-z0-9]+(?:-[a-z0-9]+)*))?$`)
 
 // CollectCitations walks backendDir for *_test.go files and e2eDir for
 // *.spec.ts files, extracting every // spec: marker. Malformed references are
@@ -192,10 +205,19 @@ func scanFile(path string, e2e bool) ([]Citation, []Violation, error) {
 			if ref == "" {
 				continue
 			}
+			// @ is RESERVED for a future content-hash suffix and is checked
+			// before the grammar, so a citation that carries one gets a
+			// forward-looking message instead of degrading into the generic
+			// malformed one. Nothing may squat the character meanwhile.
+			if strings.Contains(ref, "@") {
+				probs = append(probs, Violation{Path: path, Line: i + 1,
+					Msg: fmt.Sprintf("spec citation %q uses the reserved @hash suffix, which is not yet supported", ref)})
+				continue
+			}
 			rm := citationRef.FindStringSubmatch(ref)
 			if rm == nil {
 				probs = append(probs, Violation{Path: path, Line: i + 1,
-					Msg: fmt.Sprintf("malformed spec citation %q (want <ID> or <ID>[<then-index>])", ref)})
+					Msg: fmt.Sprintf("malformed spec citation %q (want <ID>, <ID>.<then-item-key>, or <ID>[<then-index>])", ref)})
 				continue
 			}
 			then := -1
@@ -208,10 +230,37 @@ func scanFile(path string, e2e bool) ([]Citation, []Violation, error) {
 				}
 				then = n
 			}
-			cites = append(cites, Citation{Path: path, Line: i + 1, ID: rm[1], Then: then, E2E: e2e})
+			cites = append(cites, Citation{Path: path, Line: i + 1, ID: rm[1], Key: rm[3], Then: then, E2E: e2e})
 		}
 	}
 	return cites, probs, nil
+}
+
+// hasThenKey reports whether the behavior carries a then item with this key.
+func hasThenKey(b *Behavior, key string) bool {
+	for _, it := range b.Then {
+		if it.Key != "" && it.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// availableKeys renders the behavior's then-item keys for a dangling-citation
+// message, in ITEM order so the output mirrors the YAML. Listing the candidates
+// is what turns "this key is wrong" into a fix; a behavior with no keyed items
+// says so rather than rendering an empty list.
+func availableKeys(b *Behavior) string {
+	var keys []string
+	for _, it := range b.Then {
+		if it.Key != "" {
+			keys = append(keys, it.Key)
+		}
+	}
+	if len(keys) == 0 {
+		return "behavior has no keyed then items"
+	}
+	return "behavior has: " + strings.Join(keys, ", ")
 }
 
 // ComputeCoverage validates every citation against the parsed corpus and
@@ -237,10 +286,24 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 
 	// Validate citations; index the valid ones for the coverage pass, keyed on
 	// harness: E2E cites feed ui coverage, Go cites feed api coverage.
-	e2eBare := map[string]bool{}         // ID cited bare by an E2E spec
-	e2eItem := map[string]map[int]bool{} // ID -> then indexes cited by E2E specs
-	goBare := map[string]bool{}          // ID cited bare by a Go test
-	goItem := map[string]map[int]bool{}  // ID -> then indexes cited by Go tests
+	e2eBare := map[string]bool{}           // ID cited bare by an E2E spec
+	e2eItem := map[string]map[int]bool{}   // ID -> then indexes cited by E2E specs
+	e2eKey := map[string]map[string]bool{} // ID -> then-item keys cited by E2E specs
+	goBare := map[string]bool{}            // ID cited bare by a Go test
+	goItem := map[string]map[int]bool{}    // ID -> then indexes cited by Go tests
+	goKey := map[string]map[string]bool{}  // ID -> then-item keys cited by Go tests
+	mark := func(m map[string]map[int]bool, id string, n int) {
+		if m[id] == nil {
+			m[id] = map[int]bool{}
+		}
+		m[id][n] = true
+	}
+	markKey := func(m map[string]map[string]bool, id, key string) {
+		if m[id] == nil {
+			m[id] = map[string]bool{}
+		}
+		m[id][key] = true
+	}
 	for _, c := range cites {
 		ref, ok := byID[c.ID]
 		if !ok {
@@ -275,18 +338,30 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 				continue
 			}
 		}
+		if c.Key != "" {
+			if b.Statement != "" {
+				cov.Problems = append(cov.Problems, Violation{Path: c.Path, Line: c.Line,
+					Msg: fmt.Sprintf("citation %s names a then-item key on a statement behavior (no then items)", c.Ref())})
+				continue
+			}
+			if !hasThenKey(b, c.Key) {
+				cov.Problems = append(cov.Problems, Violation{Path: c.Path, Line: c.Line,
+					Msg: fmt.Sprintf("citation %s names an unknown then-item key (%s)", c.Ref(), availableKeys(b))})
+				continue
+			}
+		}
 		if c.E2E {
 			if b.Surface != "ui" {
 				cov.Warnings = append(cov.Warnings, Violation{Path: c.Path, Line: c.Line,
 					Msg: fmt.Sprintf("E2E citation %s names a %s-surface behavior (should this be surface: ui?)", c.Ref(), b.Surface)})
 			}
-			if c.Then < 0 {
+			switch {
+			case c.Key != "":
+				markKey(e2eKey, c.ID, c.Key)
+			case c.Then < 0:
 				e2eBare[c.ID] = true
-			} else {
-				if e2eItem[c.ID] == nil {
-					e2eItem[c.ID] = map[int]bool{}
-				}
-				e2eItem[c.ID][c.Then] = true
+			default:
+				mark(e2eItem, c.ID, c.Then)
 			}
 		} else {
 			// Go cites credit api coverage. There is deliberately NO
@@ -294,13 +369,13 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 			// warning): Go tests legitimately cite ui and none behaviors all
 			// over the tree, and the none cites are the future none-coverage
 			// corpus.
-			if c.Then < 0 {
+			switch {
+			case c.Key != "":
+				markKey(goKey, c.ID, c.Key)
+			case c.Then < 0:
 				goBare[c.ID] = true
-			} else {
-				if goItem[c.ID] == nil {
-					goItem[c.ID] = map[int]bool{}
-				}
-				goItem[c.ID][c.Then] = true
+			default:
+				mark(goItem, c.ID, c.Then)
 			}
 		}
 	}
@@ -342,9 +417,9 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 			// citation maps, api behaviors read the Go-test maps. The two paths
 			// are otherwise identical (bare covers all items, indexed covers
 			// item n, a statement is one implicit item coverable bare).
-			bareMap, itemMap, citeKind := e2eBare, e2eItem, "E2E"
+			bareMap, itemMap, keyMap, citeKind := e2eBare, e2eItem, e2eKey, "E2E"
 			if b.Surface == "api" {
-				bareMap, itemMap, citeKind = goBare, goItem, "Go"
+				bareMap, itemMap, keyMap, citeKind = goBare, goItem, goKey, "Go"
 			}
 			// Both waiver forms are resolved to an item index here, so the rest
 			// of the pass stays index-keyed and form-agnostic. An unresolvable
@@ -358,12 +433,12 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 			if b.Statement != "" {
 				// A statement behavior has one implicit item, coverable only
 				// by a bare citation and waivable as index 0.
-				dc.Items = append(dc.Items, itemState(f.Path, b.ID, -1, b.Statement, b.Surface, citeKind, bareMap[b.ID], waived[0], cov))
+				dc.Items = append(dc.Items, itemState(f.Path, b.ID, "", -1, b.Statement, b.Surface, citeKind, bareMap[b.ID], waived[0], cov))
 				continue
 			}
 			for n, item := range b.Then {
-				covered := bareMap[b.ID] || itemMap[b.ID][n]
-				dc.Items = append(dc.Items, itemState(f.Path, b.ID, n, item.Text, b.Surface, citeKind, covered, waived[n], cov))
+				covered := bareMap[b.ID] || itemMap[b.ID][n] || (item.Key != "" && keyMap[b.ID][item.Key])
+				dc.Items = append(dc.Items, itemState(f.Path, b.ID, item.Key, n, item.Text, b.Surface, citeKind, covered, waived[n], cov))
 			}
 		}
 		cov.Domains = append(cov.Domains, dc)
@@ -376,8 +451,8 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 // The stale-waiver message names the citing harness by citeKind ("E2E" → "an
 // E2E test", "Go" → "a Go test") so the ui path stays byte-identical to the
 // original message while the api path reads correctly.
-func itemState(path, id string, then int, text, surface, citeKind string, covered bool, waiverReason string, cov *Coverage) ItemCoverage {
-	ic := ItemCoverage{ID: id, Then: then, Text: text, Surface: surface}
+func itemState(path, id, key string, then int, text, surface, citeKind string, covered bool, waiverReason string, cov *Coverage) ItemCoverage {
+	ic := ItemCoverage{ID: id, Key: key, Then: then, Text: text, Surface: surface}
 	switch {
 	case covered && waiverReason != "":
 		ic.State = ItemCovered

--- a/backend/internal/spec/coverage.go
+++ b/backend/internal/spec/coverage.go
@@ -346,9 +346,14 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 			if b.Surface == "api" {
 				bareMap, itemMap, citeKind = goBare, goItem, "Go"
 			}
+			// Both waiver forms are resolved to an item index here, so the rest
+			// of the pass stays index-keyed and form-agnostic. An unresolvable
+			// keyed waiver waives nothing (spec-lint reports it).
 			waived := map[int]string{}
 			for _, w := range b.Waivers {
-				waived[w.Then] = w.Reason
+				if n, ok := resolveWaiverIndex(b, w); ok {
+					waived[n] = w.Reason
+				}
 			}
 			if b.Statement != "" {
 				// A statement behavior has one implicit item, coverable only
@@ -356,9 +361,9 @@ func ComputeCoverage(files []*File, cites []Citation, citeProblems []Violation) 
 				dc.Items = append(dc.Items, itemState(f.Path, b.ID, -1, b.Statement, b.Surface, citeKind, bareMap[b.ID], waived[0], cov))
 				continue
 			}
-			for n, text := range b.Then {
+			for n, item := range b.Then {
 				covered := bareMap[b.ID] || itemMap[b.ID][n]
-				dc.Items = append(dc.Items, itemState(f.Path, b.ID, n, text, b.Surface, citeKind, covered, waived[n], cov))
+				dc.Items = append(dc.Items, itemState(f.Path, b.ID, n, item.Text, b.Surface, citeKind, covered, waived[n], cov))
 			}
 		}
 		cov.Domains = append(cov.Domains, dc)

--- a/backend/internal/spec/coverage_test.go
+++ b/backend/internal/spec/coverage_test.go
@@ -1,6 +1,8 @@
 package spec
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -231,6 +233,302 @@ func TestComputeCoverageClean(t *testing.T) {
 	covered, waived, orphans := cov.Domains[0].Counts()
 	if covered != 1 || waived != 0 || orphans != 0 {
 		t.Errorf("counts = %d/%d/%d, want 1/0/0", covered, waived, orphans)
+	}
+}
+
+// markerPrefix is the citation-marker prefix, assembled from two literals so
+// that this file never contains one. coverage_test.go is a *_test.go OUTSIDE
+// testdata/, so the repo's own `make spec-coverage` run walks it — a literal
+// marker here (even inside a Go string) would surface as a spurious INVALID in
+// the real report.
+const markerPrefix = "// spec" + ": "
+
+// marker renders one whole-line citation marker for the temp-tree fixtures.
+func marker(refs string) string { return markerPrefix + refs + "\n" }
+
+// scanMarkers writes one Go test file carrying the given marker lines into a
+// throwaway repo-shaped tree and returns what CollectCitations extracts. The
+// grammar cases need no corpus, so a temp tree keeps them out of the shared
+// coverage fixtures (whose per-item verdicts other tests pin exactly).
+func scanMarkers(t *testing.T, body string) ([]Citation, []Violation) {
+	t.Helper()
+	root := t.TempDir()
+	backend := filepath.Join(root, "backend")
+	e2e := filepath.Join(root, "frontend", "tests", "e2e")
+	for _, d := range []string{backend, e2e} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(backend, "x_test.go"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	cites, probs, err := CollectCitations(backend, e2e)
+	if err != nil {
+		t.Fatalf("CollectCitations returned error: %v", err)
+	}
+	return cites, probs
+}
+
+// TestCollectCitationsKeyedForm pins the keyed reference: it parses into Key
+// (leaving Then at -1, the bare sentinel), and Ref() round-trips all three
+// written forms.
+func TestCollectCitationsKeyedForm(t *testing.T) {
+	cites, probs := scanMarkers(t, "package x\n"+
+		marker("ALP-001.live-contact-flag")+
+		marker("ALP-002[3]")+
+		marker("ALP-003")+
+		marker("ALP-004.a1-b2, ALP-005.k"))
+	if len(probs) != 0 {
+		t.Fatalf("no problems expected, got:\n%s", joinViolations(probs))
+	}
+	want := []struct {
+		id, key string
+		then    int
+		ref     string
+	}{
+		{"ALP-001", "live-contact-flag", -1, "ALP-001.live-contact-flag"},
+		{"ALP-002", "", 3, "ALP-002[3]"},
+		{"ALP-003", "", -1, "ALP-003"},
+		{"ALP-004", "a1-b2", -1, "ALP-004.a1-b2"},
+		{"ALP-005", "k", -1, "ALP-005.k"},
+	}
+	if len(cites) != len(want) {
+		t.Fatalf("want %d citations, got %d: %#v", len(want), len(cites), cites)
+	}
+	for i, w := range want {
+		c := cites[i]
+		if c.ID != w.id || c.Key != w.key || c.Then != w.then {
+			t.Errorf("citation %d = {ID:%q Key:%q Then:%d}, want {ID:%q Key:%q Then:%d}", i, c.ID, c.Key, c.Then, w.id, w.key, w.then)
+		}
+		if got := c.Ref(); got != w.ref {
+			t.Errorf("citation %d Ref() = %q, want %q", i, got, w.ref)
+		}
+	}
+}
+
+// TestCollectCitations_HashSuffixReserved pins the @ reservation: a reference
+// carrying one gets its OWN forward-looking message, not the generic malformed
+// one, so the character cannot be squatted before the suffix is designed.
+func TestCollectCitations_HashSuffixReserved(t *testing.T) {
+	cites, probs := scanMarkers(t, "package x\n"+marker("ALP-001.live-contact-flag@a3f2"))
+	if len(cites) != 0 {
+		t.Errorf("a reserved-suffix reference must not be collected: %#v", cites)
+	}
+	if len(probs) != 1 {
+		t.Fatalf("want 1 problem, got %d:\n%s", len(probs), joinViolations(probs))
+	}
+	want := `spec citation "ALP-001.live-contact-flag@a3f2" uses the reserved @hash suffix, which is not yet supported`
+	if probs[0].Msg != want {
+		t.Errorf("problem = %q, want %q", probs[0].Msg, want)
+	}
+	if strings.Contains(probs[0].Msg, "malformed") {
+		t.Error("the reserved-suffix message must be distinct from the generic malformed one")
+	}
+}
+
+// TestCollectCitations_MalformedKey pins that the key charset is enforced at
+// the citation site too — a key outside it could never match a linted then-item
+// key, so accepting it would only defer the failure.
+func TestCollectCitations_MalformedKey(t *testing.T) {
+	for _, ref := range []string{"ALP-001.Bad_Key", "ALP-001.", "ALP-001.-lead", "ALP-001.trail-", "ALP-001.a--b"} {
+		cites, probs := scanMarkers(t, "package x\n"+marker(ref))
+		if len(cites) != 0 {
+			t.Errorf("%s: must not be collected, got %#v", ref, cites)
+		}
+		if len(probs) != 1 || !strings.Contains(probs[0].Msg, "malformed spec citation") {
+			t.Errorf("%s: want a malformed-citation problem, got %#v", ref, probs)
+		}
+	}
+}
+
+// TestComputeCoverageKeyedVerdicts pins keyed resolution end to end: a keyed
+// citation covers exactly its item, a keyed waiver waives exactly its item, the
+// reserved "statement" waiver waives a statement behavior's implicit item, and
+// legacy indexed citations still cover item n alongside them.
+func TestComputeCoverageKeyedVerdicts(t *testing.T) {
+	cov := loadCoverage(t, "testdata/coverage-keys")
+	if len(cov.Problems) != 0 {
+		t.Fatalf("no problems expected, got:\n%s", joinViolations(cov.Problems))
+	}
+	if len(cov.Domains) != 1 {
+		t.Fatalf("want 1 domain, got %d", len(cov.Domains))
+	}
+	d := cov.Domains[0]
+
+	cases := []struct{ ref, state string }{
+		{"ALP-001.first-outcome", ItemCovered},  // keyed E2E citation
+		{"ALP-001.second-outcome", ItemCovered}, // keyed E2E citation
+		{"ALP-001.waived-outcome", ItemWaived},  // keyed waiver
+		{"ALP-002[0]", ItemCovered},             // legacy indexed citation
+		{"ALP-002[1]", ItemCovered},             // legacy indexed citation
+		{"ALP-003", ItemWaived},                 // statement waived by the reserved token
+		{"ALP-004.rejects-bad-input", ItemCovered},
+	}
+	for _, tc := range cases {
+		it := findItem(d.Items, tc.ref)
+		if it == nil {
+			t.Errorf("item %s missing from report: %#v", tc.ref, d.Items)
+			continue
+		}
+		if it.State != tc.state {
+			t.Errorf("%s state = %s, want %s", tc.ref, it.State, tc.state)
+		}
+	}
+	// A keyed citation covers ONLY its own item: nothing else went covered by
+	// accident, and no item stayed orphaned.
+	if _, _, orphans := d.Counts(); orphans != 0 {
+		t.Errorf("want 0 orphans, got %d: %#v", orphans, d.Items)
+	}
+}
+
+// TestComputeCoverage_KeyedCitationSurvivesThenInsertion is acceptance
+// criterion 2, both directions in one test: two corpora differing only by an
+// item inserted at position 1. Every KEYED citation keeps the identical verdict
+// for the identical assertion text, while the INDEXED citations in the same
+// fixture demonstrably re-point — which is the failure this arc exists to end.
+func TestComputeCoverage_KeyedCitationSurvivesThenInsertion(t *testing.T) {
+	before := loadCoverage(t, "testdata/coverage-keys")
+	after := loadCoverage(t, "testdata/coverage-keys-inserted")
+
+	stateByText := func(cov *Coverage) map[string]string {
+		out := map[string]string{}
+		for _, d := range cov.Domains {
+			for _, it := range d.Items {
+				out[it.Text] = it.State
+			}
+		}
+		return out
+	}
+	b, a := stateByText(before), stateByText(after)
+
+	// Keyed: the assertion's verdict is unchanged by the insertion above it.
+	for _, text := range []string{
+		"the first outcome holds",
+		"the second outcome holds",
+		"the waived outcome is not browser-observable",
+	} {
+		if b[text] == "" {
+			t.Fatalf("precondition: %q missing from the base corpus", text)
+		}
+		if a[text] != b[text] {
+			t.Errorf("keyed item %q: state %s → %s across the insertion (must be stable)", text, b[text], a[text])
+		}
+	}
+
+	// Indexed, same fixture, same insertion: the citation now names a different
+	// assertion, and the one it used to name is orphaned. If this ever stops
+	// failing, the test has stopped discriminating.
+	const shifted = "the indexed second outcome holds"
+	if b[shifted] != ItemCovered {
+		t.Fatalf("precondition: %q must be covered before the insertion, got %q", shifted, b[shifted])
+	}
+	if a[shifted] != ItemOrphan {
+		t.Errorf("indexed citation should have re-pointed: %q is %q after the insertion, want %s", shifted, a[shifted], ItemOrphan)
+	}
+	if a["an indexed outcome inserted at position 1"] != ItemCovered {
+		t.Errorf("the inserted item should have absorbed the indexed citation, got %q", a["an indexed outcome inserted at position 1"])
+	}
+	// The keyed inserted item is a fresh orphan — correct: nothing cites it yet.
+	if a["an outcome inserted at position 1"] != ItemOrphan {
+		t.Errorf("a newly inserted keyed item should be orphaned, got %q", a["an outcome inserted at position 1"])
+	}
+}
+
+// TestComputeCoverage_DanglingKeyCitation is acceptance criterion 3: renaming
+// (or deleting) a cited item's key fails loudly, naming the citing path:line,
+// the reference, and the behavior's available keys.
+func TestComputeCoverage_DanglingKeyCitation(t *testing.T) {
+	cov := loadCoverage(t, "testdata/coverage-dangling-key")
+	if len(cov.Problems) != 1 {
+		t.Fatalf("want 1 problem, got %d:\n%s", len(cov.Problems), joinViolations(cov.Problems))
+	}
+	p := cov.Problems[0]
+	const want = "citation ALP-001.renamed-key names an unknown then-item key (behavior has: alpha, beta)"
+	if p.Msg != want {
+		t.Errorf("problem = %q, want %q", p.Msg, want)
+	}
+	if !strings.HasSuffix(p.Path, "alpha_test.go") || p.Line == 0 {
+		t.Errorf("problem must name the citing site, got %s:%d", p.Path, p.Line)
+	}
+}
+
+// TestComputeCoverage_DanglingKeyOnUnkeyedBehavior pins the empty-enumeration
+// branch of the same message: a behavior with no keyed items says so rather
+// than rendering "behavior has: ".
+func TestComputeCoverage_DanglingKeyOnUnkeyedBehavior(t *testing.T) {
+	files := []*File{{Domain: "alpha", Prefix: "ALP", Path: "spec/alpha.yaml", Behaviors: []Behavior{{
+		ID: "ALP-001", Type: "api", Status: "current", Surface: "api", When: "w",
+		Then: []ThenItem{{Text: "an unkeyed outcome"}},
+	}}}}
+	cites := []Citation{{Path: "backend/x_test.go", Line: 3, ID: "ALP-001", Key: "nope"}}
+	cov := ComputeCoverage(files, cites, nil)
+	if len(cov.Problems) != 1 {
+		t.Fatalf("want 1 problem, got %#v", cov.Problems)
+	}
+	const want = "citation ALP-001.nope names an unknown then-item key (behavior has no keyed then items)"
+	if cov.Problems[0].Msg != want {
+		t.Errorf("problem = %q, want %q", cov.Problems[0].Msg, want)
+	}
+}
+
+// TestComputeCoverage_KeyedCitationOfStatementBehavior pins that a keyed
+// citation of a statement behavior is invalid, with a message distinct from the
+// indexed case (a statement behavior has no then list at all, so neither an
+// index nor a key can address it).
+func TestComputeCoverage_KeyedCitationOfStatementBehavior(t *testing.T) {
+	files := []*File{{Domain: "alpha", Prefix: "ALP", Path: "spec/alpha.yaml", Behaviors: []Behavior{{
+		ID: "ALP-001", Type: "invariant", Status: "current", Surface: "api",
+		Statement: "every read filters soft-deleted rows",
+	}}}}
+	keyed := ComputeCoverage(files, []Citation{{Path: "backend/x_test.go", Line: 3, ID: "ALP-001", Key: "some-key", Then: -1}}, nil)
+	indexed := ComputeCoverage(files, []Citation{{Path: "backend/x_test.go", Line: 3, ID: "ALP-001", Then: 0}}, nil)
+	if len(keyed.Problems) != 1 || len(indexed.Problems) != 1 {
+		t.Fatalf("want 1 problem each, got keyed=%#v indexed=%#v", keyed.Problems, indexed.Problems)
+	}
+	const want = "citation ALP-001.some-key names a then-item key on a statement behavior (no then items)"
+	if keyed.Problems[0].Msg != want {
+		t.Errorf("keyed problem = %q, want %q", keyed.Problems[0].Msg, want)
+	}
+	if keyed.Problems[0].Msg == indexed.Problems[0].Msg {
+		t.Error("the keyed and indexed statement-citation messages must be distinct")
+	}
+}
+
+// TestComputeCoverage_LegacyIndexWaiverStillWaives exercises the index-form
+// waiver through the waiver→index resolution that now sits in front of the
+// waived map — the one site whose type changed.
+func TestComputeCoverage_LegacyIndexWaiverStillWaives(t *testing.T) {
+	files := []*File{{Domain: "alpha", Prefix: "ALP", Path: "spec/alpha.yaml", Behaviors: []Behavior{{
+		ID: "ALP-001", Type: "api", Status: "current", Surface: "api", When: "w",
+		Then:    []ThenItem{{Text: "covered by nothing"}, {Text: "waived positionally"}},
+		Waivers: []Waiver{{Index: 1, Reason: "not deterministically provable"}},
+	}}}}
+	cov := ComputeCoverage(files, nil, nil)
+	items := cov.Domains[0].Items
+	if it := findItem(items, "ALP-001[1]"); it == nil || it.State != ItemWaived || it.Reason == "" {
+		t.Errorf("index-form waiver should still waive item 1: %#v", items)
+	}
+	if it := findItem(items, "ALP-001[0]"); it == nil || it.State != ItemOrphan {
+		t.Errorf("item 0 should stay orphaned: %#v", items)
+	}
+}
+
+// TestItemCoverageRef pins the three rendering forms. It is load-bearing rather
+// than cosmetic: coverage_test's findItem helper looks items up BY Ref().
+func TestItemCoverageRef(t *testing.T) {
+	cases := []struct {
+		ic   ItemCoverage
+		want string
+	}{
+		{ItemCoverage{ID: "ALP-001", Key: "live-contact-flag", Then: 0}, "ALP-001.live-contact-flag"},
+		{ItemCoverage{ID: "ALP-001", Then: 2}, "ALP-001[2]"},
+		{ItemCoverage{ID: "ALP-001", Then: -1}, "ALP-001"},
+	}
+	for _, tc := range cases {
+		if got := tc.ic.Ref(); got != tc.want {
+			t.Errorf("Ref(%#v) = %q, want %q", tc.ic, got, tc.want)
+		}
 	}
 }
 

--- a/backend/internal/spec/coverage_test.go
+++ b/backend/internal/spec/coverage_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -336,8 +337,15 @@ func TestCollectCitations_MalformedKey(t *testing.T) {
 		if len(cites) != 0 {
 			t.Errorf("%s: must not be collected, got %#v", ref, cites)
 		}
-		if len(probs) != 1 || !strings.Contains(probs[0].Msg, "malformed spec citation") {
-			t.Errorf("%s: want a malformed-citation problem, got %#v", ref, probs)
+		if len(probs) != 1 {
+			t.Fatalf("%s: want 1 malformed-citation problem, got %#v", ref, probs)
+		}
+		// The HINT is pinned by equality, not by a "malformed" prefix match:
+		// it enumerates the accepted forms, so it is the one line an author
+		// reads to learn the grammar, and a prefix assertion would let it rot.
+		want := fmt.Sprintf("malformed spec citation %q (want <ID>, <ID>.<then-item-key>, or <ID>[<then-index>])", ref)
+		if probs[0].Msg != want {
+			t.Errorf("%s: msg = %q, want %q", ref, probs[0].Msg, want)
 		}
 	}
 }
@@ -461,7 +469,9 @@ func TestComputeCoverage_DanglingKeyOnUnkeyedBehavior(t *testing.T) {
 		ID: "ALP-001", Type: "api", Status: "current", Surface: "api", When: "w",
 		Then: []ThenItem{{Text: "an unkeyed outcome"}},
 	}}}}
-	cites := []Citation{{Path: "backend/x_test.go", Line: 3, ID: "ALP-001", Key: "nope"}}
+	// Then: -1 mirrors what scanFile produces: the grammar's alternation is
+	// exclusive, so a keyed citation never carries an index.
+	cites := []Citation{{Path: "backend/x_test.go", Line: 3, ID: "ALP-001", Key: "nope", Then: -1}}
 	cov := ComputeCoverage(files, cites, nil)
 	if len(cov.Problems) != 1 {
 		t.Fatalf("want 1 problem, got %#v", cov.Problems)

--- a/backend/internal/spec/drift.go
+++ b/backend/internal/spec/drift.go
@@ -20,11 +20,18 @@ import (
 // (a then-item reorder counts as a change). Title, notes, provenance, type,
 // status, surface, serves, and waivers are deliberately excluded — only the
 // given/when/then/statement assertions are drift-relevant.
+//
+// The then lists are compared as TEXTS (ThenTexts), never as ThenItem structs.
+// Line would make any insertion anywhere in a file drift every behavior below
+// it, and Key is a citation handle rather than an assertion: minting one
+// changes what a test may write, not what the behavior claims. A key rename
+// cannot happen silently either — spec-coverage hard-fails naming every
+// dangling citation — so drift has nothing to add there.
 func assertablesEqual(a, b *Behavior) bool {
 	return a.When == b.When &&
 		a.Statement == b.Statement &&
 		slices.Equal(a.Given, b.Given) &&
-		slices.Equal(a.Then, b.Then)
+		slices.Equal(a.ThenTexts(), b.ThenTexts())
 }
 
 // SpecDrift compares the assertable content of each HEAD behavior against its

--- a/backend/internal/spec/drift_test.go
+++ b/backend/internal/spec/drift_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+// thenItems builds an unkeyed then list from plain texts — the shape the
+// parser produces for plain-string YAML items.
+func thenItems(texts ...string) []ThenItem {
+	out := make([]ThenItem, len(texts))
+	for i, t := range texts {
+		out[i] = ThenItem{Text: t}
+	}
+	return out
+}
+
 // baseGWT is a fully-populated GWT behavior; per-case mutations clone it and
 // change exactly one field so each row isolates one axis of the comparison.
 func baseGWT() Behavior {
@@ -17,7 +27,7 @@ func baseGWT() Behavior {
 		Surface:    "api",
 		Given:      []string{"g1"},
 		When:       "w1",
-		Then:       []string{"t1", "t2"},
+		Then:       thenItems("t1", "t2"),
 		Provenance: []string{"p1"},
 		Notes:      "notes",
 		Line:       7,
@@ -68,14 +78,14 @@ func TestSpecDrift(t *testing.T) {
 		{
 			name:    "then changed",
 			base:    []Behavior{baseGWT()},
-			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = []string{"t1", "t2-changed"} })},
+			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = thenItems("t1", "t2-changed") })},
 			cites:   defaultCites,
 			wantIDs: []string{"X-001"}, wantFileCount: map[string]int{"X-001": 1},
 		},
 		{
 			name:    "then reorder",
 			base:    []Behavior{baseGWT()},
-			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = []string{"t2", "t1"} })},
+			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = thenItems("t2", "t1") })},
 			cites:   defaultCites,
 			wantIDs: []string{"X-001"},
 		},
@@ -139,7 +149,7 @@ func TestSpecDrift(t *testing.T) {
 		},
 		{
 			name: "waivers changed", base: []Behavior{baseGWT()},
-			head:  []Behavior{with(baseGWT(), func(b *Behavior) { b.Waivers = []Waiver{{Then: 0, Reason: "r"}} })},
+			head:  []Behavior{with(baseGWT(), func(b *Behavior) { b.Waivers = []Waiver{{Index: 0, Reason: "r"}} })},
 			cites: defaultCites, wantIDs: nil,
 		},
 
@@ -147,7 +157,7 @@ func TestSpecDrift(t *testing.T) {
 		{
 			name:    "then changed + citing file touched → silent",
 			base:    []Behavior{baseGWT()},
-			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = []string{"t1", "t2x"} })},
+			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = thenItems("t1", "t2x") })},
 			cites:   defaultCites,
 			changed: []string{citeFile},
 			wantIDs: nil,
@@ -155,7 +165,7 @@ func TestSpecDrift(t *testing.T) {
 		{
 			name:    "then changed + no citing file touched → warn",
 			base:    []Behavior{baseGWT()},
-			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = []string{"t1", "t2x"} })},
+			head:    []Behavior{with(baseGWT(), func(b *Behavior) { b.Then = thenItems("t1", "t2x") })},
 			cites:   defaultCites,
 			changed: []string{"backend/unrelated_test.go"},
 			wantIDs: []string{"X-001"},
@@ -283,6 +293,51 @@ func TestSpecDrift(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestSpecDrift_KeyingOnlyEditIsSilent pins that minting then-item keys is not
+// an assertion change. The keying pass gives every item a Key and shifts every
+// Line (a keyed item occupies two YAML lines where a plain one occupied
+// one) while changing no text — and drift must stay silent, or the migration
+// would fire a warning storm across every cited behavior. Comparing ThenItem
+// structs instead of ThenTexts() is exactly the mistake this catches.
+func TestSpecDrift_KeyingOnlyEditIsSilent(t *testing.T) {
+	base := []*File{{Path: "spec/x.yaml", Behaviors: []Behavior{baseGWT()}}}
+	keyed := with(baseGWT(), func(b *Behavior) {
+		b.Then = []ThenItem{
+			{Key: "first-outcome", Text: "t1", Line: 40},
+			{Key: "second-outcome", Text: "t2", Line: 42},
+		}
+	})
+	head := []*File{{Path: "spec/x.yaml", Behaviors: []Behavior{keyed}}}
+
+	if got := SpecDrift(base, head, []Citation{cite(citeFile, 10, "X-001")}, map[string]bool{}); len(got) != 0 {
+		t.Fatalf("keying-only edit must not drift, got %+v", got)
+	}
+
+	// The same fixture with ONE text changed still warns, so the silence above
+	// is the exclusion working rather than the comparison being dead.
+	textChanged := with(keyed, func(b *Behavior) { b.Then[1].Text = "t2-changed" })
+	head = []*File{{Path: "spec/x.yaml", Behaviors: []Behavior{textChanged}}}
+	if got := SpecDrift(base, head, []Citation{cite(citeFile, 10, "X-001")}, map[string]bool{}); len(got) != 1 {
+		t.Fatalf("a text change alongside keys must still warn, got %+v", got)
+	}
+}
+
+// TestSpecDriftThenTexts pins the projection drift compares on.
+func TestSpecDriftThenTexts(t *testing.T) {
+	b := baseGWT()
+	if got := b.ThenTexts(); !equalStrs(got, []string{"t1", "t2"}) {
+		t.Errorf("ThenTexts() = %#v, want [t1 t2]", got)
+	}
+	b.Then = nil
+	if got := b.ThenTexts(); got != nil {
+		t.Errorf("an absent then must project to nil, got %#v", got)
+	}
+	b.Then = []ThenItem{}
+	if got := b.ThenTexts(); got == nil || len(got) != 0 {
+		t.Errorf("a present-but-empty then must project to an empty non-nil slice, got %#v", got)
 	}
 }
 

--- a/backend/internal/spec/parser.go
+++ b/backend/internal/spec/parser.go
@@ -334,13 +334,14 @@ func (pf *parsedFile) walkBehavior(idx int, node *yaml.Node) *parsedBehavior {
 	pb.b.When = pf.behaviorWhen(pb, fields)
 	pb.b.Statement = pf.behaviorString(pb, fields, "statement")
 
-	// given / then / serves: !!str scalar (→ one-element list) or a sequence
-	// of !!str.
+	// given / serves: !!str scalar (→ one-element list) or a sequence of !!str.
+	// then has its own walker — it is the only one of the three that also
+	// accepts the keyed {key, text} mapping form.
 	pb.b.Given = pf.behaviorStrList(pb, fields, "given")
-	pb.b.Then = pf.behaviorStrList(pb, fields, "then")
+	pb.b.Then = pf.behaviorThen(pb, fields)
 	pb.b.Serves = pf.behaviorStrList(pb, fields, "serves")
 
-	// waivers: a sequence of {then: <int>, reason: <string>} mappings.
+	// waivers: a sequence of {then: <key|int>, reason: <string>} mappings.
 	pb.b.Waivers = pf.behaviorWaivers(pb, fields)
 
 	// provenance: best-effort scalar list, no checks (non-load-bearing).
@@ -453,12 +454,129 @@ func (pf *parsedFile) behaviorStrList(pb *parsedBehavior, fields map[string]*yam
 	}
 }
 
+// behaviorThen extracts the then field. It accepts everything behaviorStrList
+// accepts — a !!str scalar (normalized to a one-element list), a !!null scalar
+// (nil, absent-equivalent), or a sequence of !!str scalars — plus the keyed
+// item form: a sequence item may be a {key, text} mapping, both sub-fields
+// required, both !!str, key non-empty, no unknown sub-keys.
+//
+// Fail-closed like behaviorWaivers: the FIRST structural deviation marks the
+// whole field broken, emits exactly one violation, and returns nil, so the
+// semantic pass never sees a half-parsed then list (a silently-dropped item
+// would delete a coverage obligation).
+//
+// The item tier is deliberately stricter than the behavior tier, where
+// walkBehavior silently ignores unknown behavior-level keys: a then item is the
+// unit citations bind to, so a typo'd sub-key (`txt:`) would otherwise mint an
+// empty-text item that lints clean and can never be cited.
+func (pf *parsedFile) behaviorThen(pb *parsedBehavior, fields map[string]*yaml.Node) []ThenItem {
+	node, ok := fields["then"]
+	if !ok {
+		return nil
+	}
+	pb.keys["then"] = true
+
+	brk := func(line int, msg string) []ThenItem {
+		pb.broken["then"] = true
+		pf.emit(orderStructural, pb.idx, line, pb.ref, msg)
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Tag == tagNull {
+			return nil // present but null — absent-equivalent value
+		}
+		if node.Tag != tagStr {
+			return brk(node.Line, "then items must be strings")
+		}
+		return []ThenItem{{Text: node.Value, Line: node.Line}}
+	case yaml.SequenceNode:
+		out := make([]ThenItem, 0, len(node.Content))
+		for _, item := range node.Content {
+			switch {
+			case item.Kind == yaml.ScalarNode && item.Tag == tagStr:
+				out = append(out, ThenItem{Text: item.Value, Line: item.Line})
+			case item.Kind == yaml.ScalarNode:
+				// A non-!!str scalar item keeps the ORIGINAL message: it is
+				// still simply not a string, and widening it here would silently
+				// reclassify the pre-existing non-string-scalars fixture.
+				return brk(item.Line, "then items must be strings")
+			case item.Kind == yaml.MappingNode:
+				it, ok := pf.thenItemMapping(pb, item)
+				if !ok {
+					return nil // thenItemMapping already emitted + marked broken
+				}
+				out = append(out, it)
+			default:
+				return brk(item.Line, "then items must be strings or {key, text} mappings")
+			}
+		}
+		return out
+	default:
+		return brk(node.Line, "then must be a string or a list of strings")
+	}
+}
+
+// thenItemMapping parses one keyed then item: exactly {key, text}, both !!str,
+// key non-empty. Any deviation marks the then field broken and emits one
+// violation (ok=false).
+//
+// The empty-key rejection is load-bearing and belongs at the PARSER tier:
+// strScalar reports both `key: ""` and `key: null` as ("", true), so an
+// empty-keyed mapping would otherwise parse to a ThenItem indistinguishable
+// from a plain-string item — uncitable, yet lint-green. Only the parser can
+// still see that the author wrote a mapping.
+func (pf *parsedFile) thenItemMapping(pb *parsedBehavior, item *yaml.Node) (ThenItem, bool) {
+	brk := func(line int, msg string) (ThenItem, bool) {
+		pb.broken["then"] = true
+		pf.emit(orderStructural, pb.idx, line, pb.ref, msg)
+		return ThenItem{}, false
+	}
+
+	f, dup := mappingFields(item)
+	if len(dup) > 0 {
+		return brk(item.Line, fmt.Sprintf("duplicate key %q in then item mapping", dup[0]))
+	}
+	for _, k := range sortedKeys(f) {
+		if k != "key" && k != "text" {
+			return brk(item.Line, fmt.Sprintf("unknown key %q in then item mapping (want key, text)", k))
+		}
+	}
+	keyNode, keyOK := f["key"]
+	textNode, textOK := f["text"]
+	if !keyOK || !textOK {
+		return brk(item.Line, "then item mapping must have a key and a text")
+	}
+	key, strOK := strScalar(keyNode)
+	if !strOK || key == "" {
+		return brk(keyNode.Line, "then item key must be a non-empty string")
+	}
+	text, strOK := strScalar(textNode)
+	if !strOK {
+		return brk(textNode.Line, "then item text must be a string")
+	}
+	return ThenItem{Key: key, Text: text, Line: item.Line}, true
+}
+
+// sortedKeys returns a mapping's keys in sorted order, so an unknown-sub-key
+// report names the same key on every run (Go map iteration is randomized).
+func sortedKeys(f map[string]*yaml.Node) []string {
+	out := make([]string, 0, len(f))
+	for k := range f {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // behaviorWaivers extracts the waivers field: a sequence of mappings, each with
-// an integer `then` and a string `reason`. Any shape deviation (non-sequence,
-// non-mapping item, missing/mistyped sub-field, duplicate key in an item) is a
-// behavior-field-tier structural violation that marks the whole field broken —
-// the semantic pass (index range, duplicates, reason non-empty, ui-or-api
-// placement) never sees a partially-parsed waiver list.
+// a `then` naming the waived item — a !!str then-item key (the current form) or
+// an !!int index (the legacy form) — and a string `reason`. Any shape deviation
+// (non-sequence, non-mapping item, missing/mistyped sub-field, duplicate key in
+// an item) is a behavior-field-tier structural violation that marks the whole
+// field broken — the semantic pass (key/index resolution, duplicates, reason
+// non-empty, ui-or-api placement) never sees a partially-parsed waiver list.
 func (pf *parsedFile) behaviorWaivers(pb *parsedBehavior, fields map[string]*yaml.Node) []Waiver {
 	node, ok := fields["waivers"]
 	if !ok {
@@ -493,18 +611,24 @@ func (pf *parsedFile) behaviorWaivers(pb *parsedBehavior, fields map[string]*yam
 			return nil
 		}
 		thenNode, thenOK := wf["then"]
-		if !thenOK || thenNode.Kind != yaml.ScalarNode || thenNode.Tag != tagInt {
+		if !thenOK || thenNode.Kind != yaml.ScalarNode || (thenNode.Tag != tagInt && thenNode.Tag != tagStr) {
 			pb.broken["waivers"] = true
 			pf.emit(orderStructural, pb.idx, item.Line, pb.ref,
-				"waiver then must be an integer then-item index")
+				"waiver then must be a then-item key or an integer index")
 			return nil
 		}
-		idx, err := strconv.Atoi(thenNode.Value)
-		if err != nil {
-			pb.broken["waivers"] = true
-			pf.emit(orderStructural, pb.idx, thenNode.Line, pb.ref,
-				"waiver then must be an integer then-item index")
-			return nil
+		w := Waiver{}
+		if thenNode.Tag == tagStr {
+			w.Key, w.Keyed = thenNode.Value, true
+		} else {
+			idx, err := strconv.Atoi(thenNode.Value)
+			if err != nil {
+				pb.broken["waivers"] = true
+				pf.emit(orderStructural, pb.idx, thenNode.Line, pb.ref,
+					"waiver then must be a then-item key or an integer index")
+				return nil
+			}
+			w.Index = idx
 		}
 		reasonNode, reasonOK := wf["reason"]
 		if !reasonOK {
@@ -518,7 +642,8 @@ func (pf *parsedFile) behaviorWaivers(pb *parsedBehavior, fields map[string]*yam
 			pf.emit(orderStructural, pb.idx, reasonNode.Line, pb.ref, "waiver reason must be a string")
 			return nil
 		}
-		out = append(out, Waiver{Then: idx, Reason: reason})
+		w.Reason = reason
+		out = append(out, w)
 		lines = append(lines, item.Line)
 	}
 	pb.waiverLines = lines

--- a/backend/internal/spec/parser.go
+++ b/backend/internal/spec/parser.go
@@ -534,13 +534,20 @@ func (pf *parsedFile) thenItemMapping(pb *parsedBehavior, item *yaml.Node) (Then
 		return ThenItem{}, false
 	}
 
+	// Reported line, by case: a violation with an offending NODE reports at
+	// that node's line; one that is a property of the mapping as a whole
+	// reports at the mapping's own line. So the unknown sub-key below points at
+	// the offending sub-key rather than at `- key:` two lines up, while a
+	// duplicate sub-key (mappingFields keeps only the name, not the second
+	// node — same as walkBehavior's duplicate handling) and a missing sub-field
+	// (no node to point at) stay on the mapping.
 	f, dup := mappingFields(item)
 	if len(dup) > 0 {
 		return brk(item.Line, fmt.Sprintf("duplicate key %q in then item mapping", dup[0]))
 	}
 	for _, k := range sortedKeys(f) {
 		if k != "key" && k != "text" {
-			return brk(item.Line, fmt.Sprintf("unknown key %q in then item mapping (want key, text)", k))
+			return brk(f[k].Line, fmt.Sprintf("unknown key %q in then item mapping (want key, text)", k))
 		}
 	}
 	keyNode, keyOK := f["key"]

--- a/backend/internal/spec/spec.go
+++ b/backend/internal/spec/spec.go
@@ -32,20 +32,69 @@ type Behavior struct {
 	Surface    string   // ui | api | none; required for non-intent, non-retired behaviors (intents are judge-only and take no surface)
 	Given      []string // scalar input normalized to a one-element list; nil = absent
 	When       string
-	Then       []string // same normalization as Given
-	Statement  string   // invariant and intent types only; mutually exclusive with GWT
-	Serves     []string // ux and intent types only; targets must be intent behavior IDs
-	Waivers    []Waiver // ui- or api-surface behaviors only: then-items deliberately excluded from deterministic coverage
+	Then       []ThenItem // same normalization as Given (scalar → one-element list; nil = absent)
+	Statement  string     // invariant and intent types only; mutually exclusive with GWT
+	Serves     []string   // ux and intent types only; targets must be intent behavior IDs
+	Waivers    []Waiver   // ui- or api-surface behaviors only: then-items deliberately excluded from deterministic coverage
 	Provenance []string
 	Notes      string
 	Line       int // 1-based source line of the behavior mapping; set by the parser, used in drift annotations
 }
 
+// ThenItem is one observable outcome in a behavior's then list. Key is the
+// stable citation handle — empty when the item carries none (uncited items stay
+// plain strings in YAML). Line is the item's 1-based source line.
+//
+// A keyed item is written as a {key, text} mapping; an unkeyed one stays a
+// plain scalar. Key is what a // spec: ID.key citation binds to, so it survives
+// reordering, insertion, and deletion of sibling items — the positional index
+// does not.
+type ThenItem struct {
+	Key  string
+	Text string
+	Line int
+}
+
+// ThenTexts projects the then list down to its assertion texts, dropping keys
+// and source lines. It is the only sanctioned way to compare two behaviors'
+// then lists as assertions: a key is a citation handle, not an assertion, and
+// Line moves whenever anything above it in the file does.
+func (b *Behavior) ThenTexts() []string {
+	if b.Then == nil {
+		return nil
+	}
+	out := make([]string, len(b.Then))
+	for i, it := range b.Then {
+		out[i] = it.Text
+	}
+	return out
+}
+
+// waiverStatementKey is the reserved token a waiver uses to address a statement
+// behavior's single implicit coverage item, which has no then list to key. It
+// is rejected as a then-item key so the two meanings can never collide.
+const waiverStatementKey = "statement"
+
 // Waiver records the DROP verdict for one then-item of a ui- or api-surface
 // behavior: the item is neither deterministically provable nor worth a judge
 // intent, so the coverage scanner reports it as waived (with the reason)
 // instead of orphaned.
+//
+// A waiver addresses its item by key (the current form) or by 0-based index
+// (the legacy form); Keyed says which. Index and Keyed are TRANSITIONAL — they
+// exist only while the corpus still carries index-form waivers and are removed
+// once it does not.
 type Waiver struct {
-	Then   int // 0-based index into the behavior's then list
+	// Key is a then-item key of the same behavior, or the reserved token
+	// "statement" addressing a statement behavior's single implicit item.
+	// Valid only when Keyed.
+	Key string
+	// Index is the legacy 0-based then-item index. Valid only when !Keyed. It
+	// may legitimately be NEGATIVE — a negative index is a linted violation
+	// (out of range), never a sentinel for "the keyed form is in use". That is
+	// what Keyed is for.
+	Index int
+	// Keyed discriminates which of Key/Index carries the reference.
+	Keyed  bool
 	Reason string
 }

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -1,6 +1,8 @@
 package spec
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -75,7 +77,7 @@ func TestLintValidCorpus(t *testing.T) {
 		if len(b.Given) != 2 {
 			t.Errorf("CON-003 want 2 given items, got %#v", b.Given)
 		}
-		if len(b.Then) != 1 || b.Then[0] != "the row is persisted" {
+		if len(b.Then) != 1 || b.Then[0].Text != "the row is persisted" {
 			t.Errorf("CON-003 scalar then not normalized: %#v", b.Then)
 		}
 	}
@@ -163,7 +165,7 @@ func TestLintViolationClasses(t *testing.T) {
 		{"waivers-bad-shape", 5, []string{
 			"waivers must be a list of {then, reason} mappings",
 			"waivers items must be {then, reason} mappings",
-			"waiver then must be an integer then-item index",
+			"waiver then must be a then-item key or an integer index",
 			"waiver must have a reason",
 			"waiver reason must be a string",
 		}},
@@ -178,6 +180,27 @@ func TestLintViolationClasses(t *testing.T) {
 		{"settled-non-string-item", 1, []string{"settled items must be surfaces"}},
 		{"legacy-e2e-settled", 1, []string{"e2e_settled is retired; use a settled: [ui] list"}},
 		{"prefix-bad-format", 1, []string{`prefix "Gc" must be uppercase alphanumeric starting with a letter`}},
+		// --- then-item keys ---
+		{"then-key-bad-charset", 3, []string{
+			`then item key "bad_key" must be lowercase alphanumeric words separated by hyphens`,
+			`then item key "BadKey" must be lowercase alphanumeric words separated by hyphens`,
+			`then item key "trailing-" must be lowercase alphanumeric words separated by hyphens`,
+		}},
+		{"then-key-empty", 3, []string{"then item key must be a non-empty string"}},
+		{"then-key-reserved", 1, []string{`then item key "statement" is reserved for statement-behavior waivers`}},
+		{"then-key-dup", 1, []string{`duplicate then item key "same-key"`}},
+		{"then-text-empty", 1, []string{"then list items must be non-empty strings"}},
+		{"then-item-bad-shape", 5, []string{
+			"then items must be strings or {key, text} mappings",
+			`unknown key "txt" in then item mapping (want key, text)`,
+			"then item mapping must have a key and a text",
+			`duplicate key "text" in then item mapping`,
+			"then item text must be a string",
+		}},
+		{"waiver-key-unknown", 1, []string{`waiver then "no-such-key" names no then-item key of this behavior`}},
+		{"waiver-statement-bad-key", 1, []string{
+			`waiver then "some-key" is not valid for a statement behavior (use the reserved key "statement")`,
+		}},
 	}
 
 	for _, tc := range cases {
@@ -268,7 +291,7 @@ func TestLintSurfaceAndWaivers(t *testing.T) {
 		if b.Surface != "ui" {
 			t.Errorf("CON-001 surface = %q, want ui", b.Surface)
 		}
-		if len(b.Waivers) != 1 || b.Waivers[0].Then != 1 || b.Waivers[0].Reason == "" {
+		if len(b.Waivers) != 1 || b.Waivers[0].Keyed || b.Waivers[0].Index != 1 || b.Waivers[0].Reason == "" {
 			t.Errorf("CON-001 waivers not parsed: %#v", b.Waivers)
 		}
 	}
@@ -285,7 +308,7 @@ func TestLintSurfaceAndWaivers(t *testing.T) {
 	// An api-surface behavior may carry a waiver (relaxed from ui-only).
 	if b := findBehavior(files, "CON-005"); b == nil {
 		t.Fatal("CON-005 missing")
-	} else if b.Surface != "api" || len(b.Waivers) != 1 || b.Waivers[0].Then != 0 || b.Waivers[0].Reason == "" {
+	} else if b.Surface != "api" || len(b.Waivers) != 1 || b.Waivers[0].Keyed || b.Waivers[0].Index != 0 || b.Waivers[0].Reason == "" {
 		t.Errorf("CON-005 api-surface waiver not parsed clean: %#v", b)
 	}
 }
@@ -307,6 +330,295 @@ func TestLintSettledAbsent(t *testing.T) {
 	}
 	if files[0].Settled != nil {
 		t.Errorf("absent settled should parse as nil, got %#v", files[0].Settled)
+	}
+}
+
+// TestLintThenKeysAndKeyedWaivers pins the keyed then-item form on a valid
+// corpus: keyed and plain items coexist in one then list, a keyed item carries
+// its Key/Text/Line, a plain one carries an empty Key, a waiver addresses an
+// item by key, the reserved "statement" token addresses a statement behavior's
+// implicit item, and the legacy index form still parses alongside them.
+func TestLintThenKeysAndKeyedWaivers(t *testing.T) {
+	files, viol, err := Lint("testdata/valid-then-keys")
+	if err != nil {
+		t.Fatalf("Lint returned error: %v", err)
+	}
+	if len(viol) != 0 {
+		t.Fatalf("valid-then-keys corpus should be clean, got %d violations:\n%s", len(viol), joinViolations(viol))
+	}
+
+	b := findBehavior(files, "KEY-001")
+	if b == nil {
+		t.Fatal("KEY-001 missing")
+	}
+	if len(b.Then) != 3 {
+		t.Fatalf("KEY-001 want 3 then items, got %#v", b.Then)
+	}
+	want := []ThenItem{
+		{Key: "live-contact-flag", Text: "a live contact is returned with a has_pending_followup flag", Line: 13},
+		{Key: "", Text: "an unkeyed outcome stays a plain string", Line: 15},
+		{Key: "pending-followup-count", Text: "the pending followup count is returned", Line: 16},
+	}
+	for i, w := range want {
+		if b.Then[i] != w {
+			t.Errorf("KEY-001 then[%d] = %#v, want %#v", i, b.Then[i], w)
+		}
+	}
+	if got := b.ThenTexts(); len(got) != 3 || got[0] != want[0].Text || got[1] != want[1].Text {
+		t.Errorf("KEY-001 ThenTexts() = %#v", got)
+	}
+	if len(b.Waivers) != 1 || !b.Waivers[0].Keyed || b.Waivers[0].Key != "pending-followup-count" {
+		t.Errorf("KEY-001 keyed waiver not parsed: %#v", b.Waivers)
+	}
+
+	if b := findBehavior(files, "KEY-002"); b == nil {
+		t.Fatal("KEY-002 missing")
+	} else if len(b.Waivers) != 1 || !b.Waivers[0].Keyed || b.Waivers[0].Key != "statement" {
+		t.Errorf("KEY-002 statement waiver not parsed: %#v", b.Waivers)
+	}
+
+	// The legacy index form survives alongside the keyed one, and Keyed is what
+	// tells them apart — not a sentinel value of Index.
+	if b := findBehavior(files, "KEY-003"); b == nil {
+		t.Fatal("KEY-003 missing")
+	} else if len(b.Waivers) != 1 || b.Waivers[0].Keyed || b.Waivers[0].Index != 1 || b.Waivers[0].Key != "" {
+		t.Errorf("KEY-003 legacy index waiver not parsed: %#v", b.Waivers)
+	}
+}
+
+// TestParserThenMessagesAreDistinct guards the message split that keeps this
+// change inert. A single widened message ("then items must be strings or
+// {key, text} mappings") would still satisfy the pre-existing
+// strings.Contains assertion on non-string-scalars/ as a PREFIX, so the suite
+// would stay green while the stated byte-identity invariant was broken. This
+// asserts the pre-existing case's message by EQUALITY, and that the two
+// messages are different strings.
+func TestParserThenMessagesAreDistinct(t *testing.T) {
+	const scalarMsg = "then items must be strings"
+	const shapeMsg = "then items must be strings or {key, text} mappings"
+	if scalarMsg == shapeMsg {
+		t.Fatal("the two then-item messages must be distinct")
+	}
+	if !strings.HasPrefix(shapeMsg, scalarMsg) {
+		t.Fatal("precondition: the widened message shares the old one's prefix — that is exactly why equality is required below")
+	}
+
+	_, viol, err := Lint("testdata/invalid/non-string-scalars")
+	if err != nil {
+		t.Fatalf("Lint returned error: %v", err)
+	}
+	want := Violation{
+		Path: "testdata/invalid/non-string-scalars/bad.yaml",
+		Ref:  "CON-003",
+		Line: 26,
+		Msg:  scalarMsg,
+	}
+	found := false
+	for _, v := range viol {
+		if v.Ref == "CON-003" {
+			found = true
+			if v != want {
+				t.Errorf("CON-003 violation = %#v, want %#v", v, want)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no CON-003 violation in:\n%s", joinViolations(viol))
+	}
+
+	// The non-scalar, non-mapping item gets the OTHER message.
+	_, viol, err = Lint("testdata/invalid/then-item-bad-shape")
+	if err != nil {
+		t.Fatalf("Lint returned error: %v", err)
+	}
+	for _, v := range viol {
+		if v.Ref == "CON-001" && v.Msg != shapeMsg {
+			t.Errorf("CON-001 msg = %q, want %q", v.Msg, shapeMsg)
+		}
+	}
+}
+
+// TestLint_ThenKeyDuplicateIgnoresEmptyKeys pins the non-empty qualifier on
+// key uniqueness. Without it every behavior with two or more plain-string then
+// items would report `duplicate then item key ""` and the whole corpus would
+// fail lint — testdata/valid's CON-001 has exactly that shape.
+func TestLint_ThenKeyDuplicateIgnoresEmptyKeys(t *testing.T) {
+	files, viol, err := Lint("testdata/valid")
+	if err != nil {
+		t.Fatalf("Lint returned error: %v", err)
+	}
+	b := findBehavior(files, "CON-001")
+	if b == nil {
+		t.Fatal("CON-001 missing")
+	}
+	if len(b.Then) < 2 {
+		t.Fatalf("precondition: CON-001 must have >=2 unkeyed then items, got %#v", b.Then)
+	}
+	for _, it := range b.Then {
+		if it.Key != "" {
+			t.Fatalf("precondition: CON-001's then items must all be unkeyed, got %#v", b.Then)
+		}
+	}
+	if strings.Contains(joinViolations(viol), "duplicate then item key") {
+		t.Errorf("unkeyed items must not collide:\n%s", joinViolations(viol))
+	}
+}
+
+// TestLint_WaiverNegativeIndexStillOutOfRange is the union-soundness guard. A
+// negative index is a REPRESENTABLE legacy value, so it must never be read as a
+// "the keyed form is in use" sentinel — the discriminator is Waiver.Keyed. If
+// the sentinel encoding were ever reintroduced, this range check would become
+// unreachable and the assertion below would fail.
+func TestLint_WaiverNegativeIndexStillOutOfRange(t *testing.T) {
+	files, viol, err := Lint("testdata/invalid/waivers-bad-index")
+	if err != nil {
+		t.Fatalf("Lint returned error: %v", err)
+	}
+	b := findBehavior(files, "CON-001")
+	if b == nil {
+		t.Fatal("CON-001 missing")
+	}
+	var negative *Waiver
+	for i := range b.Waivers {
+		if b.Waivers[i].Index == -1 {
+			negative = &b.Waivers[i]
+		}
+	}
+	if negative == nil {
+		t.Fatalf("precondition: the fixture must carry a `then: -1` waiver, got %#v", b.Waivers)
+	}
+	if negative.Keyed {
+		t.Errorf("a negative index must parse as the INDEX form, not the keyed one: %#v", *negative)
+	}
+	if !strings.Contains(joinViolations(viol), "waiver then index -1 out of range") {
+		t.Errorf("negative index must still report out of range:\n%s", joinViolations(viol))
+	}
+}
+
+// TestLint_WaiverDuplicateAcrossForms pins that duplicate detection keys on the
+// RESOLVED item index: a key-form waiver and an index-form waiver naming the
+// same item are one duplicate, not two independent waivers.
+func TestLint_WaiverDuplicateAcrossForms(t *testing.T) {
+	_, viol, err := Lint("testdata/invalid/waiver-dup-across-forms")
+	if err != nil {
+		t.Fatalf("Lint returned error: %v", err)
+	}
+	if len(viol) != 1 {
+		t.Fatalf("want exactly 1 violation, got %d:\n%s", len(viol), joinViolations(viol))
+	}
+	if !strings.Contains(viol[0].Msg, "duplicate waiver for then item 1") {
+		t.Errorf("want the resolved-index duplicate message, got %q", viol[0].Msg)
+	}
+}
+
+// TestLintThenItemBrokenSuppressesSemantics pins the tiered-degradation
+// contract for the new walker: the FIRST structural deviation in a then list
+// reports once and suppresses every then-dependent semantic check below it —
+// key charset/uniqueness, the empty-text check, and waiver key resolution.
+func TestLintThenItemBrokenSuppressesSemantics(t *testing.T) {
+	_, viol, err := Lint("testdata/invalid/then-broken-suppresses")
+	if err != nil {
+		t.Fatalf("Lint returned error: %v", err)
+	}
+	if len(viol) != 1 {
+		t.Fatalf("a broken then must report exactly once, got %d:\n%s", len(viol), joinViolations(viol))
+	}
+	if !strings.Contains(viol[0].Msg, `unknown key "txt" in then item mapping`) {
+		t.Errorf("want the first structural deviation, got %q", viol[0].Msg)
+	}
+	out := joinViolations(viol)
+	for _, suppressed := range []string{
+		"duplicate then item key",
+		"then list items must be non-empty strings",
+		"names no then-item key of this behavior",
+		"must have a then with at least one outcome",
+	} {
+		if strings.Contains(out, suppressed) {
+			t.Errorf("a broken then must suppress %q; got:\n%s", suppressed, out)
+		}
+	}
+
+	// Fail-closed is the other half of the contract and the half that survives
+	// into the EXPORTED output: a broken then must parse to nil, never to a
+	// partial list with the offending item silently dropped. A dropped item
+	// would delete a coverage obligation while lint stayed at one violation, so
+	// the violation count above cannot detect it on its own.
+	files, _, err := ParseDir("testdata/invalid/then-broken-suppresses")
+	if err != nil {
+		t.Fatalf("ParseDir returned error: %v", err)
+	}
+	b := findBehavior(files, "CON-001")
+	if b == nil {
+		t.Fatal("CON-001 missing from the parsed output")
+	}
+	if b.Then != nil {
+		t.Errorf("a structurally broken then must parse to nil, got %#v", b.Then)
+	}
+}
+
+// TestParserThenScalarForms pins the scalar branches of the then walker, which
+// the fixture corpus only exercises in its sequence form. Each broken form must
+// yield nil — never a partially-populated list and never an empty non-nil slice
+// — because absent-vs-present-but-empty is decidable off exactly that
+// distinction downstream.
+func TestParserThenScalarForms(t *testing.T) {
+	const header = "domain: contacts\nprefix: CON\nmaturity: reviewed\nbehaviors:\n  - id: CON-001\n    title: t\n    type: business-logic\n    status: current\n    surface: none\n    when: w\n    "
+	cases := []struct {
+		name    string
+		then    string
+		wantLen int // -1 = nil
+		wantNil bool
+		wantMsg string // "" = no violation
+	}{
+		{"string scalar normalizes to one item", "then: a single outcome", 1, false, ""},
+		{"null is absent-equivalent", "then: null", 0, true, ""},
+		{"int scalar keeps the original message", "then: 42", 0, true, "then items must be strings"},
+		{"bool scalar keeps the original message", "then: true", 0, true, "then items must be strings"},
+		{"mapping keeps the original message", "then:\n      a: b", 0, true, "then must be a string or a list of strings"},
+		{"empty sequence is present-but-empty", "then: []", 0, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "spec.yaml")
+			if err := os.WriteFile(path, []byte(header+tc.then+"\n"), 0o644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			// ParseDir is parse-only, so no semantic noise (a missing then would
+			// otherwise also report "must have a then with at least one outcome").
+			files, viol, err := ParseDir(dir)
+			if err != nil {
+				t.Fatalf("ParseDir returned error: %v", err)
+			}
+			if tc.wantMsg == "" {
+				if len(viol) != 0 {
+					t.Fatalf("want no violations, got:\n%s", joinViolations(viol))
+				}
+			} else {
+				if len(viol) != 1 {
+					t.Fatalf("want 1 violation, got %d:\n%s", len(viol), joinViolations(viol))
+				}
+				if viol[0].Msg != tc.wantMsg {
+					t.Errorf("msg = %q, want %q", viol[0].Msg, tc.wantMsg)
+				}
+			}
+			b := findBehavior(files, "CON-001")
+			if b == nil {
+				t.Fatal("CON-001 missing")
+			}
+			if tc.wantNil && b.Then != nil {
+				t.Fatalf("want a nil then, got %#v", b.Then)
+			}
+			if !tc.wantNil && b.Then == nil {
+				t.Fatal("want a non-nil then, got nil")
+			}
+			if len(b.Then) != tc.wantLen {
+				t.Fatalf("want %d then items, got %#v", tc.wantLen, b.Then)
+			}
+			if tc.wantLen == 1 && b.Then[0].Text != "a single outcome" {
+				t.Errorf("scalar then not normalized: %#v", b.Then)
+			}
+		})
 	}
 }
 
@@ -461,6 +773,55 @@ func TestParseFile(t *testing.T) {
 	if _, _, err := ParseFile("testdata/valid/does-not-exist.yaml"); err == nil {
 		t.Error("ParseFile on a missing file should error")
 	}
+}
+
+// TestParseFileThenItemLines pins that keyed items survive the parse-only path
+// (ParseFile, which the traceability scanner and the drift CLI both use) and
+// that ThenItem.Line carries the item's own source line — the anchor a
+// line-oriented rewriter needs, since a waiver's `- then: 1` entry shares the
+// six-space indent of a then item and cannot be told apart by indentation.
+func TestParseFileThenItemLines(t *testing.T) {
+	file, viol, err := ParseFile("testdata/valid-then-keys/spec.yaml")
+	if err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+	if len(viol) != 0 {
+		t.Fatalf("valid file should have no parse violations:\n%s", joinViolations(viol))
+	}
+	b := findBehavior([]*File{file}, "KEY-001")
+	if b == nil {
+		t.Fatal("KEY-001 missing")
+	}
+	// Every item's Line must name a line that actually holds it, and the lines
+	// must strictly increase down the list.
+	src := strings.Split(readFixture(t, "testdata/valid-then-keys/spec.yaml"), "\n")
+	prev := 0
+	for i, it := range b.Then {
+		if it.Line <= prev {
+			t.Errorf("then[%d].Line = %d is not after the previous item's %d", i, it.Line, prev)
+		}
+		prev = it.Line
+		if it.Line < 1 || it.Line > len(src) {
+			t.Fatalf("then[%d].Line = %d is outside the file", i, it.Line)
+		}
+		line := src[it.Line-1]
+		if it.Key != "" {
+			if !strings.Contains(line, "key: "+it.Key) {
+				t.Errorf("then[%d].Line %d = %q, expected the `key: %s` line", i, it.Line, line, it.Key)
+			}
+		} else if !strings.Contains(line, it.Text) {
+			t.Errorf("then[%d].Line %d = %q, expected the item's own text", i, it.Line, line)
+		}
+	}
+}
+
+func readFixture(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	return string(data)
 }
 
 func TestViolationString(t *testing.T) {

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -198,8 +198,11 @@ func TestLintViolationClasses(t *testing.T) {
 			"then item text must be a string",
 		}},
 		{"waiver-key-unknown", 1, []string{`waiver then "no-such-key" names no then-item key of this behavior`}},
-		{"waiver-statement-bad-key", 1, []string{
+		// Both directions of misusing the reserved token, each with its own
+		// message — the generic unknown-key wording would misdirect either way.
+		{"waiver-statement-bad-key", 2, []string{
 			`waiver then "some-key" is not valid for a statement behavior (use the reserved key "statement")`,
+			`waiver then "statement" is reserved for statement behaviors; waive a then item of this behavior by its key`,
 		}},
 	}
 
@@ -426,15 +429,24 @@ func TestParserThenMessagesAreDistinct(t *testing.T) {
 		t.Fatalf("no CON-003 violation in:\n%s", joinViolations(viol))
 	}
 
-	// The non-scalar, non-mapping item gets the OTHER message.
+	// The non-scalar, non-mapping item gets the OTHER message. The found guard
+	// matters as much as the comparison: without it a change that dropped the
+	// violation entirely would satisfy an empty loop.
 	_, viol, err = Lint("testdata/invalid/then-item-bad-shape")
 	if err != nil {
 		t.Fatalf("Lint returned error: %v", err)
 	}
+	found = false
 	for _, v := range viol {
-		if v.Ref == "CON-001" && v.Msg != shapeMsg {
-			t.Errorf("CON-001 msg = %q, want %q", v.Msg, shapeMsg)
+		if v.Ref == "CON-001" {
+			found = true
+			if v.Msg != shapeMsg {
+				t.Errorf("CON-001 msg = %q, want %q", v.Msg, shapeMsg)
+			}
 		}
+	}
+	if !found {
+		t.Fatalf("no CON-001 violation in:\n%s", joinViolations(viol))
 	}
 }
 

--- a/backend/internal/spec/testdata/coverage-dangling-key/backend/alpha_test.go
+++ b/backend/internal/spec/testdata/coverage-dangling-key/backend/alpha_test.go
@@ -1,0 +1,4 @@
+package alpha
+
+// spec: ALP-001.renamed-key
+func TestRenamed(t *testing.T) {}

--- a/backend/internal/spec/testdata/coverage-dangling-key/spec/alpha.yaml
+++ b/backend/internal/spec/testdata/coverage-dangling-key/spec/alpha.yaml
@@ -1,0 +1,15 @@
+domain: alpha
+prefix: ALP
+maturity: reviewed
+behaviors:
+  - id: ALP-001
+    title: a keyed api behavior whose key was renamed
+    type: api
+    status: current
+    surface: api
+    when: the request is validated
+    then:
+      - key: alpha
+        text: the alpha outcome holds
+      - key: beta
+        text: the beta outcome holds

--- a/backend/internal/spec/testdata/coverage-keys-inserted/backend/alpha_test.go
+++ b/backend/internal/spec/testdata/coverage-keys-inserted/backend/alpha_test.go
@@ -1,0 +1,4 @@
+package alpha
+
+// spec: ALP-004.rejects-bad-input
+func TestRejectsBadInput(t *testing.T) {}

--- a/backend/internal/spec/testdata/coverage-keys-inserted/frontend/tests/e2e/alpha.spec.ts
+++ b/backend/internal/spec/testdata/coverage-keys-inserted/frontend/tests/e2e/alpha.spec.ts
@@ -1,0 +1,8 @@
+// spec: ALP-001.first-outcome
+test('first', () => {})
+// spec: ALP-001.second-outcome
+test('second', () => {})
+// spec: ALP-002[0]
+test('indexed first', () => {})
+// spec: ALP-002[1]
+test('indexed second', () => {})

--- a/backend/internal/spec/testdata/coverage-keys-inserted/spec/alpha.yaml
+++ b/backend/internal/spec/testdata/coverage-keys-inserted/spec/alpha.yaml
@@ -1,0 +1,50 @@
+domain: alpha
+prefix: ALP
+maturity: reviewed
+behaviors:
+  - id: ALP-001
+    title: a keyed ui behavior
+    type: ux
+    status: current
+    surface: ui
+    when: the trigger fires
+    then:
+      - key: first-outcome
+        text: the first outcome holds
+      - key: inserted-outcome
+        text: an outcome inserted at position 1
+      - key: second-outcome
+        text: the second outcome holds
+      - key: waived-outcome
+        text: the waived outcome is not browser-observable
+    waivers:
+      - then: waived-outcome
+        reason: not deterministically provable in the browser
+  - id: ALP-002
+    title: a ui behavior still cited positionally
+    type: ux
+    status: current
+    surface: ui
+    when: the trigger fires
+    then:
+      - the indexed first outcome holds
+      - an indexed outcome inserted at position 1
+      - the indexed second outcome holds
+  - id: ALP-003
+    title: a statement behavior waived by the reserved token
+    type: invariant
+    status: current
+    surface: ui
+    statement: every read filters soft-deleted rows
+    waivers:
+      - then: statement
+        reason: structural, enforced by the query layer rather than observable
+  - id: ALP-004
+    title: a keyed api behavior credited by a Go citation
+    type: api
+    status: current
+    surface: api
+    when: the request is validated
+    then:
+      - key: rejects-bad-input
+        text: an invalid request is rejected with a validation error (400)

--- a/backend/internal/spec/testdata/coverage-keys/backend/alpha_test.go
+++ b/backend/internal/spec/testdata/coverage-keys/backend/alpha_test.go
@@ -1,0 +1,4 @@
+package alpha
+
+// spec: ALP-004.rejects-bad-input
+func TestRejectsBadInput(t *testing.T) {}

--- a/backend/internal/spec/testdata/coverage-keys/frontend/tests/e2e/alpha.spec.ts
+++ b/backend/internal/spec/testdata/coverage-keys/frontend/tests/e2e/alpha.spec.ts
@@ -1,0 +1,8 @@
+// spec: ALP-001.first-outcome
+test('first', () => {})
+// spec: ALP-001.second-outcome
+test('second', () => {})
+// spec: ALP-002[0]
+test('indexed first', () => {})
+// spec: ALP-002[1]
+test('indexed second', () => {})

--- a/backend/internal/spec/testdata/coverage-keys/spec/alpha.yaml
+++ b/backend/internal/spec/testdata/coverage-keys/spec/alpha.yaml
@@ -1,0 +1,47 @@
+domain: alpha
+prefix: ALP
+maturity: reviewed
+behaviors:
+  - id: ALP-001
+    title: a keyed ui behavior
+    type: ux
+    status: current
+    surface: ui
+    when: the trigger fires
+    then:
+      - key: first-outcome
+        text: the first outcome holds
+      - key: second-outcome
+        text: the second outcome holds
+      - key: waived-outcome
+        text: the waived outcome is not browser-observable
+    waivers:
+      - then: waived-outcome
+        reason: not deterministically provable in the browser
+  - id: ALP-002
+    title: a ui behavior still cited positionally
+    type: ux
+    status: current
+    surface: ui
+    when: the trigger fires
+    then:
+      - the indexed first outcome holds
+      - the indexed second outcome holds
+  - id: ALP-003
+    title: a statement behavior waived by the reserved token
+    type: invariant
+    status: current
+    surface: ui
+    statement: every read filters soft-deleted rows
+    waivers:
+      - then: statement
+        reason: structural, enforced by the query layer rather than observable
+  - id: ALP-004
+    title: a keyed api behavior credited by a Go citation
+    type: api
+    status: current
+    surface: api
+    when: the request is validated
+    then:
+      - key: rejects-bad-input
+        text: an invalid request is rejected with a validation error (400)

--- a/backend/internal/spec/testdata/invalid/then-broken-suppresses/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/then-broken-suppresses/bad.yaml
@@ -1,0 +1,22 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  # A structurally broken then list must report ONCE and suppress every
+  # then-dependent semantic check: the duplicate key and the empty text below
+  # it, the empty-list-item check, and the waiver's key resolution.
+  - id: CON-001
+    title: a broken then list suppresses its own semantic checks
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: dup-key
+        txt: y
+      - key: dup-key
+        text: ""
+      - ""
+    waivers:
+      - then: no-such-key
+        reason: r

--- a/backend/internal/spec/testdata/invalid/then-item-bad-shape/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/then-item-bad-shape/bad.yaml
@@ -1,0 +1,49 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  # One deviation per BEHAVIOR: the walker fails closed on the first one.
+  - id: CON-001
+    title: a then item that is neither a string nor a mapping
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - - nested
+  - id: CON-002
+    title: a then item mapping with an unknown sub-key
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: some-key
+        txt: y
+  - id: CON-003
+    title: a then item mapping missing its text
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: some-key
+  - id: CON-004
+    title: a then item mapping with a duplicate sub-key
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: some-key
+        text: y
+        text: z
+  - id: CON-005
+    title: a then item mapping whose text is not a string
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: some-key
+        text: 7

--- a/backend/internal/spec/testdata/invalid/then-key-bad-charset/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/then-key-bad-charset/bad.yaml
@@ -1,0 +1,31 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  - id: CON-001
+    title: a then item key with an underscore
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: bad_key
+        text: y
+  - id: CON-002
+    title: a then item key with uppercase
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: BadKey
+        text: y
+  - id: CON-003
+    title: a then item key with a trailing hyphen
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: trailing-
+        text: y

--- a/backend/internal/spec/testdata/invalid/then-key-dup/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/then-key-dup/bad.yaml
@@ -1,0 +1,15 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  - id: CON-001
+    title: two then items sharing one key
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: same-key
+        text: y
+      - key: same-key
+        text: z

--- a/backend/internal/spec/testdata/invalid/then-key-empty/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/then-key-empty/bad.yaml
@@ -1,0 +1,33 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  # One deviation per BEHAVIOR: the walker returns nil on the first one, so a
+  # second case inside the same then list would be unreachable.
+  - id: CON-001
+    title: a then item key written as an empty string
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: ""
+        text: y
+  - id: CON-002
+    title: a then item key written as null
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: null
+        text: y
+  - id: CON-003
+    title: a then item key that is not a string
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: 7
+        text: y

--- a/backend/internal/spec/testdata/invalid/then-key-reserved/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/then-key-reserved/bad.yaml
@@ -1,0 +1,13 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  - id: CON-001
+    title: a then item key using the reserved statement token
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: statement
+        text: y

--- a/backend/internal/spec/testdata/invalid/then-text-empty/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/then-text-empty/bad.yaml
@@ -1,0 +1,13 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  - id: CON-001
+    title: a keyed then item with empty text
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: some-key
+        text: ""

--- a/backend/internal/spec/testdata/invalid/waiver-dup-across-forms/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/waiver-dup-across-forms/bad.yaml
@@ -1,0 +1,19 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  - id: CON-001
+    title: a key-form and an index-form waiver naming the same item
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - y
+      - key: second-item
+        text: z
+    waivers:
+      - then: 1
+        reason: first reason
+      - then: second-item
+        reason: second reason

--- a/backend/internal/spec/testdata/invalid/waiver-key-unknown/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/waiver-key-unknown/bad.yaml
@@ -1,0 +1,16 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  - id: CON-001
+    title: a waiver naming a then-item key that does not exist
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: real-key
+        text: y
+    waivers:
+      - then: no-such-key
+        reason: r

--- a/backend/internal/spec/testdata/invalid/waiver-statement-bad-key/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/waiver-statement-bad-key/bad.yaml
@@ -1,0 +1,13 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  - id: CON-001
+    title: a statement waiver keyed with anything but the reserved token
+    type: invariant
+    status: current
+    surface: ui
+    statement: every read filters soft-deleted rows
+    waivers:
+      - then: some-key
+        reason: not provable

--- a/backend/internal/spec/testdata/invalid/waiver-statement-bad-key/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/waiver-statement-bad-key/bad.yaml
@@ -11,3 +11,16 @@ behaviors:
     waivers:
       - then: some-key
         reason: not provable
+  # The mirror case: the reserved token on a behavior that has a then list.
+  - id: CON-002
+    title: a given/when/then waiver keyed with the reserved statement token
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: real-key
+        text: y
+    waivers:
+      - then: statement
+        reason: not provable

--- a/backend/internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml
@@ -21,8 +21,10 @@ behaviors:
       - y
     waivers:
       - just a string
+  # `then` accepts both a key (a string) and an index (an integer), so this
+  # case must be a node that is NEITHER — a sequence, not a mistyped scalar.
   - id: CON-003
-    title: waiver then not an integer
+    title: waiver then is neither a key nor an integer
     type: ux
     status: current
     surface: ui
@@ -30,7 +32,7 @@ behaviors:
     then:
       - y
     waivers:
-      - then: first
+      - then: [1]
         reason: r
   - id: CON-004
     title: waiver without a reason

--- a/backend/internal/spec/testdata/valid-then-keys/spec.yaml
+++ b/backend/internal/spec/testdata/valid-then-keys/spec.yaml
@@ -1,0 +1,42 @@
+domain: keys
+prefix: KEY
+maturity: reviewed
+behaviors:
+  - id: KEY-001
+    title: a behavior mixing keyed and plain then items
+    type: ux
+    status: current
+    surface: ui
+    given: a starting state
+    when: the trigger fires
+    then:
+      - key: live-contact-flag
+        text: a live contact is returned with a has_pending_followup flag
+      - an unkeyed outcome stays a plain string
+      - key: pending-followup-count
+        text: the pending followup count is returned
+    waivers:
+      - then: pending-followup-count
+        reason: the count is not deterministically provable in the browser
+  - id: KEY-002
+    title: a statement behavior waived by the reserved token
+    type: invariant
+    status: current
+    surface: ui
+    statement: every read filters soft-deleted rows
+    waivers:
+      - then: statement
+        reason: structural, enforced by the query layer rather than observable
+  - id: KEY-003
+    title: a behavior whose waiver still uses the legacy index form
+    type: api
+    status: current
+    surface: api
+    when: the request is validated
+    then:
+      - key: rejects-bad-input
+        text: an invalid request is rejected with a validation error (400)
+      - the legacy-waived outcome
+    waivers:
+      - then: 1
+        reason: the legacy index form is still accepted

--- a/backend/internal/spec/validate.go
+++ b/backend/internal/spec/validate.go
@@ -58,6 +58,11 @@ const (
 	orderServesResolve    = 29 // serves targets resolve to intent behaviors
 	orderSurface          = 30 // surface enum + required for non-intent non-retired + forbidden on intent
 	orderWaivers          = 31 // waivers only on ui- or api-surface; index in range; no dups; reason non-empty
+	// orderThenKeys is APPENDED rather than slotted next to orderListItems so
+	// the 20-31 ranks (and the report-order assertions that pin them) do not
+	// renumber. Consequence: a bad or duplicated then-item key sorts AFTER the
+	// orderWaivers finding it may have caused, so the root cause reads second.
+	orderThenKeys = 32 // then-item key charset, reserved words, uniqueness
 )
 
 var (
@@ -81,6 +86,12 @@ func idRegex(prefix string) *regexp.Regexp {
 // prefixRegex is the charset the citation grammar (coverage.go citationRef)
 // can parse back out of a // spec: marker — keep the two in lockstep.
 var prefixRegex = regexp.MustCompile(`^[A-Z][A-Z0-9]*$`)
+
+// thenKeyRegex is the then-item key charset: lowercase alphanumeric words
+// separated by single hyphens. It must stay in lockstep with the key
+// alternative of coverage.go's citationRef — a key outside it could never be
+// cited.
+var thenKeyRegex = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 // Lint parses and validates the spec corpus in dir, returning the parsed files,
 // every violation (parse/structural + semantic + cross-file) in deterministic
@@ -311,10 +322,14 @@ func checkBehavior(pf *parsedFile, pb *parsedBehavior, idRe *regexp.Regexp, c *c
 	}
 	// GWT xor statement, presence-based by type.
 	checkGWT(pf, pb, c)
-	// given/then/serves list items non-empty.
+	// given/then/serves list items non-empty. then is projected to its texts:
+	// emptiness is a property of the assertion, not of the citation handle, and
+	// the message + reported line stay exactly as they were.
 	checkListItems(pf, pb, c, "given", pb.b.Given, pb.broken["given"])
-	checkListItems(pf, pb, c, "then", pb.b.Then, pb.broken["then"])
+	checkListItems(pf, pb, c, "then", pb.b.ThenTexts(), pb.broken["then"])
 	checkListItems(pf, pb, c, "serves", pb.b.Serves, pb.broken["serves"])
+	// then-item key charset / reserved words / uniqueness.
+	checkThenKeys(pf, pb, c)
 
 	// serves is only for ux and intent behaviors (decidable only when the
 	// type is a known enum value; an absent/invalid type is already reported).
@@ -365,11 +380,50 @@ func checkSurface(pf *parsedFile, pb *parsedBehavior, c *collector) {
 	}
 }
 
+// checkThenKeys enforces then-item key semantics: the charset, the reserved
+// "statement" token, and uniqueness within the behavior. A structurally broken
+// then list is skipped, the same tiered guard checkListItems carries. Both are
+// belt-and-braces rather than live filters — behaviorThen returns nil whenever
+// it marks the field broken, so there is nothing to iterate either way — and
+// both stay because the guard, not the walker's current return value, is what
+// states the tier contract.
+//
+// Uniqueness is checked among NON-EMPTY keys only. An unkeyed item is a plain
+// string with an empty key, and a behavior routinely has several of those —
+// treating them as colliding would fail the entire corpus.
+func checkThenKeys(pf *parsedFile, pb *parsedBehavior, c *collector) {
+	if pb.broken["then"] {
+		return
+	}
+	seen := map[string]bool{}
+	for _, it := range pb.b.Then {
+		if it.Key == "" {
+			continue // an unkeyed (plain-string) item
+		}
+		switch {
+		case !thenKeyRegex.MatchString(it.Key):
+			c.add(pf, orderThenKeys, pb.idx, it.Line, pb.ref,
+				fmt.Sprintf("then item key %q must be lowercase alphanumeric words separated by hyphens", it.Key))
+		case it.Key == waiverStatementKey:
+			c.add(pf, orderThenKeys, pb.idx, it.Line, pb.ref,
+				`then item key "statement" is reserved for statement-behavior waivers`)
+		case seen[it.Key]:
+			c.add(pf, orderThenKeys, pb.idx, it.Line, pb.ref,
+				fmt.Sprintf("duplicate then item key %q", it.Key))
+		}
+		seen[it.Key] = true
+	}
+}
+
 // checkWaivers enforces waiver semantics: waivers may appear only on ui- or
-// api-surface behaviors (never on none, never on intents), every waived then
-// index must be in range, indexes must be unique, and every reason must be
+// api-surface behaviors (never on none, never on intents), every waived
+// reference must resolve to an item of this behavior (a key that names one, or
+// an index in range), references must be unique, and every reason must be
 // non-empty. Placement is decidable only when the fields it depends on (type,
-// surface) parsed clean; index range needs a clean then list.
+// surface) parsed clean; resolution needs a clean then list.
+//
+// Duplicate detection keys on the RESOLVED index, so a key-form waiver and an
+// index-form waiver naming the same item are one duplicate, not two waivers.
 func checkWaivers(pf *parsedFile, pb *parsedBehavior, c *collector) {
 	if !pb.keys["waivers"] || pb.broken["waivers"] || len(pb.b.Waivers) == 0 {
 		return
@@ -405,22 +459,69 @@ func checkWaivers(pf *parsedFile, pb *parsedBehavior, c *collector) {
 		if w.Reason == "" {
 			c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref, "waiver reason must be non-empty")
 		}
-		if seen[w.Then] {
-			c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,
-				fmt.Sprintf("duplicate waiver for then item %d", w.Then))
+		if w.Keyed {
+			// A key that names nothing is the root cause — reporting it and
+			// stopping keeps one finding per bad reference.
+			switch {
+			case statement:
+				if w.Key != waiverStatementKey {
+					c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,
+						fmt.Sprintf("waiver then %q is not valid for a statement behavior (use the reserved key %q)", w.Key, waiverStatementKey))
+					continue
+				}
+			case pb.broken["then"]:
+				continue // the then list never parsed; a key cannot be resolved
+			default:
+				if _, ok := resolveWaiverIndex(pb.b, w); !ok {
+					c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,
+						fmt.Sprintf("waiver then %q names no then-item key of this behavior", w.Key))
+					continue
+				}
+			}
 		}
-		seen[w.Then] = true
+		idx, _ := resolveWaiverIndex(pb.b, w)
+		if seen[idx] {
+			c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,
+				fmt.Sprintf("duplicate waiver for then item %d", idx))
+		}
+		seen[idx] = true
+		if w.Keyed {
+			continue // a resolved key is in range by construction
+		}
 		switch {
 		case statement:
-			if w.Then != 0 {
+			if idx != 0 {
 				c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,
-					fmt.Sprintf("waiver then index %d out of range (a statement behavior has one implicit item, index 0)", w.Then))
+					fmt.Sprintf("waiver then index %d out of range (a statement behavior has one implicit item, index 0)", idx))
 			}
-		case !pb.broken["then"] && (w.Then < 0 || w.Then >= len(pb.b.Then)):
+		case !pb.broken["then"] && (idx < 0 || idx >= len(pb.b.Then)):
 			c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,
-				fmt.Sprintf("waiver then index %d out of range (behavior has %d then items)", w.Then, len(pb.b.Then)))
+				fmt.Sprintf("waiver then index %d out of range (behavior has %d then items)", idx, len(pb.b.Then)))
 		}
 	}
+}
+
+// resolveWaiverIndex resolves a waiver's reference to a 0-based then-item
+// index. It reports ok=false only for a keyed waiver whose key names nothing:
+// the reserved "statement" token on a behavior that has no statement, or a key
+// that matches no then item. The legacy index form always resolves to itself —
+// whether the index is IN RANGE is checkWaivers' job, not this function's, so
+// a negative or past-the-end index still comes back ok.
+func resolveWaiverIndex(b *Behavior, w Waiver) (int, bool) {
+	if !w.Keyed {
+		return w.Index, true
+	}
+	if w.Key == waiverStatementKey {
+		// A statement behavior's single implicit item occupies index 0, the
+		// same slot the legacy index form addressed.
+		return 0, b.Statement != ""
+	}
+	for i, it := range b.Then {
+		if it.Key != "" && it.Key == w.Key {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 func checkRequiredBehaviorField(pf *parsedFile, pb *parsedBehavior, c *collector, key, val string) {

--- a/backend/internal/spec/validate.go
+++ b/backend/internal/spec/validate.go
@@ -382,11 +382,11 @@ func checkSurface(pf *parsedFile, pb *parsedBehavior, c *collector) {
 
 // checkThenKeys enforces then-item key semantics: the charset, the reserved
 // "statement" token, and uniqueness within the behavior. A structurally broken
-// then list is skipped, the same tiered guard checkListItems carries. Both are
-// belt-and-braces rather than live filters — behaviorThen returns nil whenever
-// it marks the field broken, so there is nothing to iterate either way — and
-// both stay because the guard, not the walker's current return value, is what
-// states the tier contract.
+// then list is skipped, the same tiered guard checkListItems carries. Both
+// guards are currently UNREACHABLE, not live filters — behaviorThen returns nil
+// whenever it marks the field broken, so the loop below has nothing to iterate
+// either way — and both stay because the guard, not the walker's present return
+// value, is what states the tier contract.
 //
 // Uniqueness is checked among NON-EMPTY keys only. An unkeyed item is a plain
 // string with an empty key, and a behavior routinely has several of those —
@@ -471,6 +471,14 @@ func checkWaivers(pf *parsedFile, pb *parsedBehavior, c *collector) {
 				}
 			case pb.broken["then"]:
 				continue // the then list never parsed; a key cannot be resolved
+			case w.Key == waiverStatementKey:
+				// The mirror of the case above, and it needs its own message:
+				// "statement" is reserved rather than merely absent, so the
+				// generic unknown-key wording would send the author looking for
+				// a then item they never meant to name.
+				c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,
+					fmt.Sprintf("waiver then %q is reserved for statement behaviors; waive a then item of this behavior by its key", waiverStatementKey))
+				continue
 			default:
 				if _, ok := resolveWaiverIndex(pb.b, w); !ok {
 					c.add(pf, orderWaivers, pb.idx, waiverLine(i), pb.ref,


### PR DESCRIPTION
PR1 of 3 for #760. Teaches the spec toolchain the keyed then-item form end to end, **without touching the corpus** — all three spec gates are byte-identical to `develop` on today's unmigrated `spec/*.yaml`. That inertness is what makes it safe to land alone, ahead of the mechanical rewrite (PR2) and the retirement of the indexed form (PR3).

## The premise, verified on this branch's base

#760 says: *if the "before" case does not go green on a genuinely broken state, stop — the premise is wrong.* It was executed on a committed scratch branch at `030a400`, twice.

**Probe B** — a then-item inserted at position 1 of `CON-002`, citing file untouched: `spec-drift` WARNs naming all 12 citation sites, `spec-coverage` blocks on `ORPHAN (blocking) CON-002[7]`. The tooling does react when nothing else moves.

**Probe A** — the same insertion *plus* the citation a diligent author adds to quiet the resulting orphan: **lint 0, coverage 0, drift 0**, zero ORPHAN, zero INVALID, drift output 0 bytes — while 11 of 12 marker lines silently re-point to different assertions. `spec-drift` is doubly blind here: it materializes both corpora from git, and even committed it stays silent because the citing file *was* touched.

Premise confirmed. Full transcripts below.

## What lands

- **Parser** accepts both then-item forms — plain string (uncited) or `{key, text}` — and both waiver forms. Any other mapping shape is a structural violation that marks the field broken and returns nil, so a partially-parsed `then` list never reaches the semantic pass. Empty/null `key` is rejected at the **parser** tier, because `strScalar` returns `("", true)` for both `""` and `null`, making a mapping-with-empty-key indistinguishable from a plain string at any later layer.
- **`spec-lint`** validates key charset (`^[a-z0-9]+(-[a-z0-9]+)*$`), uniqueness within a behavior over non-empty keys, non-empty text, waiver-key resolution, and reserves `statement` as a then-item key.
- **`spec-coverage`** resolves `ID.key` alongside legacy `ID[n]`, and **reserves `@`** with a forward-looking message so the deferred `@hash` suffix stays a pure addition later.
- **`spec-drift`** compares projected then *texts* via `ThenTexts()`, not `ThenItem` structs — including `Line` would drift every behavior below any insertion anywhere in a file.
- `Waiver` uses an explicit `Keyed bool` discriminator rather than an `Index == -1` sentinel, because `then: -1` is a real fixture value that must keep linting as out-of-range.

## Acceptance criteria (#760)

| Criterion | Where |
|---|---|
| **Before** — current system green on a broken state | Probes A/B above, re-run on this branch's base |
| **After** — the same insertion changes nothing | `TestComputeCoverage_KeyedCitationSurvivesThenInsertion` (unit) + `TestSpecCoverage_KeyedCorpusInsertionStable` (CLI, `coverage-keys/` vs `coverage-keys-inserted/`) |
| **After** — renaming/deleting a cited key fails loudly, naming the dangling citation | `TestComputeCoverage_DanglingKeyCitation` + `TestSpecCoverage_DanglingKeyExitsOne` — CLI exits 1 with `citation ALP-001.renamed-key names an unknown then-item key (behavior has: alpha, beta)` |

## Gate honesty

Per the repo rule that *a gate that cannot fail is indistinguishable from one that always passes*, every new gate was shown to fail on injected bad input before being claimed as passing — 15 injections during implementation plus 7 more during review, each grep-confirmed to land, each exit code read directly rather than through a pipe. Two injections initially failed to discriminate and the **tests were strengthened rather than the result accepted**: the broken-`then` case now asserts `Then == nil`, and `TestParserThenScalarForms` covers scalar branches the fixture corpus never exercised.

One injection is worth calling out: collapsing the two then-item messages into one **passes** the pre-existing `strings.Contains` assertion while **failing** the new `TestParserThenMessagesAreDistinct` equality check — the accidental-substring leak this PR was written to close, demonstrated live.

Review also replaced an unfalsifiable guard in `TestSpecCoverage_KeyedCorpusInsertionStable`: it checked for an `ALP-002[2]` line that the two-item fixture can never produce, while its comment claimed to prove the pair still discriminates. It now asserts positively and is verified discriminating.

## Verification

All exit codes read directly (`cmd >out 2>&1; echo $?`), never through a pipe — `make` masks tool exit codes (`make spec-coverage` returns 2 where the CLI returns 1), so CLI assertions invoke `go run ./cmd/spec-coverage` directly.

- `make spec-lint` / `spec-coverage` / `spec-drift` → 0/0/0, each **byte-identical to `develop`**
- Whole-tree `spec-lint` sweep over all of `testdata/` vs `develop`: the only removals are the 3 predicted `waivers-bad-shape` lines; every other delta is an addition for a new fixture dir. Dual acceptance silently reclassifies fixtures, so this sweep is what proves no pre-existing case changed verdict unnoticed.
- `make test-unit` 0 · `make lint` 0 (0 issues) · `cd frontend && bun run test` 0 (74 files, 1248 tests — proves the judge harness is unaffected)

## Scope notes

- The corpus, `frontend/`, and `bun.lock` are untouched — the diff is confined to `backend/internal/spec/**` and `backend/cmd/spec-coverage/main_test.go`.
- The `@hash` suffix (#760 step 4) is **deferred**; `@` is reserved from here so it needs no second migration. `spec-drift` is **retained** for the same reason.
- `frontend/tests/tours/judge/**` deliberately stays index-based — its indexes address the judge's own transcribed `then` array and are embedded in already-shipped Langfuse trace IDs. Re-keying them would de-correlate existing human labels from their traces. Follow-up issue to be filed.

Closes nothing on its own — #760 closes after PR3.

<details><summary>Full evidence — probe transcripts, inertness diff, whole-tree testdata diff</summary>

# PR1 evidence — GH #760 (feat/spec-then-item-keys, base 030a400, HEAD 378278a)

## Step 0 — before-demonstration probes, re-run on PR1's base commit
```
########## PROBE B — corpus edited at CON-002 position 1, citing file UNTOUCHED (base 030a400) ##########
$ make spec-lint
exit=0
spec-lint: 12 files, 430 behaviors — OK

$ make spec-coverage
exit=2
  ORPHAN (blocking) CON-002[7]: a valid request creates the contact and returns it (201)
spec-coverage: 1 orphaned then-items (ui 0, api 1), 0 invalid citations

$ cd backend && go run ./cmd/spec-coverage .. (direct CLI, unmasked exit)
exit=1

$ make spec-drift
exit=0
WARN: spec/contacts.yaml:22: CON-002: behavior assertions changed but none of its 1 citing test file(s) were touched (backend/tests/api/contact_validation_test.go:113, backend/tests/api/contact_validation_test.go:137, backend/tests/api/contact_validation_test.go:175, backend/tests/api/contact_validation_test.go:198, backend/tests/api/contact_validation_test.go:222, backend/tests/api/contact_validation_test.go:265, backend/tests/api/contact_validation_test.go:300, backend/tests/api/contact_validation_test.go:325, backend/tests/api/contact_validation_test.go:350, backend/tests/api/contact_validation_test.go:402, backend/tests/api/contact_validation_test.go:427, backend/tests/api/contact_validation_test.go:464)
########## PROBE A — same insertion PLUS the citation a diligent author adds (base 030a400) ##########
$ make spec-lint
exit=0
spec-lint: 12 files, 430 behaviors — OK

$ make spec-coverage
exit=0
  waived TDS-035[2]: a structural-absence property with no deterministic browser observable — the provider-less E2E env cannot seed a real cadence_due row (the contact-page task routes are OAuth-gated and route-mocked in E2E, so an absence assertion would only prove the mock), and the exclusion is enforced by the contact page's lifecycle-scoped task queries (manual + followup_loop only), which structurally omit cadence_due projections
spec-coverage: all ui- and api-surface then-items covered or waived
ORPHAN lines: 0  INVALID lines: 0

$ cd backend && go run ./cmd/spec-coverage .. (direct CLI, unmasked exit)
exit=0

$ make spec-drift
exit=0
--- drift output (bytes: 0) ---
```

## Inertness proof — all three spec targets vs develop @ 030a400 (post-polish, committed tree)
```
make spec-lint     -> exit 0, diff vs develop: EMPTY
make spec-coverage -> exit 0, diff vs develop: EMPTY
make spec-drift    -> exit 0, diff vs develop: EMPTY
```

## Whole-tree spec-lint output diff over backend/internal/spec/testdata/ (develop -> branch)
Only removals are the 3 waivers-bad-shape lines (the one predicted delta). All other hunks are additions for new fixture dirs.
```diff
23a24,32
> ===== internal/spec/testdata/coverage-dangling-key/
> spec-lint: no spec files found in internal/spec/testdata/coverage-dangling-key/ — OK
> ----- exit=0
> ===== internal/spec/testdata/coverage-keys/
> spec-lint: no spec files found in internal/spec/testdata/coverage-keys/ — OK
> ----- exit=0
> ===== internal/spec/testdata/coverage-keys-inserted/
> spec-lint: no spec files found in internal/spec/testdata/coverage-keys-inserted/ — OK
> ----- exit=0
258a268,272
> ===== internal/spec/testdata/invalid/then-broken-suppresses/
> internal/spec/testdata/invalid/then-broken-suppresses/bad.yaml:16: CON-001: unknown key "txt" in then item mapping (want key, text)
> spec-lint: 1 files, 1 behaviors — 1 violations
> exit status 1
> ----- exit=1
263a278,310
> ===== internal/spec/testdata/invalid/then-item-bad-shape/
> internal/spec/testdata/invalid/then-item-bad-shape/bad.yaml:13: CON-001: then items must be strings or {key, text} mappings
> internal/spec/testdata/invalid/then-item-bad-shape/bad.yaml:22: CON-002: unknown key "txt" in then item mapping (want key, text)
> internal/spec/testdata/invalid/then-item-bad-shape/bad.yaml:30: CON-003: then item mapping must have a key and a text
> internal/spec/testdata/invalid/then-item-bad-shape/bad.yaml:38: CON-004: duplicate key "text" in then item mapping
> internal/spec/testdata/invalid/then-item-bad-shape/bad.yaml:49: CON-005: then item text must be a string
> spec-lint: 1 files, 5 behaviors — 5 violations
> exit status 1
> ----- exit=1
> ===== internal/spec/testdata/invalid/then-key-bad-charset/
> internal/spec/testdata/invalid/then-key-bad-charset/bad.yaml:12: CON-001: then item key "bad_key" must be lowercase alphanumeric words separated by hyphens
> internal/spec/testdata/invalid/then-key-bad-charset/bad.yaml:21: CON-002: then item key "BadKey" must be lowercase alphanumeric words separated by hyphens
> internal/spec/testdata/invalid/then-key-bad-charset/bad.yaml:30: CON-003: then item key "trailing-" must be lowercase alphanumeric words separated by hyphens
> spec-lint: 1 files, 3 behaviors — 3 violations
> exit status 1
> ----- exit=1
> ===== internal/spec/testdata/invalid/then-key-dup/
> internal/spec/testdata/invalid/then-key-dup/bad.yaml:14: CON-001: duplicate then item key "same-key"
> spec-lint: 1 files, 1 behaviors — 1 violations
> exit status 1
> ----- exit=1
> ===== internal/spec/testdata/invalid/then-key-empty/
> internal/spec/testdata/invalid/then-key-empty/bad.yaml:14: CON-001: then item key must be a non-empty string
> internal/spec/testdata/invalid/then-key-empty/bad.yaml:23: CON-002: then item key must be a non-empty string
> internal/spec/testdata/invalid/then-key-empty/bad.yaml:32: CON-003: then item key must be a non-empty string
> spec-lint: 1 files, 3 behaviors — 3 violations
> exit status 1
> ----- exit=1
> ===== internal/spec/testdata/invalid/then-key-reserved/
> internal/spec/testdata/invalid/then-key-reserved/bad.yaml:12: CON-001: then item key "statement" is reserved for statement-behavior waivers
> spec-lint: 1 files, 1 behaviors — 1 violations
> exit status 1
> ----- exit=1
268a316,330
> ===== internal/spec/testdata/invalid/then-text-empty/
> internal/spec/testdata/invalid/then-text-empty/bad.yaml:5: CON-001: then list items must be non-empty strings
> spec-lint: 1 files, 1 behaviors — 1 violations
> exit status 1
> ----- exit=1
> ===== internal/spec/testdata/invalid/waiver-dup-across-forms/
> internal/spec/testdata/invalid/waiver-dup-across-forms/bad.yaml:18: CON-001: duplicate waiver for then item 1
> spec-lint: 1 files, 1 behaviors — 1 violations
> exit status 1
> ----- exit=1
> ===== internal/spec/testdata/invalid/waiver-key-unknown/
> internal/spec/testdata/invalid/waiver-key-unknown/bad.yaml:15: CON-001: waiver then "no-such-key" names no then-item key of this behavior
> spec-lint: 1 files, 1 behaviors — 1 violations
> exit status 1
> ----- exit=1
278,280c340,342
< internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml:33: CON-003: waiver then must be an integer then-item index
< internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml:44: CON-004: waiver must have a reason
< internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml:55: CON-005: waiver reason must be a string
---
> internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml:35: CON-003: waiver then must be a then-item key or an integer index
> internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml:46: CON-004: waiver must have a reason
> internal/spec/testdata/invalid/waivers-bad-shape/bad.yaml:57: CON-005: waiver reason must be a string
308a371,376
> ===== internal/spec/testdata/invalid/waiver-statement-bad-key/
> internal/spec/testdata/invalid/waiver-statement-bad-key/bad.yaml:12: CON-001: waiver then "some-key" is not valid for a statement behavior (use the reserved key "statement")
> internal/spec/testdata/invalid/waiver-statement-bad-key/bad.yaml:25: CON-002: waiver then "statement" is reserved for statement behaviors; waive a then item of this behavior by its key
> spec-lint: 1 files, 2 behaviors — 2 violations
> exit status 1
> ----- exit=1
338a407,409
> ----- exit=0
> ===== internal/spec/testdata/valid-then-keys/
> spec-lint: 1 files, 3 behaviors — OK
```

</details>
