### PR TITLE
refactor(spec): cite then-items by key, not by index (PR2/3, #760)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ test: test-unit test-integration test-frontend
 
 test-unit:
 	@echo "Running backend unit tests..."
-	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/synthetic ./internal/synthetic/factory/... ./internal/synthetic/replay/... ./internal/spec/... ./cmd/spec-lint/... ./cmd/spec-coverage/... ./cmd/spec-drift/... $(GOTEST_VERBOSE) -short
+	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/synthetic ./internal/synthetic/factory/... ./internal/synthetic/replay/... ./internal/spec/... ./cmd/spec-lint/... ./cmd/spec-coverage/... ./cmd/spec-drift/... ./cmd/specmigrate/... $(GOTEST_VERBOSE) -short
 
 # Provisions the per-worktree Postgres instance BEFORE the integration recipes
 # expand $(TEST_DATABASE_URL) (gh #433). As a prerequisite it runs to

--- a/backend/cmd/specmigrate/README.md
+++ b/backend/cmd/specmigrate/README.md
@@ -1,0 +1,38 @@
+# specmigrate — one-shot spec citation key migration (GH #760)
+
+This is a throwaway artifact of the spec-citation-by-key arc's PR2. It ran once, against one corpus, to key the 393 cited-or-waived then-items and rewrite the 616 positional references that addressed them. It is wired into **nothing** — no CI job, no git hook, no pre-push phase — and exactly one `make` target: `test-unit`'s package list, which runs `slug_test.go`. **PR3 deletes this directory and that Makefile entry.** It is committed only so the migration's correctness proof is reproducible by a reviewer instead of resting on pasted numbers.
+
+Re-running `keys` on a migrated corpus is a byte-level no-op: keys are permanent (arc §3.6) and the tool only ever keys items that lack one.
+
+## Subcommands
+
+| Command | What it does |
+|---|---|
+| `keys -out <dir> [--write] <root>` | Pass A. Mints a key for every cited-or-waived unkeyed then-item and rewrites `      - <text>` into `      - key: <slug>` + `        text: <text>`. Writes `slug-table.txt` (all rows) and `slug-review.txt` (the flagged weak-slug subset). |
+| `cite -out <dir> [--write] <root>` | Pass B. Re-reads the **final** corpus, builds one `(ID, index) → key` map, and rewrites the waiver lines, the marker lines in the two scan roots, and the out-of-root markers. Writes `substitutions.txt`, the 616-row ledger. |
+| `g1 <base-ref> <root>` | Map faithfulness over all 616 references. `old_index` comes from a materialized checkout of `<base-ref>`, never from the ledger — the ledger is the thing under test. |
+| `g2 [-subs <f>] <base> <tool> <passB> <head> <root>` | Diff shape: G2a (scan roots + substitution exactness), G2b (path allowlist + production-untouched), G2c (corpus shape + inverse-transform identity), plus three-way commit disjointness. Four refs because the branch has four boundaries and each clause needs a different pair. |
+| `g3 <base-ref> <root>` | Corpus text preservation: then texts, given/when/statement, metadata, and waiver reasons identical before and after. |
+
+Exit codes are meaningful: `0` ok, `1` a violation was found, `2` an operational error.
+
+**Read them from a BUILT BINARY, not from `go run`.** Measured on go1.25: `go run` collapses any non-zero program exit to **1**, so the 1-vs-2 distinction — the one that separates "the migration is not faithful" from "the tool refused to run" — is invisible through it. `make` is worse, normalizing any recipe failure to 2. Build once and invoke the binary:
+
+```
+go build -o /tmp/specmigrate ./cmd/specmigrate
+/tmp/specmigrate g1 <base> ..; echo $?
+```
+
+Never read an exit code through a pipe either — the status is the last stage's.
+
+## Fail-closed rules
+
+- `--write` is opt-in; the default is a dry run that prints the plan and writes only the `-out` artifacts.
+- `--write` refuses to run on a dirty tree, which is what makes `git checkout --` an unambiguous rollback for either pass.
+- `-out` is required and must resolve **outside** the repository, so no artifact can become an untracked file that breaks the guards' `git status --short` checks.
+- Both passes validate the whole corpus before writing any file — a failure on file 7 of 12 must not leave 6 rewritten files on disk.
+- `cite` aborts before its first byte if the key map has no entry for a reference it must rewrite, naming every unresolvable one.
+
+## Two passes, and why they are not fused
+
+Keys are permanent. Pass A writes them; a human reviews and hand-edits the weak ones; Pass B then re-reads the final corpus and rewrites the references from it. Fusing the passes would bake 393 unreviewed names into 616 references. The state between the passes is deliberately a valid, fully green tree: keyed items with index-form waivers and index-form citations are all forms the parser accepts.

--- a/backend/cmd/specmigrate/guards.go
+++ b/backend/cmd/specmigrate/guards.go
@@ -1,0 +1,973 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"personal-crm/backend/internal/spec"
+)
+
+// The three mechanical guards that carry PR2's correctness proof. The
+// before/after spec-coverage report diff is explicitly NOT the proof: report()
+// prints nothing for covered items, so any permutation of the (ID, n) -> key
+// map inside a fully-covered behavior is byte-invisible to it.
+
+// Counts re-measured at this PR's base with the scanner's own code. A guard
+// that silently checks fewer references than it should is indistinguishable
+// from one that passes.
+const (
+	expectG1InRoot  = 597 // indexed citations inside the two scan roots
+	expectG1Extra   = 2   // indexed citations in extraCitationPaths
+	expectG1Waivers = 17  // index-form waivers
+	expectG1Total   = expectG1InRoot + expectG1Extra + expectG1Waivers
+
+	expectG2aFiles = 68  // scan-root files whose marker lines are rewritten
+	expectG2aPairs = 510 // marker lines rewritten (one - and one + each)
+
+	expectG2cRemoved   = 410 // 393 then-item lines + 17 waiver lines
+	expectG2cAdded     = 803 // 786 keyed then-item lines + 17 waiver lines
+	expectG2cItemPairs = 393
+	expectG2cWaivers   = 17
+)
+
+// i4Path is the single non-scan-root, non-corpus file the mechanical range may
+// touch — the hand-sweep target from the plan's D5.
+const i4Path = "frontend/src/lib/__tests__/contact-recency.test.ts"
+
+// guard accumulates violations so one run reports every failure rather than the
+// first.
+type guard struct {
+	name  string
+	viols []string
+}
+
+func (g *guard) fail(format string, a ...any) {
+	g.viols = append(g.viols, fmt.Sprintf(format, a...))
+}
+
+func (g *guard) opFail(format string, a ...any) int {
+	return opErr("%s: "+format, append([]any{g.name}, a...)...)
+}
+
+func (g *guard) report() int {
+	if len(g.viols) == 0 {
+		fmt.Printf("%s: PASS\n", g.name)
+		return 0
+	}
+	fmt.Printf("%s: FAIL — %d violation(s)\n", g.name, len(g.viols))
+	for _, v := range g.viols {
+		fmt.Printf("  %s\n", v)
+	}
+	return 1
+}
+
+// ---------------------------------------------------------------- git access
+
+// archivePaths are the trees the guards need from a historical ref: the corpus,
+// the two scan roots, and the out-of-root citation file's directory.
+var archivePaths = []string{"spec", "backend", "frontend/tests/e2e", "frontend/src/lib/__tests__"}
+
+// materialize extracts a ref's tree into a temporary directory with git
+// archive. It deliberately avoids `git worktree add`, which would write
+// bookkeeping into the repository the guards are inspecting.
+func materialize(root, ref string) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "specmigrate-")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	tarPath := filepath.Join(dir, "tree.tar")
+	f, err := os.Create(tarPath)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	args := append([]string{"-C", root, "archive", "--format=tar", ref, "--"}, archivePaths...)
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = f
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", func() {}, fmt.Errorf("git archive %s: %w", ref, err)
+	}
+	// cmd.Stdout is an *os.File, so os/exec hands the descriptor straight to
+	// the child and the parent buffers nothing — a Close error here cannot
+	// truncate the archive, and this check is not what makes a short archive
+	// safe. That chain is `tar -xf` failing plus G1's per-leg count
+	// assertions. Checked anyway because ignoring it would be a silent
+	// discard of a real error (and errcheck agrees).
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("write archive of %s: %w", ref, err)
+	}
+	tree := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(tree, 0o755); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if out, err := exec.Command("tar", "-xf", tarPath, "-C", tree).CombinedOutput(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("tar -xf: %w: %s", err, out)
+	}
+	return tree, cleanup, nil
+}
+
+func gitLines(root string, args ...string) ([]string, error) {
+	out, err := exec.Command("git", append([]string{"-C", root}, args...)...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	var res []string
+	for _, l := range strings.Split(string(out), "\n") {
+		if l != "" {
+			res = append(res, l)
+		}
+	}
+	return res, nil
+}
+
+func gitNames(root, rng, filter string) ([]string, error) {
+	args := []string{"diff", "--name-only"}
+	if filter != "" {
+		args = append(args, "--diff-filter="+filter)
+	}
+	return gitLines(root, append(args, rng)...)
+}
+
+func gitShow(root, spec string) (string, error) {
+	out, err := exec.Command("git", "-C", root, "show", spec).Output()
+	if err != nil {
+		return "", fmt.Errorf("git show %s: %w", spec, err)
+	}
+	return string(out), nil
+}
+
+// diffHunk is one -U0 hunk: the removed lines and the added lines, with the
+// 1-based line each group starts at.
+type diffHunk struct {
+	Path               string
+	OldStart, NewStart int
+	Removed, Added     []string
+}
+
+var hunkHeader = regexp.MustCompile(`^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
+
+// gitDiffHunks assumes no changed line's own text begins with "-- " or "++ ",
+// which would render as "--- ..." / "+++ ..." and be mistaken for a file
+// header. That cannot occur in this migration's diff — every changed line is a
+// `// spec:` marker or a six-space YAML sequence entry — and this tool does not
+// outlive PR3, so the parser stays simple rather than tracking header position.
+
+func gitDiffHunks(root, rng string) ([]diffHunk, error) {
+	out, err := exec.Command("git", "-C", root, "diff", "-U0", "--no-color", "--no-ext-diff", rng).Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff %s: %w", rng, err)
+	}
+	var hunks []diffHunk
+	path := ""
+	cur := -1
+	for _, l := range strings.Split(string(out), "\n") {
+		switch {
+		case strings.HasPrefix(l, "+++ "):
+			p := strings.TrimPrefix(l, "+++ ")
+			path = strings.TrimPrefix(p, "b/")
+			cur = -1
+		case strings.HasPrefix(l, "--- "):
+			cur = -1
+		case strings.HasPrefix(l, "@@"):
+			m := hunkHeader.FindStringSubmatch(l)
+			if m == nil {
+				return nil, fmt.Errorf("unparsable hunk header %q", l)
+			}
+			oldStart, _ := strconv.Atoi(m[1])
+			newStart, _ := strconv.Atoi(m[2])
+			hunks = append(hunks, diffHunk{Path: path, OldStart: oldStart, NewStart: newStart})
+			cur = len(hunks) - 1
+		case cur >= 0 && strings.HasPrefix(l, "-"):
+			hunks[cur].Removed = append(hunks[cur].Removed, l[1:])
+		case cur >= 0 && strings.HasPrefix(l, "+"):
+			hunks[cur].Added = append(hunks[cur].Added, l[1:])
+		}
+	}
+	return hunks, nil
+}
+
+// inScanRoots reports whether a repository-relative path is one of the two
+// surfaces the coverage scanner reads.
+func inScanRoots(p string) bool {
+	return (strings.HasPrefix(p, "backend/") && strings.HasSuffix(p, "_test.go")) ||
+		(strings.HasPrefix(p, "frontend/tests/e2e/") && strings.HasSuffix(p, ".spec.ts"))
+}
+
+func inCorpus(p string) bool {
+	return strings.HasPrefix(p, "spec/") && strings.HasSuffix(p, ".yaml")
+}
+
+// ---------------------------------------------------------------- G1
+
+// lineCache reads a file once and serves its lines.
+type lineCache map[string][]string
+
+func (c lineCache) get(path string) ([]string, error) {
+	if l, ok := c[path]; ok {
+		return l, nil
+	}
+	l, err := readLines(path)
+	if err != nil {
+		return nil, err
+	}
+	c[path] = l
+	return l, nil
+}
+
+// cmdG1 proves map faithfulness: for EVERY rewritten positional reference —
+// citation and waiver — index_of_key(behavior, new_key) equals the old index.
+// The old index comes from a materialized checkout of the base, never from the
+// substitutions ledger: the ledger is the thing under test.
+func cmdG1(args []string) int {
+	if len(args) != 2 {
+		usage()
+		return 2
+	}
+	g := &guard{name: "g1"}
+	root, err := absRoot(args[1])
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+	baseDir, cleanup, err := materialize(root, args[0])
+	defer cleanup()
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+
+	newFiles, err := loadCorpus(root)
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+	idxOf := indexOfKey(newFiles)
+	cache := lineCache{}
+
+	// checkLine pairs the references on one marker line, old against new, and
+	// returns how many indexed references it checked. The pairing is positional
+	// and sound because no marker line in the corpus mixes indexed with
+	// non-indexed references, and the rewrite preserves reference order.
+	checkLine := func(rel string, line int) int {
+		oldLines, err := cache.get(filepath.Join(baseDir, rel))
+		if err != nil {
+			g.fail("%s: %v", rel, err)
+			return 0
+		}
+		newLines, err := cache.get(filepath.Join(root, rel))
+		if err != nil {
+			g.fail("%s: %v", rel, err)
+			return 0
+		}
+		if line > len(oldLines) || line > len(newLines) {
+			g.fail("%s:%d: line is past the end of one of the two trees", rel, line)
+			return 0
+		}
+		oldRefs, ok1 := parseMarkerRefs(oldLines[line-1])
+		newRefs, ok2 := parseMarkerRefs(newLines[line-1])
+		if !ok1 || !ok2 {
+			g.fail("%s:%d: not a whole-line spec marker in both trees", rel, line)
+			return 0
+		}
+		if len(oldRefs) != len(newRefs) {
+			g.fail("%s:%d: reference count changed (%d -> %d)", rel, line, len(oldRefs), len(newRefs))
+			return 0
+		}
+		checked := 0
+		for k := range oldRefs {
+			o, n := oldRefs[k], newRefs[k]
+			if o.ID != n.ID {
+				g.fail("%s:%d: reference %d changed behavior (%s -> %s)", rel, line, k, o.Text, n.Text)
+				continue
+			}
+			if o.Index < 0 {
+				if o.Text != n.Text {
+					g.fail("%s:%d: non-indexed reference %q was rewritten to %q", rel, line, o.Text, n.Text)
+				}
+				continue
+			}
+			checked++
+			if n.Key == "" {
+				g.fail("%s:%d: %s was not rewritten to a keyed reference (now %q)", rel, line, o.Text, n.Text)
+				continue
+			}
+			got, ok := idxOf[n.ID][n.Key]
+			if !ok {
+				g.fail("%s:%d: %s names key %q, which no then item of %s carries", rel, line, n.Text, n.Key, n.ID)
+				continue
+			}
+			if got != o.Index {
+				g.fail("%s:%d: %s -> %s MIS-REPOINTED: key sits at index %d, old index was %d",
+					rel, line, o.Text, n.Text, got, o.Index)
+			}
+		}
+		return checked
+	}
+
+	// Leg 1 — the two scan roots, discovered with the scanner's own code.
+	baseCites, probs, err := spec.CollectCitations(filepath.Join(baseDir, "backend"), filepath.Join(baseDir, "frontend", "tests", "e2e"))
+	if err != nil {
+		return g.opFail("collect base citations: %v", err)
+	}
+	if len(probs) > 0 {
+		return g.opFail("base tree has citation problems: %v", probs)
+	}
+	type pl struct {
+		path string
+		line int
+	}
+	done := map[pl]bool{}
+	var order []pl
+	for _, c := range baseCites {
+		if c.Key != "" || c.Then < 0 {
+			continue
+		}
+		rel, err := filepath.Rel(baseDir, c.Path)
+		if err != nil {
+			return g.opFail("%v", err)
+		}
+		k := pl{rel, c.Line}
+		if !done[k] {
+			done[k] = true
+			order = append(order, k)
+		}
+	}
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].path != order[j].path {
+			return order[i].path < order[j].path
+		}
+		return order[i].line < order[j].line
+	})
+	inRoot := 0
+	for _, k := range order {
+		inRoot += checkLine(k.path, k.line)
+	}
+
+	// Leg 2 — the out-of-root markers the scanner cannot see. Without this leg
+	// they would be the only positional references in the migration with no
+	// mechanical guard at all.
+	extraChecked := 0
+	for _, rel := range extraCitationPaths {
+		lines, err := cache.get(filepath.Join(baseDir, rel))
+		if err != nil {
+			return g.opFail("%v", err)
+		}
+		for i, l := range lines {
+			refs, ok := parseMarkerRefs(l)
+			if !ok {
+				continue
+			}
+			indexed := false
+			for _, r := range refs {
+				if r.Index >= 0 {
+					indexed = true
+				}
+			}
+			if indexed {
+				extraChecked += checkLine(rel, i+1)
+			}
+		}
+	}
+
+	// Leg 3 — waivers.
+	baseFiles, err := loadCorpus(baseDir)
+	if err != nil {
+		return g.opFail("base corpus: %v", err)
+	}
+	newByID := behaviorsByID(newFiles)
+	waivers := 0
+	for _, f := range baseFiles {
+		for bi := range f.Behaviors {
+			ob := &f.Behaviors[bi]
+			if len(ob.Waivers) == 0 {
+				continue
+			}
+			nb, ok := newByID[ob.ID]
+			if !ok {
+				g.fail("%s: behavior disappeared from the corpus", ob.ID)
+				continue
+			}
+			if len(nb.Waivers) != len(ob.Waivers) {
+				g.fail("%s: waiver count changed (%d -> %d)", ob.ID, len(ob.Waivers), len(nb.Waivers))
+				continue
+			}
+			for wi := range ob.Waivers {
+				ow, nw := ob.Waivers[wi], nb.Waivers[wi]
+				if ow.Keyed {
+					continue // already keyed at the base — nothing was rewritten
+				}
+				waivers++
+				if !nw.Keyed {
+					g.fail("%s waiver %d: still in the index form after the migration", ob.ID, wi)
+					continue
+				}
+				got, ok := idxOf[ob.ID][nw.Key]
+				if !ok {
+					g.fail("%s waiver %d: key %q matches no then item", ob.ID, wi, nw.Key)
+					continue
+				}
+				if got != ow.Index {
+					g.fail("%s waiver %d: MIS-REPOINTED: key %q sits at index %d, old index was %d",
+						ob.ID, wi, nw.Key, got, ow.Index)
+				}
+			}
+		}
+	}
+
+	if inRoot != expectG1InRoot {
+		g.fail("in-root citation leg checked %d references, expected %d", inRoot, expectG1InRoot)
+	}
+	if extraChecked != expectG1Extra {
+		g.fail("out-of-root citation leg checked %d references, expected %d", extraChecked, expectG1Extra)
+	}
+	if waivers != expectG1Waivers {
+		g.fail("waiver leg checked %d references, expected %d", waivers, expectG1Waivers)
+	}
+	total := inRoot + extraChecked + waivers
+	if total != expectG1Total {
+		g.fail("checked %d references in total, expected %d", total, expectG1Total)
+	}
+	fmt.Printf("g1: %d references checked (%d in-root citations + %d out-of-root citations + %d waivers)\n",
+		total, inRoot, extraChecked, waivers)
+	return g.report()
+}
+
+// ---------------------------------------------------------------- G2
+
+var (
+	keyedItemLine  = regexp.MustCompile(`^      - key: ([a-z0-9]+(?:-[a-z0-9]+)*)$`)
+	waiverKeyLine  = regexp.MustCompile(`^      - then: ([a-z0-9]+(?:-[a-z0-9]+)*)$`)
+	markerDiffLine = regexp.MustCompile(`^\s*// spec: `)
+)
+
+func cmdG2(args []string) int {
+	fs := newFlagSet("g2")
+	subsPath := fs.String("subs", "/tmp/pr2-artifacts/substitutions.txt", "the pass-B substitutions ledger")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 5 {
+		usage()
+		return 2
+	}
+	g := &guard{name: "g2"}
+	base, tool, passB, head := fs.Arg(0), fs.Arg(1), fs.Arg(2), fs.Arg(3)
+	root, err := absRoot(fs.Arg(4))
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+	mech := tool + ".." + passB
+	branch := base + ".." + head
+
+	ledger, err := loadLedger(*subsPath)
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+	hunks, err := gitDiffHunks(root, mech)
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+
+	g2aShape(g, root, mech, hunks, ledger)
+	g2bPaths(g, root, mech, branch)
+	g2cCorpus(g, root, tool, hunks)
+	g2Disjoint(g, root, base, tool, passB, head)
+	return g.report()
+}
+
+func loadLedger(path string) (map[string][]substitution, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read substitutions ledger: %w", err)
+	}
+	out := map[string][]substitution{}
+	n := 0
+	for _, l := range strings.Split(string(data), "\n") {
+		if l == "" {
+			continue
+		}
+		parts := strings.Split(l, "\t")
+		if len(parts) != 4 {
+			return nil, fmt.Errorf("malformed ledger row %q", l)
+		}
+		line, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("malformed ledger row %q", l)
+		}
+		k := fmt.Sprintf("%s:%d", parts[0], line)
+		out[k] = append(out[k], substitution{Path: parts[0], Line: line, Old: parts[2], New: parts[3]})
+		n++
+	}
+	if n != expectedSubstitutions {
+		return nil, fmt.Errorf("ledger has %d rows, expected %d", n, expectedSubstitutions)
+	}
+	return out, nil
+}
+
+// g2aShape proves the bulk rewrite in the two scan roots touched nothing but
+// marker lines, and that each marker line's change was EXACTLY the reference
+// substitution — a shape regex alone would pass a one-character edit to a key.
+func g2aShape(g *guard, root, mech string, hunks []diffHunk, ledger map[string][]substitution) {
+	files := map[string]bool{}
+	removed, added := 0, 0
+	for _, h := range hunks {
+		if !inScanRoots(h.Path) {
+			continue
+		}
+		files[h.Path] = true
+		removed += len(h.Removed)
+		added += len(h.Added)
+		for _, l := range h.Removed {
+			if !markerDiffLine.MatchString(l) {
+				g.fail("g2a %s: removed a non-marker line: %q", h.Path, l)
+			}
+		}
+		for _, l := range h.Added {
+			if !markerDiffLine.MatchString(l) {
+				g.fail("g2a %s: added a non-marker line: %q", h.Path, l)
+			}
+		}
+		if len(h.Removed) != len(h.Added) {
+			g.fail("g2a %s@%d: hunk is not a 1:1 replacement (%d removed, %d added)",
+				h.Path, h.OldStart, len(h.Removed), len(h.Added))
+			continue
+		}
+		for k := range h.Removed {
+			oldLine, newLine := h.Removed[k], h.Added[k]
+			lineNo := h.NewStart + k
+			if h.OldStart+k != lineNo {
+				g.fail("g2a %s:%d: line number moved (old %d, new %d)", h.Path, lineNo, h.OldStart+k, lineNo)
+			}
+			rows := ledger[fmt.Sprintf("%s:%d", h.Path, lineNo)]
+			if len(rows) == 0 {
+				g.fail("g2a %s:%d: marker line changed but the ledger has no substitution for it", h.Path, lineNo)
+				continue
+			}
+			got, err := applySubs(oldLine, rows)
+			if err != nil {
+				g.fail("g2a %s:%d: %v", h.Path, lineNo, err)
+				continue
+			}
+			if got != newLine {
+				g.fail("g2a %s:%d: the change was not exactly the ledger substitution\n      ledger yields %q\n      tree has     %q",
+					h.Path, lineNo, got, newLine)
+			}
+		}
+	}
+	if len(files) != expectG2aFiles {
+		g.fail("g2a: %d scan-root files changed, expected %d", len(files), expectG2aFiles)
+	}
+	if removed != expectG2aPairs || added != expectG2aPairs {
+		g.fail("g2a: %d removed / %d added scan-root lines, expected %d / %d",
+			removed, added, expectG2aPairs, expectG2aPairs)
+	}
+	adr, err := gitNames(root, mech, "ADR")
+	if err != nil {
+		g.fail("g2a: %v", err)
+	}
+	for _, p := range adr {
+		if inScanRoots(p) {
+			g.fail("g2a: %s was added, deleted, or renamed in the mechanical range", p)
+		}
+	}
+	fmt.Printf("g2a: %d files, %d removed + %d added marker lines (%d total), substitution-exact\n",
+		len(files), removed, added, removed+added)
+}
+
+// applySubs replays the ledger rows for one line against the OLD line and
+// returns what the rewrite should have produced, byte for byte.
+func applySubs(oldLine string, rows []substitution) (string, error) {
+	refs, ok := parseMarkerRefs(oldLine)
+	if !ok {
+		return "", fmt.Errorf("old line is not a whole-line spec marker")
+	}
+	var indexed []ref
+	for _, r := range refs {
+		if r.Index >= 0 {
+			indexed = append(indexed, r)
+		}
+	}
+	if len(indexed) != len(rows) {
+		return "", fmt.Errorf("line has %d indexed references but the ledger has %d rows", len(indexed), len(rows))
+	}
+	repl := make([]string, len(rows))
+	for k, r := range rows {
+		if r.Old != indexed[k].Text {
+			return "", fmt.Errorf("ledger row %d names %q, the old line has %q", k, r.Old, indexed[k].Text)
+		}
+		repl[k] = r.New
+	}
+	return replaceSpans(oldLine, indexed, repl), nil
+}
+
+// g2bPaths is the hand-sweep control plus the production-untouched assertion.
+// The mechanical range may touch exactly one path outside the scan roots and
+// the corpus; across the whole branch, PR2 MODIFIES no production source.
+func g2bPaths(g *guard, root, mech, branch string) {
+	changed, err := gitNames(root, mech, "")
+	if err != nil {
+		g.fail("g2b: %v", err)
+		return
+	}
+	var outside []string
+	for _, p := range changed {
+		if !inScanRoots(p) && !inCorpus(p) {
+			outside = append(outside, p)
+		}
+	}
+	if len(outside) != 1 || outside[0] != i4Path {
+		g.fail("g2b: the mechanical range touches %v outside the scan roots and the corpus, expected exactly [%s]",
+			outside, i4Path)
+	}
+
+	modified, err := gitNames(root, branch, "M")
+	if err != nil {
+		g.fail("g2b: %v", err)
+		return
+	}
+	for _, p := range modified {
+		switch {
+		case p == "Makefile", inCorpus(p), inScanRoots(p), p == i4Path:
+			continue
+		}
+		g.fail("g2b: %s is MODIFIED across the branch, which the allowlist does not permit", p)
+	}
+	for _, p := range modified {
+		if strings.HasPrefix(p, "frontend/src/") && p != i4Path {
+			g.fail("g2b: %s is a modified frontend/src path other than the one hand-swept test file", p)
+		}
+		if strings.HasPrefix(p, "backend/") && !strings.HasSuffix(p, "_test.go") {
+			g.fail("g2b: %s is a modified backend path that is not a _test.go file", p)
+		}
+	}
+
+	addedFiles, err := gitNames(root, branch, "A")
+	if err != nil {
+		g.fail("g2b: %v", err)
+		return
+	}
+	for _, p := range addedFiles {
+		if strings.HasPrefix(p, "backend/cmd/specmigrate/") ||
+			strings.HasPrefix(p, "backend/internal/spec/testdata/invalid/waiver-key-empty/") {
+			continue
+		}
+		g.fail("g2b: %s is ADDED across the branch, which the allowlist does not permit", p)
+	}
+	for _, filter := range []string{"D", "R"} {
+		names, err := gitNames(root, branch, filter)
+		if err != nil {
+			g.fail("g2b: %v", err)
+			continue
+		}
+		for _, p := range names {
+			g.fail("g2b: %s was %sed across the branch; the branch deletes and renames nothing", p, filter)
+		}
+	}
+	fmt.Printf("g2b: mechanical range touches 1 path outside the scan roots and the corpus (%s); "+
+		"branch modifies %d files, adds %d, deletes 0\n", i4Path, len(modified), len(addedFiles))
+}
+
+// g2cCorpus proves the corpus diff is only the keying transform: nothing
+// reflowed a notes: scalar, moved a comment, or touched a given/when line. The
+// classification counts are the plan's clauses; the inverse-transform identity
+// below is the stronger statement that subsumes them.
+func g2cCorpus(g *guard, root, toolRef string, hunks []diffHunk) {
+	removed, added := 0, 0
+	itemPairs, waiverPairs, unclassified := 0, 0, 0
+	for _, h := range hunks {
+		if !strings.HasPrefix(h.Path, "spec/") {
+			continue
+		}
+		if !inCorpus(h.Path) {
+			g.fail("g2c: %s changed under spec/ but is not a corpus yaml file", h.Path)
+			continue
+		}
+		removed += len(h.Removed)
+		added += len(h.Added)
+		ri, ai := 0, 0
+		for ri < len(h.Removed) {
+			r := h.Removed[ri]
+			switch {
+			case waiverIndexLine.MatchString(r):
+				if ai < len(h.Added) && waiverKeyLine.MatchString(h.Added[ai]) {
+					ri, ai = ri+1, ai+1
+					waiverPairs++
+					continue
+				}
+			case strings.HasPrefix(r, "      - "):
+				text := r[len("      - "):]
+				if ai+1 < len(h.Added) && keyedItemLine.MatchString(h.Added[ai]) &&
+					h.Added[ai+1] == "        text: "+text {
+					ri, ai = ri+1, ai+2
+					itemPairs++
+					continue
+				}
+			}
+			g.fail("g2c %s@%d: unclassified removed line %q", h.Path, h.OldStart, r)
+			unclassified++
+			ri++
+		}
+		for ; ai < len(h.Added); ai++ {
+			g.fail("g2c %s@%d: unclassified added line %q", h.Path, h.NewStart, h.Added[ai])
+			unclassified++
+		}
+	}
+	if removed != expectG2cRemoved || added != expectG2cAdded {
+		g.fail("g2c: %d removed / %d added corpus lines, expected %d / %d",
+			removed, added, expectG2cRemoved, expectG2cAdded)
+	}
+	if itemPairs != expectG2cItemPairs {
+		g.fail("g2c: %d then-item conversions, expected %d", itemPairs, expectG2cItemPairs)
+	}
+	if waiverPairs != expectG2cWaivers {
+		g.fail("g2c: %d waiver conversions, expected %d", waiverPairs, expectG2cWaivers)
+	}
+	g2cInverse(g, root, toolRef)
+	fmt.Printf("g2c: %d removed / %d added corpus lines; %d then-item + %d waiver conversions; %d unclassified\n",
+		removed, added, itemPairs, waiverPairs, unclassified)
+}
+
+// g2cInverse reconstructs each corpus file's pre-migration bytes by undoing the
+// keying transform on the FINAL file, and asserts byte identity against the
+// tool commit's blob. Anything the migration touched that is not a key or a
+// waiver target shows up here as a byte difference.
+//
+// It relies on the base corpus carrying zero keyed items and zero key-form
+// waivers, which is true at this PR's base and is what makes "undo every key"
+// the correct inverse.
+func g2cInverse(g *guard, root, toolRef string) {
+	files, err := loadCorpus(root)
+	if err != nil {
+		g.fail("g2c: %v", err)
+		return
+	}
+	idxOf := indexOfKey(files)
+	for _, f := range files {
+		rel, err := filepath.Rel(root, f.Path)
+		if err != nil {
+			g.fail("g2c: %v", err)
+			continue
+		}
+		lines, err := readLines(f.Path)
+		if err != nil {
+			g.fail("g2c: %v", err)
+			continue
+		}
+		repl := map[int]string{}
+		drop := map[int]bool{}
+		for bi := range f.Behaviors {
+			b := &f.Behaviors[bi]
+			for _, it := range b.Then {
+				if it.Key == "" {
+					continue
+				}
+				if it.Line+1 > len(lines) {
+					g.fail("g2c %s:%d: keyed item has no text line", rel, it.Line)
+					continue
+				}
+				if lines[it.Line-1] != "      - key: "+it.Key || lines[it.Line] != "        text: "+it.Text {
+					g.fail("g2c %s:%d: keyed item is not the canonical two-line form", rel, it.Line)
+					continue
+				}
+				repl[it.Line] = "      - " + it.Text
+				drop[it.Line+1] = true
+			}
+		}
+		wl, err := waiverThenLines(f.Path)
+		if err != nil {
+			g.fail("g2c: %v", err)
+			continue
+		}
+		for bi := range f.Behaviors {
+			b := &f.Behaviors[bi]
+			for wi, w := range b.Waivers {
+				if !w.Keyed || wi >= len(wl[b.ID]) {
+					continue
+				}
+				n, ok := idxOf[b.ID][w.Key]
+				if !ok {
+					g.fail("g2c %s: waiver key %q of %s matches no then item", rel, w.Key, b.ID)
+					continue
+				}
+				repl[wl[b.ID][wi]] = fmt.Sprintf("      - then: %d", n)
+			}
+		}
+		out := make([]string, 0, len(lines))
+		for i, l := range lines {
+			if drop[i+1] {
+				continue
+			}
+			if r, ok := repl[i+1]; ok {
+				out = append(out, r)
+				continue
+			}
+			out = append(out, l)
+		}
+		want, err := gitShow(root, toolRef+":"+rel)
+		if err != nil {
+			g.fail("g2c: %v", err)
+			continue
+		}
+		if got := strings.Join(out, "\n"); got != want {
+			g.fail("g2c %s: undoing the keying transform does not reproduce %s — the diff carries more than the transform (%s)",
+				rel, toolRef, firstDiff(want, got))
+		}
+	}
+}
+
+// firstDiff names the first differing line so a G2c failure points somewhere.
+func firstDiff(want, got string) string {
+	a, b := strings.Split(want, "\n"), strings.Split(got, "\n")
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] != b[i] {
+			return fmt.Sprintf("first difference at line %d: want %q, got %q", i+1, a[i], b[i])
+		}
+	}
+	return fmt.Sprintf("line counts differ: %d vs %d", len(a), len(b))
+}
+
+// g2Disjoint proves no file appears in more than one of the branch's three
+// commit ranges, closing the "hide a bad edit in the tool commit or the
+// carry-forward commit" hole in both directions.
+func g2Disjoint(g *guard, root, base, tool, passB, head string) {
+	ranges := []struct {
+		name string
+		rng  string
+	}{
+		{"base..tool", base + ".." + tool},
+		{"tool..passB", tool + ".." + passB},
+		{"passB..head", passB + ".." + head},
+	}
+	sets := make([]map[string]bool, len(ranges))
+	for i, r := range ranges {
+		names, err := gitNames(root, r.rng, "")
+		if err != nil {
+			g.fail("g2 disjointness: %v", err)
+			return
+		}
+		sets[i] = map[string]bool{}
+		for _, p := range names {
+			sets[i][p] = true
+		}
+	}
+	live := 0
+	for i := 0; i < len(sets); i++ {
+		for j := i + 1; j < len(sets); j++ {
+			if len(sets[i]) == 0 || len(sets[j]) == 0 {
+				continue
+			}
+			live++
+			for p := range sets[i] {
+				if sets[j][p] {
+					g.fail("g2 disjointness: %s appears in both %s and %s", p, ranges[i].name, ranges[j].name)
+				}
+			}
+		}
+	}
+	if len(sets[2]) == 0 {
+		fmt.Printf("g2 disjointness: third range empty, branch head == mechanical head; %d of 3 pairs live\n", live)
+		return
+	}
+	fmt.Printf("g2 disjointness: %d of 3 pairs live\n", live)
+}
+
+// ---------------------------------------------------------------- G3
+
+// cmdG3 proves the keying pass changed no assertion: every behavior's then
+// TEXTS, its given/when/statement, its metadata, and its waiver reasons are
+// identical before and after.
+func cmdG3(args []string) int {
+	if len(args) != 2 {
+		usage()
+		return 2
+	}
+	g := &guard{name: "g3"}
+	root, err := absRoot(args[1])
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+	baseDir, cleanup, err := materialize(root, args[0])
+	defer cleanup()
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+	baseFiles, err := loadCorpus(baseDir)
+	if err != nil {
+		return g.opFail("base corpus: %v", err)
+	}
+	newFiles, err := loadCorpus(root)
+	if err != nil {
+		return g.opFail("%v", err)
+	}
+	oldByID, newByID := behaviorsByID(baseFiles), behaviorsByID(newFiles)
+	for id := range oldByID {
+		if _, ok := newByID[id]; !ok {
+			g.fail("%s: behavior disappeared", id)
+		}
+	}
+	for id := range newByID {
+		if _, ok := oldByID[id]; !ok {
+			g.fail("%s: behavior appeared", id)
+		}
+	}
+	ids := make([]string, 0, len(oldByID))
+	for id := range oldByID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	items := 0
+	for _, id := range ids {
+		o, n := oldByID[id], newByID[id]
+		if n == nil {
+			continue
+		}
+		cmpStr := func(field, a, b string) {
+			if a != b {
+				g.fail("%s: %s changed (%q -> %q)", id, field, a, b)
+			}
+		}
+		cmpStr("title", o.Title, n.Title)
+		cmpStr("type", o.Type, n.Type)
+		cmpStr("status", o.Status, n.Status)
+		cmpStr("surface", o.Surface, n.Surface)
+		cmpStr("when", o.When, n.When)
+		cmpStr("statement", o.Statement, n.Statement)
+		cmpStr("notes", o.Notes, n.Notes)
+		cmpList(g, id, "given", o.Given, n.Given)
+		cmpList(g, id, "serves", o.Serves, n.Serves)
+		cmpList(g, id, "then", o.ThenTexts(), n.ThenTexts())
+		items += len(o.Then)
+		var or, nr []string
+		for _, w := range o.Waivers {
+			or = append(or, w.Reason)
+		}
+		for _, w := range n.Waivers {
+			nr = append(nr, w.Reason)
+		}
+		cmpList(g, id, "waiver reasons", or, nr)
+	}
+	fmt.Printf("g3: %d behaviors, %d then items compared\n", len(ids), items)
+	return g.report()
+}
+
+func cmpList(g *guard, id, field string, a, b []string) {
+	if len(a) != len(b) {
+		g.fail("%s: %s length changed (%d -> %d)", id, field, len(a), len(b))
+		return
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			g.fail("%s: %s[%d] changed (%q -> %q)", id, field, i, a[i], b[i])
+		}
+	}
+}

--- a/backend/cmd/specmigrate/main.go
+++ b/backend/cmd/specmigrate/main.go
@@ -1,0 +1,961 @@
+// Command specmigrate is the one-shot migration and verification tool for the
+// spec-citation-by-key arc (GH #760, PR2). It keys the cited-and-waived
+// then-items of the behavior corpus, rewrites every positional citation and
+// waiver to the keyed form, and carries the three mechanical guards (G1-G3)
+// that prove the rewrite faithful.
+//
+// It is wired into nothing — no CI job, no git hook, and exactly one make
+// target (test-unit's package list, which runs slug_test.go). PR3 deletes the
+// whole directory. See README.md.
+//
+// Exit codes are meaningful and are read directly by the caller:
+//
+//	0  ok
+//	1  a violation was found (guards) — the migration is not faithful
+//	2  operational error (bad arguments, dirty tree, unresolvable reference)
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"personal-crm/backend/internal/spec"
+)
+
+// Re-measured at this PR's base (1dd9b72) with the scanner's own code. The tool
+// aborts rather than proceeding if the corpus has moved underneath it.
+const (
+	// expectedKeyedItems is the number of cited-or-waived then-items:
+	// 380 distinct cited (behavior, index) pairs + 13 waived-but-uncited.
+	expectedKeyedItems = 393
+	// expectedSubstitutions is the number of positional references Pass B
+	// rewrites: 597 in-root citations + 2 out-of-root I4 citations + 17
+	// waivers.
+	expectedSubstitutions = 616
+)
+
+// extraCitationPaths are real whole-line `// spec:` markers that live OUTSIDE
+// CollectCitations' two scan roots (backend/**/*_test.go and
+// frontend/tests/e2e/**/*.spec.ts) and are therefore invisible to the scanner.
+// Pass B rewrites them from the same key map as everything else, and G1 folds
+// them into its citation leg — otherwise they would be the only positional
+// references in the whole migration with no mechanical guard at all.
+var extraCitationPaths = []string{
+	"frontend/src/lib/__tests__/contact-recency.test.ts",
+}
+
+// markerLine and refPattern mirror coverage.go's unexported citationLine and
+// citationRef. They exist here because this tool must parse marker lines it
+// also has to REWRITE (byte spans, not just parsed values) and must apply the
+// scanner's own rules to the extra paths above, which the scanner cannot see.
+// Keep them in lockstep with coverage.go for the life of this tool (PR3).
+var (
+	markerLine = regexp.MustCompile(`^\s*// spec: (.+?)\s*$`)
+	refPattern = regexp.MustCompile(`^([A-Z][A-Z0-9]*-\d+)(?:\[(\d+)\]|\.([a-z0-9]+(?:-[a-z0-9]+)*))?$`)
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	var code int
+	switch os.Args[1] {
+	case "keys":
+		code = cmdKeys(os.Args[2:])
+	case "cite":
+		code = cmdCite(os.Args[2:])
+	case "g1":
+		code = cmdG1(os.Args[2:])
+	case "g2":
+		code = cmdG2(os.Args[2:])
+	case "g3":
+		code = cmdG3(os.Args[2:])
+	default:
+		usage()
+		code = 2
+	}
+	os.Exit(code)
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `specmigrate — one-shot spec citation key migration (GH #760, PR2)
+
+  specmigrate keys -out <dir> [--write] <root>            pass A: key the cited/waived then-items
+  specmigrate cite -out <dir> [--write] <root>            pass B: rewrite waivers and citations
+  specmigrate g1 <base-ref> <root>                        map faithfulness over all 616 references
+  specmigrate g2 [-subs <f>] <base> <tool> <passB> <head> <root>   diff shape + commit disjointness
+  specmigrate g3 <base-ref> <root>                        corpus text preservation
+`)
+}
+
+// newFlagSet returns a subcommand flag set that reports its own usage rather
+// than the package-level default.
+func newFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.Usage = usage
+	return fs
+}
+
+func opErr(format string, a ...any) int {
+	fmt.Fprintf(os.Stderr, "specmigrate: "+format+"\n", a...)
+	return 2
+}
+
+// ---------------------------------------------------------------- helpers
+
+func absRoot(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+// requireCleanTree refuses to write into a tree with uncommitted changes. It is
+// what makes the rollback recipe unambiguous: pass A runs right after the tool
+// commit and pass B right after the pass-A commit, so `git checkout --` always
+// restores exactly the pass that failed.
+func requireCleanTree(root string) error {
+	out, err := exec.Command("git", "-C", root, "status", "--porcelain").Output()
+	if err != nil {
+		return fmt.Errorf("git status: %w", err)
+	}
+	if len(strings.TrimSpace(string(out))) > 0 {
+		return fmt.Errorf("working tree is dirty; --write refuses to run:\n%s", out)
+	}
+	return nil
+}
+
+// requireOutsideRoot rejects an artifact directory inside the repository:
+// artifacts written into the working tree would be untracked files that break
+// the `git status --short` must-be-empty checks the guards depend on.
+func requireOutsideRoot(out, root string) error {
+	abs, err := absRoot(out)
+	if err != nil {
+		return err
+	}
+	if abs == root || strings.HasPrefix(abs, root+string(filepath.Separator)) {
+		return fmt.Errorf("-out %s resolves inside the repository at %s; choose a path outside it", abs, root)
+	}
+	return os.MkdirAll(abs, 0o755)
+}
+
+// loadCorpus parses <dir>/spec and fails on any lint violation: every pass and
+// guard reasons over a corpus the linter accepts.
+func loadCorpus(dir string) ([]*spec.File, error) {
+	files, viols, err := spec.Lint(filepath.Join(dir, "spec"))
+	if err != nil {
+		return nil, err
+	}
+	if len(viols) > 0 {
+		var b strings.Builder
+		for _, v := range viols {
+			fmt.Fprintf(&b, "  %s:%d: %s\n", v.Path, v.Line, v.Msg)
+		}
+		return nil, fmt.Errorf("corpus at %s has %d lint violation(s):\n%s", dir, len(viols), b.String())
+	}
+	return files, nil
+}
+
+func behaviorsByID(files []*spec.File) map[string]*spec.Behavior {
+	out := map[string]*spec.Behavior{}
+	for _, f := range files {
+		for i := range f.Behaviors {
+			out[f.Behaviors[i].ID] = &f.Behaviors[i]
+		}
+	}
+	return out
+}
+
+// keyAtIndex maps (behavior ID, then index) to the item's key.
+func keyAtIndex(files []*spec.File) map[string]map[int]string {
+	out := map[string]map[int]string{}
+	for _, f := range files {
+		for _, b := range f.Behaviors {
+			m := map[int]string{}
+			for i, it := range b.Then {
+				if it.Key != "" {
+					m[i] = it.Key
+				}
+			}
+			out[b.ID] = m
+		}
+	}
+	return out
+}
+
+// indexOfKey maps (behavior ID, then-item key) to the item's 0-based index —
+// derived from the FINAL corpus through the exported parser, never from a
+// ledger. It is what G1 checks the old indexes against.
+func indexOfKey(files []*spec.File) map[string]map[string]int {
+	out := map[string]map[string]int{}
+	for _, f := range files {
+		for _, b := range f.Behaviors {
+			m := map[string]int{}
+			for i, it := range b.Then {
+				if it.Key != "" {
+					m[it.Key] = i
+				}
+			}
+			out[b.ID] = m
+		}
+	}
+	return out
+}
+
+// ref is one reference parsed out of a marker line, with the byte span it
+// occupies so a rewrite can replace exactly those bytes and leave every other
+// byte of the line — indentation, spacing, separators — untouched.
+type ref struct {
+	Text       string
+	ID         string
+	Index      int // -1 when the reference carries no index
+	Key        string
+	Start, End int
+}
+
+// parseMarkerRefs returns the references on a whole-line `// spec:` marker, in
+// source order. ok=false when the line is not such a marker.
+func parseMarkerRefs(line string) ([]ref, bool) {
+	m := markerLine.FindStringSubmatchIndex(line)
+	if m == nil {
+		return nil, false
+	}
+	base, content := m[2], line[m[2]:m[3]]
+	var out []ref
+	start := 0
+	for i := 0; i <= len(content); i++ {
+		if i != len(content) && content[i] != ',' {
+			continue
+		}
+		seg := content[start:i]
+		ls, rs := 0, len(seg)
+		for ls < rs && (seg[ls] == ' ' || seg[ls] == '\t') {
+			ls++
+		}
+		for rs > ls && (seg[rs-1] == ' ' || seg[rs-1] == '\t') {
+			rs--
+		}
+		if rs > ls {
+			r := ref{Text: seg[ls:rs], Index: -1, Start: base + start + ls, End: base + start + rs}
+			if rm := refPattern.FindStringSubmatch(r.Text); rm != nil {
+				r.ID = rm[1]
+				if rm[2] != "" {
+					n, err := strconv.Atoi(rm[2])
+					if err == nil {
+						r.Index = n
+					}
+				}
+				r.Key = rm[3]
+			}
+			out = append(out, r)
+		}
+		start = i + 1
+	}
+	return out, true
+}
+
+// replaceSpans rewrites the given byte spans of line, right to left so earlier
+// offsets stay valid.
+func replaceSpans(line string, spans []ref, repl []string) string {
+	out := line
+	for k := len(spans) - 1; k >= 0; k-- {
+		out = out[:spans[k].Start] + repl[k] + out[spans[k].End:]
+	}
+	return out
+}
+
+func readLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(data), "\n"), nil
+}
+
+func writeLines(path string, lines []string) error {
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
+}
+
+// yamlMapValue returns the value node for key in a mapping node.
+func yamlMapValue(n *yaml.Node, key string) *yaml.Node {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// yamlMapKeyNode returns the KEY node for key in a mapping node. Its Line is
+// the source line the sub-key is written on.
+func yamlMapKeyNode(n *yaml.Node, key string) *yaml.Node {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i]
+		}
+	}
+	return nil
+}
+
+// waiverThenLines discovers, per behavior ID, the 1-based source line of each
+// waiver's `then:` entry, with a READ-ONLY yaml.Node decode.
+//
+// The node tree is never re-encoded: a re-encode would reflow the corpus's long
+// notes: scalars and relocate its 97 comments, producing an unreviewable diff.
+// Reading line numbers and then editing bytes line-by-line keeps the diff
+// minimal. An indentation search would not do — a waiver's `- then: 1` sits at
+// exactly the same six-space indent as a then item.
+func waiverThenLines(path string) (map[string][]int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	if len(doc.Content) == 0 {
+		return nil, fmt.Errorf("decode %s: empty document", path)
+	}
+	behaviors := yamlMapValue(doc.Content[0], "behaviors")
+	if behaviors == nil || behaviors.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("decode %s: no behaviors sequence", path)
+	}
+	out := map[string][]int{}
+	for _, bn := range behaviors.Content {
+		idNode := yamlMapValue(bn, "id")
+		wv := yamlMapValue(bn, "waivers")
+		if idNode == nil || wv == nil || wv.Kind != yaml.SequenceNode {
+			continue
+		}
+		lines := make([]int, 0, len(wv.Content))
+		for _, wn := range wv.Content {
+			kn := yamlMapKeyNode(wn, "then")
+			if kn == nil {
+				return nil, fmt.Errorf("decode %s: waiver of %s has no then", path, idNode.Value)
+			}
+			lines = append(lines, kn.Line)
+		}
+		out[idNode.Value] = lines
+	}
+	return out, nil
+}
+
+var waiverIndexLine = regexp.MustCompile(`^      - then: (\d+)$`)
+
+// ---------------------------------------------------------------- pass A
+
+type slugRow struct {
+	ID    string
+	Index int
+	Key   string
+	Text  string
+	Path  string
+	Line  int
+	Flags []string
+}
+
+func cmdKeys(args []string) int {
+	fs := newFlagSet("keys")
+	out := fs.String("out", "", "artifact output directory (must resolve outside <root>)")
+	write := fs.Bool("write", false, "write the corpus edits (default: dry run)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 || *out == "" {
+		usage()
+		return 2
+	}
+	root, err := absRoot(fs.Arg(0))
+	if err != nil {
+		return opErr("%v", err)
+	}
+	if err := requireOutsideRoot(*out, root); err != nil {
+		return opErr("%v", err)
+	}
+	outDir, _ := absRoot(*out)
+	if *write {
+		if err := requireCleanTree(root); err != nil {
+			return opErr("%v", err)
+		}
+	}
+
+	files, err := loadCorpus(root)
+	if err != nil {
+		return opErr("%v", err)
+	}
+	byID := behaviorsByID(files)
+
+	// Which items must be keyed: every cited (behavior, index) pair — from the
+	// two scan roots AND the extra out-of-root paths — plus every waived item.
+	need := map[string]map[int]bool{}
+	mark := func(id string, n int) {
+		if need[id] == nil {
+			need[id] = map[int]bool{}
+		}
+		need[id][n] = true
+	}
+	cites, probs, err := spec.CollectCitations(filepath.Join(root, "backend"), filepath.Join(root, "frontend", "tests", "e2e"))
+	if err != nil {
+		return opErr("collect citations: %v", err)
+	}
+	if len(probs) > 0 {
+		return opErr("citation problems in the scan roots: %v", probs)
+	}
+	for _, c := range cites {
+		if c.Key == "" && c.Then >= 0 {
+			mark(c.ID, c.Then)
+		}
+	}
+	extra, err := scanExtraPaths(root)
+	if err != nil {
+		return opErr("%v", err)
+	}
+	for _, c := range extra {
+		if c.Index >= 0 {
+			mark(c.ID, c.Index)
+		}
+	}
+	for _, f := range files {
+		for i := range f.Behaviors {
+			b := &f.Behaviors[i]
+			for _, w := range b.Waivers {
+				n, ok := resolveWaiver(b, w)
+				if !ok {
+					return opErr("waiver of %s resolves to no then item", b.ID)
+				}
+				mark(b.ID, n)
+			}
+		}
+	}
+	total := 0
+	for id, m := range need {
+		b, ok := byID[id]
+		if !ok {
+			return opErr("cited behavior %s is not in the corpus", id)
+		}
+		for n := range m {
+			if n < 0 || n >= len(b.Then) {
+				return opErr("%s[%d] is out of range (behavior has %d then items)", id, n, len(b.Then))
+			}
+			total++
+		}
+	}
+	if total != expectedKeyedItems {
+		return opErr("cited-or-waived then items = %d, expected %d — the corpus moved; re-measure before proceeding",
+			total, expectedKeyedItems)
+	}
+
+	// Preconditions, asserted across the WHOLE corpus before any file is
+	// written: the transform moves a text from sequence-entry position to
+	// mapping-value position, and a plain scalar's legality differs between
+	// them by its first character.
+	if err := checkPreconditions(files); err != nil {
+		return opErr("%v", err)
+	}
+
+	// Mint. Deterministic order: files in the linter's resolution order,
+	// behaviors in file order, items in list order. Uniqueness is over the
+	// NON-EMPTY keys of one behavior — an unkeyed sibling is a plain string
+	// with an empty key and is not a collision.
+	var rows []slugRow
+	edits := map[string]map[int][]string{} // path -> 1-based line -> replacement lines
+	minted, skipped := 0, 0
+	for _, f := range files {
+		for bi := range f.Behaviors {
+			b := &f.Behaviors[bi]
+			taken := map[string]bool{}
+			for _, it := range b.Then {
+				if it.Key != "" {
+					taken[it.Key] = true
+				}
+			}
+			for i, it := range b.Then {
+				if !need[b.ID][i] {
+					continue
+				}
+				if it.Key != "" {
+					// Never re-key an item that already has one — that rule,
+					// not any property of the slug function, is what makes the
+					// migration idempotent. The row is still emitted so the
+					// table always covers every cited-or-waived item, and a
+					// partially-migrated corpus cannot yield a short table.
+					skipped++
+					rows = append(rows, slugRow{ID: b.ID, Index: i, Key: it.Key, Text: it.Text,
+						Path: f.Path, Line: it.Line, Flags: flagSlug(it.Key, it.Text)})
+					continue
+				}
+				key, err := mintSlug(it.Text, taken)
+				if err != nil {
+					return opErr("%s[%d]: %v", b.ID, i, err)
+				}
+				taken[key] = true
+				minted++
+				rows = append(rows, slugRow{ID: b.ID, Index: i, Key: key, Text: it.Text,
+					Path: f.Path, Line: it.Line, Flags: flagSlug(key, it.Text)})
+				if edits[f.Path] == nil {
+					edits[f.Path] = map[int][]string{}
+				}
+				edits[f.Path][it.Line] = []string{"      - key: " + key, "        text: " + it.Text}
+			}
+		}
+	}
+
+	// Validate-all-then-write-any: build every file's new content in memory and
+	// only then write, so a failure on file 7 of 12 leaves nothing on disk.
+	staged := map[string][]string{}
+	for _, f := range files {
+		fileEdits := edits[f.Path]
+		if len(fileEdits) == 0 {
+			continue
+		}
+		lines, err := readLines(f.Path)
+		if err != nil {
+			return opErr("%v", err)
+		}
+		nums := make([]int, 0, len(fileEdits))
+		for n := range fileEdits {
+			nums = append(nums, n)
+		}
+		// Bottom-up within the file: pass A is the only pass that changes line
+		// counts, and descending order needs no offset bookkeeping.
+		sort.Sort(sort.Reverse(sort.IntSlice(nums)))
+		for _, n := range nums {
+			repl := fileEdits[n]
+			text := strings.TrimPrefix(repl[1], "        text: ")
+			if lines[n-1] != "      - "+text {
+				return opErr("%s:%d: expected %q, found %q — refusing to write", f.Path, n, "      - "+text, lines[n-1])
+			}
+			lines = append(lines[:n-1], append(append([]string{}, repl...), lines[n:]...)...)
+		}
+		staged[f.Path] = lines
+	}
+
+	if len(rows) != total {
+		return opErr("slug table has %d rows for %d cited-or-waived items", len(rows), total)
+	}
+	if err := writeSlugArtifacts(outDir, rows); err != nil {
+		return opErr("%v", err)
+	}
+	fmt.Printf("keys: %d cited-or-waived items; %d slugs minted, %d already keyed (skipped)\n", total, minted, skipped)
+	fmt.Printf("keys: %d corpus files to rewrite; artifacts in %s\n", len(staged), outDir)
+	if !*write {
+		fmt.Println("keys: DRY RUN — pass --write to apply the corpus edits")
+		return 0
+	}
+	for path, lines := range staged {
+		if err := writeLines(path, lines); err != nil {
+			return opErr("write %s: %v", path, err)
+		}
+	}
+	fmt.Printf("keys: wrote %d corpus files\n", len(staged))
+	return 0
+}
+
+// resolveWaiver mirrors the linter's waiver resolution for the two forms this
+// migration sees: an index-form waiver resolves to itself, a key-form one to
+// the index of the item carrying that key.
+func resolveWaiver(b *spec.Behavior, w spec.Waiver) (int, bool) {
+	if !w.Keyed {
+		return w.Index, true
+	}
+	for i, it := range b.Then {
+		if it.Key != "" && it.Key == w.Key {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// yamlIndicator matches the YAML indicator characters that can change how a
+// plain scalar resolves — or make it a parse error — in MAPPING-VALUE position,
+// which is where the transform moves every then-item text.
+var yamlIndicator = regexp.MustCompile("^[-?:,\\[\\]{}#&*!|>'\"%@`]")
+
+func checkPreconditions(files []*spec.File) error {
+	var probs []string
+	items := 0
+	for _, f := range files {
+		lines, err := readLines(f.Path)
+		if err != nil {
+			return err
+		}
+		for _, b := range f.Behaviors {
+			seen := map[string]bool{}
+			for _, it := range b.Then {
+				items++
+				if seen[it.Text] {
+					probs = append(probs, fmt.Sprintf("%s:%d: %s has two then items with the same text", f.Path, it.Line, b.ID))
+				}
+				seen[it.Text] = true
+				if it.Key != "" {
+					continue // already a mapping; the transform does not touch it
+				}
+				if it.Line < 1 || it.Line > len(lines) {
+					probs = append(probs, fmt.Sprintf("%s:%d: then item line out of file range", f.Path, it.Line))
+					continue
+				}
+				raw := lines[it.Line-1]
+				switch {
+				case !strings.HasPrefix(raw, "      - "):
+					probs = append(probs, fmt.Sprintf("%s:%d: then item is not a six-space `      - ` sequence entry: %q", f.Path, it.Line, raw))
+				case raw[len("      - "):] != it.Text:
+					probs = append(probs, fmt.Sprintf("%s:%d: then item is not a single-line plain scalar (raw %q != parsed %q)", f.Path, it.Line, raw[8:], it.Text))
+				}
+				if strings.Contains(it.Text, ": ") {
+					probs = append(probs, fmt.Sprintf("%s:%d: then item text contains %q, illegal in mapping-value position", f.Path, it.Line, ": "))
+				}
+				if strings.Contains(it.Text, " #") {
+					probs = append(probs, fmt.Sprintf("%s:%d: then item text contains %q, which would open a comment", f.Path, it.Line, " #"))
+				}
+				if yamlIndicator.MatchString(it.Text) {
+					probs = append(probs, fmt.Sprintf("%s:%d: then item text begins with a YAML indicator character: %q", f.Path, it.Line, it.Text))
+				}
+				if it.Text != strings.TrimSpace(it.Text) {
+					probs = append(probs, fmt.Sprintf("%s:%d: then item text has leading or trailing whitespace", f.Path, it.Line))
+				}
+			}
+		}
+	}
+	if len(probs) > 0 {
+		return fmt.Errorf("corpus preconditions failed (%d):\n  %s", len(probs), strings.Join(probs, "\n  "))
+	}
+	fmt.Printf("keys: corpus preconditions OK over %d then items\n", items)
+	return nil
+}
+
+// flagSlug labels the weak-slug classes the human review checkpoint works
+// through first. These are advisory: the checkpoint reads every row, but a
+// flagged one is where hand-editing pays off.
+func flagSlug(key, text string) []string {
+	var flags []string
+	toks := strings.Split(key, "-")
+	has := func(t string) bool {
+		for _, k := range toks {
+			if k == t {
+				return true
+			}
+		}
+		return false
+	}
+	for _, frag := range apostropheFragments(text) {
+		if has(frag) {
+			flags = append(flags, "apostrophe")
+			break
+		}
+	}
+	if key != slugBase(text) {
+		flags = append(flags, "disambiguated")
+	}
+	for _, tok := range toks {
+		if _, err := strconv.Atoi(tok); err == nil {
+			flags = append(flags, "numeric-token")
+			break
+		}
+	}
+	if n := len(toks); n < 4 {
+		flags = append(flags, fmt.Sprintf("short-%d-tokens", n))
+	}
+	if len(key) >= 38 {
+		flags = append(flags, fmt.Sprintf("long-%d-chars", len(key)))
+	}
+	for _, tok := range toks {
+		switch tok {
+		case "no", "not", "never", "without", "unless", "nothing", "none":
+			flags = append(flags, "negation:"+tok)
+		}
+	}
+	return flags
+}
+
+func writeSlugArtifacts(outDir string, rows []slugRow) error {
+	var table, review strings.Builder
+	flagged := 0
+	for _, r := range rows {
+		fmt.Fprintf(&table, "%s[%d]\t%s\t%s\n", r.ID, r.Index, r.Key, r.Text)
+		if len(r.Flags) > 0 {
+			flagged++
+			fmt.Fprintf(&review, "%-24s %-40s [%s]\n    %s:%d  %s\n",
+				fmt.Sprintf("%s[%d]", r.ID, r.Index), r.Key, strings.Join(r.Flags, " "),
+				filepath.Base(r.Path), r.Line, r.Text)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "slug-table.txt"), []byte(table.String()), 0o644); err != nil {
+		return err
+	}
+	header := fmt.Sprintf("# %d of %d minted slugs carry a review flag (advisory — read the full table too)\n\n", flagged, len(rows))
+	return os.WriteFile(filepath.Join(outDir, "slug-review.txt"), []byte(header+review.String()), 0o644)
+}
+
+// ---------------------------------------------------------------- pass B
+
+type substitution struct {
+	Path string // repository-relative
+	Line int
+	Old  string
+	New  string
+}
+
+type extraCite struct {
+	Path  string
+	Line  int
+	ID    string
+	Index int
+}
+
+// scanExtraPaths applies the scanner's own marker rules to the out-of-root
+// citation paths.
+func scanExtraPaths(root string) ([]extraCite, error) {
+	var out []extraCite
+	for _, rel := range extraCitationPaths {
+		lines, err := readLines(filepath.Join(root, rel))
+		if err != nil {
+			return nil, fmt.Errorf("read extra citation path %s: %w", rel, err)
+		}
+		for i, line := range lines {
+			refs, ok := parseMarkerRefs(line)
+			if !ok {
+				continue
+			}
+			for _, r := range refs {
+				if r.ID == "" {
+					return nil, fmt.Errorf("%s:%d: malformed reference %q", rel, i+1, r.Text)
+				}
+				out = append(out, extraCite{Path: rel, Line: i + 1, ID: r.ID, Index: r.Index})
+			}
+		}
+	}
+	return out, nil
+}
+
+func cmdCite(args []string) int {
+	fs := newFlagSet("cite")
+	out := fs.String("out", "", "artifact output directory (must resolve outside <root>)")
+	write := fs.Bool("write", false, "write the rewrites (default: dry run)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 || *out == "" {
+		usage()
+		return 2
+	}
+	root, err := absRoot(fs.Arg(0))
+	if err != nil {
+		return opErr("%v", err)
+	}
+	if err := requireOutsideRoot(*out, root); err != nil {
+		return opErr("%v", err)
+	}
+	outDir, _ := absRoot(*out)
+	if *write {
+		if err := requireCleanTree(root); err != nil {
+			return opErr("%v", err)
+		}
+	}
+
+	// Re-read the FINAL corpus: one (ID, index) -> key map serves both the
+	// waivers and the citations, so the human's checkpoint hand-edits are what
+	// every reference points at.
+	files, err := loadCorpus(root)
+	if err != nil {
+		return opErr("%v", err)
+	}
+	keyOf := keyAtIndex(files)
+
+	var subs []substitution
+	var unresolved []string
+	staged := map[string][]string{}
+	resolve := func(id string, n int) (string, bool) {
+		k, ok := keyOf[id][n]
+		return k, ok
+	}
+
+	// Marker lines: the two scan roots (via the scanner itself, so the scoping
+	// is identical) plus the explicit extra paths.
+	cites, probs, err := spec.CollectCitations(filepath.Join(root, "backend"), filepath.Join(root, "frontend", "tests", "e2e"))
+	if err != nil {
+		return opErr("collect citations: %v", err)
+	}
+	if len(probs) > 0 {
+		return opErr("citation problems in the scan roots: %v", probs)
+	}
+	markerFiles := map[string]map[int]bool{}
+	touch := func(path string, line int) {
+		if markerFiles[path] == nil {
+			markerFiles[path] = map[int]bool{}
+		}
+		markerFiles[path][line] = true
+	}
+	for _, c := range cites {
+		if c.Key == "" && c.Then >= 0 {
+			touch(c.Path, c.Line)
+		}
+	}
+	extra, err := scanExtraPaths(root)
+	if err != nil {
+		return opErr("%v", err)
+	}
+	for _, c := range extra {
+		if c.Index >= 0 {
+			touch(filepath.Join(root, c.Path), c.Line)
+		}
+	}
+
+	paths := make([]string, 0, len(markerFiles))
+	for p := range markerFiles {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		lines, err := readLines(path)
+		if err != nil {
+			return opErr("%v", err)
+		}
+		nums := make([]int, 0, len(markerFiles[path]))
+		for n := range markerFiles[path] {
+			nums = append(nums, n)
+		}
+		sort.Ints(nums)
+		rel, _ := filepath.Rel(root, path)
+		for _, n := range nums {
+			refs, ok := parseMarkerRefs(lines[n-1])
+			if !ok {
+				return opErr("%s:%d is not a whole-line spec marker", rel, n)
+			}
+			var spans []ref
+			var repl []string
+			for _, r := range refs {
+				if r.Index < 0 {
+					continue
+				}
+				key, found := resolve(r.ID, r.Index)
+				if !found {
+					unresolved = append(unresolved, fmt.Sprintf("%s has no key for %s[%d]  (cited at %s:%d)", r.ID, r.ID, r.Index, rel, n))
+					continue
+				}
+				spans = append(spans, r)
+				repl = append(repl, r.ID+"."+key)
+				subs = append(subs, substitution{Path: rel, Line: n, Old: r.Text, New: r.ID + "." + key})
+			}
+			if len(spans) > 0 {
+				lines[n-1] = replaceSpans(lines[n-1], spans, repl)
+			}
+		}
+		staged[path] = lines
+	}
+
+	// Waivers: line discovery through a read-only node decode, cross-checked
+	// against the parsed Waiver.Index before a byte is touched.
+	for _, f := range files {
+		lines, ok := staged[f.Path]
+		if !ok {
+			lines, err = readLines(f.Path)
+			if err != nil {
+				return opErr("%v", err)
+			}
+		}
+		wl, err := waiverThenLines(f.Path)
+		if err != nil {
+			return opErr("%v", err)
+		}
+		rel, _ := filepath.Rel(root, f.Path)
+		changed := false
+		for bi := range f.Behaviors {
+			b := &f.Behaviors[bi]
+			if len(b.Waivers) == 0 {
+				continue
+			}
+			ls := wl[b.ID]
+			if len(ls) != len(b.Waivers) {
+				return opErr("%s: %s has %d waivers but %d discovered lines", rel, b.ID, len(b.Waivers), len(ls))
+			}
+			for wi, w := range b.Waivers {
+				if w.Keyed {
+					continue // already migrated
+				}
+				n := ls[wi]
+				m := waiverIndexLine.FindStringSubmatch(lines[n-1])
+				if m == nil {
+					return opErr("%s:%d: waiver line %q does not match the index form", rel, n, lines[n-1])
+				}
+				got, _ := strconv.Atoi(m[1])
+				if got != w.Index {
+					return opErr("%s:%d: waiver line names index %d but the parser read %d", rel, n, got, w.Index)
+				}
+				key, found := resolve(b.ID, w.Index)
+				if !found {
+					unresolved = append(unresolved, fmt.Sprintf("%s has no key for %s[%d]  (waived at %s:%d)", b.ID, b.ID, w.Index, rel, n))
+					continue
+				}
+				lines[n-1] = "      - then: " + key
+				subs = append(subs, substitution{Path: rel, Line: n,
+					Old: fmt.Sprintf("%s[%d]", b.ID, w.Index), New: b.ID + "." + key})
+				changed = true
+			}
+		}
+		if changed {
+			staged[f.Path] = lines
+		}
+	}
+
+	// Fail closed BEFORE writing a byte: a reference with no key is an
+	// operational error, not something to half-apply.
+	if len(unresolved) > 0 {
+		sort.Strings(unresolved)
+		fmt.Fprintf(os.Stderr, "specmigrate: cite aborted — %d reference(s) have no key in the corpus; nothing was written:\n", len(unresolved))
+		for _, u := range unresolved {
+			fmt.Fprintf(os.Stderr, "  %s\n", u)
+		}
+		return 2
+	}
+	if len(subs) != expectedSubstitutions {
+		return opErr("built %d substitutions, expected %d — the corpus or the citing files moved; nothing was written",
+			len(subs), expectedSubstitutions)
+	}
+
+	// STABLE, and on (path, line) only: the rows for a single marker line must
+	// stay in SOURCE order, because G2a replays them positionally against the
+	// line's references to prove the rewrite was exactly the substitution.
+	sort.SliceStable(subs, func(i, j int) bool {
+		if subs[i].Path != subs[j].Path {
+			return subs[i].Path < subs[j].Path
+		}
+		return subs[i].Line < subs[j].Line
+	})
+	var ledger strings.Builder
+	for _, s := range subs {
+		fmt.Fprintf(&ledger, "%s\t%d\t%s\t%s\n", s.Path, s.Line, s.Old, s.New)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "substitutions.txt"), []byte(ledger.String()), 0o644); err != nil {
+		return opErr("%v", err)
+	}
+	fmt.Printf("cite: %d substitutions across %d files; ledger in %s\n", len(subs), len(staged), outDir)
+	if !*write {
+		fmt.Println("cite: DRY RUN — pass --write to apply the rewrites")
+		return 0
+	}
+	for path, lines := range staged {
+		if err := writeLines(path, lines); err != nil {
+			return opErr("write %s: %v", path, err)
+		}
+	}
+	fmt.Printf("cite: wrote %d files\n", len(staged))
+	return 0
+}

--- a/backend/cmd/specmigrate/slug.go
+++ b/backend/cmd/specmigrate/slug.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Slug generation for the #760 migration, per the arc's §3.8 as amended by the
+// PR2 plan's D2. The output is a PERMANENT citation key: once minted it is
+// never regenerated or renamed by tooling, which is why the migration runs in
+// two passes with a human review checkpoint between them.
+
+// slugStopwords are the tokens dropped from a then-item text before the key is
+// minted.
+//
+// Negation-bearing tokens — no, not, never, without, unless, nothing, none —
+// are DELIBERATELY absent from this set. Dropping one would let a permanent key
+// read as the exact negation of the item it names ("the banner is not shown
+// when nothing is stale" → banner-shown). 36 of the corpus's minted keys retain
+// such a token; 24 of them retain `no` or `not` specifically.
+var slugStopwords = map[string]bool{
+	"a": true, "an": true, "and": true, "are": true, "as": true, "at": true,
+	"be": true, "by": true, "for": true, "from": true, "in": true, "is": true,
+	"it": true, "its": true, "of": true, "on": true, "or": true, "that": true,
+	"the": true, "this": true, "to": true, "with": true,
+}
+
+const (
+	// slugTakeTokens is how many surviving tokens the base slug takes.
+	slugTakeTokens = 4
+	// slugMaxLen caps the final key, including any disambiguating suffix.
+	slugMaxLen = 40
+	// slugReserved is the token a waiver uses to address a statement
+	// behavior's implicit item. It matches the key charset, so the generator
+	// must never mint it as a then-item key.
+	slugReserved = "statement"
+)
+
+// slugCharset is the key charset the corpus lints against
+// (spec/validate.go's thenKeyRegex). Every minted slug is asserted against it.
+var slugCharset = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// slugTokens lowercases the text, collapses every run of non-[a-z0-9] into a
+// separator, splits, and drops stopwords. If the stopword filter empties the
+// list the unfiltered list is kept, so a text made entirely of stopwords still
+// yields a key. A text with no alphanumeric content at all yields nil.
+func slugTokens(text string) []string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(text) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	raw := strings.FieldsFunc(b.String(), func(r rune) bool { return r == '-' })
+	if len(raw) == 0 {
+		return nil
+	}
+	kept := make([]string, 0, len(raw))
+	for _, t := range raw {
+		if !slugStopwords[t] {
+			kept = append(kept, t)
+		}
+	}
+	if len(kept) == 0 {
+		return raw
+	}
+	return kept
+}
+
+// truncateSlug hard-truncates to max and trims any trailing separator the cut
+// left behind. A truncation landing mid-token would otherwise leave "...-",
+// which produces "...--2" once a numeric suffix is appended and fails the
+// charset assertion.
+func truncateSlug(s string, max int) string {
+	if max < 0 {
+		max = 0
+	}
+	if len(s) > max {
+		s = s[:max]
+	}
+	return strings.TrimRight(s, "-")
+}
+
+// capTokens joins the tokens and caps the result at max by dropping trailing
+// tokens until it fits, hard-truncating only when a single over-long token
+// remains.
+func capTokens(toks []string, max int) string {
+	for len(toks) > 1 && len(strings.Join(toks, "-")) > max {
+		toks = toks[:len(toks)-1]
+	}
+	return truncateSlug(strings.Join(toks, "-"), max)
+}
+
+// slugBase is the candidate mintSlug starts from, before any collision or
+// reserved-token disambiguation. Comparing a minted key against it is how the
+// review artifact flags the keys that needed disambiguating.
+func slugBase(text string) string {
+	toks := slugTokens(text)
+	if len(toks) == 0 {
+		return ""
+	}
+	n := slugTakeTokens
+	if n > len(toks) {
+		n = len(toks)
+	}
+	return capTokens(toks[:n], slugMaxLen)
+}
+
+// apostropheFragments returns the alphanumeric runs that immediately follow an
+// apostrophe in text, lowercased. The separator rule turns each into a
+// standalone token, which is the corpus's single largest weak-slug class:
+// "a method's value" yields updating-method-s-value.
+func apostropheFragments(text string) []string {
+	var out []string
+	lower := strings.ToLower(text)
+	for i := 0; i < len(lower); i++ {
+		if lower[i] != '\'' {
+			continue
+		}
+		j := i + 1
+		for j < len(lower) && (lower[j] >= 'a' && lower[j] <= 'z' || lower[j] >= '0' && lower[j] <= '9') {
+			j++
+		}
+		if j > i+1 {
+			out = append(out, lower[i+1:j])
+		}
+	}
+	return out
+}
+
+// mintSlug derives a key for text that does not collide with taken (the keys
+// already minted for the SAME behavior, in item order — uniqueness is
+// per-behavior) and is never the reserved "statement" token.
+//
+// Collision resolution appends the next unused token from the post-stopword
+// token list one at a time, re-applying the length cap after every append. If
+// that list is exhausted the fallback is a -2/-3/... suffix, with the base
+// truncated from the token side so the disambiguator always survives.
+func mintSlug(text string, taken map[string]bool) (string, error) {
+	toks := slugTokens(text)
+	if len(toks) == 0 {
+		return "", fmt.Errorf("then-item text %q has no alphanumeric content, so it cannot yield a key", text)
+	}
+	n := slugTakeTokens
+	if n > len(toks) {
+		n = len(toks)
+	}
+	cand := capTokens(toks[:n], slugMaxLen)
+	for i := slugTakeTokens; (taken[cand] || cand == slugReserved) && i < len(toks); i++ {
+		cand = capTokens(toks[:i+1], slugMaxLen)
+	}
+	if taken[cand] || cand == slugReserved {
+		base := capTokens(toks[:n], slugMaxLen)
+		found := false
+		for k := 2; k < 1000; k++ {
+			suffix := strconv.Itoa(k)
+			c := truncateSlug(base, slugMaxLen-len(suffix)-1) + "-" + suffix
+			if !taken[c] && c != slugReserved {
+				cand, found = c, true
+				break
+			}
+		}
+		if !found {
+			return "", fmt.Errorf("exhausted numeric disambiguators for %q", text)
+		}
+	}
+	if !slugCharset.MatchString(cand) {
+		return "", fmt.Errorf("minted slug %q for %q violates the key charset", cand, text)
+	}
+	return cand, nil
+}

--- a/backend/cmd/specmigrate/slug_test.go
+++ b/backend/cmd/specmigrate/slug_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMintSlug pins every parameter of the slug algorithm (D2). The keys it
+// mints are permanent, so each rule gets its own row: inverting any one of them
+// changes exactly one expectation here.
+func TestMintSlug(t *testing.T) {
+	// A 40-char base whose 38-char truncation lands ON a separator, which is
+	// what makes the trailing-hyphen trim in the numeric-suffix path
+	// observable: without it the result would be "...ccccccccccc--2".
+	const base40 = "aaaaaaaaaaaa-bbbbbbbbbbbb-ccccccccccc-dd"
+	// A 37-char base built from 5 tokens, where appending the 5th overflows
+	// the cap and is therefore dropped again — so the append cannot resolve
+	// the collision and the numeric fallback must.
+	const base37 = "aaaaaaaaa-bbbbbbbbb-ccccccccc-ddddddd"
+
+	cases := []struct {
+		name  string
+		text  string
+		taken []string
+		want  string
+	}{
+		{
+			name: "stopwords dropped",
+			text: "the row is removed from the overdue list",
+			want: "row-removed-overdue-list",
+		},
+		{
+			name: "negation token not is retained",
+			text: "the banner is not shown when nothing is stale",
+			want: "banner-not-shown-when",
+		},
+		{
+			name: "negation token never is retained",
+			text: "a revoked host is never listed",
+			want: "revoked-host-never-listed",
+		},
+		{
+			name: "negation token without is retained",
+			text: "the import completes without a duplicate",
+			want: "import-completes-without-duplicate",
+		},
+		{
+			name: "all-stopword text keeps the unfiltered tokens",
+			text: "the and of",
+			want: "the-and-of",
+		},
+		{
+			name: "only the first four surviving tokens are taken",
+			text: "alpha beta gamma delta epsilon zeta",
+			want: "alpha-beta-gamma-delta",
+		},
+		{
+			name: "non-alphanumeric runs collapse to a single separator",
+			text: "a contact's methods are displayed",
+			want: "contact-s-methods-displayed",
+		},
+		{
+			name: "cap drops a trailing token rather than truncating it",
+			text: "aaaaaaaaaaaa bbbbbbbbbbbb cccccccccccc dddd",
+			want: "aaaaaaaaaaaa-bbbbbbbbbbbb-cccccccccccc",
+		},
+		{
+			name: "a single over-long token is hard-truncated to the cap",
+			text: strings.Repeat("a", 45),
+			want: strings.Repeat("a", 40),
+		},
+		{
+			name:  "a collision appends the next unused token",
+			text:  "alpha beta gamma delta epsilon zeta",
+			taken: []string{"alpha-beta-gamma-delta"},
+			want:  "alpha-beta-gamma-delta-epsilon",
+		},
+		{
+			name:  "the cap is re-applied after a collision append, so an overflowing token cannot resolve it",
+			text:  "aaaaaaaaa bbbbbbbbb ccccccccc ddddddd eeeeeeee",
+			taken: []string{base37},
+			want:  base37 + "-2",
+		},
+		{
+			name:  "the numeric fallback trims a separator left by truncating the base",
+			text:  "aaaaaaaaaaaa bbbbbbbbbbbb ccccccccccc dd",
+			taken: []string{base40},
+			want:  "aaaaaaaaaaaa-bbbbbbbbbbbb-ccccccccccc-2",
+		},
+		{
+			name:  "the numeric fallback keeps counting past an already-taken suffix",
+			text:  "alpha beta gamma delta",
+			taken: []string{"alpha-beta-gamma-delta", "alpha-beta-gamma-delta-2"},
+			want:  "alpha-beta-gamma-delta-3",
+		},
+		{
+			name: "the reserved statement token is never minted",
+			text: "statement",
+			want: "statement-2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			taken := map[string]bool{}
+			for _, k := range tc.taken {
+				taken[k] = true
+			}
+			got, err := mintSlug(tc.text, taken)
+			if err != nil {
+				t.Fatalf("mintSlug(%q) returned error: %v", tc.text, err)
+			}
+			if got != tc.want {
+				t.Errorf("mintSlug(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+			if !slugCharset.MatchString(got) {
+				t.Errorf("mintSlug(%q) = %q, which violates the key charset", tc.text, got)
+			}
+			if len(got) > slugMaxLen {
+				t.Errorf("mintSlug(%q) = %q (%d chars), over the %d-char cap", tc.text, got, len(got), slugMaxLen)
+			}
+			if got == slugReserved {
+				t.Errorf("mintSlug(%q) minted the reserved token %q", tc.text, slugReserved)
+			}
+		})
+	}
+}
+
+// TestMintSlugNoAlphanumericAborts pins the abort in D2 step 2: a text with no
+// alphanumeric content cannot yield a key, and the tool must say so rather than
+// mint an empty one.
+func TestMintSlugNoAlphanumericAborts(t *testing.T) {
+	if got, err := mintSlug("--- !!! ---", map[string]bool{}); err == nil {
+		t.Fatalf("mintSlug on an alphanumeric-free text returned %q, want an error", got)
+	}
+}
+
+// TestSlugTokensDropsStopwordsButNotNegations guards the stopword set itself:
+// every negation-bearing token must survive the filter, because a permanent key
+// that loses one reads as the inverse of the item it names.
+func TestSlugTokensDropsStopwordsButNotNegations(t *testing.T) {
+	for _, tok := range []string{"no", "not", "never", "without", "unless", "nothing", "none"} {
+		if slugStopwords[tok] {
+			t.Errorf("%q is a stopword, but negation-bearing tokens must be retained", tok)
+		}
+		got := slugTokens("the " + tok + " case")
+		if len(got) == 0 || got[0] != tok {
+			t.Errorf("slugTokens(%q) = %v, want %q retained as the first token", "the "+tok+" case", got, tok)
+		}
+	}
+	for _, tok := range []string{"a", "the", "of", "with", "that"} {
+		if !slugStopwords[tok] {
+			t.Errorf("%q must be a stopword", tok)
+		}
+	}
+}

--- a/backend/internal/api/handlers/contact_create_test.go
+++ b/backend/internal/api/handlers/contact_create_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// spec: CON-001[0]
+// spec: CON-001.last-contacted-left-unset
 // last_contacted records a two-way connection (CAD-006). A brand-new contact has
 // had none, so the column stays NULL rather than being seeded with the creation
 // instant — contact_by falls back to created_at (CAD-002[0]). Seeding it made the

--- a/backend/internal/api/handlers/contact_methods_test.go
+++ b/backend/internal/api/handlers/contact_methods_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// spec: CON-015[0]
+// spec: CON-015.blank-valued-entries-dropped
 func TestNormalizeContactMethodRequests(t *testing.T) {
 	methods, err := normalizeContactMethodRequests([]ContactMethodRequest{
 		{Type: " twitter ", Value: " @handle "},
@@ -32,7 +32,7 @@ func TestValidateContactMethods_DuplicateTypesAllowed(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// spec: CON-015[5]
+// spec: CON-015.two-entries-same-type
 func TestValidateContactMethods_DuplicateNormalizedValuePerType(t *testing.T) {
 	validate := validator.New()
 	err := validateContactMethods(validate, []ContactMethodRequest{
@@ -42,7 +42,7 @@ func TestValidateContactMethods_DuplicateNormalizedValuePerType(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// spec: CON-015[6]
+// spec: CON-015.more-than-one-entry
 func TestValidateContactMethods_MultiplePrimary(t *testing.T) {
 	validate := validator.New()
 	err := validateContactMethods(validate, []ContactMethodRequest{
@@ -84,7 +84,7 @@ func TestValidateContactMethods_WhatsAppLength(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// spec: CON-015[3]
+// spec: CON-015.email-family-values-valid
 func TestValidateContactMethods_GChatValidation(t *testing.T) {
 	validate := validator.New()
 	err := validateContactMethods(validate, []ContactMethodRequest{
@@ -93,7 +93,7 @@ func TestValidateContactMethods_GChatValidation(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// spec: CON-015[4]
+// spec: CON-015.phone-family-values-limited
 func TestValidateContactMethods_SignalLength(t *testing.T) {
 	validate := validator.New()
 

--- a/backend/internal/api/handlers/ingest_test.go
+++ b/backend/internal/api/handlers/ingest_test.go
@@ -19,7 +19,7 @@ import (
 // external_contact and call version gates end-to-end
 // (external_contact_ingest and phone_call_ingest test files).
 
-// spec: ING-005[0]
+// spec: ING-005.version-below-supported-minimum
 func TestValidateRawMessagePayload_VersionBelowMin_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "messages",
@@ -33,7 +33,7 @@ func TestValidateRawMessagePayload_VersionBelowMin_Rejected(t *testing.T) {
 	require.Contains(t, ierr.Message, "version")
 }
 
-// spec: ING-005[1]
+// spec: ING-005.version-above-highest-known
 func TestValidateRawMessagePayload_VersionTooHigh_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "messages",
@@ -47,7 +47,7 @@ func TestValidateRawMessagePayload_VersionTooHigh_Rejected(t *testing.T) {
 	require.Contains(t, ierr.Message, "upgrade Pi")
 }
 
-// spec: ING-005[0]
+// spec: ING-005.version-below-supported-minimum
 func TestValidateMeetingNotePayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "anarlog_sessions",
@@ -61,7 +61,7 @@ func TestValidateMeetingNotePayloadVersion_VersionBelowMin_Rejected(t *testing.T
 	require.Contains(t, ierr.Message, "version")
 }
 
-// spec: ING-005[1]
+// spec: ING-005.version-above-highest-known
 func TestValidateMeetingNotePayloadVersion_VersionTooHigh_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "anarlog_sessions",
@@ -75,7 +75,7 @@ func TestValidateMeetingNotePayloadVersion_VersionTooHigh_Rejected(t *testing.T)
 	require.Contains(t, ierr.Message, "upgrade Pi")
 }
 
-// spec: ING-005[0]
+// spec: ING-005.version-below-supported-minimum
 func TestValidateExternalContactPayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "icloud_contacts",
@@ -89,7 +89,7 @@ func TestValidateExternalContactPayloadVersion_VersionBelowMin_Rejected(t *testi
 	require.Contains(t, ierr.Message, "version")
 }
 
-// spec: ING-005[1]
+// spec: ING-005.version-above-highest-known
 func TestValidateExternalContactPayloadVersion_VersionTooHigh_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "icloud_contacts",
@@ -103,7 +103,7 @@ func TestValidateExternalContactPayloadVersion_VersionTooHigh_Rejected(t *testin
 	require.Contains(t, ierr.Message, "upgrade Pi")
 }
 
-// spec: ING-005[0]
+// spec: ING-005.version-below-supported-minimum
 func TestValidateCallPayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "phone_calls",
@@ -117,7 +117,7 @@ func TestValidateCallPayloadVersion_VersionBelowMin_Rejected(t *testing.T) {
 	require.Contains(t, ierr.Message, "version")
 }
 
-// spec: ING-005[1]
+// spec: ING-005.version-above-highest-known
 func TestValidateCallPayloadVersion_VersionTooHigh_Rejected(t *testing.T) {
 	ev := IngestEventRequest{
 		Source:   "phone_calls",

--- a/backend/internal/api/handlers/mac_host_test.go
+++ b/backend/internal/api/handlers/mac_host_test.go
@@ -102,7 +102,7 @@ func alwaysMatch(_ []byte, _ []byte) error { return nil }
 // the middleware read and the rotate tx's FOR UPDATE lookup).
 // Deterministically exercises the handler's response shape without
 // needing tx-internal hooks.
-// spec: MAC-010[3]
+// spec: MAC-010.missing-revoked-host
 func TestRotateKey_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -155,7 +155,7 @@ func TestRotateKey_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 // are proven at the service layer by
 // TestMacHostRotateKey_ConcurrentRotation_DifferentTokens/_SameToken),
 // so this pins the wire contract without a real race.
-// spec: MAC-010[2]
+// spec: MAC-010.rotated-out-key-stale-auth
 func TestRotateKey_ConcurrentRotationLoser_MapsStaleAuthTo401(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -203,7 +203,7 @@ func TestRotateKey_ConcurrentRotationLoser_MapsStaleAuthTo401(t *testing.T) {
 // TestHeartbeat_HostRevokedBetweenMiddlewareAndTx covers the
 // handler's db.ErrNotFound -> 401 UNKNOWN_HOST branch: the host was
 // revoked between the middleware's read and the heartbeat write.
-// spec: MAC-011[3]
+// spec: MAC-011.host-revoked-between-authentication
 func TestHeartbeat_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/api/handlers/meeting_note_test.go
+++ b/backend/internal/api/handlers/meeting_note_test.go
@@ -67,7 +67,7 @@ func TestResolveLink_PathParamInvalidUUID(t *testing.T) {
 
 // TestResolveLink_EmptyBody — handler returns 400 when the body is
 // empty (action is required).
-// spec: NTS-018[0]
+// spec: NTS-018.action-required-must-link
 func TestResolveLink_EmptyBody(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -76,7 +76,7 @@ func TestResolveLink_EmptyBody(t *testing.T) {
 }
 
 // TestResolveLink_NullBody — handler returns 400 on literal null JSON.
-// spec: NTS-018[0]
+// spec: NTS-018.action-required-must-link
 func TestResolveLink_NullBody(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -86,7 +86,7 @@ func TestResolveLink_NullBody(t *testing.T) {
 
 // TestResolveLink_UnknownAction — handler returns 400 for an action
 // outside {link, none_of_these}.
-// spec: NTS-018[0]
+// spec: NTS-018.action-required-must-link
 func TestResolveLink_UnknownAction(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -97,7 +97,7 @@ func TestResolveLink_UnknownAction(t *testing.T) {
 
 // TestResolveLink_LinkMissingKindAndID — action=link without kind+id
 // returns 400.
-// spec: NTS-018[1]
+// spec: NTS-018.action-link-requires-kind
 func TestResolveLink_LinkMissingKindAndID(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -108,7 +108,7 @@ func TestResolveLink_LinkMissingKindAndID(t *testing.T) {
 }
 
 // TestResolveLink_LinkMissingID — action=link with only kind returns 400.
-// spec: NTS-018[1]
+// spec: NTS-018.action-link-requires-kind
 func TestResolveLink_LinkMissingID(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -118,7 +118,7 @@ func TestResolveLink_LinkMissingID(t *testing.T) {
 }
 
 // TestResolveLink_LinkMissingKind — action=link with only id returns 400.
-// spec: NTS-018[1]
+// spec: NTS-018.action-link-requires-kind
 func TestResolveLink_LinkMissingKind(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -129,7 +129,7 @@ func TestResolveLink_LinkMissingKind(t *testing.T) {
 
 // TestResolveLink_LinkInvalidKind — action=link with an unrecognized
 // kind returns 400.
-// spec: NTS-018[1]
+// spec: NTS-018.action-link-requires-kind
 func TestResolveLink_LinkInvalidKind(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -141,7 +141,7 @@ func TestResolveLink_LinkInvalidKind(t *testing.T) {
 
 // TestResolveLink_LinkInvalidIDFormat — action=link with a malformed
 // uuid returns 400.
-// spec: NTS-018[1]
+// spec: NTS-018.action-link-requires-kind
 func TestResolveLink_LinkInvalidIDFormat(t *testing.T) {
 	router := newTestHandler(t, nil)
 	id := uuid.New().String()
@@ -178,7 +178,7 @@ func TestResolveLink_NoneOfTheseValidBody(t *testing.T) {
 
 // TestListNeedsAttention_InvalidHostID — bad host_id query param
 // returns 400.
-// spec: NTS-025[0]
+// spec: NTS-025.malformed-host-id-query
 func TestListNeedsAttention_InvalidHostID(t *testing.T) {
 	router := newTestHandler(t, nil)
 	w := httptest.NewRecorder()

--- a/backend/internal/api/handlers/oauth_test.go
+++ b/backend/internal/api/handlers/oauth_test.go
@@ -176,7 +176,7 @@ func TestGetGoogleAuthURL(t *testing.T) {
 	})
 }
 
-// spec: SET-002[0]
+// spec: SET-002.random-csrf-state-generated
 func TestGetGoogleAuthURL_StoresStateServerSide(t *testing.T) {
 	mock := &MockOAuthService{}
 	handler := NewOAuthHandler(mock, "http://localhost:3000")
@@ -373,7 +373,7 @@ func TestGoogleCallback(t *testing.T) {
 	})
 }
 
-// spec: SET-003[3]
+// spec: SET-003.expired-unknown-already-used
 func TestGoogleCallback_ExpiredStateAbortsBeforeExchange(t *testing.T) {
 	exchangeCalled := false
 	mock := &MockOAuthService{
@@ -414,7 +414,7 @@ func TestGoogleCallback_ExpiredStateAbortsBeforeExchange(t *testing.T) {
 	assert.False(t, exchangeCalled, "an expired state must abort the flow before the code exchange")
 }
 
-// spec: SET-003[3]
+// spec: SET-003.expired-unknown-already-used
 // An unknown (never-stored) state must abort the callback with an
 // invalid_state outcome WITHOUT the authorization code ever being exchanged.
 func TestGoogleCallback_UnknownStateAbortsBeforeExchange(t *testing.T) {
@@ -444,7 +444,7 @@ func TestGoogleCallback_UnknownStateAbortsBeforeExchange(t *testing.T) {
 	assert.False(t, exchangeCalled, "an unknown state must abort the flow before the code exchange")
 }
 
-// spec: SET-003[3]
+// spec: SET-003.expired-unknown-already-used
 // An already-used state must abort a REPLAYED callback with an invalid_state
 // outcome without invoking the code exchange a second time: the state is
 // stored once, consumed by a first (successful) callback, then replayed.
@@ -491,7 +491,7 @@ func TestGoogleCallback_AlreadyUsedStateAbortsBeforeExchange(t *testing.T) {
 
 func TestGoogleCallback_FailureRedirectsIncludeProvider(t *testing.T) {
 	t.Run("provider error carries provider name", func(t *testing.T) {
-		// spec: SET-004[2]
+		// spec: SET-004.failure-carries-outcome-error
 		mock := &MockOAuthService{}
 		handler := NewOAuthHandler(mock, "http://localhost:3000")
 
@@ -509,7 +509,7 @@ func TestGoogleCallback_FailureRedirectsIncludeProvider(t *testing.T) {
 	})
 
 	t.Run("invalid state carries provider name", func(t *testing.T) {
-		// spec: SET-004[2]
+		// spec: SET-004.failure-carries-outcome-error
 		mock := &MockOAuthService{}
 		handler := NewOAuthHandler(mock, "http://localhost:3000")
 
@@ -527,7 +527,7 @@ func TestGoogleCallback_FailureRedirectsIncludeProvider(t *testing.T) {
 	})
 
 	t.Run("exchange failure carries provider name", func(t *testing.T) {
-		// spec: SET-004[2]
+		// spec: SET-004.failure-carries-outcome-error
 		mock := &MockOAuthService{
 			ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
 				return nil, errors.New("exchange failed")
@@ -552,7 +552,7 @@ func TestGoogleCallback_FailureRedirectsIncludeProvider(t *testing.T) {
 	})
 }
 
-// spec: SET-004[3]
+// spec: SET-004.redirect-params-url-encoded
 func TestGoogleCallback_ErrorRedirectIsProperlyURLEncoded(t *testing.T) {
 	mock := &MockOAuthService{}
 	handler := NewOAuthHandler(mock, "http://localhost:3000")
@@ -850,7 +850,7 @@ func TestStateValidation(t *testing.T) {
 		state := "one-time-state"
 		handler.storeState(state)
 
-		// spec: SET-003[2]
+		// spec: SET-003.state-accepted-at-most-once
 		// First validation should succeed
 		assert.True(t, handler.validateState(state))
 
@@ -890,7 +890,7 @@ func validateStateAfterShift(t *testing.T, shiftSeconds int64) bool {
 	return handler.validateState(state)
 }
 
-// spec: SET-002[1]
+// spec: SET-002.stored-state-expires-ten-minutes
 // Pins BOTH sides of the ten-minute TTL boundary: a state validated just
 // under ten minutes after storage is still accepted, and one validated just
 // over ten minutes after storage is rejected. A single gross shift would pass
@@ -898,19 +898,19 @@ func validateStateAfterShift(t *testing.T, shiftSeconds int64) bool {
 // either direction.
 func TestOAuthState_ExpiresAfterTenMinutes(t *testing.T) {
 	t.Run("state is still valid just under ten minutes after storage", func(t *testing.T) {
-		// spec: SET-002[1]
+		// spec: SET-002.stored-state-expires-ten-minutes
 		assert.True(t, validateStateAfterShift(t, 570),
 			"a state validated 9m30s after storage must still be accepted (TTL is ten minutes)")
 	})
 
 	t.Run("state is invalid just over ten minutes after storage", func(t *testing.T) {
-		// spec: SET-002[1]
+		// spec: SET-002.stored-state-expires-ten-minutes
 		assert.False(t, validateStateAfterShift(t, 630),
 			"a state validated 10m30s after storage must be rejected (TTL is ten minutes)")
 	})
 }
 
-// spec: SET-002[2]
+// spec: SET-002.returns-authorization-url-and-state
 // Twin of TestGetGoogleAuthURL: proves the Todoist auth-URL response also
 // carries both the provider authorization URL and the state.
 func TestGetTodoistAuthURL(t *testing.T) {
@@ -947,7 +947,7 @@ func TestGetTodoistAuthURL(t *testing.T) {
 	})
 }
 
-// spec: SET-003[0]
+// spec: SET-003.provider-supplied-error-parameter
 // Twin of the Google error-short-circuit ordering: a provider error param
 // must abort the flow before any state validation or code exchange. A
 // valid state is stored ahead of the request so that, if the short-circuit
@@ -987,7 +987,7 @@ func TestTodoistCallback_ErrorShortCircuitsBeforeStateOrExchange(t *testing.T) {
 	assert.True(t, handler.validateState(state), "a provider error must short-circuit before state validation, leaving the state unconsumed")
 }
 
-// spec: SET-003[1]
+// spec: SET-003.csrf-state-validated-consumed
 // Twin of the Google validate-then-exchange ordering: an invalid state
 // aborts before the exchange runs, and a valid state is validated and
 // consumed (single-use) before the exchange is attempted -- regardless of
@@ -1065,7 +1065,7 @@ func assertTrivialRedirectBody(t *testing.T, w *httptest.ResponseRecorder) {
 	assert.Less(t, len(body), 300, "a callback redirect's body must be trivially small (net/http's boilerplate anchor link, at most) -- never a rendered page")
 }
 
-// spec: SET-004[0]
+// spec: SET-004.response-redirect-back-settings
 // Neither provider's callback redirect may carry a rendered page or JSON
 // body -- the response must be a bare redirect (allowing only net/http's
 // own trivial boilerplate anchor body, never one this handler wrote).
@@ -1098,7 +1098,7 @@ func TestOAuthCallbackRedirect_BodyIsEmpty(t *testing.T) {
 	})
 }
 
-// spec: SET-004[0]
+// spec: SET-004.response-redirect-back-settings
 // Twin of the Google redirect-shape assertions: every TodoistCallback
 // outcome must redirect to the settings surface carrying the matching
 // outcome and provider name.
@@ -1163,7 +1163,7 @@ func TestTodoistCallback_RedirectShape(t *testing.T) {
 	})
 }
 
-// spec: SET-004[1]
+// spec: SET-004.success-carries-outcome-success
 // Twin of TestGoogleCallback's "redirects to success on valid exchange":
 // a successful Todoist exchange redirects with auth=success and
 // provider=todoist.
@@ -1196,7 +1196,7 @@ func TestTodoistCallback_SuccessRedirectIncludesProvider(t *testing.T) {
 	assert.Contains(t, location, "provider=todoist")
 }
 
-// spec: SET-008[0]
+// spec: SET-008.listing-returns-array-connected
 // Twin of TestListGoogleAccounts: proves ListTodoistAccounts' 200 response
 // carries an array of connected-account objects. The shape assertion below
 // decodes into map[string]interface{} (the raw wire shape) rather than the
@@ -1315,7 +1315,7 @@ func TestListTodoistAccounts(t *testing.T) {
 // counterpart.
 func TestGetTodoistAccountStatus(t *testing.T) {
 	t.Run("returns error on invalid UUID", func(t *testing.T) {
-		// spec: SET-008[1]
+		// spec: SET-008.malformed-account-id
 		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
 		handler.SetTodoistOAuth(&MockTodoistOAuthService{})
 
@@ -1330,7 +1330,7 @@ func TestGetTodoistAccountStatus(t *testing.T) {
 	})
 
 	t.Run("returns 404 for non-existent account", func(t *testing.T) {
-		// spec: SET-008[2]
+		// spec: SET-008.unknown-account-id
 		mock := &MockTodoistOAuthService{
 			GetAccountStatusFunc: func(ctx context.Context, id uuid.UUID) (*repository.OAuthCredentialStatus, error) {
 				return nil, db.ErrNotFound
@@ -1351,7 +1351,7 @@ func TestGetTodoistAccountStatus(t *testing.T) {
 	})
 
 	t.Run("returns account status", func(t *testing.T) {
-		// spec: SET-008[3]
+		// spec: SET-008.status-and-revoke-return-200
 		accountID := uuid.New()
 		externalAccountID := "todoist-user-" + uuid.New().String()[:8]
 		accountName := "Todoist Status User " + uuid.New().String()[:8]
@@ -1408,7 +1408,7 @@ func TestGetTodoistAccountStatus(t *testing.T) {
 // Google counterpart.
 func TestRevokeTodoistAccount(t *testing.T) {
 	t.Run("returns error on invalid UUID", func(t *testing.T) {
-		// spec: SET-008[1]
+		// spec: SET-008.malformed-account-id
 		handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
 		handler.SetTodoistOAuth(&MockTodoistOAuthService{})
 
@@ -1423,7 +1423,7 @@ func TestRevokeTodoistAccount(t *testing.T) {
 	})
 
 	t.Run("returns 404 for non-existent account", func(t *testing.T) {
-		// spec: SET-008[2]
+		// spec: SET-008.unknown-account-id
 		mock := &MockTodoistOAuthService{
 			RevokeAccountFunc: func(ctx context.Context, id uuid.UUID) error {
 				return db.ErrNotFound
@@ -1444,7 +1444,7 @@ func TestRevokeTodoistAccount(t *testing.T) {
 	})
 
 	t.Run("successfully revokes account", func(t *testing.T) {
-		// spec: SET-008[3]
+		// spec: SET-008.status-and-revoke-return-200
 		revokedID := uuid.Nil
 		mock := &MockTodoistOAuthService{
 			RevokeAccountFunc: func(ctx context.Context, id uuid.UUID) error {

--- a/backend/internal/auth/mac_host_middleware_test.go
+++ b/backend/internal/auth/mac_host_middleware_test.go
@@ -86,7 +86,7 @@ func TestMacHostAuth_HappyPath(t *testing.T) {
 	require.Equal(t, int64(1), cmp.calls.Load())
 }
 
-// spec: MAC-007[0]
+// spec: MAC-007.missing-malformed-host-id
 func TestMacHostAuth_MissingHeader(t *testing.T) {
 	id := uuid.New()
 	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{
@@ -102,7 +102,7 @@ func TestMacHostAuth_MissingHeader(t *testing.T) {
 	require.Equal(t, int64(0), cmp.calls.Load(), "bcrypt must not be invoked on missing-header path")
 }
 
-// spec: MAC-007[0]
+// spec: MAC-007.missing-malformed-host-id
 func TestMacHostAuth_MalformedUUID(t *testing.T) {
 	repo := &fakeHostRepo{}
 	r := newMacAuthTestRouter(t, repo, DefaultPasswordComparator, DefaultMacHostAuthLimiterConfig())
@@ -115,7 +115,7 @@ func TestMacHostAuth_MalformedUUID(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
-// spec: MAC-007[1]
+// spec: MAC-007.presenting-global-api-key
 func TestMacHostAuth_AmbiguousAuth_XAPIKey(t *testing.T) {
 	id := uuid.New()
 	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{
@@ -134,7 +134,7 @@ func TestMacHostAuth_AmbiguousAuth_XAPIKey(t *testing.T) {
 	require.Equal(t, int64(0), cmp.calls.Load(), "bcrypt must not run on ambiguous-auth path")
 }
 
-// spec: MAC-007[1]
+// spec: MAC-007.presenting-global-api-key
 func TestMacHostAuth_AmbiguousAuth_ApiKeyScheme(t *testing.T) {
 	id := uuid.New()
 	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{
@@ -151,7 +151,7 @@ func TestMacHostAuth_AmbiguousAuth_ApiKeyScheme(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// spec: MAC-007[2]
+// spec: MAC-007.missing-empty-bearer-token
 func TestMacHostAuth_MissingOrEmptyBearer_401(t *testing.T) {
 	id := uuid.New()
 	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{
@@ -192,7 +192,7 @@ func TestMacHostAuth_MissingOrEmptyBearer_401(t *testing.T) {
 	}
 }
 
-// spec: MAC-007[3]
+// spec: MAC-007.unknown-revoked-host-rejected
 func TestMacHostAuth_RevokedOrMissingHost_401(t *testing.T) {
 	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{}}
 	cmp := &countingComparator{}
@@ -207,7 +207,7 @@ func TestMacHostAuth_RevokedOrMissingHost_401(t *testing.T) {
 	require.Equal(t, int64(0), cmp.calls.Load(), "bcrypt must not run when host is unknown")
 }
 
-// spec: MAC-007[4]
+// spec: MAC-007.bearer-token-fails-constant
 func TestMacHostAuth_InvalidKey_401(t *testing.T) {
 	id := uuid.New()
 	repo := &fakeHostRepo{hosts: map[uuid.UUID]*repository.MacHost{
@@ -225,7 +225,7 @@ func TestMacHostAuth_InvalidKey_401(t *testing.T) {
 	require.Equal(t, int64(1), cmp.calls.Load(), "bcrypt runs once for the failing attempt")
 }
 
-// spec: MAC-007[5]
+// spec: MAC-007.route-id-mismatch-forbidden
 func TestMacHostAuth_IDParamMismatch_403(t *testing.T) {
 	id := uuid.New()
 	other := uuid.New()

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// spec: SET-006[0]
+// spec: SET-006.key-read-from-api-key-header
 func TestAPIKeyMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -30,7 +30,7 @@ func TestAPIKeyMiddleware(t *testing.T) {
 		middleware := APIKeyMiddleware(testConfig)
 		middleware(c)
 
-		// spec: SET-006[3]
+		// spec: SET-006.matching-key-allows-request
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.False(t, c.IsAborted())
 	})
@@ -56,7 +56,7 @@ func TestAPIKeyMiddleware(t *testing.T) {
 		middleware := APIKeyMiddleware(testConfig)
 		middleware(c)
 
-		// spec: SET-006[1]
+		// spec: SET-006.missing-key-rejected-401
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 		assert.True(t, c.IsAborted())
 		assert.Contains(t, w.Body.String(), "MISSING_API_KEY")
@@ -71,7 +71,7 @@ func TestAPIKeyMiddleware(t *testing.T) {
 		middleware := APIKeyMiddleware(testConfig)
 		middleware(c)
 
-		// spec: SET-006[2]
+		// spec: SET-006.key-does-not-match
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 		assert.True(t, c.IsAborted())
 		assert.Contains(t, w.Body.String(), "INVALID_API_KEY")

--- a/backend/internal/repository/sync_test.go
+++ b/backend/internal/repository/sync_test.go
@@ -9,7 +9,7 @@ import (
 // Pure unit coverage of extractBackfillComplete: the flag is opaque to
 // the backend, so absent keys and malformed values must default to
 // false rather than erroring or defaulting to true.
-// spec: MAC-015[2]
+// spec: MAC-015.backfill-complete-flag-opaque
 func TestExtractBackfillComplete(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/backend/internal/service/contact_method_blank_test.go
+++ b/backend/internal/service/contact_method_blank_test.go
@@ -23,7 +23,7 @@ import (
 // length-checked only, and telegram/discord/twitter have no format rule at all.
 // The handle and phone rows are the ones that reach this check in production.
 //
-// spec: CON-015[2]
+// spec: CON-015.empty-normalized-value-rejected
 func TestRequireTypeAndValue_RejectsValuesEmptyAfterNormalization(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -98,7 +98,7 @@ func TestEligibleMethods_FiltersToRegisteredHandlers(t *testing.T) {
 		{Type: "telegram", Value: "alice"},
 		{Type: "discord", Value: "alice#1"},
 	}
-	// spec: IMP-019[0]
+	// spec: IMP-019.rematch-event-published-methods
 	got := svc.EligibleMethods(input)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 eligible methods, got %d: %+v", len(got), got)

--- a/backend/internal/spec/coverage_test.go
+++ b/backend/internal/spec/coverage_test.go
@@ -547,3 +547,59 @@ func TestCollectCitationsMissingRoot(t *testing.T) {
 		t.Error("missing backend root should return an error")
 	}
 }
+
+// TestComputeCoverage_UnresolvableKeyedWaiverWaivesNothing pins the `ok` guard
+// at coverage.go's waiver loop. It cannot be a CLI test: an unresolvable keyed
+// waiver is a lint violation, and spec-coverage exits before it ever reaches
+// ComputeCoverage — so the only place this behavior is observable is here.
+//
+// Dropping the ok check (`n, _ := resolveWaiverIndex(...)`) makes every
+// unresolvable waiver waive item 0, because that is what the resolver returns
+// alongside ok=false. The behavior below is built so that would be visible:
+// item 0 is orphaned and nothing else is, so a spurious waiver flips exactly
+// one verdict.
+func TestComputeCoverage_UnresolvableKeyedWaiverWaivesNothing(t *testing.T) {
+	files := []*File{{
+		Domain:  "alpha",
+		Prefix:  "ALP",
+		Path:    "spec/alpha.yaml",
+		Settled: []string{"ui"},
+		Behaviors: []Behavior{{
+			ID:      "ALP-001",
+			Title:   "a behavior whose waiver names a key no item carries",
+			Type:    "ux",
+			Status:  "current",
+			Surface: "ui",
+			When:    "x",
+			Then: []ThenItem{
+				{Key: "first", Text: "the first outcome"},
+				{Key: "second", Text: "the second outcome"},
+			},
+			Waivers: []Waiver{{Key: "no-such-key", Keyed: true, Reason: "r"}},
+		}},
+	}}
+
+	cov := ComputeCoverage(files, nil, nil)
+	if len(cov.Domains) != 1 {
+		t.Fatalf("want 1 domain, got %d", len(cov.Domains))
+	}
+	items := cov.Domains[0].Items
+	for _, want := range []struct {
+		ref   string
+		state string
+	}{
+		{"ALP-001.first", ItemOrphan},
+		{"ALP-001.second", ItemOrphan},
+	} {
+		it := findItem(items, want.ref)
+		if it == nil {
+			t.Fatalf("%s missing from the coverage report", want.ref)
+		}
+		if it.State != want.state {
+			t.Errorf("%s is %q, want %q — an unresolvable keyed waiver must waive nothing", want.ref, it.State, want.state)
+		}
+		if it.Reason != "" {
+			t.Errorf("%s carries waiver reason %q, want none", want.ref, it.Reason)
+		}
+	}
+}

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -198,6 +198,12 @@ func TestLintViolationClasses(t *testing.T) {
 			"then item text must be a string",
 		}},
 		{"waiver-key-unknown", 1, []string{`waiver then "no-such-key" names no then-item key of this behavior`}},
+		// An empty waiver key resolves to nothing, so it waives nothing. The
+		// fixture's then[1] is a PLAIN STRING on purpose: an unkeyed item
+		// carries an empty key, so without resolveWaiverIndex's it.Key != ""
+		// guard this waiver would match it and silently waive a real
+		// assertion at whatever index the unkeyed item happens to sit.
+		{"waiver-key-empty", 1, []string{`waiver then "" names no then-item key of this behavior`}},
 		// Both directions of misusing the reserved token, each with its own
 		// message — the generic unknown-key wording would misdirect either way.
 		{"waiver-statement-bad-key", 2, []string{

--- a/backend/internal/spec/testdata/invalid/waiver-key-empty/bad.yaml
+++ b/backend/internal/spec/testdata/invalid/waiver-key-empty/bad.yaml
@@ -1,0 +1,23 @@
+domain: contacts
+prefix: CON
+maturity: reviewed
+behaviors:
+  # then[1] is deliberately a PLAIN STRING, not a keyed mapping. An all-keyed
+  # behavior would make this fixture non-discriminating: with the it.Key != ""
+  # guard removed from resolveWaiverIndex, an empty waiver key matches the
+  # first item whose key is empty — so the violation only disappears when such
+  # an item exists, and it sits at index 1 to show the waiver would silently
+  # waive an arbitrary item rather than item 0.
+  - id: CON-001
+    title: a waiver whose then is an empty string
+    type: ux
+    status: current
+    surface: ui
+    when: x
+    then:
+      - key: real-key
+        text: y
+      - z
+    waivers:
+      - then: ""
+        reason: r

--- a/backend/tests/api/contact_ids_test.go
+++ b/backend/tests/api/contact_ids_test.go
@@ -173,8 +173,8 @@ func TestContactAPI_ListContactIDs(t *testing.T) {
 	})
 
 	t.Run("returns sorted IDs when sort parameter provided", func(t *testing.T) {
-		// spec: CON-018[0]
-		// spec: CON-018[1]
+		// spec: CON-018.sort-accepts-name-location
+		// spec: CON-018.order-accepts-asc-desc
 		// Create contacts with different names for sorting
 		id1 := createContact("IDs Sort Zebra " + ns)
 		id2 := createContact("IDs Sort Alpha " + ns)
@@ -274,7 +274,7 @@ func TestContactAPI_ListContactIDs(t *testing.T) {
 	})
 
 	t.Run("sorts by cadence frequency descending (most frequent first)", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		// Create contacts with different cadences
 		// We need to use the full API to set cadence, so use raw request
 		createContactWithCadence := func(name, cadence string) string {

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -167,7 +167,7 @@ func TestContactMerge_Integration(t *testing.T) {
 	})
 
 	t.Run("GetMergePreview_InteractionsAndCalendarEvents", func(t *testing.T) {
-		// spec: CON-037[0]
+		// spec: CON-037.preview-reports-affected-counts
 		// Create target contact
 		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
 			FullName: "Merge Target Events " + ns,
@@ -844,7 +844,7 @@ func TestContactMergePreviewAPI_Errors(t *testing.T) {
 	}
 
 	t.Run("GetMergePreview_UnknownSourceID_NotFound", func(t *testing.T) {
-		// spec: CON-037[1]
+		// spec: CON-037.missing-source-target
 		target := createContactViaAPI(t, "Preview Errors Target A "+ns)
 
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+target.String()+"/merge/preview?source_id="+uuid.New().String(), nil)
@@ -861,7 +861,7 @@ func TestContactMergePreviewAPI_Errors(t *testing.T) {
 	})
 
 	t.Run("GetMergePreview_UnknownTargetID_NotFound", func(t *testing.T) {
-		// spec: CON-037[1]
+		// spec: CON-037.missing-source-target
 		source := createContactViaAPI(t, "Preview Errors Source B "+ns)
 
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+uuid.New().String()+"/merge/preview?source_id="+source.String(), nil)
@@ -878,7 +878,7 @@ func TestContactMergePreviewAPI_Errors(t *testing.T) {
 	})
 
 	t.Run("GetMergePreview_MissingSourceID_ValidationError", func(t *testing.T) {
-		// spec: CON-037[2]
+		// spec: CON-037.missing-malformed-source-id
 		target := createContactViaAPI(t, "Preview Errors Target C "+ns)
 
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+target.String()+"/merge/preview", nil)
@@ -895,7 +895,7 @@ func TestContactMergePreviewAPI_Errors(t *testing.T) {
 	})
 
 	t.Run("GetMergePreview_MalformedSourceID_ValidationError", func(t *testing.T) {
-		// spec: CON-037[2]
+		// spec: CON-037.missing-malformed-source-id
 		target := createContactViaAPI(t, "Preview Errors Target D "+ns)
 
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+target.String()+"/merge/preview?source_id=not-a-uuid", nil)
@@ -946,7 +946,7 @@ func TestContactMergePreviewAPI_SuccessCounts(t *testing.T) {
 	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 	t.Run("GetMergePreview_AllFiveCountersInResponse", func(t *testing.T) {
-		// spec: CON-037[0]
+		// spec: CON-037.preview-reports-affected-counts
 		target, err := seedContactForMerge(ctx, contactService, repository.CreateContactRequest{
 			FullName: "Preview Counts Target " + ns,
 		})

--- a/backend/tests/api/contact_method_operations_test.go
+++ b/backend/tests/api/contact_method_operations_test.go
@@ -211,7 +211,7 @@ func uniqueEmail() string {
 // needlessly reinserted every row would preserve id, type, value and is_primary
 // while silently moving created_at and updated_at — passing a weaker test named
 // for catching exactly that.
-// spec: CON-062[0]
+// spec: CON-062.unnamed-method-untouched
 func TestMethodOps_UnnamedMethodsSurvive(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -237,7 +237,7 @@ func TestMethodOps_UnnamedMethodsSurvive(t *testing.T) {
 // rule above: at most one primary is a database constraint, so promoting one
 // necessarily demotes another. That is a real side effect on an unnamed row and
 // is stated rather than hidden.
-// spec: CON-062[0]
+// spec: CON-062.unnamed-method-untouched
 func TestMethodOps_PromoteDemotesPreviousPrimary(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -267,7 +267,7 @@ func TestMethodOps_ClearNonPrimaryDoesNotDemoteCurrentPrimary(t *testing.T) {
 		"clearing a non-primary row demoted the actual primary")
 }
 
-// spec: CON-062[8]
+// spec: CON-062.named-primary-can-be-cleared
 func TestMethodOps_ClearNamedPrimaryLeavesNone(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -284,7 +284,7 @@ func TestMethodOps_ClearNamedPrimaryLeavesNone(t *testing.T) {
 
 // --- CON-062[1]: all or nothing --------------------------------------------
 
-// spec: CON-062[1]
+// spec: CON-062.whole-request-applies-atomically
 func TestMethodOps_InvalidOperationAppliesNothing(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -470,7 +470,7 @@ func TestMethodOps_TwoAddsOrderIndependent(t *testing.T) {
 // the method set as read back over HTTP and the persisted rows. Contact-owned
 // ids and timestamps are the only fields excluded: they differ per contact by
 // construction and carry no outcome semantics.
-// spec: CON-062[2]
+// spec: CON-062.outcome-not-order-dependent
 func TestMethodOps_MixedOperationOrderYieldsIdenticalCompleteState(t *testing.T) {
 	t.Parallel()
 
@@ -559,7 +559,7 @@ func TestMethodOps_MixedOperationOrderYieldsIdenticalCompleteState(t *testing.T)
 
 // --- CON-062[3][4]: idempotency --------------------------------------------
 
-// spec: CON-062[3]
+// spec: CON-062.adding-method-already-exists
 func TestMethodOps_DuplicateAddIsNoOp(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -587,7 +587,7 @@ func TestMethodOps_IdenticalAddsCoalesce(t *testing.T) {
 	assert.Equal(t, body.Results[0].MethodID, body.Results[1].MethodID)
 }
 
-// spec: CON-062[4]
+// spec: CON-062.removing-method-already-absent
 func TestMethodOps_RemoveAlreadyAbsentSucceeds(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -640,7 +640,7 @@ func TestMethodOps_NamedRemovalSucceeds(t *testing.T) {
 // and pre-SQL determinism is the entire property the fold exists to provide.
 // The fold's message names the colliding pair; the database backstop's does not.
 //
-// spec: CON-062[5]
+// spec: CON-062.duplicate-resulting-set-rejected
 func TestMethodOps_DuplicateFinalStateRejected(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -663,7 +663,7 @@ func TestMethodOps_DuplicateFinalStateRejected(t *testing.T) {
 	assert.Equal(t, b.Value, f.storedByID(b.ID).Value, "a rejected payload mutated a row")
 }
 
-// spec: CON-062[6]
+// spec: CON-062.multiple-primaries-rejected
 func TestMethodOps_TwoPrimaryDesignationsRejected(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -682,7 +682,7 @@ func TestMethodOps_TwoPrimaryDesignationsRejected(t *testing.T) {
 // bypassed the precheck would otherwise regress silently. It is asserted where
 // it protects a destructive operation, not merely where it is convenient.
 //
-// spec: CON-062[7]
+// spec: CON-062.operation-naming-method-id
 func TestMethodOps_ForeignMethodIDRejected(t *testing.T) {
 	t.Parallel()
 
@@ -748,7 +748,7 @@ func TestMethodOps_RemoveNonexistentSucceedsButForeignRejected(t *testing.T) {
 // application would be the same silent-corruption class this endpoint exists to
 // eliminate.
 //
-// spec: CON-062[9]
+// spec: CON-062.request-whose-operations-conflict
 func TestMethodOps_ConflictingOperationsRejected(t *testing.T) {
 	t.Parallel()
 
@@ -863,7 +863,7 @@ func TestMethodOps_UpdateWithPrimaryDesignationSucceeds(t *testing.T) {
 // in-place update phase the endpoint returns 200 having discarded the edit —
 // the failure must land on the stored-value assertion, not on an error.
 //
-// spec: CON-062[10]
+// spec: CON-062.updating-method-value-takes-effect
 func TestMethodOps_StableKeyUpdatePersistsThroughAPI(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -890,7 +890,7 @@ func TestMethodOps_StableKeyUpdatePersistsThroughAPI(t *testing.T) {
 // phrased as a designation delta fires neither demote nor promote here and
 // leaves the contact with NO primary.
 //
-// spec: CON-062[11]
+// spec: CON-062.updating-primary-keeps-primary
 func TestMethodOps_KeyChangingPrimaryUpdateKeepsPrimaryThroughAPI(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -922,7 +922,7 @@ func TestMethodOps_KeyChangingPrimaryUpdateKeepsPrimaryThroughAPI(t *testing.T) 
 // advance depends on: a client that cannot learn which row its own addition
 // resolved to will later fail to edit or remove that method.
 //
-// spec: CON-062[12]
+// spec: CON-062.response-reports-one-result
 func TestMethodOps_ResultsCoverEveryOperation(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -956,7 +956,7 @@ func TestMethodOps_ResultsCoverEveryOperation(t *testing.T) {
 // TestMethodOps_ResultsIndexAgainstSubmittedNotFoldedOperations uses payloads
 // whose folds are NOT one-to-one. Earlier cases all folded one-to-one, so an
 // implementation emitting one result per folded operation passed them.
-// spec: CON-062[12]
+// spec: CON-062.response-reports-one-result
 func TestMethodOps_ResultsIndexAgainstSubmittedNotFoldedOperations(t *testing.T) {
 	t.Parallel()
 
@@ -1077,7 +1077,7 @@ func TestMethodOps_ResultsResolveAddToExistingRow(t *testing.T) {
 // result is checked against a follow-up read of the contact's stored
 // methods, not against the request that produced it.
 //
-// spec: CON-062[13]
+// spec: CON-062.each-result-identifies-method
 func TestMethodOps_MixedOperationsResultsIdentifyAndReflectStoredState(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -1135,7 +1135,7 @@ func TestMethodOps_MixedOperationsResultsIdentifyAndReflectStoredState(t *testin
 // path. Create DROPS a blank entry; an explicit add or update must REJECT it.
 // Dropping here would turn an unsatisfiable intent into a silent success.
 //
-// spec: CON-015[1]
+// spec: CON-015.blank-value-operation-rejected
 func TestMethodOps_BlankValueRejected(t *testing.T) {
 	t.Parallel()
 	f := newMethodOpsFx(t)
@@ -1359,7 +1359,7 @@ func (s stubApplierResult) ApplyOperations(context.Context, uuid.UUID, []service
 // response carries rematch_job_id on the literal wire, both when a job was
 // minted and when it wasn't (the field is omitempty, so no job means the
 // key is absent rather than an empty string).
-// spec: IMP-019[1]
+// spec: IMP-019.caller-receives-rematch-job
 func TestMethodOps_RematchJobIDPropagatesToResponse(t *testing.T) {
 	t.Parallel()
 

--- a/backend/tests/api/contact_sort_test.go
+++ b/backend/tests/api/contact_sort_test.go
@@ -381,7 +381,7 @@ func TestContactSort_ContactBy(t *testing.T) {
 	})
 
 	t.Run("contact_by sort is accepted by API validation", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=contact_by&order=asc", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -534,7 +534,7 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 	})
 
 	t.Run("last_response_at sort is accepted by API validation", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=last_response_at&order=desc", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -542,7 +542,7 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 	})
 
 	t.Run("legacy last_contacted sort still accepted", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		// last_contacted remains a valid sort value on the API even though no UI
 		// surface emits it; regression-guard for any external caller still using
 		// the legacy field.
@@ -577,7 +577,7 @@ func TestContactSort_Location(t *testing.T) {
 	h := &sortTestHelper{router: router, t: t}
 
 	t.Run("location ascending sorts alphabetically", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		prefix := "SortLocAsc"
 		idA := h.createContactWithLocation(prefix+" Alpha Test", "Alphaville")
 		idZ := h.createContactWithLocation(prefix+" Zulu Test", "Zurich Town")
@@ -595,7 +595,7 @@ func TestContactSort_Location(t *testing.T) {
 	})
 
 	t.Run("location descending sorts reverse alphabetically", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		prefix := "SortLocDesc"
 		idA := h.createContactWithLocation(prefix+" Alpha Test", "Alphaville")
 		idZ := h.createContactWithLocation(prefix+" Zulu Test", "Zurich Town")
@@ -613,7 +613,7 @@ func TestContactSort_Location(t *testing.T) {
 	})
 
 	t.Run("location sort is accepted by API validation and returned in the response body", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		prefix := "SortLocShape" + uuid.New().String()[:8]
 		id := h.createContactWithLocation(prefix+" Shape Test", "Shapeburg")
 		defer h.deleteContact(id)
@@ -655,7 +655,7 @@ func TestContactSort_Birthday(t *testing.T) {
 	h := &sortTestHelper{router: router, t: t}
 
 	t.Run("birthday ascending sorts earliest first", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		prefix := "SortBdayAsc"
 		idOld := h.createContactWithBirthday(prefix+" Old Test", "1980-01-01")
 		idYoung := h.createContactWithBirthday(prefix+" Young Test", "2000-06-01")
@@ -673,7 +673,7 @@ func TestContactSort_Birthday(t *testing.T) {
 	})
 
 	t.Run("birthday descending sorts latest first", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		prefix := "SortBdayDesc"
 		idOld := h.createContactWithBirthday(prefix+" Old Test", "1980-01-01")
 		idYoung := h.createContactWithBirthday(prefix+" Young Test", "2000-06-01")
@@ -691,7 +691,7 @@ func TestContactSort_Birthday(t *testing.T) {
 	})
 
 	t.Run("birthday sort is accepted by API validation and returned in the response body", func(t *testing.T) {
-		// spec: CON-018[0]
+		// spec: CON-018.sort-accepts-name-location
 		prefix := "SortBdayShape" + uuid.New().String()[:8]
 		id := h.createContactWithBirthday(prefix+" Shape Test", "1990-01-15")
 		defer h.deleteContact(id)

--- a/backend/tests/api/contact_task_api_test.go
+++ b/backend/tests/api/contact_task_api_test.go
@@ -205,7 +205,7 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 	}
 
 	t.Run("StateFilterEachClosedSetMember", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		for _, state := range stateClosedSet {
 			req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks?state="+state, nil)
 			w := httptest.NewRecorder()
@@ -224,7 +224,7 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 	})
 
 	t.Run("UnfilteredListReturnsAllStates", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks", nil)
 		w := httptest.NewRecorder()
 		h.router.ServeHTTP(w, req)
@@ -306,7 +306,7 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 	}
 
 	t.Run("KindFilterEachClosedSetMember", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		for _, kind := range kindClosedSet {
 			got := listExternalIDs(t, "/api/v1/contacts/"+filterContactID.String()+"/tasks?kind="+kind)
 			require.NotEmpty(t, got, "kind=%s should return the seeded task(s), not an empty list", kind)
@@ -316,7 +316,7 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 	})
 
 	t.Run("LifecycleFilterEachClosedSetMember", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		for _, lifecycle := range lifecycleClosedSet {
 			got := listExternalIDs(t, "/api/v1/contacts/"+filterContactID.String()+"/tasks?lifecycle="+lifecycle)
 			require.NotEmpty(t, got, "lifecycle=%s should return the seeded task(s), not an empty list", lifecycle)
@@ -326,7 +326,7 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 	})
 
 	t.Run("InvalidStateRejected", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks?state=archived", nil)
 		w := httptest.NewRecorder()
 		h.router.ServeHTTP(w, req)
@@ -334,7 +334,7 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 	})
 
 	t.Run("InvalidLifecycleRejected", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID.String()+"/tasks?lifecycle=recurring", nil)
 		w := httptest.NewRecorder()
 		h.router.ServeHTTP(w, req)
@@ -342,7 +342,7 @@ func TestContactTaskAPI_ListFilters(t *testing.T) {
 	})
 
 	t.Run("UnknownContactNotFound", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+uuid.NewString()+"/tasks", nil)
 		w := httptest.NewRecorder()
 		h.router.ServeHTTP(w, req)
@@ -373,7 +373,7 @@ func TestContactTaskAPI_CreateManualTask(t *testing.T) {
 	contactID := createContactTaskTestContact(t, h, "Task Create API Test "+uuid.NewString()[:8])
 
 	t.Run("ValidCreateReturns201WithCreatedTask", func(t *testing.T) {
-		// spec: CAD-032[1]
+		// spec: CAD-032.task-creation-requires-kind-text
 		w := postManualTask(t, h, contactID, map[string]any{
 			"kind": "reach_out",
 			"text": "Follow up about the conference",
@@ -401,7 +401,7 @@ func TestContactTaskAPI_CreateManualTask(t *testing.T) {
 	})
 
 	t.Run("PickableKindSendAccepted", func(t *testing.T) {
-		// spec: CAD-032[1]
+		// spec: CAD-032.task-creation-requires-kind-text
 		w := postManualTask(t, h, contactID, map[string]any{
 			"kind": "send",
 			"text": "Send the signed contract",
@@ -414,7 +414,7 @@ func TestContactTaskAPI_CreateManualTask(t *testing.T) {
 	})
 
 	t.Run("NonPickableKindRejected", func(t *testing.T) {
-		// spec: CAD-032[1]
+		// spec: CAD-032.task-creation-requires-kind-text
 		// action and meet are valid listing-filter kinds but NOT user-pickable
 		// for manual creation.
 		for _, kind := range []string{"action", "meet"} {
@@ -427,7 +427,7 @@ func TestContactTaskAPI_CreateManualTask(t *testing.T) {
 	})
 
 	t.Run("TextLengthBoundary", func(t *testing.T) {
-		// spec: CAD-032[1]
+		// spec: CAD-032.task-creation-requires-kind-text
 		// Min boundary accept side: a single-character text is valid.
 		w := postManualTask(t, h, contactID, map[string]any{
 			"kind": "reminder",
@@ -449,7 +449,7 @@ func TestContactTaskAPI_CreateManualTask(t *testing.T) {
 	})
 
 	t.Run("NotesLengthBoundary", func(t *testing.T) {
-		// spec: CAD-032[1]
+		// spec: CAD-032.task-creation-requires-kind-text
 		w := postManualTask(t, h, contactID, map[string]any{
 			"kind":  "reminder",
 			"text":  "boundary notes task",
@@ -466,7 +466,7 @@ func TestContactTaskAPI_CreateManualTask(t *testing.T) {
 	})
 
 	t.Run("MissingTextRejected", func(t *testing.T) {
-		// spec: CAD-032[1]
+		// spec: CAD-032.task-creation-requires-kind-text
 		w := postManualTask(t, h, contactID, map[string]any{
 			"kind": "reach_out",
 		})
@@ -488,7 +488,7 @@ func TestContactTaskAPI_DeleteTaskLink(t *testing.T) {
 	contactID := createContactTaskTestContact(t, h, "Task Unlink API Test "+suffix)
 
 	t.Run("UnlinkRemovesOnlyCRMLink", func(t *testing.T) {
-		// spec: CAD-032[2]
+		// spec: CAD-032.unlinking-removes-only-crm
 		task, err := h.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 			ContactID:      contactID,
 			Provider:       todoist.SourceName,
@@ -519,7 +519,7 @@ func TestContactTaskAPI_DeleteTaskLink(t *testing.T) {
 	})
 
 	t.Run("TaskOfDifferentContactNotFound", func(t *testing.T) {
-		// spec: CAD-032[2]
+		// spec: CAD-032.unlinking-removes-only-crm
 		otherContactID := createContactTaskTestContact(t, h, "Task Unlink Other Contact "+suffix)
 		otherTask, err := h.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 			ContactID:      otherContactID,

--- a/backend/tests/api/contact_validation_test.go
+++ b/backend/tests/api/contact_validation_test.go
@@ -110,7 +110,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	defer cleanup()
 
 	t.Run("CreateContact_MissingRequiredField", func(t *testing.T) {
-		// spec: CON-002[5]
+		// spec: CON-002.invalid-request-rejected-validation
 		requestBody := handlers.CreateContactRequest{
 			FullName: "", // Required field empty
 		}
@@ -134,7 +134,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_InvalidEmailFormat", func(t *testing.T) {
-		// spec: CON-002[5]
+		// spec: CON-002.invalid-request-rejected-validation
 		invalidEmails := []string{
 			"not-an-email",
 			"@domain.com",
@@ -172,7 +172,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_FullNameTooLong", func(t *testing.T) {
-		// spec: CON-002[5]
+		// spec: CON-002.invalid-request-rejected-validation
 		requestBody := handlers.CreateContactRequest{
 			FullName: strings.Repeat("a", 256), // Exceeds max 255
 		}
@@ -195,7 +195,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_InvalidCadence", func(t *testing.T) {
-		// spec: CON-002[5]
+		// spec: CON-002.invalid-request-rejected-validation
 		requestBody := handlers.CreateContactRequest{
 			FullName: "Test User",
 			Cadence:  stringPtr("daily"), // Invalid cadence value
@@ -219,7 +219,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_InvalidProfilePhotoURL", func(t *testing.T) {
-		// spec: CON-002[5]
+		// spec: CON-002.invalid-request-rejected-validation
 		requestBody := handlers.CreateContactRequest{
 			FullName:     "Test User",
 			ProfilePhoto: stringPtr("not-a-url"), // Invalid URL
@@ -262,7 +262,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_FullNameSingleCharAccepted", func(t *testing.T) {
-		// spec: CON-002[0]
+		// spec: CON-002.full-name-required-bounded
 		ns := uuid.New().String()[:8]
 		requestBody := handlers.CreateContactRequest{
 			FullName: "A", // Lower bound of the 1-255 range
@@ -297,7 +297,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_LocationTooLong", func(t *testing.T) {
-		// spec: CON-002[1]
+		// spec: CON-002.location-limited-255-characters
 		requestBody := handlers.CreateContactRequest{
 			FullName: "Test User",
 			Location: stringPtr(strings.Repeat("a", 256)), // Exceeds max 255
@@ -322,7 +322,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_HowMetTooLong", func(t *testing.T) {
-		// spec: CON-002[1]
+		// spec: CON-002.location-limited-255-characters
 		requestBody := handlers.CreateContactRequest{
 			FullName: "Test User",
 			HowMet:   stringPtr(strings.Repeat("a", 501)), // Exceeds max 500
@@ -347,7 +347,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_ProfilePhotoTooLong", func(t *testing.T) {
-		// spec: CON-002[2]
+		// spec: CON-002.profile-photo-must-url
 		// Pin the 500-character cap exactly: a syntactically valid URL of
 		// exactly 500 characters is accepted, and one of exactly 501 is
 		// rejected, so a validator capped anywhere else fails one side.
@@ -399,7 +399,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_MalformedBirthday", func(t *testing.T) {
-		// spec: CON-002[3]
+		// spec: CON-002.birthday-must-parse-valid
 		requestBody := map[string]interface{}{
 			"full_name": "Test User",
 			"birthday":  "not-a-date",
@@ -424,7 +424,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_AllCadenceValuesAccepted", func(t *testing.T) {
-		// spec: CON-002[4]
+		// spec: CON-002.cadence-must-one-weekly
 		validCadences := []string{"weekly", "biweekly", "monthly", "quarterly", "biannual", "annual"}
 
 		for _, cadence := range validCadences {
@@ -461,7 +461,7 @@ func TestContactAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("CreateContact_AllFieldsMaxLength", func(t *testing.T) {
-		// spec: CON-002[6]
+		// spec: CON-002.valid-request-creates-contact
 		// Use unique email to avoid conflicts in CI
 		uniqueEmail := strings.Repeat("a", 235) + uuid.New().String()[:10] + "@test.com" // Total ~255 chars
 
@@ -591,7 +591,7 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	// silent-success failure — the same class the operations endpoint exists to
 	// eliminate, merely inverted from silent destruction.
 	t.Run("UpdateContact_RejectsLegacyMethodsField", func(t *testing.T) {
-		// spec: CON-064[0], CON-064[1], CON-064[2]
+		// spec: CON-064.request-rejected-naming-operations, CON-064.explicit-null-empty-list, CON-064.no-other-fields-applied
 		originalName := "Update Test User " + ns
 
 		cases := []struct {
@@ -648,7 +648,7 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	})
 
 	t.Run("UpdateContact_BlankFullNameRejected", func(t *testing.T) {
-		// spec: CON-047[0]
+		// spec: CON-047.field-validation-matches-create
 		updateReq := handlers.UpdateContactRequest{
 			FullName: "",
 		}
@@ -671,7 +671,7 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	})
 
 	t.Run("UpdateContact_FullNameTooLongRejected", func(t *testing.T) {
-		// spec: CON-047[0]
+		// spec: CON-047.field-validation-matches-create
 		updateReq := handlers.UpdateContactRequest{
 			FullName: strings.Repeat("a", 256), // Exceeds max 255
 		}
@@ -694,8 +694,8 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	})
 
 	t.Run("UpdateContact_InvalidCadenceRejected", func(t *testing.T) {
-		// spec: CON-047[0]
-		// spec: CON-047[1]
+		// spec: CON-047.field-validation-matches-create
+		// spec: CON-047.invalid-request-rejected-validation
 		updateReq := handlers.UpdateContactRequest{
 			FullName: "Update Test User " + ns,
 			Cadence:  stringPtr("daily"), // Not in the closed set
@@ -720,7 +720,7 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	})
 
 	t.Run("UpdateContact_UnknownContactNotFound", func(t *testing.T) {
-		// spec: CON-047[2]
+		// spec: CON-047.unknown-soft-deleted-contact
 		unknownID := uuid.New().String()
 		updateReq := handlers.UpdateContactRequest{
 			FullName: "Updated Name",
@@ -744,7 +744,7 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	})
 
 	t.Run("UpdateContact_SoftDeletedContactNotFound", func(t *testing.T) {
-		// spec: CON-047[2]
+		// spec: CON-047.unknown-soft-deleted-contact
 		createReq := handlers.CreateContactRequest{
 			FullName: "Update SoftDeleted " + ns,
 		}
@@ -785,7 +785,7 @@ func TestContactAPI_UpdateValidation(t *testing.T) {
 	})
 
 	t.Run("UpdateContact_ValidRequestReturnsUpdatedContact", func(t *testing.T) {
-		// spec: CON-047[3]
+		// spec: CON-047.valid-request-returns-updated
 		updatedName := "Updated Name " + ns
 		updateReq := handlers.UpdateContactRequest{
 			FullName: updatedName,
@@ -845,7 +845,7 @@ func TestContactAPI_DeleteValidation(t *testing.T) {
 	ns := uuid.New().String()[:8]
 
 	t.Run("DeleteContact_MalformedIDRejected", func(t *testing.T) {
-		// spec: CON-048[0]
+		// spec: CON-048.malformed-id-returns-validation
 		req, _ := http.NewRequest("DELETE", "/api/v1/contacts/not-a-uuid", nil)
 
 		w := httptest.NewRecorder()
@@ -862,7 +862,7 @@ func TestContactAPI_DeleteValidation(t *testing.T) {
 	})
 
 	t.Run("DeleteContact_UnknownContactNotFound", func(t *testing.T) {
-		// spec: CON-048[1]
+		// spec: CON-048.unknown-already-deleted-contact
 		unknownID := uuid.New().String()
 		req, _ := http.NewRequest("DELETE", "/api/v1/contacts/"+unknownID, nil)
 
@@ -880,7 +880,7 @@ func TestContactAPI_DeleteValidation(t *testing.T) {
 	})
 
 	t.Run("DeleteContact_AlreadyDeletedContactNotFound", func(t *testing.T) {
-		// spec: CON-048[1]
+		// spec: CON-048.unknown-already-deleted-contact
 		createReq := handlers.CreateContactRequest{
 			FullName: "Delete Twice " + ns,
 		}
@@ -915,7 +915,7 @@ func TestContactAPI_DeleteValidation(t *testing.T) {
 	})
 
 	t.Run("DeleteContact_SuccessfulDeleteReturnsEmptyNoContent", func(t *testing.T) {
-		// spec: CON-048[2]
+		// spec: CON-048.successful-delete-returns-204
 		createReq := handlers.CreateContactRequest{
 			FullName: "Delete Success " + ns,
 		}
@@ -939,7 +939,7 @@ func TestContactAPI_DeleteValidation(t *testing.T) {
 	})
 
 	t.Run("DeleteContact_NoHardDeleteRouteExposed", func(t *testing.T) {
-		// spec: CON-048[3]
+		// spec: CON-048.no-hard-delete-operation
 		// Registers the contact-resource registrar (RegisterContactRoutes) and
 		// enumerates every DELETE route it serves under /contacts. Other
 		// registrars mount subresources under /contacts/:id/..., but the
@@ -1125,7 +1125,7 @@ func TestContactAPI_QueryValidation(t *testing.T) {
 	})
 
 	t.Run("ListContacts_DefaultPagination", func(t *testing.T) {
-		// spec: CON-017[0]
+		// spec: CON-017.default-page-1-20-rows
 		// Seed more than the default page size so the un-paginated request is
 		// guaranteed to have a 20-row page to return regardless of what other
 		// tests have left in the shared DB.
@@ -1172,7 +1172,7 @@ func TestContactAPI_QueryValidation(t *testing.T) {
 	})
 
 	t.Run("ListContacts_LimitCapAccepted", func(t *testing.T) {
-		// spec: CON-017[1]
+		// spec: CON-017.page-size-capped-1000
 		req, _ := http.NewRequest("GET", "/api/v1/contacts?limit=1000", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -1187,7 +1187,7 @@ func TestContactAPI_QueryValidation(t *testing.T) {
 	})
 
 	t.Run("ListContacts_PaginationMetaAccurate", func(t *testing.T) {
-		// spec: CON-017[2]
+		// spec: CON-017.response-meta-reports-total
 		ns := uuid.New().String()[:8]
 		const seeded = 7
 		var ids []string
@@ -1234,7 +1234,7 @@ func TestContactAPI_QueryValidation(t *testing.T) {
 	})
 
 	t.Run("ListContacts_CadenceFilter", func(t *testing.T) {
-		// spec: CON-018[2]
+		// spec: CON-018.cadence-filter-closed-set
 		ns := uuid.New().String()[:8]
 		var withCadenceIDs, withoutCadenceIDs []string
 
@@ -1309,7 +1309,7 @@ func TestContactAPI_QueryValidation(t *testing.T) {
 	})
 
 	t.Run("ListContacts_InvalidCadenceFilter", func(t *testing.T) {
-		// spec: CON-018[4]
+		// spec: CON-018.anything-else-rejected-validation
 		req, _ := http.NewRequest("GET", "/api/v1/contacts?cadence_filter=bogus", nil)
 
 		w := httptest.NewRecorder()
@@ -1326,7 +1326,7 @@ func TestContactAPI_QueryValidation(t *testing.T) {
 	})
 
 	t.Run("ListContacts_InvalidFollowupFilter", func(t *testing.T) {
-		// spec: CON-018[4]
+		// spec: CON-018.anything-else-rejected-validation
 		req, _ := http.NewRequest("GET", "/api/v1/contacts?followup_filter=bogus", nil)
 
 		w := httptest.NewRecorder()
@@ -1358,7 +1358,7 @@ func TestContactAPI_GetContactValidation(t *testing.T) {
 	defer cleanup()
 
 	t.Run("GetContact_InvalidUUID", func(t *testing.T) {
-		// spec: CON-005[2]
+		// spec: CON-005.malformed-id-returns-validation
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/not-a-uuid", nil)
 
 		w := httptest.NewRecorder()
@@ -1392,7 +1392,7 @@ func TestContactAPI_GetContactValidation(t *testing.T) {
 	})
 
 	t.Run("GetContact_SoftDeleted_NotFound", func(t *testing.T) {
-		// spec: CON-005[1]
+		// spec: CON-005.unknown-soft-deleted-contact
 		ns := uuid.New().String()[:8]
 		createReq := handlers.CreateContactRequest{
 			FullName: "SoftDeleted Test " + ns,

--- a/backend/tests/api/direction_api_test.go
+++ b/backend/tests/api/direction_api_test.go
@@ -187,7 +187,7 @@ func TestContactAPI_HasPendingFollowup(t *testing.T) {
 	contactID := createDirectionTestContact(t, router, "Pending Followup API Test "+uuid.NewString()[:8])
 
 	t.Run("NoPendingFollowup", func(t *testing.T) {
-		// spec: CON-005[0]
+		// spec: CON-005.live-contact-flag
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID, nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -200,7 +200,7 @@ func TestContactAPI_HasPendingFollowup(t *testing.T) {
 	})
 
 	t.Run("WithPendingFollowup", func(t *testing.T) {
-		// spec: CON-005[0]
+		// spec: CON-005.live-contact-flag
 		// Create a managed follow-up task
 		id, err := uuid.Parse(contactID)
 		require.NoError(t, err)
@@ -294,7 +294,7 @@ func TestContactAPI_FollowupFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("has_followup_includes_contact", func(t *testing.T) {
-		// spec: CON-018[3]
+		// spec: CON-018.followup-filter-closed-set
 		req, _ := http.NewRequest("GET", "/api/v1/contacts?followup_filter=has_followup&search="+searchQuery, nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -315,7 +315,7 @@ func TestContactAPI_FollowupFilter(t *testing.T) {
 	})
 
 	t.Run("no_followup_excludes_contact", func(t *testing.T) {
-		// spec: CON-018[3]
+		// spec: CON-018.followup-filter-closed-set
 		req, _ := http.NewRequest("GET", "/api/v1/contacts?followup_filter=no_followup&search="+searchQuery, nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -373,7 +373,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("FilterByFollowUpLifecycle", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		// Post-046, follow-up tasks are identified by lifecycle=followup_loop
 		// (kind is reach_out for live follow-up rows). The legacy
 		// ?kind=follow_up filter is no longer valid.
@@ -393,7 +393,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	})
 
 	t.Run("FilterByAction_ExcludesFollowUp", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID+"/tasks?kind=action", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -413,7 +413,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	})
 
 	t.Run("InvalidKindRejected", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID+"/tasks?kind=invalid", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -421,7 +421,7 @@ func TestContactTaskAPI_FollowUpKindValidation(t *testing.T) {
 	})
 
 	t.Run("LegacyFollowUpKindRejected", func(t *testing.T) {
-		// spec: CAD-032[0]
+		// spec: CAD-032.task-listing-filters-state
 		// kind=follow_up is no longer a valid kind enum post-046; the
 		// validator rejects it at the handler boundary.
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+contactID+"/tasks?kind=follow_up", nil)

--- a/backend/tests/api/import_suggestions_api_test.go
+++ b/backend/tests/api/import_suggestions_api_test.go
@@ -116,7 +116,7 @@ func findSuggestionItemIndex(items []suggestionItem, kind, id string) int {
 // The method-suggestion group rides on top of the confidence-ranked
 // candidates, but ONLY on page 1 — the group is small and always returned
 // in full above the fold; paginating to page 2 must never repeat it.
-// spec: IMP-022[0]
+// spec: IMP-022.method-suggestions-ride-top
 func TestImportSuggestionsAPI_MethodGroupOnlyOnFirstPage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -171,7 +171,7 @@ func TestImportSuggestionsAPI_MethodGroupOnlyOnFirstPage(t *testing.T) {
 // /imports/candidates) and paginate over the candidate group only, with no
 // overlap between pages. Asserted through the /imports/suggestions endpoint
 // itself, not the shared sort helper.
-// spec: IMP-022[1]
+// spec: IMP-022.contact-candidates-follow-confidence
 func TestImportSuggestionsAPI_CandidatesRankedAndPaginated(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -266,7 +266,7 @@ func TestImportSuggestionsAPI_CandidatesRankedAndPaginated(t *testing.T) {
 // Each candidate's allowed_actions is the server-side derivation for its
 // source: a link-only source (gmail_correspondence) never offers "import";
 // an ordinary source offers all three. Asserted on the literal wire key.
-// spec: IMP-022[2]
+// spec: IMP-022.each-candidate-declares-server
 func TestImportSuggestionsAPI_CandidateAllowedActionsPerSource(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -2169,7 +2169,7 @@ func TestImportAPI_ImportValidation(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, response.Success)
 		require.NotNil(t, response.Error)
-		// spec: IMP-011[3]
+		// spec: IMP-011.unknown-candidate-not-found
 		assert.Equal(t, "NOT_FOUND", response.Error.Code)
 	})
 
@@ -2214,7 +2214,7 @@ func TestImportAPI_ImportValidation(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: IMP-011[0]
+		// spec: IMP-011.already-processed-candidate-rejected
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 
 		var response api.APIResponse
@@ -2254,7 +2254,7 @@ func TestImportAPI_ImportValidation(t *testing.T) {
 		err = json.Unmarshal(w.Body.Bytes(), &response)
 		require.NoError(t, err)
 		assert.False(t, response.Success)
-		// spec: IMP-011[2]
+		// spec: IMP-011.import-without-name-rejected
 		assert.Contains(t, response.Error.Message, "name")
 	})
 

--- a/backend/tests/api/ingest_host_liveness_test.go
+++ b/backend/tests/api/ingest_host_liveness_test.go
@@ -54,7 +54,7 @@ func (s *stubFailingHostLiveness) GetActiveHostByIDForUpdateTx(
 	return nil, db.ErrNotFound
 }
 
-// spec: ING-006[0]
+// spec: ING-006.whole-batch-rolled-back
 func TestIngest_HostRevokedMidTx_AbortsBatch(t *testing.T) {
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
@@ -385,7 +385,7 @@ func TestIngest_ConcurrentRevokeBlocksUntilBatchCommit(t *testing.T) {
 // the shared DB and hard-deletes all hosts in cleanup, same as the
 // mac_host_* test files.
 //
-// spec: ING-006[1]
+// spec: ING-006.unauthorized-401-stops-retries
 func TestIngest_HostRevokedMidBatch_Returns401UnknownHost(t *testing.T) {
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -336,7 +336,7 @@ func (a adminRiverInserter) Insert(ctx context.Context, args river.JobArgs, opts
 // TestIngestRawMessage_HappyPath_StagesRowAndEnqueuesJob asserts a
 // well-formed raw_message.received with a known contact's phone number
 // produces a staging row with matched_contact_id and one River job.
-// spec: ING-007[0]
+// spec: ING-007.daemon-push-kinds-accepted
 func TestIngestRawMessage_HappyPath_StagesRowAndEnqueuesJob(t *testing.T) {
 	env := setupRawIngestEnv(t)
 	t.Parallel()
@@ -367,7 +367,7 @@ func TestIngestRawMessage_HappyPath_StagesRowAndEnqueuesJob(t *testing.T) {
 // happy-path test for the outbound kind: a raw_message.sent for a known
 // contact stages a row with is_outgoing=true and a matched contact, and
 // enqueues one aggregator River job.
-// spec: ING-007[0]
+// spec: ING-007.daemon-push-kinds-accepted
 func TestIngestRawMessage_Sent_StagesOutgoingRowAndEnqueuesJob(t *testing.T) {
 	env := setupRawIngestEnv(t)
 	t.Parallel()
@@ -446,7 +446,7 @@ func TestIngestRawMessage_UnmatchedPeer_StagedWithoutContactNoJob(t *testing.T) 
 // TestIngestRawMessage_GlobalKeyPath_RejectedWithCode asserts that
 // raw_message.* events submitted via the global API key (no
 // X-Mac-Host-ID) are REJECTED per-event with HOST_ONLY_REQUIRES_HOST_AUTH.
-// spec: ING-001[2], ING-007[0], ING-007[2]
+// spec: ING-001.request-without-host-header, ING-007.daemon-push-kinds-accepted, ING-007.kind-wrong-path-rejected
 func TestIngestRawMessage_GlobalKeyPath_RejectedWithCode(t *testing.T) {
 	env := setupRawIngestEnv(t)
 	t.Parallel()
@@ -467,7 +467,7 @@ func TestIngestRawMessage_GlobalKeyPath_RejectedWithCode(t *testing.T) {
 // TestIngestRawMessage_HostAuthForeignKind_Rejected asserts a non-
 // raw_message kind submitted via the host-auth path is REJECTED with
 // UNSUPPORTED_HOST_AUTH_KIND.
-// spec: ING-007[1]
+// spec: ING-007.internally-published-kinds-accepted
 func TestIngestRawMessage_HostAuthForeignKind_Rejected(t *testing.T) {
 	env := setupRawIngestEnv(t)
 	t.Parallel()
@@ -489,7 +489,7 @@ func TestIngestRawMessage_HostAuthForeignKind_Rejected(t *testing.T) {
 	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
 		"events": []any{ev},
 	})
-	// spec: ING-007[2]
+	// spec: ING-007.kind-wrong-path-rejected
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	resp := parseIngestResp(t, w)
 	require.Equal(t, 0, resp.Accepted)
@@ -501,7 +501,7 @@ func TestIngestRawMessage_HostAuthForeignKind_Rejected(t *testing.T) {
 // TestIngestRawMessage_PayloadHostMismatch_Rejected asserts an
 // envelope whose payload.host_id disagrees with the authenticated host
 // is REJECTED with PAYLOAD_INVARIANT.
-// spec: ING-001[1]
+// spec: ING-001.request-carrying-mac-host
 func TestIngestRawMessage_PayloadHostMismatch_Rejected(t *testing.T) {
 	env := setupRawIngestEnv(t)
 	t.Parallel()

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -211,7 +211,7 @@ func uniqueIngestSource(prefix string) string {
 	return prefix + "-" + uuid.NewString()
 }
 
-// spec: ING-001[0], ING-007[1], ING-004[1]
+// spec: ING-001.endpoint-registered-when-enabled, ING-007.internally-published-kinds-accepted, ING-004.kind-required-must-known
 func TestIngest_ValidBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -244,7 +244,7 @@ func TestIngest_ValidBatch(t *testing.T) {
 	require.Equal(t, int64(3), count)
 }
 
-// spec: ING-001[2]
+// spec: ING-001.request-without-host-header
 func TestIngest_AuthFailure_MissingKey(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -261,7 +261,7 @@ func TestIngest_AuthFailure_MissingKey(t *testing.T) {
 	require.Contains(t, w.Body.String(), "MISSING_API_KEY")
 }
 
-// spec: ING-001[2]
+// spec: ING-001.request-without-host-header
 func TestIngest_AuthFailure_InvalidKey(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -278,7 +278,7 @@ func TestIngest_AuthFailure_InvalidKey(t *testing.T) {
 	require.Contains(t, w.Body.String(), "INVALID_API_KEY")
 }
 
-// spec: ING-002[1]
+// spec: ING-002.malformed-json-body-rejected
 func TestIngest_MalformedJSON(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -293,7 +293,7 @@ func TestIngest_MalformedJSON(t *testing.T) {
 // a mixed batch where events are missing source / kind / payload /
 // observed_at must return HTTP 200 with those events surfaced in
 // errors[] — NOT 400'd wholesale at gin's bind step.
-// spec: ING-003[1]
+// spec: ING-003.each-rejected-event-appears
 func TestIngest_MissingFields(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -345,20 +345,20 @@ func TestIngest_MissingFields(t *testing.T) {
 		require.Equal(t, "MISSING_FIELD", e.Code)
 		indexes[e.Index] = e.Message
 	}
-	// spec: ING-004[2]
+	// spec: ING-004.observed-at-required-non-zero
 	require.Contains(t, indexes, 1)
 	require.Contains(t, indexes[1], "observed_at")
-	// spec: ING-004[0]
+	// spec: ING-004.source-required-length-bounded
 	require.Contains(t, indexes, 2)
 	require.Contains(t, indexes[2], "source")
-	// spec: ING-004[1]
+	// spec: ING-004.kind-required-must-known
 	require.Contains(t, indexes, 3)
 	require.Contains(t, indexes[3], "kind")
-	// spec: ING-004[3]
+	// spec: ING-004.payload-required-size-bounded
 	require.Contains(t, indexes, 4)
 	require.Contains(t, indexes[4], "payload")
 	require.Contains(t, indexes, 5)
-	// spec: ING-004[2]
+	// spec: ING-004.observed-at-required-non-zero
 	require.Contains(t, indexes[5], "observed_at")
 
 	// The valid event at index 0 persisted.
@@ -371,7 +371,7 @@ func TestIngest_MissingFields(t *testing.T) {
 // would silently decode null into a zero-value struct, so the ingest
 // boundary must reject it as PAYLOAD_INVALID rather than persist a row
 // with all-zero payload fields.
-// spec: ING-003[0], ING-004[3]
+// spec: ING-003.http-response-success-200, ING-004.payload-required-size-bounded
 func TestIngest_NullPayload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -402,7 +402,7 @@ func TestIngest_NullPayload(t *testing.T) {
 	require.Equal(t, int64(0), count)
 }
 
-// spec: ING-004[1]
+// spec: ING-004.kind-required-must-known
 func TestIngest_UnknownKind(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -430,7 +430,7 @@ func TestIngest_UnknownKind(t *testing.T) {
 	require.Equal(t, "UNKNOWN_KIND", resp.Errors[0].Code)
 }
 
-// spec: ING-004[3]
+// spec: ING-004.payload-required-size-bounded
 func TestIngest_PayloadStructurallyInvalid(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -484,7 +484,7 @@ func padUniqueTo(n int) string {
 	return id + strings.Repeat("a", n-len(id))
 }
 
-// spec: ING-004[0]
+// spec: ING-004.source-required-length-bounded
 func TestIngest_SourceLengthBound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -528,7 +528,7 @@ func TestIngest_SourceLengthBound(t *testing.T) {
 	})
 }
 
-// spec: ING-004[0]
+// spec: ING-004.source-required-length-bounded
 func TestIngest_SourceIDLengthBound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -584,7 +584,7 @@ func TestIngest_SourceIDLengthBound(t *testing.T) {
 // being large). Description is padded byte-for-byte (plain ASCII, no
 // JSON escaping) so the computed overhead is exact.
 //
-// spec: ING-004[3]
+// spec: ING-004.payload-required-size-bounded
 func TestIngest_PayloadSizeBound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -671,7 +671,7 @@ func TestIngest_PayloadSizeBound(t *testing.T) {
 	})
 }
 
-// spec: ING-002[3]
+// spec: ING-002.batch-over-max-count-rejected
 func TestIngest_BatchTooLarge(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -692,7 +692,7 @@ func TestIngest_BatchTooLarge(t *testing.T) {
 	require.Contains(t, w.Body.String(), "VALIDATION_ERROR")
 }
 
-// spec: ING-002[2]
+// spec: ING-002.empty-events-array-rejected
 func TestIngest_EmptyBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -809,7 +809,7 @@ func TestIngest_NullSourceID_NotDeduped(t *testing.T) {
 // criterion: EVENT_BUS_INGEST_ENABLED=false → 404. The route is not
 // registered; gin's default NoRoute handler emits 404 without running the
 // v1 group's API-key middleware.
-// spec: ING-001[0]
+// spec: ING-001.endpoint-registered-when-enabled
 func TestIngest_GateDisabled_Returns404(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -842,7 +842,7 @@ func TestIngest_GateDisabled_NoKey_StillReturns404(t *testing.T) {
 	require.NotContains(t, w.Body.String(), "MISSING_API_KEY")
 }
 
-// spec: ING-003[2]
+// spec: ING-003.response-reports-separate-accepted
 func TestIngest_MixedBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -889,7 +889,7 @@ func TestIngest_MixedBatch(t *testing.T) {
 // per-payload size check would also reject this but the MaxBytesReader
 // wrap at the handler boundary fires first because it's enforced during
 // JSON decode, before any per-field validation runs.
-// spec: ING-002[0]
+// spec: ING-002.body-over-size-cap
 func TestIngest_BodyTooLarge_Returns413(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -914,7 +914,7 @@ func TestIngest_BodyTooLarge_Returns413(t *testing.T) {
 // production IngestResponse struct cannot distinguish an absent key
 // from `"needs_attention": null` or `[]` — hence the raw map decode
 // with a key-presence check.
-// spec: ING-035[1]
+// spec: ING-035.field-omitted-daemons-predate
 func TestIngest_NeedsAttentionKeyAbsentWhenNoAttention(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/backend/tests/api/mac_host_auth_test.go
+++ b/backend/tests/api/mac_host_auth_test.go
@@ -109,7 +109,7 @@ func TestMacHost_Auth_MinProtocolVersion_412(t *testing.T) {
 	require.True(t, ok, "body: %v", body)
 	require.Equal(t, "UPGRADE_REQUIRED", errObj["code"])
 
-	// spec: MAC-012[1]
+	// spec: MAC-012.response-carries-minimum-acceptable
 	// The 412 body must carry the minimum acceptable protocol version
 	// literally as min_version so the daemon knows what to upgrade to.
 	minVersion, ok := errObj["min_version"]

--- a/backend/tests/api/mac_host_get_admin_test.go
+++ b/backend/tests/api/mac_host_get_admin_test.go
@@ -20,7 +20,7 @@ type hostDetailView struct {
 // TestMacHost_GetAdmin_DetailView covers the admin host-detail read:
 // a live host is returned, a revoked host is still returned (the admin
 // view does not filter revocation), and an unknown id is 404.
-// spec: MAC-018[1]
+// spec: MAC-018.detail-view-returns-single
 func TestMacHost_GetAdmin_DetailView(t *testing.T) {
 
 	env := setupMacHostEnv(t)

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -271,7 +271,7 @@ func TestMacHost_FullPairingFlow(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "expected 200; body: %s", w.Body.String())
 
 	// 7. GET cursor → returns committed value AND backfill_complete.
-	// spec: MAC-015[0]
+	// spec: MAC-015.committed-cursor-returned-along
 	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+pair.HostID.String()+"/sync/messages/cursor", hostHeaders, nil)
 	require.Equal(t, http.StatusOK, w.Code)
 	var cur struct {
@@ -346,7 +346,7 @@ func TestMacHost_PairingToken_Unknown(t *testing.T) {
 	require.Equal(t, http.StatusGone, w.Code, "unknown token must be 410, body: %s", w.Body.String())
 }
 
-// spec: MAC-003[3]
+// spec: MAC-003.missing-pairing-token-hostname
 func TestMacHost_Pair_MissingHostname_400(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -365,7 +365,7 @@ func TestMacHost_Pair_MissingHostname_400(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code, "empty hostname must surface 400, body: %s", w.Body.String())
 }
 
-// spec: MAC-003[3]
+// spec: MAC-003.missing-pairing-token-hostname
 func TestMacHost_Pair_MissingToken_400(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -379,7 +379,7 @@ func TestMacHost_Pair_MissingToken_400(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code, "empty token must surface 400, body: %s", w.Body.String())
 }
 
-// spec: MAC-003[2]
+// spec: MAC-003.second-pairing-attempt-conflict
 func TestMacHost_Singleton_SecondPairBlocked(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -473,8 +473,8 @@ func TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 
-	// spec: MAC-011[1]
-	// spec: MAC-011[2]
+	// spec: MAC-011.response-echoes-current-cursor
+	// spec: MAC-011.response-reports-protocol-versions
 	// Literal wire keys on the heartbeat response body — decoded via a
 	// local struct with matching json tags, not the handler's private
 	// response type. Each numeric field is compared against an
@@ -494,7 +494,7 @@ func TestMacHost_Heartbeat_PersistsFieldsAndEchoesProtocolState(t *testing.T) {
 	require.Equal(t, mac.ProtocolVersion, hbResp.ProtocolVersion, "protocol_version must be the server's current version (mac.ProtocolVersion)")
 	require.Equal(t, mac.MinProtocolVersion, hbResp.MinProtocolVersion, "min_protocol_version must be the server's floor (mac.MinProtocolVersion)")
 
-	// spec: MAC-011[0]
+	// spec: MAC-011.heartbeat-fields-recorded
 	// Read the host back via the admin GET route and assert every
 	// heartbeat-supplied field was actually persisted.
 	w = macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String(), map[string]string{
@@ -545,7 +545,7 @@ func TestMacHost_GetCursor_PreCommit_EmptyBaseline(t *testing.T) {
 		"Authorization": "Bearer " + res.APIKey,
 	}
 
-	// spec: MAC-015[1]
+	// spec: MAC-015.before-commit-empty-cursor
 	// No commit has happened yet for this host+source.
 	w := macHTTP(t, env, http.MethodGet, "/api/v1/host/"+res.HostID.String()+"/sync/messages/cursor", hostHeaders, nil)
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
@@ -621,7 +621,7 @@ func TestMacHost_Pair_PlaintextKeyNeverLeaksInSubsequentReads(t *testing.T) {
 	plain, _, err := env.macService.CreatePairingToken(context.Background())
 	require.NoError(t, err)
 
-	// spec: MAC-003[0]
+	// spec: MAC-003.valid-token-pairs-host
 	w := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, map[string]any{
 		"pairing_token":    plain,
 		"hostname":         "plaintext-sweep-" + uuid.NewString()[:8],
@@ -674,7 +674,7 @@ func TestMacHost_Pair_PlaintextKeyNeverLeaksInSubsequentReads(t *testing.T) {
 	require.NotContains(t, w.Body.String(), `"api_key"`, "GetHostAdmin response must never carry an api_key wire key at all (not even hashed)")
 }
 
-// spec: MAC-003[1]
+// spec: MAC-003.invalid-already-consumed-expired
 // TestMacHost_Pair_TokenStateFailures_Opaque410 drives all three
 // token-state failures through the actual pairing endpoint — an invalid
 // (never-minted) token, an already-consumed token (successful pair, then
@@ -738,7 +738,7 @@ func TestMacHost_Pair_TokenStateFailures_Opaque410(t *testing.T) {
 // mutable field and asserts the 412 rejection AND that none of those
 // fields moved — proving the protocol gate runs before any database
 // write, not merely before the response is sent.
-// spec: MAC-012[0]
+// spec: MAC-012.request-rejected-upgrade-required
 func TestMacHost_Heartbeat_TooOldProtocol_NoWriteBefore412(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -792,7 +792,7 @@ func TestMacHost_Heartbeat_TooOldProtocol_NoWriteBefore412(t *testing.T) {
 // TestMacHost_Cursor_BackfillComplete_DefaultsFalseWhenAbsent commits a
 // cursor whose request body omits the backfill_complete key entirely
 // (not merely sets it false) and asserts the read-back flag is false.
-// spec: MAC-015[2]
+// spec: MAC-015.backfill-complete-flag-opaque
 func TestMacHost_Cursor_BackfillComplete_DefaultsFalseWhenAbsent(t *testing.T) {
 
 	env := setupMacHostEnv(t)

--- a/backend/tests/api/mac_host_rotate_key_test.go
+++ b/backend/tests/api/mac_host_rotate_key_test.go
@@ -130,7 +130,7 @@ func TestMacHostRotateKey_HappyPath(t *testing.T) {
 	require.NotNil(t, post.APIKeyRotatedAt, "api_key_rotated_at written")
 }
 
-// spec: MAC-010[1]
+// spec: MAC-010.token-state-failures-distinct
 func TestMacHostRotateKey_TokenAlreadyUsed(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -164,7 +164,7 @@ func TestMacHostRotateKey_TokenAlreadyUsed(t *testing.T) {
 	require.Equal(t, "TOKEN_ALREADY_USED", errBody.Error.Code)
 }
 
-// spec: MAC-010[1]
+// spec: MAC-010.token-state-failures-distinct
 func TestMacHostRotateKey_InvalidPairingToken(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -183,7 +183,7 @@ func TestMacHostRotateKey_InvalidPairingToken(t *testing.T) {
 	require.Equal(t, "INVALID_PAIRING_TOKEN", errBody.Error.Code)
 }
 
-// spec: MAC-010[1]
+// spec: MAC-010.token-state-failures-distinct
 func TestMacHostRotateKey_TokenExpired(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -238,7 +238,7 @@ func TestMacHostRotateKey_HostNotFound_MiddlewareCatches(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "token should still be usable after middleware-rejected attempt: %s", w.Body.String())
 }
 
-// spec: MAC-007[3]
+// spec: MAC-007.unknown-revoked-host-rejected
 func TestMacHostRotateKey_RevokedHostRotation(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -297,7 +297,7 @@ func callRotateAPIKeyDirect(
 	return env.macService.RotateAPIKey(context.Background(), hostID, startingHash, token)
 }
 
-// spec: MAC-010[2]
+// spec: MAC-010.rotated-out-key-stale-auth
 func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -365,7 +365,7 @@ func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
 	require.Equal(t, 1, consumedCount, "exactly one token must be consumed")
 }
 
-// spec: MAC-010[2]
+// spec: MAC-010.rotated-out-key-stale-auth
 func TestMacHostRotateKey_ConcurrentRotation_SameToken(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -450,7 +450,7 @@ func TestMacHostRotateKey_OldKeyImmediatelyInvalid(t *testing.T) {
 // host's key and sweeps every subsequent read surface (heartbeat
 // response, admin ListHosts, admin GetHostAdmin) for the rotated
 // plaintext key, asserting on the raw response body string.
-// spec: MAC-010[0]
+// spec: MAC-010.success-returns-new-plaintext
 func TestMacHostRotateKey_PlaintextNeverLeaksInSubsequentReads(t *testing.T) {
 
 	env := setupMacHostEnv(t)

--- a/backend/tests/api/mac_host_source_counts_test.go
+++ b/backend/tests/api/mac_host_source_counts_test.go
@@ -98,7 +98,7 @@ func TestMacHost_GetSourceCounts_HappyPath(t *testing.T) {
 // TestMacHost_GetSourceCounts_UnknownHost_404 covers the host-existence
 // pre-check: an unknown host id returns 404 (not 200 with empty
 // counts).
-// spec: MAC-018[2]
+// spec: MAC-018.per-source-live-counts
 func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
 
 	env := setupMacHostEnv(t)
@@ -111,7 +111,7 @@ func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
 // TestMacHost_GetSourceCounts_NoRowsReturnsEmpty asserts that a host
 // with no external_contact rows returns 200 with counts={} rather than
 // 404 or 500.
-// spec: MAC-018[2]
+// spec: MAC-018.per-source-live-counts
 func TestMacHost_GetSourceCounts_NoRowsReturnsEmpty(t *testing.T) {
 
 	env := setupMacHostEnv(t)

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -623,7 +623,7 @@ func listSessionInteractions(t *testing.T, env *meetingNoteIngestEnv, sessionUUI
 // TC-L1: 0 candidates + 0 resolved tagged humans → orphan_needs_review,
 // no interactions, needs_attention contains the session with reason=orphan.
 // ----------------------------------------------------------------------------
-// spec: ING-035[0]
+// spec: ING-035.response-carries-needs-attention
 func TestMeetingNote_OrphanNoTagged(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	sessionUUID := env.newSessionUUID()
@@ -2574,7 +2574,7 @@ func getNeedsAttention(t *testing.T, env *meetingNoteIngestEnv, hostID string) *
 // TestResolveLink_LinkToEventSuccess — seed a conflict_pending row,
 // post action=link with the winning candidate, verify the row transitions
 // to linked and the snapshot is cleared.
-// spec: NTS-018[0], NTS-018[1]
+// spec: NTS-018.action-required-must-link, NTS-018.action-link-requires-kind
 func TestResolveLink_LinkToEventSuccess(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 7, 9, 0, 0, 0, time.UTC)
@@ -2617,7 +2617,7 @@ func TestResolveLink_LinkToEventSuccess(t *testing.T) {
 // tags a resolved participant (contactA) who is NOT an attendee of the
 // linked candidate, so the link deterministically creates exactly one
 // walk-in interaction whose contact + source_ref are known up front.
-// spec: NTS-018[2]
+// spec: NTS-018.successful-resolve-returns-updated
 func TestResolveLink_ResponseIncludesUpdatedMeetingNote(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
@@ -2676,7 +2676,7 @@ func TestResolveLink_ResponseIncludesUpdatedMeetingNote(t *testing.T) {
 
 // TestResolveLink_AlreadyLinkedReturns409 — calling resolve-link on a
 // row that's not in conflict_pending returns 409.
-// spec: NTS-018[4]
+// spec: NTS-018.row-not-attention-state
 func TestResolveLink_AlreadyLinkedReturns409(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC)
@@ -2697,7 +2697,7 @@ func TestResolveLink_AlreadyLinkedReturns409(t *testing.T) {
 
 // TestResolveLink_IDNotInSnapshotReturns400 — picking an event UUID that
 // wasn't in the persisted snapshot returns 400.
-// spec: NTS-018[5]
+// spec: NTS-018.chosen-id-absent-snapshot
 func TestResolveLink_IDNotInSnapshotReturns400(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 7, 11, 0, 0, 0, time.UTC)
@@ -2724,7 +2724,7 @@ func TestResolveLink_IDNotInSnapshotReturns400(t *testing.T) {
 
 // TestResolveLink_UnknownMeetingNoteReturns404 — resolve on a random UUID
 // returns 404.
-// spec: NTS-018[3]
+// spec: NTS-018.missing-row-snapshot-target
 func TestResolveLink_UnknownMeetingNoteReturns404(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	w := postResolveLink(t, env, uuid.NewString(), map[string]any{"action": "none_of_these"})
@@ -2734,7 +2734,7 @@ func TestResolveLink_UnknownMeetingNoteReturns404(t *testing.T) {
 // TestResolveLink_NoneOfTheseToLinkedImpromptu — conflict_pending row
 // with a tagged participant, "none of these" promotes to
 // linked_impromptu with one interaction per resolved tagged contact.
-// spec: NTS-018[0]
+// spec: NTS-018.action-required-must-link
 func TestResolveLink_NoneOfTheseToLinkedImpromptu(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
@@ -2804,7 +2804,7 @@ func TestListNeedsAttention_AcceptsDaemonHostAuth(t *testing.T) {
 // with per-kind preview CONTENT: the event candidate carries the seeded
 // title + attendee count, the phone_call candidate carries the seeded
 // peer handle.
-// spec: NTS-025[2]
+// spec: NTS-025.each-conflict-pending-row
 func TestListNeedsAttention_BasicProjection(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := env.uniqueWindowBase(7)
@@ -2914,7 +2914,7 @@ func TestListNeedsAttention_BasicProjection(t *testing.T) {
 // under the same host with distinct meeting_at timestamps, seeded out
 // of chronological order, and assert the response orders them
 // newest-first by meeting_at (not by insertion order).
-// spec: NTS-025[1]
+// spec: NTS-025.returns-attention-notes-newest-first
 func TestListNeedsAttention_NewestFirstOrdering(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	base := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
@@ -2976,7 +2976,7 @@ func TestListNeedsAttention_NewestFirstOrdering(t *testing.T) {
 // wire; only conflict_pending rows project a populated candidates
 // array. Asserted via raw JSON so a "null" vs "[]" difference doesn't
 // mask a candidate entry sneaking in.
-// spec: NTS-025[2]
+// spec: NTS-025.each-conflict-pending-row
 func TestListNeedsAttention_OrphanCarriesNoCandidates(t *testing.T) {
 	type item struct {
 		AnarlogSessionID string          `json:"anarlog_session_id"`
@@ -3096,7 +3096,7 @@ func TestResolveLink_NoneOfTheseToOrphanNeedsReview(t *testing.T) {
 // snapshot whose row has since been hard-deleted; resolve-link returns
 // 404 (and the tx rolls back so the meeting_note stays
 // conflict_pending).
-// spec: NTS-018[3]
+// spec: NTS-018.missing-row-snapshot-target
 func TestResolveLink_TargetMissingReturns404(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 8, 11, 0, 0, 0, time.UTC)
@@ -3185,7 +3185,7 @@ func TestListNeedsAttention_HostFilter(t *testing.T) {
 // index only constrains live rows) purely as an FK target for a
 // repository-inserted orphan row; fixtures are namespaced via the env's
 // per-run prefix + fresh session UUIDs.
-// spec: NTS-025[1]
+// spec: NTS-025.returns-attention-notes-newest-first
 func TestListNeedsAttention_HostScope_TwoHosts(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	ctx := context.Background()
@@ -3274,7 +3274,7 @@ func TestListNeedsAttention_HostScope_TwoHosts(t *testing.T) {
 // TestListNeedsAttention_TargetMissingProjection — when a candidate's
 // target has been hard-deleted, the entry stays in the response with
 // target_missing=true and preview=nil.
-// spec: NTS-025[3]
+// spec: NTS-025.deleted-target-marked-missing
 func TestListNeedsAttention_TargetMissingProjection(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 8, 13, 0, 0, 0, time.UTC)
@@ -3330,7 +3330,7 @@ func TestListNeedsAttention_TargetMissingProjection(t *testing.T) {
 // is cleared. Exercises the LinkedKindPhoneCall branch of
 // resolveToLinked + fetchCandidateAsLinkageTx that previously had ZERO
 // integration coverage.
-// spec: NTS-018[1]
+// spec: NTS-018.action-link-requires-kind
 func TestResolveLink_LinkToPhoneCallSuccess(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 9, 9, 0, 0, 0, time.UTC)
@@ -3373,7 +3373,7 @@ func TestResolveLink_LinkToPhoneCallSuccess(t *testing.T) {
 // phone_call from the snapshot whose row has since been hard-deleted;
 // resolve-link returns 404 and the tx rolls back so the meeting_note
 // stays conflict_pending.
-// spec: NTS-018[3]
+// spec: NTS-018.missing-row-snapshot-target
 func TestResolveLink_PhoneCallTargetMissingReturns404(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 9, 10, 0, 0, 0, time.UTC)
@@ -3693,7 +3693,7 @@ func TestResolveLink_TerminalStatesReturn409(t *testing.T) {
 			env := setupMeetingNoteIngestEnv(t)
 			row := tc.drive(t, env)
 			w := postResolveLink(t, env, row.ID.String(), map[string]any{"action": "none_of_these"})
-			// spec: NTS-018[4]
+			// spec: NTS-018.row-not-attention-state
 			require.Equal(t, http.StatusConflict, w.Code,
 				"terminal state %s must 409 — body: %s", tc.name, w.Body.String())
 		})
@@ -3833,7 +3833,7 @@ func TestResolveLink_OrphanToImpromptu_WithNewlyResolvableParticipant(t *testing
 // conflict_pending, so this scenario only arises from corrupted state
 // (or a future migration footgun). Seed the row directly via the
 // repository to bypass the normal-flow invariant.
-// spec: NTS-018[6]
+// spec: NTS-018.conflict-pending-row-missing
 func TestResolveLink_SnapshotMissingReturns422(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	ctx := context.Background()

--- a/backend/tests/api/needs_attention_attendees_test.go
+++ b/backend/tests/api/needs_attention_attendees_test.go
@@ -157,7 +157,7 @@ func TestNeedsAttention_EnrichedAttendees(t *testing.T) {
 // implied set) and whose count of attendee matched=true flags (1,
 // because one attendee's display label doesn't resolve to either
 // contact's name) diverge — proving the two are carried independently.
-// spec: NTS-025[4]
+// spec: NTS-025.candidate-overlap-count-independent
 func TestNeedsAttention_OverlapCountIndependentOfMatchedFlags(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	ctx := context.Background()

--- a/backend/tests/api/note_test.go
+++ b/backend/tests/api/note_test.go
@@ -140,7 +140,7 @@ func TestNoteAPI_GetContactNotepad(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: NTS-004[1]
+		// spec: NTS-004.live-contact-without-notepad
 		assert.Equal(t, http.StatusNoContent, w.Code)
 		assert.Empty(t, w.Body.String())
 	})
@@ -163,7 +163,7 @@ func TestNoteAPI_GetContactNotepad(t *testing.T) {
 		getW := httptest.NewRecorder()
 		router.ServeHTTP(getW, getReq)
 
-		// spec: NTS-004[0]
+		// spec: NTS-004.live-contact-notepad
 		assert.Equal(t, http.StatusOK, getW.Code)
 
 		var response api.APIResponse
@@ -184,7 +184,7 @@ func TestNoteAPI_GetContactNotepad(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: NTS-004[2]
+		// spec: NTS-004.malformed-contact-id
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 
 		var response api.APIResponse
@@ -196,7 +196,7 @@ func TestNoteAPI_GetContactNotepad(t *testing.T) {
 	})
 
 	t.Run("GetNote_ContactNotFound_Returns404", func(t *testing.T) {
-		// spec: NTS-004[3]
+		// spec: NTS-004.unknown-soft-deleted-contact
 		nonExistentID := uuid.New().String()
 		req, _ := http.NewRequest("GET", "/api/v1/contacts/"+nonExistentID+"/notes", nil)
 		w := httptest.NewRecorder()
@@ -213,7 +213,7 @@ func TestNoteAPI_GetContactNotepad(t *testing.T) {
 	})
 
 	t.Run("GetNote_SoftDeletedContact_Returns404", func(t *testing.T) {
-		// spec: NTS-004[3]
+		// spec: NTS-004.unknown-soft-deleted-contact
 		contactID := createTestContact(t, router, "Soft Deleted Notepad Get Test User "+uuid.New().String()[:8])
 
 		// Soft-delete the contact via the same DELETE endpoint used by siblings
@@ -263,7 +263,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: NTS-005[0]
+		// spec: NTS-005.non-empty-body
 		assert.Equal(t, http.StatusOK, w.Code)
 
 		var response api.APIResponse
@@ -337,7 +337,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 		w2 := httptest.NewRecorder()
 		router.ServeHTTP(w2, req2)
 
-		// spec: NTS-005[1]
+		// spec: NTS-005.empty-whitespace-only-body
 		assert.Equal(t, http.StatusNoContent, w2.Code)
 		assert.Empty(t, w2.Body.String())
 
@@ -369,7 +369,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 		w2 := httptest.NewRecorder()
 		router.ServeHTTP(w2, req2)
 
-		// spec: NTS-005[1]
+		// spec: NTS-005.empty-whitespace-only-body
 		assert.Equal(t, http.StatusNoContent, w2.Code)
 
 		// Verify note is actually deleted
@@ -410,7 +410,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: NTS-005[3]
+		// spec: NTS-005.malformed-contact-id-unparseable
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 
 		var response api.APIResponse
@@ -422,7 +422,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 	})
 
 	t.Run("SaveNote_ContactNotFound_Returns404", func(t *testing.T) {
-		// spec: NTS-005[4]
+		// spec: NTS-005.unknown-soft-deleted-contact
 		nonExistentID := uuid.New().String()
 		saveReq := handlers.SaveNoteRequest{Body: "Some content"}
 		jsonBody, _ := json.Marshal(saveReq)
@@ -443,7 +443,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 	})
 
 	t.Run("SaveNote_SoftDeletedContact_Returns404", func(t *testing.T) {
-		// spec: NTS-005[4]
+		// spec: NTS-005.unknown-soft-deleted-contact
 		contactID := createTestContact(t, router, "Soft Deleted Notepad Save Test User "+uuid.New().String()[:8])
 
 		// Soft-delete the contact via the same DELETE endpoint used by siblings
@@ -484,7 +484,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: NTS-005[2]
+		// spec: NTS-005.body-limited-50000-characters
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 
 		var response api.APIResponse
@@ -509,7 +509,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: NTS-005[2]
+		// spec: NTS-005.body-limited-50000-characters
 		assert.Equal(t, http.StatusOK, w.Code)
 
 		var response api.APIResponse
@@ -532,7 +532,7 @@ func TestNoteAPI_SaveContactNotepad(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// spec: NTS-005[3]
+		// spec: NTS-005.malformed-contact-id-unparseable
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 
 		var response api.APIResponse

--- a/backend/tests/api/system_api_test.go
+++ b/backend/tests/api/system_api_test.go
@@ -140,7 +140,7 @@ func TestSystemAPI_ExportData(t *testing.T) {
 	}
 
 	t.Run("Export_IsJSONAttachmentWrappingEnvelope", func(t *testing.T) {
-		// spec: SET-030[0]
+		// spec: SET-030.response-json-attachment-content
 		w, body := exportBody(t)
 
 		assert.Equal(t, "attachment; filename=crm_export.json", w.Header().Get("Content-Disposition"))
@@ -156,7 +156,7 @@ func TestSystemAPI_ExportData(t *testing.T) {
 	})
 
 	t.Run("Export_EnvelopeCarriesVersionAndTimestamp", func(t *testing.T) {
-		// spec: SET-030[1]
+		// spec: SET-030.envelope-carries-version-tag
 		_, body := exportBody(t)
 
 		envelope, ok := body["data"].(map[string]interface{})
@@ -170,7 +170,7 @@ func TestSystemAPI_ExportData(t *testing.T) {
 	})
 
 	t.Run("Export_ContactsOnlyNoInteractionsOrNotes", func(t *testing.T) {
-		// spec: SET-030[2]
+		// spec: SET-030.exported-dataset-contacts-only
 		// Snapshot the live contact count BEFORE the export so the guard
 		// below reasons about the dataset the export saw; the margin absorbs
 		// concurrent writers between this read and the export request.
@@ -225,7 +225,7 @@ func TestSystemAPI_ExportData(t *testing.T) {
 	})
 
 	t.Run("Export_ContactsReadFailureReturns500", func(t *testing.T) {
-		// spec: SET-030[3]
+		// spec: SET-030.contacts-read-failure-500
 		// The repository has no injection seam, so force a genuine read
 		// failure: a handler whose repository sits on an already-closed pool.
 		failingDB := newSystemTestDatabase(t)

--- a/backend/tests/api/telegram_auth_api_test.go
+++ b/backend/tests/api/telegram_auth_api_test.go
@@ -188,7 +188,7 @@ func TestTelegramAuthAPI_ValidationErrors(t *testing.T) {
 	router, _ := setupTelegramAuthRouter(t, ctx)
 
 	t.Run("StartAuth_MissingOrEmptyPhone", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		for _, payload := range []interface{}{
 			map[string]string{},                      // field absent
 			map[string]string{"phone_number": ""},    // empty
@@ -201,7 +201,7 @@ func TestTelegramAuthAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("StartAuth_MalformedPhone", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		for _, phone := range []string{
 			"1234567",           // no leading +
 			"+123456",           // 6 digits — below the 7-digit minimum
@@ -216,7 +216,7 @@ func TestTelegramAuthAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("StartAuth_BoundaryValidPhonesPassValidation", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		// A dedicated harness whose session row is seeded connected: a phone
 		// that PASSES validation reaches the manager and is answered with the
 		// already-connected 409 (decided from the DB row, before any MTProto
@@ -237,49 +237,49 @@ func TestTelegramAuthAPI_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("StartAuth_MalformedBody", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/start", "{not-json")
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
 	})
 
 	t.Run("VerifyCode_MissingToken", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-code", map[string]string{"code": "12345"})
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
 	})
 
 	t.Run("VerifyCode_MissingCode", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-code", map[string]string{"auth_token": "deadbeef"})
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
 	})
 
 	t.Run("VerifyCode_MalformedBody", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-code", "{not-json")
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
 	})
 
 	t.Run("VerifyPassword_MissingToken", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-password", map[string]string{"password": "hunter2"})
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
 	})
 
 	t.Run("VerifyPassword_MissingPassword", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-password", map[string]string{"auth_token": "deadbeef"})
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
 	})
 
 	t.Run("VerifyPassword_MalformedBody", func(t *testing.T) {
-		// spec: TGM-007[0]
+		// spec: TGM-007.empty-malformed-phone-number
 		w := doTelegramJSON(t, router, http.MethodPost, "/api/v1/telegram/auth/verify-password", "{not-json")
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, api.ErrCodeValidation, telegramWireErrorCode(t, decodeTelegramWire(t, w)))
@@ -386,7 +386,7 @@ func TestTelegramAuthAPI_Disconnect(t *testing.T) {
 	t.Parallel()
 
 	t.Run("SucceedsAndClearsSession", func(t *testing.T) {
-		// spec: TGM-007[5]
+		// spec: TGM-007.disconnect-200-unless-delete-fails
 		ctx := context.Background()
 		router, sessionRepo := setupTelegramAuthRouter(t, ctx)
 		ns := uuid.NewString()[:8]
@@ -404,7 +404,7 @@ func TestTelegramAuthAPI_Disconnect(t *testing.T) {
 	})
 
 	t.Run("SessionDeleteFailureIsServerError", func(t *testing.T) {
-		// spec: TGM-007[5]
+		// spec: TGM-007.disconnect-200-unless-delete-fails
 		ctx := context.Background()
 		router, sessionRepo := setupTelegramAuthRouter(t, ctx)
 		ns := uuid.NewString()[:8]
@@ -447,7 +447,7 @@ func TestTelegramAuthAPI_Status(t *testing.T) {
 	t.Parallel()
 
 	t.Run("DisconnectedWithoutSession", func(t *testing.T) {
-		// spec: TGM-007[6]
+		// spec: TGM-007.status-always-returns-200
 		ctx := context.Background()
 		router, _ := setupTelegramAuthRouter(t, ctx)
 
@@ -465,7 +465,7 @@ func TestTelegramAuthAPI_Status(t *testing.T) {
 	})
 
 	t.Run("ConnectedFromStoredSession", func(t *testing.T) {
-		// spec: TGM-007[6]
+		// spec: TGM-007.status-always-returns-200
 		ctx := context.Background()
 		router, sessionRepo := setupTelegramAuthRouter(t, ctx)
 		ns := uuid.NewString()[:8]

--- a/backend/tests/api/telegram_chat_api_test.go
+++ b/backend/tests/api/telegram_chat_api_test.go
@@ -205,7 +205,7 @@ func TestChatAPI_ListChats(t *testing.T) {
 	assert.True(t, large, "large group should be in response")
 }
 
-// spec: TGM-014[0]
+// spec: TGM-014.list-returns-only-group
 func TestChatAPI_ListChats_ExcludesPrivate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -270,7 +270,7 @@ func TestChatAPI_ListChats_ExcludesPrivate(t *testing.T) {
 	assert.True(t, foundGroup, "group chat should appear carrying effective_tracked")
 }
 
-// spec: TGM-014[1]
+// spec: TGM-014.status-update-closed-set
 func TestChatAPI_UpdateStatus_Ignored(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -311,7 +311,7 @@ func TestChatAPI_UpdateStatus_Ignored(t *testing.T) {
 	assert.False(t, resp.Data.EffectiveTracked)
 }
 
-// spec: TGM-014[1]
+// spec: TGM-014.status-update-closed-set
 func TestChatAPI_UpdateStatus_TrackedOverridesLarge(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -352,7 +352,7 @@ func TestChatAPI_UpdateStatus_TrackedOverridesLarge(t *testing.T) {
 	assert.True(t, resp.Data.EffectiveTracked)
 }
 
-// spec: TGM-014[1]
+// spec: TGM-014.status-update-closed-set
 func TestChatAPI_UpdateStatus_Auto(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -392,7 +392,7 @@ func TestChatAPI_UpdateStatus_Auto(t *testing.T) {
 	assert.Equal(t, true, raw.Data["effective_tracked"], "small group under auto should be effective_tracked")
 }
 
-// spec: TGM-014[1]
+// spec: TGM-014.status-update-closed-set
 func TestChatAPI_UpdateStatus_InvalidStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -411,7 +411,7 @@ func TestChatAPI_UpdateStatus_InvalidStatus(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// spec: TGM-014[2]
+// spec: TGM-014.non-numeric-chat-id
 func TestChatAPI_UpdateStatus_NotFound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -432,7 +432,7 @@ func TestChatAPI_UpdateStatus_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
-// spec: TGM-014[2]
+// spec: TGM-014.non-numeric-chat-id
 func TestChatAPI_UpdateStatus_NonNumericChatID(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/backend/tests/api/todoist_api_test.go
+++ b/backend/tests/api/todoist_api_test.go
@@ -371,7 +371,7 @@ func TestTodoistAPI_Pickers_NoAccount(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ListProjects_NoAccount_Returns404", func(t *testing.T) {
-		// spec: SET-018[0]
+		// spec: SET-018.no-account-connected-404
 		router, _, _, _ := newTodoistAPITest(t)
 
 		w := doTodoistRequest(router, http.MethodGet, "/api/v1/todoist/projects", nil)
@@ -389,7 +389,7 @@ func TestTodoistAPI_Pickers_NoAccount(t *testing.T) {
 	})
 
 	t.Run("ListLabels_NoAccount_Returns404", func(t *testing.T) {
-		// spec: SET-018[0]
+		// spec: SET-018.no-account-connected-404
 		router, _, _, _ := newTodoistAPITest(t)
 
 		w := doTodoistRequest(router, http.MethodGet, "/api/v1/todoist/labels", nil)
@@ -475,7 +475,7 @@ func TestTodoistAPI_Pickers_FilterDeletedEntries(t *testing.T) {
 	t.Cleanup(server.Close)
 	withTodoistSyncEndpoint(t, server.URL)
 
-	// spec: SET-018[1]
+	// spec: SET-018.deleted-entries-filtered-out
 	w := doTodoistRequest(router, http.MethodGet, "/api/v1/todoist/projects", nil)
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	assert.Equal(t, []map[string]interface{}{
@@ -515,7 +515,7 @@ func TestTodoistAPI_Pickers_TokenOrProviderFailure500(t *testing.T) {
 		seedAccount()
 
 		for _, path := range pickerPaths {
-			// spec: SET-018[2]
+			// spec: SET-018.token-provider-api-failure
 			w := doTodoistRequest(router, http.MethodGet, path, nil)
 			assertTodoistInternalErrorWire(t, w)
 		}
@@ -534,7 +534,7 @@ func TestTodoistAPI_Pickers_TokenOrProviderFailure500(t *testing.T) {
 		withTodoistSyncEndpoint(t, server.URL)
 
 		for _, path := range pickerPaths {
-			// spec: SET-018[2]
+			// spec: SET-018.token-provider-api-failure
 			w := doTodoistRequest(router, http.MethodGet, path, nil)
 			assertTodoistInternalErrorWire(t, w)
 		}

--- a/backend/tests/contact_task_service_test.go
+++ b/backend/tests/contact_task_service_test.go
@@ -483,7 +483,7 @@ func TestContactTaskService_CRMMarkerFormat(t *testing.T) {
 // calls is a regression guard — it fails loudly if anyone later adds an
 // outbound call to the unlink path.
 func TestDeleteTaskLink_IssuesNoOutboundTodoistCall(t *testing.T) {
-	// spec: CAD-039[0], CAD-039[1]
+	// spec: CAD-039.crm-deletes-only-own, CAD-039.no-outbound-call-made
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/backend/tests/link_contact_curated_status_integration_test.go
+++ b/backend/tests/link_contact_curated_status_integration_test.go
@@ -191,7 +191,7 @@ func TestLinkContact_CuratedWithCadence_LandsImported(t *testing.T) {
 // Bare link (no curation signal) → match_status='matched'. This is the
 // sole owner of the bare-link branch: the modal always curates, so the
 // state is unreachable from the browser (waived in spec/imports-matching).
-// spec: IMP-007[2], IMP-013[1]
+// spec: IMP-007.matched-marks-rows-linked, IMP-013.bare-link-no-curation
 func TestLinkContact_Bare_LandsMatched(t *testing.T) {
 	t.Parallel()
 	env := setupLinkCuratedEnv(t)
@@ -232,7 +232,7 @@ func TestLinkContact_MethodsCuratedDeselectAll_LandsImported(t *testing.T) {
 
 // Link-only import guard: a gmail_correspondence external row cannot be
 // imported as a new contact → 403, and the row stays unmatched.
-// spec: IMP-011[1]
+// spec: IMP-011.link-only-source-forbidden
 func TestImportContact_LinkOnlySource_Forbidden(t *testing.T) {
 	t.Parallel()
 	env := setupLinkCuratedEnv(t)

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -494,7 +494,7 @@ func TestRematch_NoHandlerForType_ReturnsNilJobID(t *testing.T) {
 // unhandled method type would mint a jobID + enqueue a no-op river
 // job. Only the email handler is registered; adding a phone method
 // must produce uuid.Nil.
-// spec: IMP-019[2]
+// spec: IMP-019.no-job-minted-without-handler
 func TestRematch_Publisher_NoHandler_ReturnsNilJobID(t *testing.T) {
 	t.Parallel()
 	env := setupRematchEnv(t)
@@ -794,7 +794,7 @@ func TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction(t *tes
 // every method named in the request. The trigger moved from the contact PUT to
 // the operations endpoint when the PUT's method-replacing branch was retired;
 // the diff behavior it asserts is unchanged.
-// spec: IMP-019[0]
+// spec: IMP-019.rematch-event-published-methods
 func TestRematch_ApplyMethodOperations_FiresForNewMethodOnly(t *testing.T) {
 	t.Parallel()
 	env := setupRematchEnv(t)

--- a/backend/tests/suggestion_service_integration_test.go
+++ b/backend/tests/suggestion_service_integration_test.go
@@ -150,7 +150,7 @@ func TestSuggestions_List_SourceScopeExcludesNonAddressBook(t *testing.T) {
 	}
 }
 
-// spec: IMP-018[0]
+// spec: IMP-018.resolve-confirms-requested-methods
 func TestSuggestions_Resolve_AddsMethodAndClearsPending(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -182,7 +182,7 @@ func TestSuggestions_Resolve_AddsMethodAndClearsPending(t *testing.T) {
 	assert.GreaterOrEqual(t, jobs, int64(1))
 }
 
-// spec: IMP-018[3]
+// spec: IMP-018.actions-re-check-live
 func TestSuggestions_Resolve_Idempotent(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -211,7 +211,7 @@ func TestSuggestions_Resolve_Idempotent(t *testing.T) {
 // requesting only one confirms exactly that one (enrichment + pending
 // clear) and leaves the other untouched in pending.
 //
-// spec: IMP-018[0]
+// spec: IMP-018.resolve-confirms-requested-methods
 func TestSuggestions_Resolve_RequestedSubset_OnlyRequestedConfirmed(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -242,7 +242,7 @@ func TestSuggestions_Resolve_RequestedSubset_OnlyRequestedConfirmed(t *testing.T
 // confirms EVERY live pending method (not just one), enriching all of
 // them and fully clearing pending.
 //
-// spec: IMP-018[0]
+// spec: IMP-018.resolve-confirms-requested-methods
 func TestSuggestions_Resolve_Unspecified_ConfirmsAllPending(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -335,7 +335,7 @@ func TestSuggestions_Resolve_MalformedMethod400(t *testing.T) {
 // dismissed email is sticky and a second PENDING entry of the SAME type
 // but a DIFFERENT value survives.
 //
-// spec: IMP-018[1]
+// spec: IMP-018.dismiss-sticky-per-method
 func TestSuggestions_Dismiss_RecordsStickyAndDropsPending(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -373,7 +373,7 @@ func TestSuggestions_Dismiss_RecordsStickyAndDropsPending(t *testing.T) {
 	}
 }
 
-// spec: IMP-018[3]
+// spec: IMP-018.actions-re-check-live
 func TestSuggestions_Dismiss_Idempotent(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -405,7 +405,7 @@ func TestSuggestions_Dismiss_Idempotent(t *testing.T) {
 // both email (lowercase+trim) and telegram (strip '@'+lowercase) so the
 // VALUE half of the key is deliberately held constant while TYPE differs.
 //
-// spec: IMP-018[1]
+// spec: IMP-018.dismiss-sticky-per-method
 func TestSuggestions_Dismiss_StickyPerType_SameValueSurvivesDifferentType(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -461,7 +461,7 @@ func TestSuggestions_Dismiss_StickyPerType_SameValueSurvivesDifferentType(t *tes
 	assert.Equal(t, "email", after.DismissedMethodSuggestions[0].Type)
 }
 
-// spec: IMP-018[2]
+// spec: IMP-018.stale-entries-pruned-not-dismissed
 func TestSuggestions_Dismiss_AlreadyOnContact_NotStickyDismissed(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -497,7 +497,7 @@ func TestSuggestions_Dismiss_AlreadyOnContact_NotStickyDismissed(t *testing.T) {
 // suggestion was recorded) is pruned from pending WITHOUT being recorded
 // as a dismissal.
 //
-// spec: IMP-018[2]
+// spec: IMP-018.stale-entries-pruned-not-dismissed
 func TestSuggestions_Dismiss_NoLongerOffered_PrunedNotDismissed(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -533,7 +533,7 @@ func TestSuggestions_Dismiss_NoLongerOffered_PrunedNotDismissed(t *testing.T) {
 	assert.Nil(t, after.DismissedMethodSuggestions, "no-longer-offered entry must not be sticky-dismissed")
 }
 
-// spec: IMP-018[3]
+// spec: IMP-018.actions-re-check-live
 func TestSuggestions_Resolve_ContactGone(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -612,7 +612,7 @@ func TestSuggestions_DuplicateOfCanonical_ResolvesToCanonicalContact(t *testing.
 // production route (not the service call directly), a soft-deleted
 // effective contact reports 410 Gone on the wire.
 //
-// spec: IMP-018[3]
+// spec: IMP-018.actions-re-check-live
 func TestSuggestionsAPI_Resolve_SoftDeletedContact_Returns410(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)
@@ -635,7 +635,7 @@ func TestSuggestionsAPI_Resolve_SoftDeletedContact_Returns410(t *testing.T) {
 // counterpart: the same soft-deleted-contact-gone check applies to the
 // dismiss action route too.
 //
-// spec: IMP-018[3]
+// spec: IMP-018.actions-re-check-live
 func TestSuggestionsAPI_Dismiss_SoftDeletedContact_Returns410(t *testing.T) {
 	t.Parallel()
 	env := setupABReconcileEnv(t)

--- a/frontend/src/lib/__tests__/contact-recency.test.ts
+++ b/frontend/src/lib/__tests__/contact-recency.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { cadenceBaseDate, formatOverdueRecency } from '../contact-recency'
 
-// spec: CAD-027[2]
+// spec: CAD-027.recency-orders-longest-waiting
 // The overdue list's recency ordering answers "who have I gone longest without
 // connecting with". A never-connected contact has waited since it was added, so it
 // belongs in that ordering by its creation date — the same base the cadence engine
@@ -45,7 +45,7 @@ describe('cadenceBaseDate', () => {
   })
 })
 
-// spec: CAD-026[1]
+// spec: CAD-026.each-card-shows-urgency
 // last_contacted records a two-way connection (CAD-006) and is unset until one
 // happens (CON-001). The overdue card must not present a contact's creation instant
 // as a connection — the app knew nothing had happened and said "Last contacted N ago"

--- a/frontend/tests/e2e/birthdays.spec.ts
+++ b/frontend/tests/e2e/birthdays.spec.ts
@@ -85,8 +85,8 @@ test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
     page,
     request,
   }) => {
-    // spec: CON-045[3]
-    // spec: KNW-035[0], KNW-035[1]
+    // spec: CON-045.placeholder-year-birthdays-no-age
+    // spec: KNW-035.date-renders-month-day, KNW-035.no-age-computed-displayed
     // The list-row and detail-page assertions below prove the year-less
     // rendering (month/day only, placeholder year never shown) and the
     // birthdays-card assertions prove the age suppression.
@@ -142,7 +142,7 @@ test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
     page,
     request,
   }) => {
-    // spec: CON-045[0]
+    // spec: CON-045.contacts-grouped-into-today
     // Freeze the frame mid-year so the three groups are deterministic and
     // parallel-safe (the same per-page frame-mock idiom used for CON-045[1]).
     await mockFrozenSystemTime(page, '2026-06-15T12:00:00Z')
@@ -189,7 +189,7 @@ test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
     page,
     request,
   }) => {
-    // spec: CON-045[2]
+    // spec: CON-045.upcoming-birthdays-sort-soonest
     await mockFrozenSystemTime(page, '2026-06-15T12:00:00Z')
     const soonName = `${testApi.prefix}-Sort Soon` // 3 days out
     const laterName = `${testApi.prefix}-Sort Later` // 10 days out
@@ -240,7 +240,7 @@ test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
   })
 
   test('the birthdays page date header follows the server accelerated frame', async ({ page }) => {
-    // spec: CON-045[4]
+    // spec: CON-045.page-follows-accelerated-time
     // Freeze the frame to a fixed, non-wall-clock date and assert the page
     // header renders THAT date — proving it follows the server frame rather than
     // the wall clock (a real-frame assertion would pass trivially when the
@@ -255,7 +255,7 @@ test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
   })
 
   test('shows the gift-planning section near year end', async ({ page, request }) => {
-    // spec: CON-045[1]
+    // spec: CON-045.gift-planning-near-year-end
     // December frame → the page surfaces early-next-year (Jan-Mar) birthdays.
     await mockFrozenSystemTime(page, '2026-12-15T12:00:00Z')
     const febName = `${testApi.prefix}-Gift Feb`
@@ -276,7 +276,7 @@ test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
   })
 
   test('hides the gift-planning section away from year end', async ({ page, request }) => {
-    // spec: CON-045[1]
+    // spec: CON-045.gift-planning-near-year-end
     // June frame → no gift-planning section, even with a Jan-Mar birthday.
     await mockFrozenSystemTime(page, '2026-06-15T12:00:00Z')
     const febName = `${testApi.prefix}-Gift Feb`

--- a/frontend/tests/e2e/contact-direction.spec.ts
+++ b/frontend/tests/e2e/contact-direction.spec.ts
@@ -20,7 +20,7 @@ test.describe('Contact Direction Signals @area:contacts', () => {
   })
 
   test('shows direction signal timestamps after mutual interaction', async ({ page, request }) => {
-    // spec: CAD-029[0], CAD-029[1]
+    // spec: CAD-029.last-outreach-time-shown, CAD-029.last-response-time-shown
     const { ids } = await testApi.seedContacts([
       { full_name: 'Direction Signal Test', cadence: 'monthly' },
     ])
@@ -53,7 +53,7 @@ test.describe('Contact Direction Signals @area:contacts', () => {
     page,
     request,
   }) => {
-    // spec: CAD-029[0], CAD-029[1]
+    // spec: CAD-029.last-outreach-time-shown, CAD-029.last-response-time-shown
     // Create a fresh contact with no prior interactions
     const { ids } = await testApi.seedContacts([
       { full_name: 'Outbound Only Test', cadence: 'monthly' },
@@ -83,7 +83,7 @@ test.describe('Contact Direction Signals @area:contacts', () => {
   })
 
   test('shows awaiting-reply indicator while a follow-up pends', async ({ page, request }) => {
-    // spec: CAD-029[2]
+    // spec: CAD-029.awaiting-reply-indicator-shown
     const { ids } = await testApi.seedContacts([
       { full_name: 'Awaiting Reply Test', cadence: 'monthly' },
     ])
@@ -124,7 +124,7 @@ test.describe('Contact Direction Signals @area:contacts', () => {
   })
 
   test('shows explicit no-recent-activity state with no direction signals', async ({ page }) => {
-    // spec: CAD-029[3]
+    // spec: CAD-029.explicit-no-recent-activity
     // A freshly seeded contact has no interactions and no pending follow-up,
     // which guarantees the no-recent-activity branch (no vacuous fallback).
     const { ids } = await testApi.seedContacts([

--- a/frontend/tests/e2e/contact-knowledge.spec.ts
+++ b/frontend/tests/e2e/contact-knowledge.spec.ts
@@ -60,7 +60,7 @@ test.describe('Contact knowledge rows @area:contacts', () => {
     // Known location: a labeled row carrying the seeded value
     // (30s: this can be the suite's first page load, paying next dev's
     // on-demand route compilation on top of the data fetch)
-    // spec: KNW-034[0]
+    // spec: KNW-034.known-location-appears-labeled
     await page.goto(`/contacts/${locatedId}`)
     await expect(
       page.getByRole('heading', { name: `${testApi.prefix}-Located Contact` })
@@ -69,7 +69,7 @@ test.describe('Contact knowledge rows @area:contacts', () => {
     await expect(detailRow(page, 'Location')).toContainText(location)
 
     // Unknown location: no row renders at all
-    // spec: KNW-034[0]
+    // spec: KNW-034.known-location-appears-labeled
     await page.goto(`/contacts/${unlocatedId}`)
     await expect(
       page.getByRole('heading', { name: `${testApi.prefix}-Unlocated Contact` })
@@ -98,7 +98,7 @@ test.describe('Contact knowledge rows @area:contacts', () => {
     })
 
     // Known birthday: a labeled row with the human-readable date
-    // spec: KNW-034[1]
+    // spec: KNW-034.known-birthday-appears-labeled
     await page.goto(`/contacts/${birthdayId}`)
     await expect(
       page.getByRole('heading', { name: `${testApi.prefix}-Birthday Contact` })
@@ -107,7 +107,7 @@ test.describe('Contact knowledge rows @area:contacts', () => {
     await expect(detailRow(page, 'Birthday')).toContainText(expectedBirthday)
 
     // Unknown birthday: no row renders
-    // spec: KNW-034[1]
+    // spec: KNW-034.known-birthday-appears-labeled
     await page.goto(`/contacts/${plainId}`)
     await expect(
       page.getByRole('heading', { name: `${testApi.prefix}-No Birthday Contact` })

--- a/frontend/tests/e2e/contact-merge.spec.ts
+++ b/frontend/tests/e2e/contact-merge.spec.ts
@@ -59,7 +59,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should display target contact as "Keeping"', async ({ page }) => {
-    // spec: CON-043[0]
+    // spec: CON-043.current-contact-marked-kept
     // Create a contact to be the merge target
     const { ids } = await testApi.seedContacts([
       {
@@ -85,7 +85,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should search and select source contact', async ({ page }) => {
-    // spec: CON-043[0], CON-043[1]
+    // spec: CON-043.current-contact-marked-kept, CON-043.selecting-source-loads-preview
     // Create target and source contacts
     const { ids } = await testApi.seedContacts([
       {
@@ -128,7 +128,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should toggle field selection between source and target', async ({ page, request }) => {
-    // spec: CON-043[2]
+    // spec: CON-043.conflicting-fields-cadence-location
     // Conflicts span all three fields the spec names (cadence, location,
     // birthday), so the default-keeps-target proof covers the full clause, not
     // just location. Seeded via direct POST because the seed endpoint has no
@@ -214,7 +214,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should edit merged contact name', async ({ page }) => {
-    // spec: CON-043[3]
+    // spec: CON-043.merged-name-editable
     // Create contacts
     const { ids } = await testApi.seedContacts([
       {
@@ -255,7 +255,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should cancel name edit with Escape', async ({ page }) => {
-    // spec: CON-043[3]
+    // spec: CON-043.merged-name-editable
     // The editable-name contract's discard path: Escape must not adopt the
     // typed name (no accidental rename baked into the merge).
     const { ids } = await testApi.seedContacts([
@@ -296,7 +296,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should dismiss the modal without merging via backdrop click', async ({ page }) => {
-    // spec: CON-043[6]
+    // spec: CON-043.modal-dismissed-without-merging
     // Backdrop click dismisses the modal IN PLACE: no merge fires, the modal
     // closes, and the user stays on the detail page. The Escape path is NOT
     // asserted here: the detail page's window-level Escape handler is not
@@ -342,7 +342,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should successfully merge contacts', async ({ page }) => {
-    // spec: CON-043[5]
+    // spec: CON-043.outcome-reported-auto-dismissed
     // Create contacts with some methods
     const { ids } = await testApi.seedContacts([
       {
@@ -413,7 +413,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should show quick-fill name option when source has different name', async ({ page }) => {
-    // spec: CON-043[3]
+    // spec: CON-043.merged-name-editable
     // Create contacts with different names
     const { ids } = await testApi.seedContacts([
       {
@@ -455,7 +455,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('should disable merge button when no source selected', async ({ page }) => {
-    // spec: CON-043[4]
+    // spec: CON-043.merge-cannot-submit-until-ready
     // Create a contact
     const { ids } = await testApi.seedContacts([
       {
@@ -480,7 +480,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('keeps the merge submit disabled while the preview is loading', async ({ page }) => {
-    // spec: CON-043[4]
+    // spec: CON-043.merge-cannot-submit-until-ready
     const { ids } = await testApi.seedContacts([
       { full_name: 'Preview Loading Target' },
       { full_name: 'Preview Loading Source' },
@@ -515,7 +515,7 @@ test.describe('Contact Merge @area:contact-merge', () => {
   })
 
   test('keeps the merge submit disabled while the merge is in flight', async ({ page }) => {
-    // spec: CON-043[4]
+    // spec: CON-043.merge-cannot-submit-until-ready
     const { ids } = await testApi.seedContacts([
       { full_name: 'In Flight Target' },
       { full_name: 'In Flight Source' },

--- a/frontend/tests/e2e/contact-method-preservation.spec.ts
+++ b/frontend/tests/e2e/contact-method-preservation.spec.ts
@@ -105,7 +105,7 @@ test.describe('Contact method preservation @area:contacts', () => {
     page,
     request,
   }) => {
-    // spec: CON-063[0]
+    // spec: CON-063.method-added-another-writer
     const emailA = `pres-a-${Date.now()}@example.com`
     const emailB = `pres-b-${Date.now()}@example.com`
     const { ids } = await testApi.seedContacts([
@@ -131,7 +131,7 @@ test.describe('Contact method preservation @area:contacts', () => {
   })
 
   test('removes a method the user deleted in the form', async ({ page, request }) => {
-    // spec: CON-063[1]
+    // spec: CON-063.method-user-explicitly-deleted
     const emailA = `del-a-${Date.now()}@example.com`
     const { ids } = await testApi.seedContacts([
       {
@@ -165,7 +165,7 @@ test.describe('Contact method preservation @area:contacts', () => {
   })
 
   test('reports which parts of the save succeeded when one step fails', async ({ page }) => {
-    // spec: CON-063[2]
+    // spec: CON-063.partial-failure-names-saved-parts
     const emailA = `part-a-${Date.now()}@example.com`
     const { ids } = await testApi.seedContacts([
       { full_name: 'Partial Target', methods: [{ type: 'email', value: emailA }] },
@@ -191,7 +191,7 @@ test.describe('Contact method preservation @area:contacts', () => {
     page,
     request,
   }) => {
-    // spec: CON-063[3]
+    // spec: CON-063.retrying-after-partial-failure
     const emailA = `retry-a-${Date.now()}@example.com`
     const emailB = `retry-b-${Date.now()}@example.com`
     const { ids } = await testApi.seedContacts([
@@ -219,7 +219,7 @@ test.describe('Contact method preservation @area:contacts', () => {
     page,
     request,
   }) => {
-    // spec: CON-063[4]
+    // spec: CON-063.partial-save-add-can-be-removed
     //
     // The ordering here is load-bearing. B is added AFTER edit mode opens, so it
     // is genuinely unseen; adding it before would make it legitimately part of
@@ -270,7 +270,7 @@ test.describe('Contact method preservation @area:contacts', () => {
     page,
     request,
   }) => {
-    // spec: CON-063[5]
+    // spec: CON-063.partial-save-add-can-be-edited
     const emailA = `addedit-a-${Date.now()}@example.com`
     const phoneC = '5555550146'
     const phoneCEdited = '5555550147'
@@ -315,7 +315,7 @@ test.describe('Contact method preservation @area:contacts', () => {
     page,
     request,
   }) => {
-    // spec: CON-063[6]
+    // spec: CON-063.reverting-method-value-restores
     const emailA = `revert-a-${Date.now()}@example.com`
     const emailIntermediate = `revert-b-${Date.now()}@example.com`
     const { ids } = await testApi.seedContacts([

--- a/frontend/tests/e2e/contact-navigation.spec.ts
+++ b/frontend/tests/e2e/contact-navigation.spec.ts
@@ -20,7 +20,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('should disable keyboard navigation in edit mode', async ({ page }) => {
-    // spec: CON-040[1]
+    // spec: CON-040.arrows-inert-while-editing
     // Create 2 contacts
     const { ids } = await testApi.seedContacts([
       { full_name: 'Edit Mode Test A' },
@@ -80,7 +80,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('should not navigate when typing in input fields', async ({ page }) => {
-    // spec: CON-040[1]
+    // spec: CON-040.arrows-inert-while-editing
     // Create 2 contacts
     const { ids } = await testApi.seedContacts([
       { full_name: 'Input Field Test A' },
@@ -127,7 +127,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('should preserve URL context (sort, search) during navigation', async ({ page }) => {
-    // spec: CON-060[0]
+    // spec: CON-060.sort-order-search-context
     // Create contacts
     const { ids } = await testApi.seedContacts([
       { full_name: 'Context Test Alpha', location: 'New York' },
@@ -158,7 +158,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('should navigate via navigation bar buttons', async ({ page }) => {
-    // spec: CON-059[0], CON-059[1]
+    // spec: CON-059.buttons-move-adjacent-contact, CON-059.position-indicator-reports-contact
     // Create 3 contacts with a known name-asc order so a pass proves real
     // movement to the ADJACENT contact, not just "some navigation happened".
     const { ids } = await testApi.seedContacts([
@@ -192,7 +192,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('should restore search and sort state after Escape back to list', async ({ page }) => {
-    // spec: CON-040[3]
+    // spec: CON-040.escape-discards-edit-mode
     // Two contacts so search + sort visibly shape the list
     await testApi.seedContacts([
       { full_name: 'Restore State Alpha' },
@@ -232,7 +232,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   test('detail prev/next follows the same default (cadence) ordering as the list', async ({
     page,
   }) => {
-    // spec: CON-038[1]
+    // spec: CON-038.detail-prev-next-same-default
     // Navigate by CLICKING the seeded row in the default (cadence) list — the
     // detail must CARRY that ordering context, so prev/next walks the same
     // cadence order rather than an ordering hand-fed through the URL. Names are
@@ -298,7 +298,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   test('arrow keys move to the previous/next contact and disable at both boundaries @smoke', async ({
     page,
   }) => {
-    // spec: CON-040[0]
+    // spec: CON-040.left-right-arrows-move
     // Seed a known name-asc order and isolate the set via search, so a pass
     // proves real movement to the adjacent contact.
     const { ids } = await testApi.seedContacts([
@@ -349,7 +349,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('Enter opens edit mode when focus is outside an input', async ({ page }) => {
-    // spec: CON-040[2]
+    // spec: CON-040.enter-opens-edit-mode
     const { ids } = await testApi.seedContacts([{ full_name: 'Enter Edit Test' }])
     const fullName = `${testApi.prefix}-Enter Edit Test`
 
@@ -371,7 +371,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     page,
     request,
   }) => {
-    // spec: CON-040[3]
+    // spec: CON-040.escape-discards-edit-mode
     const { ids } = await testApi.seedContacts([{ full_name: 'Discard Edit Test' }])
     const contactId = ids[0]
     const fullName = `${testApi.prefix}-Discard Edit Test`
@@ -419,7 +419,7 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
   })
 
   test('arrows are inert while focus is in an input outside edit mode', async ({ page }) => {
-    // spec: CON-040[1]
+    // spec: CON-040.arrows-inert-while-editing
     // The Log Interaction modal keeps keyboard nav ENABLED (it is not edit
     // mode), so focusing its input exercises the hook's input-target guard
     // specifically — unlike edit mode, which disables the whole hook and would
@@ -581,7 +581,7 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
   test('the Back to list control restores full context AND page via the real journey', async ({
     page,
   }) => {
-    // spec: CON-065[0], CON-065[1]
+    // spec: CON-065.visible-return-list-control, CON-065.returning-lands-list-page
     const ids = await seedBackNavFixture()
     await journeyToBackNav21Detail(page, ids)
 
@@ -593,7 +593,7 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
   })
 
   test('Escape restores full context AND page identically to the button', async ({ page }) => {
-    // spec: CON-040[3], CON-065[1]
+    // spec: CON-040.escape-discards-edit-mode, CON-065.returning-lands-list-page
     const ids = await seedBackNavFixture()
     await journeyToBackNav21Detail(page, ids)
 
@@ -605,7 +605,7 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
   })
 
   test('an out-of-range ?page deep-link clamps to the last valid page', async ({ page }) => {
-    // spec: CON-058[3]
+    // spec: CON-058.page-past-end-clamps
     // A stale bookmark / hand-edited URL asking for a page past the end must
     // land on the last valid page with real rows, not an empty table with the
     // pagination controls hidden. The fixture is 21 has_cadence contacts → 2
@@ -638,7 +638,7 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
   test('an out-of-range ?page on a single-page list clamps to the bare page-1 URL', async ({
     page,
   }) => {
-    // spec: CON-058[3]
+    // spec: CON-058.page-past-end-clamps
     // When the whole filtered set fits on one page, the clamp target is page 1,
     // which buildContactListUrl renders as the bare (page-less) URL — the
     // distinct recovery branch from the multi-page clamp above.
@@ -661,7 +661,7 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
   })
 
   test('changing sort/search/filter from a later page resets to page 1', async ({ page }) => {
-    // spec: CON-066[0]
+    // spec: CON-066.list-returns-first-page
     await seedBackNavFixture()
     const prefix = testApi.prefix
     const backNav21 = `${prefix}-Back Nav 21`
@@ -731,7 +731,7 @@ test.describe('Contact Back-to-list navigation @area:contact-navigation', () => 
   test('using pagination reflects the page into the URL and survives a reload', async ({
     page,
   }) => {
-    // spec: CON-058[2]
+    // spec: CON-058.current-page-reflected-in-url
     await seedBackNavFixture()
     const prefix = testApi.prefix
     await page.goto(

--- a/frontend/tests/e2e/contact-tasks.spec.ts
+++ b/frontend/tests/e2e/contact-tasks.spec.ts
@@ -99,7 +99,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
 
   test.describe('Tasks Section', () => {
     test('shows tasks section on contact detail page', async ({ page }) => {
-      // spec: CAD-030[3]
+      // spec: CAD-030.no-tasks-empty-state
       const { ids } = await testApi.seedContacts([{ full_name: 'Task Test Contact' }])
 
       // Mock SUCCESSFUL empty lists for all three task queries: without the
@@ -127,7 +127,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     test('lists follow-up tasks first with a distinct pending indicator, then manual tasks', async ({
       page,
     }) => {
-      // spec: CAD-030[0]
+      // spec: CAD-030.managed-tasks-appear-first
       const { ids } = await testApi.seedContacts([{ full_name: 'Task Order Contact' }])
       const contactId = ids[0]
       const followUp = makeTask(contactId, {
@@ -161,7 +161,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     })
 
     test('derives each task badge from its kind and lifecycle', async ({ page }) => {
-      // spec: CAD-030[1]
+      // spec: CAD-030.each-task-carries-badge
       const { ids } = await testApi.seedContacts([{ full_name: 'Task Badge Contact' }])
       const contactId = ids[0]
       // Distinct kind/lifecycle pairs across the followup_loop + manual
@@ -217,7 +217,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     test('strips CRM link markers and falls back to a placeholder for empty content', async ({
       page,
     }) => {
-      // spec: TDS-035[0]
+      // spec: TDS-035.crm-link-markers-stripped
       const { ids } = await testApi.seedContacts([{ full_name: 'Task Content Contact' }])
       const contactId = ids[0]
       // The three cleanTaskContent shapes a projected task can carry: a
@@ -256,7 +256,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     })
 
     test('collapses completed tasks behind a toggle with a count', async ({ page }) => {
-      // spec: CAD-030[2]
+      // spec: CAD-030.completed-tasks-collapsed-behind
       const { ids } = await testApi.seedContacts([{ full_name: 'Task History Contact' }])
       const contactId = ids[0]
       await mockTaskLists(page, contactId, () => ({
@@ -287,7 +287,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
 
   test.describe('Add Task Modal', () => {
     test('opens add task modal and closes it with Escape', async ({ page }) => {
-      // spec: CAD-031[0]
+      // spec: CAD-031.kind-chosen-reach-out
       const { ids } = await testApi.seedContacts([{ full_name: 'Modal Test Contact' }])
 
       await page.goto(`/contacts/${ids[0]}`)
@@ -341,7 +341,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     })
 
     test('disables submit while task text is empty', async ({ page }) => {
-      // spec: CAD-031[1]
+      // spec: CAD-031.task-text-required-notes
       const { ids } = await testApi.seedContacts([{ full_name: 'Validation Test Contact' }])
 
       await page.goto(`/contacts/${ids[0]}`)
@@ -368,7 +368,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     })
 
     test('created task appears in the live tasks list', async ({ page }) => {
-      // spec: CAD-031[2]
+      // spec: CAD-031.created-task-appears-contact
       // Real creation needs a Todoist provider AND the POST route is
       // OAuth-gated (the real endpoint 404s in this env, so an unmocked
       // waitForResponse would observe that 404). Mock the write loop:
@@ -437,7 +437,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     const UNLINK_TITLE = 'Remove from CRM (keeps in Todoist)'
 
     test('offers unlink with confirmation and fires only the CRM-link DELETE', async ({ page }) => {
-      // spec: CAD-033[0]
+      // spec: CAD-033.unlink-behind-confirmation
       const { ids } = await testApi.seedContacts([{ full_name: 'Unlink Accept Contact' }])
       const contactId = ids[0]
       const linked = makeTask(contactId, { id: 'task-linked-1', content: 'Mock linked task' })
@@ -494,7 +494,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     })
 
     test('dismissing the unlink confirmation leaves the task linked', async ({ page }) => {
-      // spec: CAD-033[0]
+      // spec: CAD-033.unlink-behind-confirmation
       const { ids } = await testApi.seedContacts([{ full_name: 'Unlink Dismiss Contact' }])
       const contactId = ids[0]
       const linked = makeTask(contactId, { id: 'task-linked-2', content: 'Mock linked task' })
@@ -531,7 +531,7 @@ test.describe('Contact Tasks @area:contacts @area:tasks', () => {
     })
 
     test('exposes no in-CRM complete or dismiss control on a linked task', async ({ page }) => {
-      // spec: CAD-033[1], TDS-035[1]
+      // spec: CAD-033.no-in-crm-complete-or-dismiss, TDS-035.linked-task-deep-link
       // The CRM-side affordance: a linked task row offers ONLY unlink (plus
       // "Open in Todoist") — completing and dismissing happen in the remote
       // task app. The remote-survival guarantee (unlinking does not touch the

--- a/frontend/tests/e2e/contacts.spec.ts
+++ b/frontend/tests/e2e/contacts.spec.ts
@@ -47,7 +47,7 @@ test.describe('Contacts - TestAPI Seeded @area:contacts', () => {
     await expect(heading).not.toHaveClass(/leading-7/)
   })
 
-  // spec: NTS-007[2]
+  // spec: NTS-007.long-content-clamped-expand
   test('should show expandable notes for long content', async ({ page }) => {
     // Create notes longer than 300 characters to trigger truncation
     const longNotes = `Met at the AI conference in San Francisco, March 2024. Works as a senior ML engineer at a startup focused on personal productivity tools.
@@ -94,7 +94,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(showMoreButton).toBeVisible()
   })
 
-  // spec: NTS-007[2]
+  // spec: NTS-007.long-content-clamped-expand
   test('should not show expand button for short notes', async ({ page }) => {
     const shortNotes = 'Brief note about this contact.'
 
@@ -121,7 +121,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(page.getByRole('button', { name: 'Show more' })).not.toBeVisible()
   })
 
-  // spec: CON-053[1], CON-053[2]
+  // spec: CON-053.optional-backdated-date, CON-053.interaction-posted-chosen-direction
   test('should log a backdated interaction via the Log Interaction modal', async ({ page }) => {
     // The Log Interaction modal (direction picker + date picker)
     // replaces the previous inline pencil-edit on `last_contacted`.
@@ -211,7 +211,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
   })
 
   test('should navigate to edit mode via context menu Edit action', async ({ page }) => {
-    // spec: CON-041[0], CON-041[1]
+    // spec: CON-041.action-runs-once-edit, CON-041.parameter-stripped-from-url
     const { ids } = await testApi.seedContacts([{ full_name: 'Context Edit Test' }])
 
     const contactId = ids[0]
@@ -241,7 +241,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
   })
 
   test('should navigate to merge modal via context menu Merge action', async ({ page }) => {
-    // spec: CON-041[0], CON-041[1]
+    // spec: CON-041.action-runs-once-edit, CON-041.parameter-stripped-from-url
     const { ids } = await testApi.seedContacts([{ full_name: 'Context Merge Test' }])
 
     const contactId = ids[0]
@@ -270,7 +270,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(page).not.toHaveURL(/action=/)
   })
 
-  // spec: CON-053[0], CON-053[2]
+  // spec: CON-053.direction-chosen-outbound-inbound, CON-053.interaction-posted-chosen-direction
   test('should log a mutual interaction via the Log Interaction modal default', async ({
     page,
   }) => {
@@ -305,7 +305,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 })
   })
 
-  // spec: CON-053[0]
+  // spec: CON-053.direction-chosen-outbound-inbound
   test('should log an outbound interaction via the Log Interaction modal', async ({ page }) => {
     // The modal's direction picker reaches the API: choosing Outbound posts
     // direction=outbound. The cadence timestamp effects of each direction are
@@ -333,7 +333,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     expect(body.data.direction).toBe('outbound')
   })
 
-  // spec: CON-053[0]
+  // spec: CON-053.direction-chosen-outbound-inbound
   test('should log an inbound interaction via the Log Interaction modal', async ({ page }) => {
     // The modal's direction picker reaches the API: choosing Inbound posts
     // direction=inbound. The cadence timestamp effects of each direction are
@@ -362,7 +362,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
   })
 
   test('defaults the contact list to cadence order, most-frequent-first', async ({ page }) => {
-    // spec: CON-038[0]
+    // spec: CON-038.list-defaults-cadence-order
     // Names are chosen so ALPHABETICAL order (either direction) differs from the
     // cadence-desc order — otherwise a backend that ignored sort=cadence and fell
     // back to name order would pass this test. Cadence-desc = Yankee(weekly) →
@@ -413,7 +413,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
     page,
     request,
   }) => {
-    // spec: CON-042[0], CON-042[1], CON-042[2]
+    // spec: CON-042.confirmation-prompt-warns-action, CON-042.only-confirmation-contact-deleted, CON-042.success-user-returned-contact
     const { ids } = await testApi.seedContacts([{ full_name: 'Delete Confirm Test' }])
     const contactId = ids[0]
     const fullName = `${testApi.prefix}-Delete Confirm Test`
@@ -474,7 +474,7 @@ Follow-up: Share the pgvector article, introduce to Sarah from the embeddings te
   test('logs a mutual interaction from the list-row Mark as Contacted quick action', async ({
     page,
   }) => {
-    // spec: CON-044[0]
+    // spec: CON-044.mutual-direction-interaction-logged
     // The LIST-row context-menu quick action (distinct from the detail-page Log
     // Interaction modal): it posts a mutual, server-timestamped interaction.
     const { ids } = await testApi.seedContacts([
@@ -523,7 +523,7 @@ test.describe('Contacts - Cadence Filter @area:contacts', () => {
   })
 
   test('should filter contacts by cadence status', async ({ page }) => {
-    // spec: DSH-007[0], CON-054[0], CON-054[1]
+    // spec: DSH-007.contact-text-search-provided, CON-054.has-cadence-no-cadence, CON-054.clearing-filter-restores-unfiltered
     // Contact text search is provided through the contact list's search
     // input: the tightened search step below proves typing a term drives a
     // `search=` list request that FILTERS the results (the matching fixtures
@@ -634,7 +634,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await testApi.cleanup()
   })
 
-  // spec: CON-055[0]
+  // spec: CON-055.contact-created-user-lands
   test('should create a contact from the form @smoke', async ({ page }) => {
     const fullName = `${testApi.prefix}-Create Contact`
 
@@ -649,7 +649,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
   })
 
-  // spec: CON-055[0]
+  // spec: CON-055.contact-created-user-lands
   //
   // ContactForm and transformContactFormData are SHARED with the edit path, and
   // the edit path stopped sending `methods` on the contact PUT. Creation still
@@ -675,7 +675,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(email)).toBeVisible({ timeout: 15000 })
   })
 
-  // spec: NTS-008[2]
+  // spec: NTS-008.displayed-notepad-reflects-new
   test('should edit contact notes', async ({ page }) => {
     const notes =
       'Met at a conference in 2024. Works in AI/ML. Very interested in personal CRM tools.'
@@ -713,7 +713,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(notes)).not.toBeVisible()
   })
 
-  // spec: CON-056[0], CON-056[1], CON-056[2]
+  // spec: CON-056.methods-displayed-normalized, CON-056.primary-method-marked-only, CON-056.no-link-surface-plain-text
   test('should display contact with methods and the primary marked', async ({ page }) => {
     // A slim display proof: seeded methods render with normalized values and
     // exactly one Primary mark. The normalization RULES themselves (per-type
@@ -758,7 +758,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByRole('link', { name: gchatEmail })).toHaveCount(0)
   })
 
-  // spec: CON-061[0], CON-061[1]
+  // spec: CON-061.cadence-renders-formatted-label, CON-061.next-contact-date-or-placeholder
   test('should render formatted cadence and next-contact values in list rows', async ({ page }) => {
     // Derived-value display: a contact with a cadence + last-contacted has a
     // computed contact_by, rendered as a date in the Next Contact column; a
@@ -799,7 +799,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(noneRow.getByRole('cell').nth(nextIdx)).toHaveText('-')
   })
 
-  // spec: CON-057[0]
+  // spec: CON-057.list-refetches-column-sort-field
   test('should sort by Next Contact column when header clicked', async ({ page }) => {
     // Two sequential click -> response round trips under real parallel
     // worker load can exceed the default 30s budget; give this test room.
@@ -845,7 +845,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(`${testApi.prefix}-SortNext Contact`)).toBeVisible()
   })
 
-  // spec: CON-057[0]
+  // spec: CON-057.list-refetches-column-sort-field
   test('should sort by Last response column when header clicked', async ({ page }) => {
     // Two sequential click -> response round trips under real parallel
     // worker load can exceed the default 30s budget; give this test room.
@@ -886,7 +886,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(page.getByText(`${testApi.prefix}-SortResp Contact`)).toBeVisible()
   })
 
-  // spec: CON-058[0], CON-058[1]
+  // spec: CON-058.page-number-buttons-move, CON-058.previous-next-controls-disable
   test('should show page number buttons and top/bottom pagination when multiple pages exist', async ({
     page,
   }) => {

--- a/frontend/tests/e2e/dashboard.spec.ts
+++ b/frontend/tests/e2e/dashboard.spec.ts
@@ -35,7 +35,7 @@ function overdueEntry(over: {
 
 test.describe('Dashboard @area:dashboard', () => {
   test('should display dashboard with navigation @smoke', async ({ page }) => {
-    // spec: DSH-001[0]
+    // spec: DSH-001.user-taken-dashboard-default
     await page.goto('/')
 
     // Should redirect to dashboard (client-side redirect via useEffect)
@@ -51,7 +51,7 @@ test.describe('Dashboard @area:dashboard', () => {
   })
 
   test('caught-up state offers add-contact and view-list paths', async ({ page }) => {
-    // spec: DSH-003[0], DSH-003[1]
+    // spec: DSH-003.add-contact-action-always, DSH-003.caught-up-offers-add-and-list
     // Route-mock an EMPTY overdue list (full apiClient envelope) before first
     // load so the caught-up state renders deterministically regardless of what
     // parallel workers have seeded (per-page interception, no DB mutation).
@@ -80,7 +80,7 @@ test.describe('Dashboard @area:dashboard', () => {
   })
 
   test('dashboard exposes no dashboard-level or global search surface', async ({ page }) => {
-    // spec: DSH-007[1]
+    // spec: DSH-007.no-global-search-surface
     // NEGATIVE existence proof at a settled state: establish the dashboard
     // has fully rendered first, THEN assert that no plausible search-surface
     // shape is present (a not-yet-rendered page would pass these vacuously).
@@ -117,7 +117,7 @@ test.describe('Dashboard - Overdue Cards @area:dashboard @area:overdue', () => {
   })
 
   test('shows overdue contacts as cards with the count in the header', async ({ page }) => {
-    // spec: CAD-026[0]
+    // spec: CAD-026.overdue-contacts-appear-cards
     await page.goto('/dashboard')
     await page.waitForLoadState('domcontentloaded')
 
@@ -155,7 +155,7 @@ test.describe('Dashboard - Overdue Cards @area:dashboard @area:overdue', () => {
 
 test.describe('Dashboard - All Caught Up (mocked) @area:dashboard', () => {
   test('shows the all-caught-up state when nothing is overdue', async ({ page }) => {
-    // spec: CAD-026[2]
+    // spec: CAD-026.nothing-overdue-all-caught
     // The empty-overdue state is GLOBAL — parallel workers seed overdue
     // contacts, so it is not deterministically reachable by seeding. Mock the
     // overdue response with the full apiClient envelope (a bare array would
@@ -187,7 +187,7 @@ test.describe('Dashboard - Card Anatomy (mocked) @area:dashboard', () => {
   test('each card shows urgency tier, cadence, recency, a reachable method, and the suggested action', async ({
     page,
   }) => {
-    // spec: CAD-026[1]
+    // spec: CAD-026.each-card-shows-urgency
     await page.route('**/api/v1/contacts/overdue', route =>
       route.fulfill({
         json: {
@@ -280,7 +280,7 @@ test.describe('Dashboard - Sort Orderings (mocked) @area:dashboard', () => {
   }
 
   test('urgency (default) orders most-overdue first', async ({ page }) => {
-    // spec: CAD-027[0]
+    // spec: CAD-027.urgency-default-orders-most
     await gotoMockedDashboard(page)
     expect(await cardOrder(page)).toEqual([
       `Zulu ${fixtureSuffix}`,
@@ -291,7 +291,7 @@ test.describe('Dashboard - Sort Orderings (mocked) @area:dashboard', () => {
   })
 
   test('name orders alphabetically', async ({ page }) => {
-    // spec: CAD-027[1]
+    // spec: CAD-027.name-orders-alphabetically
     await gotoMockedDashboard(page)
     await page.getByRole('button', { name: 'Name', exact: true }).click()
     await expect
@@ -307,7 +307,7 @@ test.describe('Dashboard - Sort Orderings (mocked) @area:dashboard', () => {
   test('recency orders longest-waiting first, ranking never-connected by added date', async ({
     page,
   }) => {
-    // spec: CAD-027[2]
+    // spec: CAD-027.recency-orders-longest-waiting
     await gotoMockedDashboard(page)
     await page.getByRole('button', { name: 'Last Contacted', exact: true }).click()
     // Mike (last_contacted omitted) is ranked by its created_at (02-01), landing
@@ -323,7 +323,7 @@ test.describe('Dashboard - Sort Orderings (mocked) @area:dashboard', () => {
       ])
   })
 
-  // spec: CAD-026[1]
+  // spec: CAD-026.each-card-shows-urgency
   // The regression guard for the bug this copy exists to prevent: a contact with
   // no recorded connection must be described by when it was ADDED, never as a
   // contact that happened. Before the fix the card asserted "Last contacted
@@ -375,7 +375,7 @@ test.describe('Dashboard - With Seeded Data @area:dashboard @area:overdue', () =
   })
 
   test('header add-contact action is available on a populated dashboard', async ({ page }) => {
-    // spec: DSH-003[0]
+    // spec: DSH-003.add-contact-action-always
     // Establish the POPULATED state first — the seeded overdue card must have
     // rendered (a loading or error mask would otherwise vacuously pass a
     // state-independent affordance check) — then assert the header CTA.
@@ -390,7 +390,7 @@ test.describe('Dashboard - With Seeded Data @area:dashboard @area:overdue', () =
   test('marking contact as contacted updates dashboard immediately without navigation', async ({
     page,
   }) => {
-    // spec: DSH-005[0], CAD-028[0], CAD-028[1]
+    // spec: DSH-005.overdue-list-refreshes-reflect, CAD-028.mutual-interaction-logged-timestamped, CAD-028.contact-leaves-overdue-list
     // DSH-005[0]: the on-dashboard interaction:created trigger refreshing the
     // overdue list without a manual reload. DSH-005's broader trigger coverage
     // (merge / meeting-note-resolve), the cosmetic-edit no-op, and the

--- a/frontend/tests/e2e/error-boundary.spec.ts
+++ b/frontend/tests/e2e/error-boundary.spec.ts
@@ -13,7 +13,7 @@ test.describe('Error Boundary @area:error-boundary', () => {
   test('overdue loading shows placeholder skeletons, not an empty or caught-up state', async ({
     page,
   }) => {
-    // spec: DSH-004[0], DSH-003[0]
+    // spec: DSH-004.while-loading-placeholder-content, DSH-003.add-contact-action-always
     // Hold the overdue request open so the dashboard is pinned in its loading
     // state while we assert. The route is installed BEFORE goto (parallel-safe:
     // per-page interception, no DB mutation) and released afterwards so the
@@ -56,7 +56,7 @@ test.describe('Error Boundary @area:error-boundary', () => {
   test('overdue failure shows an error state with a reason, not empty or caught-up', async ({
     page,
   }) => {
-    // spec: DSH-004[1], DSH-004[2], DSH-003[0]
+    // spec: DSH-004.request-failure-error-state, DSH-004.shown-failure-reason-faithfully, DSH-003.add-contact-action-always
     // 500 the overdue endpoint (full apiClient failure envelope) BEFORE goto:
     // apiClient throws ApiError on !response.ok, React Query exhausts its
     // retries, and the dashboard renders its error branch.

--- a/frontend/tests/e2e/imports-actions.spec.ts
+++ b/frontend/tests/e2e/imports-actions.spec.ts
@@ -41,7 +41,7 @@ test.describe('Imports Actions @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-007[0], IMP-027[1]
+    // spec: IMP-007.unmatched-rows-await-review, IMP-027.user-chooses-import-new
     test('should display candidate cards with correct information', async ({ page }) => {
       await page.goto('/imports')
       await page.waitForLoadState('networkidle')
@@ -57,7 +57,7 @@ test.describe('Imports Actions @area:imports', () => {
       await expect(card.getByRole('button', { name: /Link/i })).toBeVisible()
     })
 
-    // spec: IMP-027[1]
+    // spec: IMP-027.user-chooses-import-new
     test('should open link modal when clicking Link button', async ({ page }) => {
       await page.goto('/imports')
       await page.waitForLoadState('networkidle')
@@ -103,8 +103,8 @@ test.describe('Imports Actions @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-012[0], IMP-012[1], IMP-012[2], IMP-012[3]
-    // spec: IMP-007[1], IMP-031[0], IMP-031[2]
+    // spec: IMP-012.crm-contact-created-normal-path, IMP-012.methods-come-from-selection, IMP-012.candidate-row-marked-imported, IMP-012.response-reports-new-contact
+    // spec: IMP-007.imported-marks-rows-resolved, IMP-031.item-leaves-queue-counts-update, IMP-031.returned-rematch-job-registered
     test('should import candidate and persist the created contact', async ({ page, request }) => {
       await page.goto('/imports')
       await page.waitForLoadState('networkidle')
@@ -124,7 +124,7 @@ test.describe('Imports Actions @area:imports', () => {
       // The modal opens on the clicked card's candidate (keyed by id); the
       // import POST below is pinned to OUR external id, proving the clicked
       // candidate is the one that gets resolved.
-      // spec: IMP-028[3]
+      // spec: IMP-028.card-opens-that-candidate
       await expectModalCandidate(page, displayName)
 
       // Capture the import POST and the frontend's first rematch-job poll
@@ -203,7 +203,7 @@ test.describe('Imports Actions @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-007[3], IMP-031[0]
+    // spec: IMP-007.ignored-terminal-sticky-row, IMP-031.item-leaves-queue-counts-update
     test('should ignore candidate stickily', async ({ page, request }) => {
       await page.goto('/imports')
       await page.waitForLoadState('networkidle')
@@ -289,7 +289,7 @@ test.describe('Imports Actions @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-013[0], IMP-007[1], IMP-031[0]
+    // spec: IMP-013.any-curation-signal-imports, IMP-007.imported-marks-rows-resolved, IMP-031.item-leaves-queue-counts-update
     test('should link candidate to existing contact', async ({ page, request }) => {
       await page.goto('/imports')
       await page.waitForLoadState('networkidle')

--- a/frontend/tests/e2e/imports-correspondence.spec.ts
+++ b/frontend/tests/e2e/imports-correspondence.spec.ts
@@ -31,7 +31,7 @@ test.describe('Imports gmail_correspondence evidence @area:imports', () => {
     await testApi.cleanup()
   })
 
-  // spec: IMP-037[0], IMP-029[2], IMP-031[0]
+  // spec: IMP-037.evidence-badge-names-cooccurring, IMP-029.import-not-offered-link, IMP-031.item-leaves-queue-counts-update
   test('evidence badge renders, Import is hidden, and link adds the method', async ({
     page,
     request,

--- a/frontend/tests/e2e/imports-features.spec.ts
+++ b/frontend/tests/e2e/imports-features.spec.ts
@@ -32,7 +32,7 @@ test.describe('Imports Features @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-026[0]
+    // spec: IMP-026.people-tab-default-holds
     test('paginates the candidate list', async ({ page }) => {
       await page.goto('/imports')
       await page.waitForLoadState('domcontentloaded')
@@ -75,7 +75,7 @@ test.describe('Imports Features @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-029[1]
+    // spec: IMP-029.without-suggestion-link-action
     test('should show "Link (select)" when no suggested match', async ({ page }) => {
       // Seed an external contact with a unique name that won't match any CRM contact
       await testApi.seedExternalContacts([
@@ -97,7 +97,7 @@ test.describe('Imports Features @area:imports', () => {
       await expect(candidateCard.getByRole('button', { name: 'Link (select)' })).toBeVisible()
     })
 
-    // spec: IMP-029[0]
+    // spec: IMP-029.link-action-names-suggested
     test('should show suggested match with confidence percentage when present', async ({
       page,
     }) => {
@@ -136,7 +136,7 @@ test.describe('Imports Features @area:imports', () => {
       await expect(linkButton).toContainText('%')
     })
 
-    // spec: IMP-028[2]
+    // spec: IMP-028.suggested-match-when-present
     test('should pre-select suggested contact in link modal', async ({ page }) => {
       // Seed matching CRM contact and external contact
       await testApi.seedOverdueContacts([
@@ -192,7 +192,7 @@ test.describe('Imports Features @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-036[0]
+    // spec: IMP-036.username-appears-chip-deep
     test('shows @username chip on Telegram candidate card', async ({ page }) => {
       // Use a prefix-scoped handle so parallel test runs don't collide on the
       // link selector and so we can scope assertions to our card.
@@ -223,7 +223,7 @@ test.describe('Imports Features @area:imports', () => {
       await expect(handleLink).toHaveAttribute('href', `https://t.me/${telegramPath}`)
     })
 
-    // spec: IMP-036[1]
+    // spec: IMP-036.no-name-fields-username-used
     test('falls back to @username when no name is set on Telegram candidate', async ({ page }) => {
       const handle = `@dale_${testApi.prefix.replace(/-/g, '_')}`
 
@@ -252,7 +252,7 @@ test.describe('Imports Features @area:imports', () => {
     // A candidate with no source name fields must still be importable without
     // editing the name — the frontend sends the @handle as `name` explicitly,
     // because the backend can't derive it from display_name/first_name/last_name.
-    // spec: IMP-012[0], IMP-012[1]
+    // spec: IMP-012.crm-contact-created-normal-path, IMP-012.methods-come-from-selection
     test('imports a handle-only Telegram candidate without requiring a name edit', async ({
       page,
       request,
@@ -317,7 +317,7 @@ test.describe('Imports Features @area:imports', () => {
       expect(methods.some(m => m.type === 'telegram')).toBe(true)
     })
 
-    // spec: IMP-027[3]
+    // spec: IMP-027.methods-selectable-one-primary
     test('shows @username method in Link to Existing modal', async ({ page }) => {
       const handle = `@dale_${testApi.prefix.replace(/-/g, '_')}`
 

--- a/frontend/tests/e2e/imports-interactions.spec.ts
+++ b/frontend/tests/e2e/imports-interactions.spec.ts
@@ -67,7 +67,7 @@ test.describe('Imports Interactions tab @area:imports', () => {
     await testApi.resetMacHosts()
   })
 
-  // spec: IMP-026[1]
+  // spec: IMP-026.interactions-tab-holds-conflicts
   test('shows the attention badge and renders orphan cards on the Interactions tab', async ({
     page,
   }) => {
@@ -114,7 +114,7 @@ test.describe('Imports Interactions tab @area:imports', () => {
     expect(badgeCountAfter).toBe(badgeCount)
   })
 
-  // spec: IMP-026[1]
+  // spec: IMP-026.interactions-tab-holds-conflicts
   test('accepts ?tab=needs-attention as a transitional alias for Interactions', async ({
     page,
   }) => {
@@ -131,7 +131,7 @@ test.describe('Imports Interactions tab @area:imports', () => {
     await expect(page).toHaveURL(/tab=interactions/, { timeout: 15000 })
   })
 
-  // spec: IMP-031[0], IMP-026[1]
+  // spec: IMP-031.item-leaves-queue-counts-update, IMP-026.interactions-tab-holds-conflicts
   test('resolves the orphan via "Log as impromptu" (orphan_needs_review → linked_impromptu)', async ({
     page,
   }) => {
@@ -169,7 +169,7 @@ test.describe('Imports Interactions tab @area:imports', () => {
     await expect(headingB).toBeVisible()
   })
 
-  // spec: IMP-038[0], IMP-038[1]
+  // spec: IMP-038.session-card-present, IMP-038.one-time-session-param
   test('lands on the ?session deep-linked card and strips the one-time param', async ({ page }) => {
     await page.goto(`/imports?tab=interactions&session=${sessionB}`)
     await page.waitForLoadState('domcontentloaded')

--- a/frontend/tests/e2e/imports-link-invalidation.spec.ts
+++ b/frontend/tests/e2e/imports-link-invalidation.spec.ts
@@ -52,7 +52,7 @@ test.describe('Import link invalidates contact detail @area:imports', () => {
     await testApi.cleanup()
   })
 
-  // spec: IMP-040[0]
+  // spec: IMP-040.returning-detail-shows-method
   test("linked candidate's new method appears on the contact detail without a refresh", async ({
     page,
     request,

--- a/frontend/tests/e2e/imports-modal.spec.ts
+++ b/frontend/tests/e2e/imports-modal.spec.ts
@@ -82,7 +82,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-028[0]
+    // spec: IMP-028.position-pager-arrow-keys
     test('should navigate with arrow keys and the position pager', async ({ page }) => {
       const displayName = `${testApi.prefix}-Modal Test Contact A`
 
@@ -169,7 +169,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-027[4]
+    // spec: IMP-027.cadence-chosen-or-prefilled
     test('link mode pre-fills the cadence from the existing contact', async ({ page }) => {
       // Seed a candidate and a target contact with an existing cadence
       await testApi.seedExternalContacts([
@@ -216,7 +216,7 @@ test.describe('Imports Modal @area:imports', () => {
       await expect(cadenceSelect).toHaveValue('quarterly', { timeout: 5000 })
     })
 
-    // spec: IMP-027[4]
+    // spec: IMP-027.cadence-chosen-or-prefilled
     test('should update cadence when linking contact', async ({ page, request }) => {
       await testApi.seedExternalContacts([
         {
@@ -307,7 +307,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-027[2]
+    // spec: IMP-027.name-editable-empty-blocks
     test('should enter edit mode when clicking name', async ({ page }) => {
       // Seed a candidate
       await testApi.seedExternalContacts([
@@ -345,7 +345,7 @@ test.describe('Imports Modal @area:imports', () => {
       await expect(nameInput).toHaveValue(new RegExp(displayName))
     })
 
-    // spec: IMP-027[2], IMP-012[0], IMP-031[0]
+    // spec: IMP-027.name-editable-empty-blocks, IMP-012.crm-contact-created-normal-path, IMP-031.item-leaves-queue-counts-update
     test('should edit name and persist on import', async ({ page, request }) => {
       // Seed a candidate
       await testApi.seedExternalContacts([
@@ -427,7 +427,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-027[3]
+    // spec: IMP-027.methods-selectable-one-primary
     test('should only allow one primary method at a time', async ({ page }) => {
       // Seed a candidate with multiple contact methods
       await testApi.seedExternalContacts([
@@ -483,7 +483,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-027[4], IMP-031[0]
+    // spec: IMP-027.cadence-chosen-or-prefilled, IMP-031.item-leaves-queue-counts-update
     test('should import contact with selected cadence', async ({ page, request }) => {
       // Seed a candidate for this isolated test
       await testApi.seedExternalContacts([
@@ -556,7 +556,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-027[2]
+    // spec: IMP-027.name-editable-empty-blocks
     test('an empty name blocks resolution', async ({ page }) => {
       const { ids } = await testApi.seedExternalContacts([
         {
@@ -611,7 +611,7 @@ test.describe('Imports Modal @area:imports', () => {
       expect(importPosts).toBe(1)
     })
 
-    // spec: IMP-027[2]
+    // spec: IMP-027.name-editable-empty-blocks
     test('an unresolved telegram peer requires a name edit before import', async ({ page }) => {
       // An unresolved peer: telegram source with no name fields, no
       // username, and no methods. Hidden by default behind the opt-in
@@ -640,7 +640,7 @@ test.describe('Imports Modal @area:imports', () => {
       // The modal opens on the clicked card's peer (keyed by id); every
       // unresolved peer displays as "Unknown", so the import POST below is
       // additionally pinned to OUR external id and fails loudly on a mixup.
-      // spec: IMP-028[3]
+      // spec: IMP-028.card-opens-that-candidate
       await expectModalCandidate(page, 'Unknown')
 
       const modal = resolverDialog(page)
@@ -677,7 +677,7 @@ test.describe('Imports Modal @area:imports', () => {
       expect(importPosts).toBe(1)
     })
 
-    // spec: IMP-027[3]
+    // spec: IMP-027.methods-selectable-one-primary
     test('link mode disables already-present methods and offers additions', async ({ page }) => {
       // The CRM contact already carries email X; the candidate carries the
       // identical X, a same-type different-value email Z, and a phone Y.
@@ -743,7 +743,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-028[1]
+    // spec: IMP-028.modal-advances-to-next
     test('advances to the next candidate after resolving, closing only when the queue is exhausted', async ({
       page,
     }) => {
@@ -844,7 +844,7 @@ test.describe('Imports Modal @area:imports', () => {
       await testApi.cleanup()
     })
 
-    // spec: IMP-039[0], IMP-039[1], IMP-039[2], IMP-039[3]
+    // spec: IMP-039.pressing-escape-closes-modal, IMP-039.clicking-backdrop-closes-modal, IMP-039.cancel-action-closes-modal, IMP-039.dismissal-resolves-nothing
     test('Escape, backdrop, and Cancel dismiss without resolving', async ({ page, request }) => {
       const { ids } = await testApi.seedExternalContacts([
         {

--- a/frontend/tests/e2e/imports-name-candidates.spec.ts
+++ b/frontend/tests/e2e/imports-name-candidates.spec.ts
@@ -42,7 +42,7 @@ test.describe('Imports name candidates (anarlog_title) @area:imports', () => {
     await testApi.cleanup()
   })
 
-  // spec: IMP-026[3]
+  // spec: IMP-026.low-confidence-names-section
   test('renders the name-candidate section with the grouped token and evidence count', async ({
     page,
   }) => {
@@ -86,7 +86,7 @@ test.describe('Imports name candidates (anarlog_title) @area:imports', () => {
       }
     })
 
-  // spec: IMP-031[0]
+  // spec: IMP-031.item-leaves-queue-counts-update
   test('imports the whole token group as a new contact', async ({ page }) => {
     await page.goto('/imports')
     await page.waitForLoadState('domcontentloaded')
@@ -112,7 +112,7 @@ test.describe('Imports name candidates (anarlog_title) @area:imports', () => {
     await expect(page.getByText(display, { exact: true })).toHaveCount(0, { timeout: 10000 })
   })
 
-  // spec: IMP-031[0]
+  // spec: IMP-031.item-leaves-queue-counts-update
   test('links the token group to an existing contact', async ({ page }) => {
     const seeded = await testApi.seedContacts([{ full_name: 'Link Target Person' }])
     const targetName = `${testApi.prefix}-Link Target Person`
@@ -142,7 +142,7 @@ test.describe('Imports name candidates (anarlog_title) @area:imports', () => {
     await expect(page.getByText(display, { exact: true })).toHaveCount(0, { timeout: 10000 })
   })
 
-  // spec: IMP-031[0]
+  // spec: IMP-031.item-leaves-queue-counts-update
   test('ignores the token group via "Not a person"', async ({ page }) => {
     await page.goto('/imports')
     await page.waitForLoadState('domcontentloaded')

--- a/frontend/tests/e2e/imports-page.spec.ts
+++ b/frontend/tests/e2e/imports-page.spec.ts
@@ -13,7 +13,7 @@ test.describe('Imports Page @area:imports', () => {
     await testApi.cleanup()
   })
 
-  // spec: IMP-026[0]
+  // spec: IMP-026.people-tab-default-holds
   test('renders candidates confidence-ranked on the People tab', async ({ page }) => {
     // Two CRM contacts; the high external matches one on name AND email
     // (high confidence), the med external matches the other on name only
@@ -58,7 +58,7 @@ test.describe('Imports Page @area:imports', () => {
     expect(highIdx).toBeLessThan(medIdx)
   })
 
-  // spec: IMP-026[0]
+  // spec: IMP-026.people-tab-default-holds
   test('source filters expose selection state and scope the candidate request', async ({
     page,
   }) => {
@@ -101,7 +101,7 @@ test.describe('Imports Page @area:imports', () => {
     await expect(googleContacts).toHaveAttribute('aria-pressed', 'false')
   })
 
-  // spec: IMP-026[2]
+  // spec: IMP-026.manual-sync-triggers-offered
   test('manual sync triggers fire per-source sync requests', async ({ page }) => {
     // The sync buttons act on connected Google accounts — an external-provider
     // dependency — so mock the account list (sanctioned route-mock technique)

--- a/frontend/tests/e2e/imports-people.spec.ts
+++ b/frontend/tests/e2e/imports-people.spec.ts
@@ -14,7 +14,7 @@ test.describe('Imports People tab — Anarlog source @area:imports', () => {
     await testApi.cleanup()
   })
 
-  // spec: IMP-026[0]
+  // spec: IMP-026.people-tab-default-holds
   test('filters to anarlog_humans candidates via the Anarlog pill', async ({ page }) => {
     await testApi.seedExternalContacts([
       {

--- a/frontend/tests/e2e/imports-suggestions.spec.ts
+++ b/frontend/tests/e2e/imports-suggestions.spec.ts
@@ -21,7 +21,7 @@ test.describe('Imports suggestions surface @area:imports', () => {
     await testApi.cleanup()
   })
 
-  // spec: IMP-026[0], IMP-030[0], IMP-030[2], IMP-031[0], IMP-031[1]
+  // spec: IMP-026.people-tab-default-holds, IMP-030.target-fixed-no-selection, IMP-030.confirm-requires-one-method, IMP-031.item-leaves-queue-counts-update, IMP-031.dependent-surfaces-invalidated
   test('method-suggestion card appears at the top; Review confirms and clears it', async ({
     page,
   }) => {
@@ -73,7 +73,7 @@ test.describe('Imports suggestions surface @area:imports', () => {
     })
   })
 
-  // spec: IMP-030[2], IMP-031[0]
+  // spec: IMP-030.confirm-requires-one-method, IMP-031.item-leaves-queue-counts-update
   test('Dismiss removes the card and it does not return after reload', async ({ page }) => {
     const email = `dismiss-${testApi.prefix}@example.invalid`
     await testApi.seedMethodSuggestions({
@@ -97,7 +97,7 @@ test.describe('Imports suggestions surface @area:imports', () => {
     await expect(page.getByText(cardText)).toHaveCount(0, { timeout: 10000 })
   })
 
-  // spec: IMP-029[2], IMP-027[1]
+  // spec: IMP-029.import-not-offered-link, IMP-027.user-chooses-import-new
   test('link-only source hides Import on the card and in the modal', async ({ page }) => {
     // Seed a gmail_correspondence unmatched candidate (link-only source).
     await testApi.seedExternalContacts([
@@ -130,7 +130,7 @@ test.describe('Imports suggestions surface @area:imports', () => {
     await expect(page.getByRole('button', { name: /Link to Existing/i })).toHaveCount(0)
   })
 
-  // spec: IMP-013[0], IMP-027[3], IMP-031[0]
+  // spec: IMP-013.any-curation-signal-imports, IMP-027.methods-selectable-one-primary, IMP-031.item-leaves-queue-counts-update
   test('deselect-all link removes the candidate', async ({ page }) => {
     // Seed a CRM contact + a same-named candidate so the modal opens with the
     // contact auto-selected (suggested match). Use icloud_contacts (not

--- a/frontend/tests/e2e/meetings.spec.ts
+++ b/frontend/tests/e2e/meetings.spec.ts
@@ -92,18 +92,18 @@ test.describe('Meetings Component @area:meetings', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // Verify Meetings section exists
-    // spec: CAL-024[0]
+    // spec: CAL-024.meetings-section-shown-with-events
     await expect(page.getByRole('heading', { name: /Meetings/i })).toBeVisible()
     const region = meetingsRegion(page)
 
     // Verify filter tabs exist with live counts derived from the seeded data
-    // spec: CAL-025[0]
+    // spec: CAL-025.three-filters-all-upcoming
     await expect(region.getByRole('button', { name: /All \(4\)/i })).toBeVisible()
     await expect(region.getByRole('button', { name: /Upcoming \(2\)/i })).toBeVisible()
     await expect(region.getByRole('button', { name: /Past \(2\)/i })).toBeVisible()
 
     // By default (Upcoming tab pressed), only upcoming events should be visible
-    // spec: CAL-025[1]
+    // spec: CAL-025.upcoming-default-view
     await expect(region.getByRole('button', { name: /Upcoming \(2\)/i })).toHaveAttribute(
       'aria-pressed',
       'true'
@@ -142,7 +142,7 @@ test.describe('Meetings Component @area:meetings', () => {
     const region = meetingsRegion(page)
 
     // Click Upcoming filter: shows only the upcoming event
-    // spec: CAL-025[0]
+    // spec: CAL-025.three-filters-all-upcoming
     await region.getByRole('button', { name: /Upcoming \(1\)/i }).click()
     await expect(region.getByRole('button', { name: /Upcoming \(1\)/i })).toHaveAttribute(
       'aria-pressed',
@@ -153,7 +153,7 @@ test.describe('Meetings Component @area:meetings', () => {
 
     // Click Past filter: only the past-seeded event shows (the end-time
     // classification boundary itself is proven by the in-progress test below)
-    // spec: CAL-025[0]
+    // spec: CAL-025.three-filters-all-upcoming
     await region.getByRole('button', { name: /Past \(1\)/i }).click()
     await expect(region.getByRole('button', { name: /Past \(1\)/i })).toHaveAttribute(
       'aria-pressed',
@@ -163,7 +163,7 @@ test.describe('Meetings Component @area:meetings', () => {
     await expect(region.getByText(`${testApi.prefix}-Upcoming Event`)).not.toBeVisible()
 
     // The past meeting's card carries the past marker (scoped to that card)
-    // spec: CAL-026[3]
+    // spec: CAL-026.past-meeting-carries-past
     await expect(
       meetingCard(page, `${testApi.prefix}-Past Event`).getByText('Past', { exact: true })
     ).toBeVisible()
@@ -185,7 +185,7 @@ test.describe('Meetings Component @area:meetings', () => {
     // Cards render most-recent-first (days_ago 1, then 5, then 10) — a
     // different order than they were seeded in (10, 1, 5), so this proves
     // the sort rather than echoing insertion order
-    // spec: CAL-025[3]
+    // spec: CAL-025.past-meetings-ordered-most
     const cards = meetingCards(page)
     await expect(cards).toHaveCount(3)
     await expect(cards.nth(0)).toContainText(`${testApi.prefix}-Past Recent`)
@@ -229,7 +229,7 @@ test.describe('Meetings Component @area:meetings', () => {
 
     // The live counts split 1/1: the in-progress meeting stays upcoming, the
     // ended one is past — end time vs the frozen accelerated now decides
-    // spec: CAL-025[2]
+    // spec: CAL-025.meeting-classified-past-once
     await expect(region.getByRole('button', { name: /Upcoming \(1\)/i })).toBeVisible()
     await expect(region.getByRole('button', { name: /Past \(1\)/i })).toBeVisible()
 
@@ -282,19 +282,19 @@ test.describe('Meetings Component @area:meetings', () => {
     await expect(bareCard).toBeVisible()
 
     // Title, date, and start-to-end time range, computed from the API data
-    // spec: CAL-026[0]
+    // spec: CAL-026.shows-title-fallback-label
     await expect(detailedCard).toContainText(expectedDateTime(detailed!.start_time))
     await expect(detailedCard).toContainText(
       expectedTimeRange(detailed!.start_time, detailed!.end_time)
     )
 
     // Location shows only on the meeting that has one
-    // spec: CAL-026[1]
+    // spec: CAL-026.shows-location-when-meeting
     await expect(detailedCard.getByText(`${testApi.prefix}-Conference Room B`)).toBeVisible()
     await expect(bareCard.getByText(`${testApi.prefix}-Conference Room B`)).not.toBeVisible()
 
     // Attendee count shows only when the meeting has more than one attendee
-    // spec: CAL-026[2]
+    // spec: CAL-026.shows-attendee-count-only
     await expect(detailedCard.getByText('2 attendees')).toBeVisible()
     await expect(bareCard.getByText(/attendees/)).not.toBeVisible()
   })
@@ -329,7 +329,7 @@ test.describe('Meetings Component @area:meetings', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // The untitled event's card renders the fallback label
-    // spec: CAL-026[0]
+    // spec: CAL-026.shows-title-fallback-label
     await expect(
       meetingCards(page).getByRole('heading', { level: 4, name: 'Untitled Meeting' })
     ).toBeVisible()
@@ -352,7 +352,7 @@ test.describe('Meetings Component @area:meetings', () => {
     const region = meetingsRegion(page)
 
     // The linked meeting's title is a link opening in a new tab
-    // spec: CAL-027[0]
+    // spec: CAL-027.title-becomes-link-opens
     const meetingLink = region.getByRole('link', {
       name: new RegExp(`${testApi.prefix}-Meeting With Link`),
     })
@@ -364,7 +364,7 @@ test.describe('Meetings Component @area:meetings', () => {
     )
 
     // The meeting without a link renders its title as plain text, not a link
-    // spec: CAL-027[1]
+    // spec: CAL-027.meeting-without-link-renders
     await expect(region.getByText(`${testApi.prefix}-Meeting Without Link`)).toBeVisible()
     await expect(
       region.getByRole('link', { name: new RegExp(`${testApi.prefix}-Meeting Without Link`) })
@@ -379,14 +379,14 @@ test.describe('Meetings Component @area:meetings', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // Meetings section should not be visible with no events
-    // spec: CAL-024[1]
+    // spec: CAL-024.nothing-shown-without-events
     await expect(
       page.getByRole('heading', { name: `${testApi.prefix}-Meeting Test Contact` })
     ).toBeVisible()
     await expect(page.getByRole('heading', { name: /Meetings/i })).not.toBeVisible()
 
     // Even with events seeded, a failing events fetch renders nothing
-    // spec: CAL-024[1]
+    // spec: CAL-024.nothing-shown-without-events
     await testApi.seedCalendarEvents(contactId, [
       { title: 'Hidden Meeting', is_past: false, days_ahead: 3 },
     ])
@@ -421,18 +421,18 @@ test.describe('Meetings Component @area:meetings', () => {
 
     // Initially 10 of the 15 seeded events show, and the control's accessible
     // name reports the remainder derived from the data
-    // spec: CAL-028[0]
+    // spec: CAL-028.fixed-number-meetings-show
     await expect(region.getByRole('button', { name: /Load more \(5 remaining\)/i })).toBeVisible()
     await expect(meetingCards(page)).toHaveCount(10)
 
     // One activation exhausts the list: all 15 show and the control disappears
-    // spec: CAL-028[1]
+    // spec: CAL-028.each-activation-reveals-more
     await region.getByRole('button', { name: /Load more \(5 remaining\)/i }).click()
     await expect(meetingCards(page)).toHaveCount(15)
     await expect(region.getByRole('button', { name: /Load more/i })).not.toBeVisible()
 
     // Switching filters resets the reveal back to the initial page
-    // spec: CAL-028[2]
+    // spec: CAL-028.switching-filters-resets-reveal
     await region.getByRole('button', { name: /All \(15\)/i }).click()
     await expect(region.getByRole('button', { name: /Load more \(5 remaining\)/i })).toBeVisible()
     await expect(meetingCards(page)).toHaveCount(10)

--- a/frontend/tests/e2e/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation.spec.ts
@@ -8,7 +8,7 @@ test.describe('Navigation @area:navigation', () => {
   test('persistent nav links all five sections and marks the current one active', async ({
     page,
   }) => {
-    // spec: DSH-002[0], DSH-002[1]
+    // spec: DSH-002.wide-sm-viewports-links, DSH-002.link-matching-current-section
     // On EVERY primary surface, all five section links must be present with
     // their correct hrefs (DSH-002[0]), and the link matching the current
     // section must carry aria-current="page" while a non-current link does
@@ -42,7 +42,7 @@ test.describe('Navigation @area:navigation', () => {
   })
 
   test('clicking a nav link navigates to that section', async ({ page }) => {
-    // spec: DSH-002[0]
+    // spec: DSH-002.wide-sm-viewports-links
     // The href loop above proves the links point at the right routes; this
     // proves the click-through actually lands on the destination surface.
     await page.goto('/dashboard')
@@ -57,7 +57,7 @@ test.describe('Navigation @area:navigation', () => {
   })
 
   test('navigation remains visible when scrolling', async ({ page }) => {
-    // spec: DSH-002[2]
+    // spec: DSH-002.navigation-bar-stays-visible
     // Navigate to contacts page (has enough content to scroll)
     await page.goto('/contacts')
     await page.waitForLoadState('domcontentloaded')

--- a/frontend/tests/e2e/notepad.spec.ts
+++ b/frontend/tests/e2e/notepad.spec.ts
@@ -27,14 +27,14 @@ test.describe('Contact notepad @area:contacts', () => {
     page,
   }) => {
     // With no note seeded, the detail page renders no Notes row at all
-    // spec: NTS-007[0]
+    // spec: NTS-007.notepad-appears-only-with-content
     await page.goto(`/contacts/${contactId}`)
     await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
     await expect(notesRow(page)).toHaveCount(0)
 
     // A short note renders the row with its body, and no expand control
     // (the control appears only when the content overflows the clamp)
-    // spec: NTS-007[0], NTS-007[2]
+    // spec: NTS-007.notepad-appears-only-with-content, NTS-007.long-content-clamped-expand
     const shortNote = `${testApi.prefix} short note body`
     await testApi.seedContactNote(contactId, shortNote)
     await page.reload()
@@ -58,14 +58,14 @@ test.describe('Contact notepad @area:contacts', () => {
     await page.reload()
     await expect(notesRow(page)).toBeVisible({ timeout: 15000 })
 
-    // spec: NTS-007[2]
+    // spec: NTS-007.long-content-clamped-expand
     const expand = notesRow(page).getByRole('button', { name: /Show more/i })
     await expect(expand).toBeVisible()
     await expand.click()
     const collapse = notesRow(page).getByRole('button', { name: /Show less/i })
     await expect(collapse).toBeVisible()
 
-    // spec: NTS-007[1]
+    // spec: NTS-007.body-preserves-line-breaks
     const body = await notesRow(page).locator('dd > div').first().innerText()
     expect(body).toContain(firstParagraph)
     expect(body).toContain(lastParagraph)
@@ -113,7 +113,7 @@ test.describe('Contact notepad @area:contacts', () => {
 
     // The contact update has landed while the notepad save is still held
     // open — the edit form must still be on screen
-    // spec: NTS-008[0]
+    // spec: NTS-008.notepad-saved-own-operation
     const contactResponse = await contactPut
     expect(contactResponse.ok()).toBe(true)
     await expect(page.getByRole('button', { name: 'Update Contact' })).toBeVisible()
@@ -122,13 +122,13 @@ test.describe('Contact notepad @area:contacts', () => {
     releaseNotesPut()
     const notesResponse = await notesPut
     expect(notesResponse.ok()).toBe(true)
-    // spec: NTS-008[0]
+    // spec: NTS-008.notepad-saved-own-operation
     await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible({
       timeout: 15000,
     })
 
     // Both new values render after the save
-    // spec: NTS-008[2]
+    // spec: NTS-008.displayed-notepad-reflects-new
     await expect(page.getByRole('heading', { name: renamed })).toBeVisible()
     await expect(notesRow(page)).toContainText(noteBody)
   })
@@ -146,7 +146,7 @@ test.describe('Contact notepad @area:contacts', () => {
     await page.getByLabel('Notes').fill('')
 
     // An empty notepad submission deletes the note: the API answers 204
-    // spec: NTS-008[1]
+    // spec: NTS-008.clearing-notepad-field-removes
     const [notesResponse] = await Promise.all([
       page.waitForResponse(
         r =>
@@ -157,7 +157,7 @@ test.describe('Contact notepad @area:contacts', () => {
     expect(notesResponse.status()).toBe(204)
 
     // Back on the detail view, the Notes row is gone
-    // spec: NTS-008[1]
+    // spec: NTS-008.clearing-notepad-field-removes
     await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible({
       timeout: 15000,
     })

--- a/frontend/tests/e2e/overdue-contact-updates.spec.ts
+++ b/frontend/tests/e2e/overdue-contact-updates.spec.ts
@@ -66,7 +66,7 @@ test.describe('Overdue Contact Updates - With Seeded Data @area:overdue', () => 
     // mutual submission from a SEEDED-OVERDUE fixture, plus the outcome
     // unique to this entry point: the logged interaction clears the
     // contact's overdue state.
-    // spec: CON-053[0], CON-053[2]
+    // spec: CON-053.direction-chosen-outbound-inbound, CON-053.interaction-posted-chosen-direction
     const contactName = `${testApi.prefix}-Overdue Test Contact`
 
     // Seeded-data precondition: the contact renders as overdue on the
@@ -108,7 +108,7 @@ test.describe('Overdue Contact Updates - With Seeded Data @area:overdue', () => 
     page,
     request,
   }) => {
-    // spec: CAD-028[2], CAD-029[1]
+    // spec: CAD-028.change-consistent-across-dashboard, CAD-029.last-response-time-shown
     const contactName = `${testApi.prefix}-Overdue Test Contact`
 
     // A SENTINEL that stays overdue: its rendered card is the data-derived
@@ -231,7 +231,7 @@ test.describe('Overdue Contact Updates - Multiple Contacts @area:overdue', () =>
 
     // CAD-023[2] (the 1000-entry bound + most-overdue-retained truncation)
     // is waived in spec/cadence-followup.yaml: not E2E-seedable.
-    // spec: CAD-023[0], CAD-023[1]
+    // spec: CAD-023.each-entry-carries-contact, CAD-023.entries-ordered-most-overdue
     const overdueRes = await request.get(`${API_BASE_URL}/api/v1/contacts/overdue`, {
       headers: API_HEADERS,
     })

--- a/frontend/tests/e2e/rematch-on-add-email.spec.ts
+++ b/frontend/tests/e2e/rematch-on-add-email.spec.ts
@@ -31,7 +31,7 @@ test.describe('Rematch on add email @area:contacts', () => {
     // CAL-019[1] (past-projects/future-links split) and CAL-019[2] (processed
     // flag not reset) are waived in spec/calendar.yaml: both are backend
     // projection plumbing owned by rematch_integration_test.go.
-    // spec: CAL-019[0]
+    // spec: CAL-019.contact-appended-each-matching
     const attendeeEmail = `rematch-${Date.now()}@example.com`
 
     // Seed a contact with no email so the rematch handler has something to link to.

--- a/frontend/tests/e2e/settings-calendar.spec.ts
+++ b/frontend/tests/e2e/settings-calendar.spec.ts
@@ -85,7 +85,7 @@ test.describe('Settings calendar sync @area:settings', () => {
   // below matches the browser's rendering on any host.
   test.use({ locale: 'en-US', timezoneId: 'UTC' })
 
-  // spec: CAL-029[0]
+  // spec: CAL-029.sync-control-shows-state
   test('the calendar badge shows the sync state and triggers a sync for the account', async ({
     page,
   }) => {
@@ -123,7 +123,7 @@ test.describe('Settings calendar sync @area:settings', () => {
     expect(triggerRequest.postDataJSON()).toMatchObject({ account_id: ACCOUNT_ID })
   })
 
-  // spec: CAL-029[1]
+  // spec: CAL-029.triggered-sync-reports-started
   test('a triggered sync reports it started and the badge reflects the polled progress', async ({
     page,
   }) => {
@@ -160,7 +160,7 @@ test.describe('Settings calendar sync @area:settings', () => {
     await expect(syncButton).toBeDisabled()
   })
 
-  // spec: CAL-030[0]
+  // spec: CAL-030.staleness-banner-names-google
   test('a stalled calendar sync is named on the staleness banner', async ({ page }) => {
     await mockCalendarAccount(page)
     await mockSyncStates(page, [gcalSyncState()])
@@ -178,7 +178,7 @@ test.describe('Settings calendar sync @area:settings', () => {
     await expect(banner).toContainText('no successful sync in 2h')
   })
 
-  // spec: CAL-030[1]
+  // spec: CAL-030.banner-quiet-when-nothing-stalled
   test('the staleness banner stays quiet when nothing is stalled', async ({ page }) => {
     await mockCalendarAccount(page)
     await mockSyncStates(page, [gcalSyncState()])

--- a/frontend/tests/e2e/settings-mac.spec.ts
+++ b/frontend/tests/e2e/settings-mac.spec.ts
@@ -93,7 +93,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await expect(page.getByTestId('mac-host-row')).toHaveCount(0)
   })
 
-  // spec: MAC-018[3]
+  // spec: MAC-018.admin-can-mint-fresh
   test('opens pairing modal with a token when Pair new Mac is clicked', async ({ page }) => {
     // No host seeding or reset needed: the pairing modal works regardless
     // of how many hosts are listed (parallel workers may own one).
@@ -133,7 +133,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await expect(dialog).not.toBeVisible()
   })
 
-  // spec: MAC-018[0]
+  // spec: MAC-018.list-returns-live-hosts
   test('renders paired host with permissions and source-health badges', async ({
     page,
     request,
@@ -190,7 +190,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await deleteAllMacHosts(request)
   })
 
-  // spec: MAC-046[0]
+  // spec: MAC-046.backfill-complete-shows-count
   test('renders icloud_contacts contact count when backfill_complete (#327)', async ({
     page,
     request,
@@ -257,7 +257,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await deleteAllMacHosts(request)
   })
 
-  // spec: MAC-046[1]
+  // spec: MAC-046.backfill-in-progress-placeholder
   test('renders dash for icloud_contacts when backfill_complete is false (#327)', async ({
     page,
     request,
@@ -301,7 +301,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await deleteAllMacHosts(request)
   })
 
-  // spec: MAC-018[3]
+  // spec: MAC-018.admin-can-mint-fresh
   test('opens rotate-key modal with templated CLI command when Rotate Key is clicked', async ({
     page,
     request,
@@ -361,7 +361,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
     await deleteAllMacHosts(request)
   })
 
-  // spec: MAC-018[3], MAC-018[0]
+  // spec: MAC-018.admin-can-mint-fresh, MAC-018.list-returns-live-hosts
   test('uninstall flow removes a paired host', async ({ page, request }) => {
     await deleteAllMacHosts(request)
     await seedMacHost(request, { hostname: 'e2e-uninstall-me', protocol_version: 1 })

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -104,7 +104,7 @@ test.describe('Settings Page @area:settings', () => {
     ).toBeVisible({ timeout: 15_000 })
   })
 
-  // spec: SET-019[0], SET-023[0], SET-023[1]
+  // spec: SET-019.each-provider-section-shows-state, SET-023.section-shows-not-connected, SET-023.lists-required-configuration
   test('unconfigured providers collapse to a not-connected state with setup guidance', async ({
     page,
   }) => {
@@ -137,7 +137,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(todoist.getByText('TODOIST_CLIENT_SECRET')).toBeVisible()
   })
 
-  // spec: SET-019[1], SET-019[2]
+  // spec: SET-019.connected-account-shows-identity, SET-019.section-offers-connect-disconnect
   test('a connected account shows its identity, connect date, and manage affordances', async ({
     page,
   }) => {
@@ -159,7 +159,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(google.getByRole('button', { name: 'Disconnect e2e-google-user' })).toBeVisible()
   })
 
-  // spec: SET-020[0]
+  // spec: SET-020.app-fetches-provider-authorization
   test('connecting a provider fetches the auth URL and navigates to it', async ({ page }) => {
     await mockGoogleAccounts(page, null)
     // Stub the provider consent screen with a same-origin URL so the
@@ -187,7 +187,7 @@ test.describe('Settings Page @area:settings', () => {
     await page.waitForURL('**/settings?consent-stub=1', { timeout: 10_000 })
   })
 
-  // spec: SET-021[0], SET-021[2]
+  // spec: SET-021.success-outcome-shows-success, SET-021.one-time-outcome-parameters
   test('a success outcome shows a notification, refreshes accounts, and strips params', async ({
     page,
   }) => {
@@ -216,7 +216,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(page).toHaveURL('/settings', { timeout: 10_000 })
   })
 
-  // spec: SET-021[1], SET-021[2]
+  // spec: SET-021.error-outcome-shows-failure, SET-021.one-time-outcome-parameters
   test('an error outcome surfaces the failure reason and strips params', async ({ page }) => {
     await mockGoogleAccounts(page, [])
     await mockSyncStates(page, [])
@@ -231,7 +231,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(page).toHaveURL('/settings', { timeout: 10_000 })
   })
 
-  // spec: SET-022[0], SET-022[1]
+  // spec: SET-022.confirmation-identifies-account, SET-022.only-confirmation-account-revoked
   test('disconnect asks for confirmation and dismissing revokes nothing', async ({ page }) => {
     await mockGoogleAccounts(page, [googleAccount('e2e-google-user')])
     await mockSyncStates(page, [])
@@ -265,7 +265,7 @@ test.describe('Settings Page @area:settings', () => {
     expect(revokeCalled).toBe(false)
   })
 
-  // spec: SET-022[2]
+  // spec: SET-022.outcome-reported-account-list
   test('confirming a disconnect revokes the account and the list reflects removal', async ({
     page,
   }) => {
@@ -307,7 +307,7 @@ test.describe('Settings Page @area:settings', () => {
     })
   })
 
-  // spec: SET-024[0]
+  // spec: SET-024.per-source-sync-affordance
   test('per-source sync affordances follow the account scopes', async ({ page }) => {
     // Gmail + Calendar granted, Contacts omitted.
     await mockGoogleAccounts(page, [
@@ -327,7 +327,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(google.getByRole('button', { name: 'Sync Contacts' })).toHaveCount(0)
   })
 
-  // spec: SET-024[1]
+  // spec: SET-024.google-chat-affordance-appears
   test('the Chat affordance appears when all chat scopes are held', async ({ page }) => {
     await mockGoogleAccounts(page, [
       googleAccount('e2e-chat-user', { scopes: [GMAIL_SCOPE, ...CHAT_SCOPES] }),
@@ -343,7 +343,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(google.getByRole('button', { name: /Chat — reconnect required/ })).toHaveCount(0)
   })
 
-  // spec: SET-024[1]
+  // spec: SET-024.google-chat-affordance-appears
   test('a partial chat grant shows a reconnect prompt instead of the Chat affordance', async ({
     page,
   }) => {
@@ -361,7 +361,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(google.getByRole('button', { name: 'Sync Chat' })).toHaveCount(0)
   })
 
-  // spec: SET-025[0], SET-025[1]
+  // spec: SET-025.reconnect-affordance-appears-account, SET-025.prompt-suppressed-once-account
   test('an auth-errored sync surfaces a reconnect prompt only while the credential is stale', async ({
     page,
   }) => {
@@ -401,7 +401,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(google.getByRole('button', { name: 'Reconnect', exact: true })).toHaveCount(1)
   })
 
-  // spec: SET-026[0], SET-026[1], SET-026[2]
+  // spec: SET-026.project-label-pickers-offered, SET-026.selecting-project-label-persists, SET-026.both-project-and-label-required
   test('the Todoist configuration guides selecting a project and label', async ({ page }) => {
     await mockTodoistAccounts(page, [googleAccount('e2e-todoist-account')])
     await mockSyncStates(page, [])
@@ -464,7 +464,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(bothRequired).toHaveCount(0, { timeout: 10_000 })
   })
 
-  // spec: TDS-034[0], TDS-034[1]
+  // spec: TDS-034.sync-requested-account-success, TDS-034.read-write-permission-visible
   test('a manual Todoist task sync can be triggered with its outcome indicated', async ({
     page,
   }) => {
@@ -522,7 +522,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(todoist.getByText(/Failed to start sync/i)).toBeVisible({ timeout: 10_000 })
   })
 
-  // spec: SET-028[0], SET-028[1], SET-028[2]
+  // spec: SET-028.export-affordance-downloads-user, SET-028.import-affordance-accepts-backup, SET-028.import-not-yet-functional
   test('the backup surface exports a JSON download and validates an uploaded backup', async ({
     page,
   }) => {
@@ -562,7 +562,7 @@ test.describe('Settings Page @area:settings', () => {
     await expect(page.getByText(/without making changes/i)).toBeVisible()
   })
 
-  // spec: SET-035[0], SET-035[1]
+  // spec: SET-035.system-information-section-present, SET-035.non-empty-application-version
   test('the system information section reports a version', async ({ page }) => {
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')

--- a/frontend/tests/e2e/telegram-settings.spec.ts
+++ b/frontend/tests/e2e/telegram-settings.spec.ts
@@ -18,7 +18,7 @@ async function mockStatus(page: Page, data: Record<string, unknown>) {
 const telegramRegion = (page: Page) => page.getByRole('region', { name: 'Telegram' })
 
 test.describe('Telegram Settings @area:settings', () => {
-  // spec: SET-027[0]
+  // spec: SET-027.section-present-settings-surface
   test('shows Telegram section on settings page', async ({ page }) => {
     await page.goto('/settings')
     await page.waitForLoadState('domcontentloaded')
@@ -29,7 +29,7 @@ test.describe('Telegram Settings @area:settings', () => {
     })
   })
 
-  // spec: SET-027[1]
+  // spec: SET-027.not-configured-state-when-disabled
   test('not-configured backend collapses to configuration guidance', async ({ page }) => {
     // Force the not-configured branch deterministically: the section keys it
     // off a 404 from the status endpoint (telegram routes are not registered
@@ -57,7 +57,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(section.getByText('TELEGRAM_API_HASH')).toBeVisible()
   })
 
-  // spec: TGM-038[0]
+  // spec: TGM-038.starting-connect-reveals-phone
   test('auth flow: phone input shows on Connect click', async ({ page }) => {
     await mockStatus(page, { status: 'disconnected', connected: false })
 
@@ -77,7 +77,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
   })
 
-  // spec: TGM-038[1]
+  // spec: TGM-038.started-flow-advances-code
   test('auth flow: phone input → code input transition', async ({ page }) => {
     await mockStatus(page, { status: 'disconnected', connected: false })
 
@@ -123,7 +123,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByLabel('Verification Code')).toBeVisible()
   })
 
-  // spec: TGM-038[2]
+  // spec: TGM-038.valid-code-either-connects
   test('auth flow: code → connected transition', async ({ page }) => {
     await mockStatus(page, { status: 'disconnected', connected: false })
 
@@ -180,7 +180,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByRole('button', { name: /Disconnect/i })).toBeVisible()
   })
 
-  // spec: TGM-038[2], TGM-038[3]
+  // spec: TGM-038.valid-code-either-connects, TGM-038.valid-password-connects-account
   test('auth flow: code → 2FA → connected transition', async ({ page }) => {
     await mockStatus(page, { status: 'disconnected', connected: false })
 
@@ -252,7 +252,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByRole('button', { name: /Disconnect/i })).toBeVisible()
   })
 
-  // spec: TGM-038[4], TGM-039[0], TGM-039[2]
+  // spec: TGM-038.connected-state-shows-account, TGM-039.account-username-phone-number, TGM-039.disconnect-offered-and-confirmed
   test('shows connected state with username', async ({ page }) => {
     // Mock status as connected
     await mockStatus(page, {
@@ -275,7 +275,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByRole('button', { name: /Disconnect/i })).toBeVisible()
   })
 
-  // spec: TGM-039[2]
+  // spec: TGM-039.disconnect-offered-and-confirmed
   test('disconnect returns the section to the disconnected state', async ({ page }) => {
     // One handler covers DELETE /auth and GET /auth/status: the glob matches
     // both, so branch on method + path and route.fallback() anything else.
@@ -337,7 +337,7 @@ test.describe('Telegram Settings @area:settings', () => {
     })
   })
 
-  // spec: TGM-040[0], TGM-040[1]
+  // spec: TGM-040.failure-reason-shown-user, TGM-040.flow-stays-code-entry
   test('shows error on invalid code', async ({ page }) => {
     await mockStatus(page, { status: 'disconnected', connected: false })
 
@@ -390,7 +390,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByLabel('Verification Code')).toBeVisible()
   })
 
-  // spec: TGM-041[0]
+  // spec: TGM-041.discovered-group-chats-listed
   test('group chat management: shows chat list', async ({ page }) => {
     await mockStatus(page, { status: 'connected', connected: true, username: 'testuser' })
 
@@ -432,7 +432,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(section.getByText('25 members').first()).toBeVisible()
   })
 
-  // spec: TGM-041[1]
+  // spec: TGM-041.before-any-chats-discovered
   test('group chat management: empty state', async ({ page }) => {
     await mockStatus(page, { status: 'connected', connected: true, username: 'testuser' })
 
@@ -452,7 +452,7 @@ test.describe('Telegram Settings @area:settings', () => {
     })
   })
 
-  // spec: TGM-039[1]
+  // spec: TGM-039.backfill-progress-counts-shown
   test('group chat management: backfill progress', async ({ page }) => {
     await mockStatus(page, {
       status: 'connected',
@@ -478,7 +478,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(page.getByText(/Syncing messages.*15\/42/)).toBeVisible({ timeout: 10000 })
   })
 
-  // spec: TGM-041[2]
+  // spec: TGM-041.changing-tracking-choice-persists
   test('group chat management: toggle auto to ignored', async ({ page }) => {
     let currentStatus = 'auto'
     let currentTracked = true
@@ -545,7 +545,7 @@ test.describe('Telegram Settings @area:settings', () => {
     await expect(select).toHaveValue('ignored', { timeout: 5000 })
   })
 
-  // spec: TGM-041[2]
+  // spec: TGM-041.changing-tracking-choice-persists
   test('group chat management: toggle auto to tracked', async ({ page }) => {
     let currentStatus = 'auto'
 

--- a/spec/cadence-followup.yaml
+++ b/spec/cadence-followup.yaml
@@ -302,7 +302,7 @@ behaviors:
       - key: list-bounded-1000-truncation
         text: the list is bounded (1000), and truncation retains the most overdue contacts
     waivers:
-      - then: 2
+      - then: list-bounded-1000-truncation
         reason: the 1000-entry bound and most-overdue-retained truncation cannot be deterministically seeded in an E2E run; the bound is applied in ContactService.ListOverdueContacts and ordering-under-limit is proven by TestContactBy_ListOverdueContacts
     provenance: [ContactHandler.ListOverdueContacts, ContactService.ListOverdueContacts]
 

--- a/spec/cadence-followup.yaml
+++ b/spec/cadence-followup.yaml
@@ -295,9 +295,12 @@ behaviors:
     given: contacts past their next-contact date
     when: the overdue list is requested
     then:
-      - each entry carries the contact plus days overdue, the next due date, and a suggested action
-      - entries are ordered most-overdue first
-      - the list is bounded (1000), and truncation retains the most overdue contacts
+      - key: each-entry-carries-contact
+        text: each entry carries the contact plus days overdue, the next due date, and a suggested action
+      - key: entries-ordered-most-overdue
+        text: entries are ordered most-overdue first
+      - key: list-bounded-1000-truncation
+        text: the list is bounded (1000), and truncation retains the most overdue contacts
     waivers:
       - then: 2
         reason: the 1000-entry bound and most-overdue-retained truncation cannot be deterministically seeded in an E2E run; the bound is applied in ContactService.ListOverdueContacts and ordering-under-limit is proven by TestContactBy_ListOverdueContacts
@@ -327,9 +330,12 @@ behaviors:
     given: contacts past their next-contact date
     when: the dashboard renders
     then:
-      - overdue contacts appear as cards with the count in the header
-      - each card shows urgency (tiers at up to 2, up to 7, and more days overdue), cadence, how long since the last connection — or how long since the contact was added, when there has never been one — reachable contact methods, and the suggested action
-      - with nothing overdue, an all-caught-up state is shown instead
+      - key: overdue-contacts-appear-cards
+        text: overdue contacts appear as cards with the count in the header
+      - key: each-card-shows-urgency
+        text: each card shows urgency (tiers at up to 2, up to 7, and more days overdue), cadence, how long since the last connection — or how long since the contact was added, when there has never been one — reachable contact methods, and the suggested action
+      - key: nothing-overdue-all-caught
+        text: with nothing overdue, an all-caught-up state is shown instead
     serves: [DSH-010, DSH-011]
     provenance: [dashboard/page.tsx, OverdueContactCard, dashboard.spec.ts]
 
@@ -341,9 +347,12 @@ behaviors:
     given: an overdue list with several contacts
     when: the user switches the sort
     then:
-      - urgency (default) orders most-overdue first
-      - name orders alphabetically
-      - recency orders longest-waiting first, ranking never-connected contacts by when they were added
+      - key: urgency-default-orders-most
+        text: urgency (default) orders most-overdue first
+      - key: name-orders-alphabetically
+        text: name orders alphabetically
+      - key: recency-orders-longest-waiting
+        text: recency orders longest-waiting first, ranking never-connected contacts by when they were added
     serves: [DSH-010]
     provenance: [dashboard/page.tsx sort controls]
 
@@ -355,9 +364,12 @@ behaviors:
     given: an overdue contact card
     when: the user marks the contact as contacted
     then:
-      - a mutual interaction is logged, timestamped by the server's accelerated clock
-      - the contact leaves the overdue list without a page reload, and the count updates
-      - the change is consistent across dashboard, contact list, and contact detail
+      - key: mutual-interaction-logged-timestamped
+        text: a mutual interaction is logged, timestamped by the server's accelerated clock
+      - key: contact-leaves-overdue-list
+        text: the contact leaves the overdue list without a page reload, and the count updates
+      - key: change-consistent-across-dashboard
+        text: the change is consistent across dashboard, contact list, and contact detail
     serves: [DSH-010, DSH-012]
     provenance: [OverdueContactCard, overdue-contact-updates.spec.ts, dashboard.spec.ts]
     notes: The list-row variant of this action is CON-044.
@@ -370,10 +382,14 @@ behaviors:
     given: a contact detail page
     when: the recent-activity summary renders
     then:
-      - the last outreach time is shown when one exists
-      - the last response time is shown when one exists
-      - an awaiting-reply indicator is shown while a follow-up is pending
-      - with none of these, an explicit no-recent-activity state is shown
+      - key: last-outreach-time-shown
+        text: the last outreach time is shown when one exists
+      - key: last-response-time-shown
+        text: the last response time is shown when one exists
+      - key: awaiting-reply-indicator-shown
+        text: an awaiting-reply indicator is shown while a follow-up is pending
+      - key: explicit-no-recent-activity
+        text: with none of these, an explicit no-recent-activity state is shown
     serves: [CAD-036]
     provenance: ['contacts/[id]/page.tsx recent activity block', contact-direction.spec.ts]
 
@@ -385,10 +401,14 @@ behaviors:
     given: a contact with follow-up, manual, and completed tasks
     when: the tasks section renders
     then:
-      - managed follow-up tasks appear first with a distinct pending indicator, then live manual tasks
-      - each task carries a badge derived from its kind and lifecycle
-      - completed tasks are collapsed behind a toggle with a count
-      - with no tasks, an empty state invites adding one
+      - key: managed-tasks-appear-first
+        text: managed follow-up tasks appear first with a distinct pending indicator, then live manual tasks
+      - key: each-task-carries-badge
+        text: each task carries a badge derived from its kind and lifecycle
+      - key: completed-tasks-collapsed-behind
+        text: completed tasks are collapsed behind a toggle with a count
+      - key: no-tasks-empty-state
+        text: with no tasks, an empty state invites adding one
     serves: [CAD-036]
     provenance: [tasks-section.tsx, contact detail task queries]
     notes: A follow-up still in pending_remote_create is not listed in the section; during that window it surfaces only via the awaiting-reply indicator (CAD-029).
@@ -401,9 +421,12 @@ behaviors:
     given: the add-task flow on a contact
     when: the user creates a task
     then:
-      - the kind is chosen from reach-out, send, and reminder
-      - task text is required; notes are optional
-      - the created task appears in the contact's live tasks
+      - key: kind-chosen-reach-out
+        text: the kind is chosen from reach-out, send, and reminder
+      - key: task-text-required-notes
+        text: task text is required; notes are optional
+      - key: created-task-appears-contact
+        text: the created task appears in the contact's live tasks
     serves: [CAD-036]
     provenance: [add-task-modal.tsx, ContactTaskService.CreateManualTask]
 
@@ -415,9 +438,12 @@ behaviors:
     given: the contact task endpoints
     when: requests are handled
     then:
-      - task listing filters by state, kind, and lifecycle from their closed sets; invalid values are rejected (400) and an unknown contact is not-found (404)
-      - task creation requires a user-pickable kind and text (1-1000 chars, notes up to 5000), returning the created task (201)
-      - unlinking removes only the CRM link, returning no content (204), and is not-found (404) when the task does not belong to the contact
+      - key: task-listing-filters-state
+        text: task listing filters by state, kind, and lifecycle from their closed sets; invalid values are rejected (400) and an unknown contact is not-found (404)
+      - key: task-creation-requires-kind-text
+        text: task creation requires a user-pickable kind and text (1-1000 chars, notes up to 5000), returning the created task (201)
+      - key: unlinking-removes-only-crm
+        text: unlinking removes only the CRM link, returning no content (204), and is not-found (404) when the task does not belong to the contact
     provenance: [contact_task_routes.go, ContactTaskHandler]
 
   - id: CAD-033
@@ -428,8 +454,10 @@ behaviors:
     given: a task linked to a contact
     when: the user manages it from the CRM
     then:
-      - the CRM offers unlink behind a confirmation prompt; confirming removes the task from the CRM
-      - the linked task row offers no in-CRM complete or dismiss control — those happen in the remote task app
+      - key: unlink-behind-confirmation
+        text: the CRM offers unlink behind a confirmation prompt; confirming removes the task from the CRM
+      - key: no-in-crm-complete-or-dismiss
+        text: the linked task row offers no in-CRM complete or dismiss control — those happen in the remote task app
     provenance: [tasks-section.tsx TaskRow, useDeleteTaskLink]
 
   - id: CAD-034
@@ -466,8 +494,10 @@ behaviors:
     given: a task linked to a contact
     when: the user unlinks it from the CRM
     then:
-      - the CRM deletes only its own tracking row for the task
-      - no outbound call is made to the remote task provider — the remote task is untouched
+      - key: crm-deletes-only-own
+        text: the CRM deletes only its own tracking row for the task
+      - key: no-outbound-call-made
+        text: no outbound call is made to the remote task provider — the remote task is untouched
     provenance: [service/contact_task.go DeleteTaskLink]
     notes: The safe-remote-state guarantee formerly expressed as the judged intent CAD-037; moved to deterministic coverage (a backend integration test asserts zero outbound calls) per the QA-program rule that deterministic guarantees belong in tests, not the judge.
 

--- a/spec/calendar.yaml
+++ b/spec/calendar.yaml
@@ -255,9 +255,12 @@ behaviors:
     given: a contact who gains an email address that appears on stored events not yet linked to them
     when: a calendar rematch runs for that email
     then:
-      - the contact is appended to each matching event's matched set
-      - past confirmed events additionally project the contact's attendance, while future events are only linked
-      - the append does not reset the event's processed flag, so already-projected attendees are not re-emitted
+      - key: contact-appended-each-matching
+        text: the contact is appended to each matching event's matched set
+      - key: past-confirmed-events-additionally
+        text: past confirmed events additionally project the contact's attendance, while future events are only linked
+      - key: append-does-not-reset
+        text: the append does not reset the event's processed flag, so already-projected attendees are not re-emitted
     waivers:
       - then: 1
         reason: the past-projects/future-links split is backend projection plumbing with no browser-added coverage; proven deterministically by TestRematch_CalendarPastEvent_RecordsInteraction and TestRematch_CalendarFutureEvent_NoInteraction in rematch_integration_test.go
@@ -323,8 +326,10 @@ behaviors:
     given: a contact detail page
     when: the page renders
     then:
-      - a Meetings section is shown when the contact has at least one calendar event
-      - nothing is shown when the contact has no events or the events fail to load
+      - key: meetings-section-shown-with-events
+        text: a Meetings section is shown when the contact has at least one calendar event
+      - key: nothing-shown-without-events
+        text: nothing is shown when the contact has no events or the events fail to load
     provenance: [contacts detail page, components/contacts/meetings.tsx]
 
   - id: CAL-025
@@ -335,10 +340,14 @@ behaviors:
     given: a contact with a mix of upcoming and past meetings
     when: the Meetings section is used
     then:
-      - three filters — all, upcoming, and past — each show a live count
-      - upcoming is the default view
-      - a meeting is classified as past once its end time is before the app's accelerated current time
-      - past meetings are ordered most-recent-first
+      - key: three-filters-all-upcoming
+        text: three filters — all, upcoming, and past — each show a live count
+      - key: upcoming-default-view
+        text: upcoming is the default view
+      - key: meeting-classified-past-once
+        text: a meeting is classified as past once its end time is before the app's accelerated current time
+      - key: past-meetings-ordered-most
+        text: past meetings are ordered most-recent-first
     provenance: [components/contacts/meetings.tsx, useAcceleratedTime]
 
   - id: CAL-026
@@ -349,10 +358,14 @@ behaviors:
     given: a meeting in the Meetings section
     when: its card renders
     then:
-      - it shows the title (a fallback label when untitled), the date, and the start-to-end time range
-      - it shows a location when the meeting has one
-      - it shows an attendee count only when the meeting has more than one attendee
-      - a past meeting carries a past marker
+      - key: shows-title-fallback-label
+        text: it shows the title (a fallback label when untitled), the date, and the start-to-end time range
+      - key: shows-location-when-meeting
+        text: it shows a location when the meeting has one
+      - key: shows-attendee-count-only
+        text: it shows an attendee count only when the meeting has more than one attendee
+      - key: past-meeting-carries-past
+        text: a past meeting carries a past marker
     provenance: [components/contacts/meetings.tsx MeetingCard]
     notes: The visual de-emphasis of past cards (reduced opacity) is presentation quality owned by the agentic judge, deliberately not pinned as a then-item.
 
@@ -364,8 +377,10 @@ behaviors:
     given: a meeting card
     when: the meeting carries a source link
     then:
-      - the title becomes a link that opens the meeting in a new tab with an external-link affordance
-      - a meeting without a link renders as plain text
+      - key: title-becomes-link-opens
+        text: the title becomes a link that opens the meeting in a new tab with an external-link affordance
+      - key: meeting-without-link-renders
+        text: a meeting without a link renders as plain text
     provenance: [components/contacts/meetings.tsx html_link branch]
 
   - id: CAL-028
@@ -376,9 +391,12 @@ behaviors:
     given: a filtered meeting list longer than the initial page
     when: the user asks for more
     then:
-      - a fixed number of meetings show initially, with a control reporting how many remain
-      - each activation reveals more until the list is exhausted, when the control disappears
-      - switching filters resets the reveal back to the initial page
+      - key: fixed-number-meetings-show
+        text: a fixed number of meetings show initially, with a control reporting how many remain
+      - key: each-activation-reveals-more
+        text: each activation reveals more until the list is exhausted, when the control disappears
+      - key: switching-filters-resets-reveal
+        text: switching filters resets the reveal back to the initial page
     provenance: [components/contacts/meetings.tsx displayLimit]
 
   - id: CAL-029
@@ -389,8 +407,10 @@ behaviors:
     given: a connected Google account granted calendar access
     when: the settings account section renders
     then:
-      - a calendar sync control shows the account's current calendar sync state and lets the user trigger a sync on demand
-      - a triggered sync reports that it started and reflects progress or errors as the state polls
+      - key: sync-control-shows-state
+        text: a calendar sync control shows the account's current calendar sync state and lets the user trigger a sync on demand
+      - key: triggered-sync-reports-started
+        text: a triggered sync reports that it started and reflects progress or errors as the state polls
     provenance: [components/settings/google-accounts-section.tsx, hooks/use-sync-states.ts]
     notes: The OAuth connect and reconnect flows themselves are settings scope (SET); the reconnect-on-auth-failure prompt is SET-025 and the scope-gated visibility of this sync affordance is SET-024. This behavior covers only the calendar sync trigger and its state surface.
 
@@ -402,7 +422,9 @@ behaviors:
     given: the calendar sync has stalled past its watchdog threshold
     when: the settings page renders
     then:
-      - a staleness banner names Google Calendar among the stalled sources
-      - the banner stays quiet while loading or when nothing is stalled
+      - key: staleness-banner-names-google
+        text: a staleness banner names Google Calendar among the stalled sources
+      - key: banner-quiet-when-nothing-stalled
+        text: the banner stays quiet while loading or when nothing is stalled
     provenance: [components/sync-staleness-banner.tsx]
     notes: The watchdog that detects staleness is settings/ingest scope; this behavior covers only the calendar labeling on the banner.

--- a/spec/calendar.yaml
+++ b/spec/calendar.yaml
@@ -262,9 +262,9 @@ behaviors:
       - key: append-does-not-reset
         text: the append does not reset the event's processed flag, so already-projected attendees are not re-emitted
     waivers:
-      - then: 1
+      - then: past-confirmed-events-additionally
         reason: the past-projects/future-links split is backend projection plumbing with no browser-added coverage; proven deterministically by TestRematch_CalendarPastEvent_RecordsInteraction and TestRematch_CalendarFutureEvent_NoInteraction in rematch_integration_test.go
-      - then: 2
+      - then: append-does-not-reset
         reason: not re-emitting already-projected attendees is a negative with no browser surface; the append path's flag preservation is proven by TestRematch_AppendPreservesProcessedFlag and the upsert path's flag semantics by TestCalendarEventUpsertResetsLastContactedUpdated (Go integration tests)
     provenance: [CalendarRematchHandler.Rematch, AppendMatchedContact, FindEventsByAttendeeEmailUnmatchedForContact]
     notes: The rematch trigger and job dispatch are imports-matching scope — cross-reference IMP-019 and IMP-020.

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -13,7 +13,8 @@ behaviors:
     given: a create request with a full name and optionally a cadence
     when: the contact is created
     then:
-      - last_contacted is left unset — no contact has happened yet
+      - key: last-contacted-left-unset
+        text: last_contacted is left unset — no contact has happened yet
       - contact_by is computed from the cadence and the creation time
       - without a cadence, contact_by is unset
     provenance: [ContactService.CreateContact, createRequestToRepo, ContactRepository.CreateContact]
@@ -27,13 +28,20 @@ behaviors:
     given: a POST to the contacts collection
     when: the request is validated
     then:
-      - full_name is required, 1-255 characters
-      - location is limited to 255 characters and how_met to 500
-      - profile_photo must be a URL of at most 500 characters
-      - birthday must parse as a valid date
-      - cadence must be one of weekly, biweekly, monthly, quarterly, biannual, annual
-      - an invalid request is rejected with a validation error (400)
-      - a valid request creates the contact and returns it (201)
+      - key: full-name-required-bounded
+        text: full_name is required, 1-255 characters
+      - key: location-limited-255-characters
+        text: location is limited to 255 characters and how_met to 500
+      - key: profile-photo-must-url
+        text: profile_photo must be a URL of at most 500 characters
+      - key: birthday-must-parse-valid
+        text: birthday must parse as a valid date
+      - key: cadence-must-one-weekly
+        text: cadence must be one of weekly, biweekly, monthly, quarterly, biannual, annual
+      - key: invalid-request-rejected-validation
+        text: an invalid request is rejected with a validation error (400)
+      - key: valid-request-creates-contact
+        text: a valid request creates the contact and returns it (201)
     provenance: [ContactHandler.CreateContact, CreateContactRequest]
 
   - id: CON-003
@@ -66,9 +74,12 @@ behaviors:
     given: a GET for a single contact by id
     when: the contact is fetched
     then:
-      - a live contact is returned with a has_pending_followup flag
-      - an unknown or soft-deleted contact returns not-found (404)
-      - a malformed id returns a validation error (400)
+      - key: live-contact-flag
+        text: a live contact is returned with a has_pending_followup flag
+      - key: unknown-soft-deleted-contact
+        text: an unknown or soft-deleted contact returns not-found (404)
+      - key: malformed-id-returns-validation
+        text: a malformed id returns a validation error (400)
     provenance: [ContactHandler.GetContact, ContactTaskRepository.HasPendingFollowUp]
     notes: has_pending_followup is best-effort — a failure computing it logs and reports false rather than failing the read.
 
@@ -202,13 +213,20 @@ behaviors:
     given: a create request or a method operations request
     when: methods are validated
     then:
-      - blank-valued entries are dropped rather than rejected on the create path
-      - an add or update operation naming a blank value is rejected rather than dropped
-      - an add or update operation whose value is empty once normalized is rejected rather than stored
-      - email-family values must be valid email addresses
-      - phone-family values are limited to 50 characters
-      - two entries with the same type and normalized value are rejected as duplicates
-      - more than one entry marked primary is rejected
+      - key: blank-valued-entries-dropped
+        text: blank-valued entries are dropped rather than rejected on the create path
+      - key: blank-value-operation-rejected
+        text: an add or update operation naming a blank value is rejected rather than dropped
+      - key: empty-normalized-value-rejected
+        text: an add or update operation whose value is empty once normalized is rejected rather than stored
+      - key: email-family-values-valid
+        text: email-family values must be valid email addresses
+      - key: phone-family-values-limited
+        text: phone-family values are limited to 50 characters
+      - key: two-entries-same-type
+        text: two entries with the same type and normalized value are rejected as duplicates
+      - key: more-than-one-entry
+        text: more than one entry marked primary is rejected
     provenance: [normalizeContactMethodRequests, validateContactMethods, validateOperationShapes, buildContactMethodOperations]
     notes: >
       Format and duplicate rules are shared by all three paths; only blank
@@ -232,9 +250,12 @@ behaviors:
     given: a GET on the contacts collection
     when: pagination parameters are applied
     then:
-      - the default is page 1 with 20 rows
-      - the page size is capped at 1000
-      - the response meta reports the total filtered row count and page count
+      - key: default-page-1-20-rows
+        text: the default is page 1 with 20 rows
+      - key: page-size-capped-1000
+        text: the page size is capped at 1000
+      - key: response-meta-reports-total
+        text: the response meta reports the total filtered row count and page count
     provenance: [ListContactsQuery, BuildPaginationMeta]
 
   - id: CON-018
@@ -245,11 +266,16 @@ behaviors:
     given: a GET on the contacts collection with sort or filter parameters
     when: parameters are validated
     then:
-      - sort accepts name, location, birthday, last_contacted, last_response_at, contact_by, cadence
-      - order accepts asc and desc
-      - cadence_filter accepts has_cadence and no_cadence
-      - followup_filter accepts has_followup and no_followup
-      - anything else is rejected with a validation error (400)
+      - key: sort-accepts-name-location
+        text: sort accepts name, location, birthday, last_contacted, last_response_at, contact_by, cadence
+      - key: order-accepts-asc-desc
+        text: order accepts asc and desc
+      - key: cadence-filter-closed-set
+        text: cadence_filter accepts has_cadence and no_cadence
+      - key: followup-filter-closed-set
+        text: followup_filter accepts has_followup and no_followup
+      - key: anything-else-rejected-validation
+        text: anything else is rejected with a validation error (400)
     provenance: [ListContactsQuery, ContactHandler.ListContacts]
     notes: sort=last_contacted is accepted by the API but no list column currently exposes it in the UI.
 
@@ -485,9 +511,12 @@ behaviors:
     given: a GET of the merge preview for a source/target pair
     when: the preview is computed
     then:
-      - it reports methods to transfer (net of duplicates), duplicate methods skipped, notes, interactions, and calendar events affected
-      - a missing source or target returns not-found (404)
-      - a missing or malformed source id returns a validation error (400)
+      - key: preview-reports-affected-counts
+        text: it reports methods to transfer (net of duplicates), duplicate methods skipped, notes, interactions, and calendar events affected
+      - key: missing-source-target
+        text: a missing source or target returns not-found (404)
+      - key: missing-malformed-source-id
+        text: a missing or malformed source id returns a validation error (400)
     provenance: [ContactHandler.GetMergePreview, MergePreviewResponse]
 
   # --- Surfaces (list page, detail, navigation, birthdays) ---
@@ -500,8 +529,10 @@ behaviors:
     given: no explicit sort has been chosen
     when: the contact list renders and a contact is opened from it
     then:
-      - the list defaults to cadence order, most frequent first
-      - the detail page's prev/next navigation uses the same default
+      - key: list-defaults-cadence-order
+        text: the list defaults to cadence order, most frequent first
+      - key: detail-prev-next-same-default
+        text: the detail page's prev/next navigation uses the same default
     serves: [CON-051]
     provenance: [DEFAULT_SORT_FIELD/DEFAULT_SORT_ORDER, contacts page, contact detail listContext]
 
@@ -522,10 +553,14 @@ behaviors:
     given: a contact detail page opened from a list
     when: keyboard input is used outside form fields
     then:
-      - left/right arrows move to the previous/next contact, disabled at the boundaries
-      - arrows are inert while editing or while focus is in an input
-      - Enter opens edit mode
-      - Escape discards edit mode, or returns to the list (context preserved) when not editing
+      - key: left-right-arrows-move
+        text: left/right arrows move to the previous/next contact, disabled at the boundaries
+      - key: arrows-inert-while-editing
+        text: arrows are inert while editing or while focus is in an input
+      - key: enter-opens-edit-mode
+        text: Enter opens edit mode
+      - key: escape-discards-edit-mode
+        text: Escape discards edit mode, or returns to the list (context preserved) when not editing
     serves: [CON-051]
     provenance: [ContactNavigationBar, use-keyboard-navigation.ts, contact-navigation.spec.ts]
 
@@ -537,8 +572,10 @@ behaviors:
     given: a detail URL carrying a one-time action parameter (edit or merge)
     when: the page mounts
     then:
-      - the action runs once (edit mode opens, or the merge modal opens)
-      - the parameter is stripped from the URL so refresh or back-navigation does not re-trigger it
+      - key: action-runs-once-edit
+        text: the action runs once (edit mode opens, or the merge modal opens)
+      - key: parameter-stripped-from-url
+        text: the parameter is stripped from the URL so refresh or back-navigation does not re-trigger it
     serves: [CON-051]
     provenance: [contact detail action-param effect, .ai/rules/core.md one-time action gotcha]
 
@@ -550,9 +587,12 @@ behaviors:
     given: a contact detail page
     when: the user asks to delete the contact
     then:
-      - a confirmation prompt warns the action cannot be undone
-      - only on confirmation is the contact deleted
-      - on success the user is returned to the contact list
+      - key: confirmation-prompt-warns-action
+        text: a confirmation prompt warns the action cannot be undone
+      - key: only-confirmation-contact-deleted
+        text: only on confirmation is the contact deleted
+      - key: success-user-returned-contact
+        text: on success the user is returned to the contact list
     serves: [CON-050]
     provenance: [contact detail handleDeleteContact, useDeleteContact]
 
@@ -564,13 +604,20 @@ behaviors:
     given: a merge started from a contact (detail button or list action)
     when: the merge modal is used
     then:
-      - the current contact is marked as kept; the user picks a source to archive from a searchable selector that excludes the target
-      - selecting a source loads a preview of what will transfer
-      - conflicting fields (cadence, location, birthday) offer a source/target toggle defaulting to keep the target's value
-      - the merged name is editable, with a quick-fill to adopt the source's name
-      - the merge cannot be submitted before a source is selected, while the preview is loading, or while a merge is in flight
-      - the outcome is reported and auto-dismissed
-      - the modal can be dismissed without performing a merge
+      - key: current-contact-marked-kept
+        text: the current contact is marked as kept; the user picks a source to archive from a searchable selector that excludes the target
+      - key: selecting-source-loads-preview
+        text: selecting a source loads a preview of what will transfer
+      - key: conflicting-fields-cadence-location
+        text: conflicting fields (cadence, location, birthday) offer a source/target toggle defaulting to keep the target's value
+      - key: merged-name-editable
+        text: the merged name is editable, with a quick-fill to adopt the source's name
+      - key: merge-cannot-submit-until-ready
+        text: the merge cannot be submitted before a source is selected, while the preview is loading, or while a merge is in flight
+      - key: outcome-reported-auto-dismissed
+        text: the outcome is reported and auto-dismissed
+      - key: modal-dismissed-without-merging
+        text: the modal can be dismissed without performing a merge
     serves: [CON-050]
     provenance: [merge-contact-modal.tsx, use-merge.ts, contact-merge.spec.ts]
 
@@ -582,7 +629,8 @@ behaviors:
     given: a contact row in the list
     when: the user marks it as contacted via the row actions
     then:
-      - a mutual-direction interaction is logged, timestamped by the server
+      - key: mutual-direction-interaction-logged
+        text: a mutual-direction interaction is logged, timestamped by the server
     provenance: [contacts page handleMarkAsContacted, useCreateInteraction]
 
   - id: CON-045
@@ -593,11 +641,16 @@ behaviors:
     given: contacts with birthdays, some with a placeholder year
     when: the birthdays page renders
     then:
-      - contacts are grouped into today, upcoming, and already-celebrated-this-year sections
-      - a gift-planning section for early next year appears only near year end
-      - upcoming birthdays sort soonest-first; celebrated ones sink to the end
-      - placeholder-year birthdays display without an age
-      - the page follows the app's accelerated time
+      - key: contacts-grouped-into-today
+        text: contacts are grouped into today, upcoming, and already-celebrated-this-year sections
+      - key: gift-planning-near-year-end
+        text: a gift-planning section for early next year appears only near year end
+      - key: upcoming-birthdays-sort-soonest
+        text: upcoming birthdays sort soonest-first; celebrated ones sink to the end
+      - key: placeholder-year-birthdays-no-age
+        text: placeholder-year birthdays display without an age
+      - key: page-follows-accelerated-time
+        text: the page follows the app's accelerated time
     serves: [CON-052]
     provenance: [birthdays/page.tsx, birthdays.spec.ts, isPlaceholderBirthday]
     notes: Month/day-only birthdays are stored with a placeholder year (1900) — the sentinel drives the age suppression.
@@ -622,10 +675,14 @@ behaviors:
     given: a PUT for an existing contact
     when: the request is handled
     then:
-      - field validation follows the same rules as create (name required and bounded, cadence from the closed set)
-      - an invalid request is rejected with a validation error (400)
-      - an unknown or soft-deleted contact returns not-found (404)
-      - a valid request returns the updated contact (200)
+      - key: field-validation-matches-create
+        text: field validation follows the same rules as create (name required and bounded, cadence from the closed set)
+      - key: invalid-request-rejected-validation
+        text: an invalid request is rejected with a validation error (400)
+      - key: unknown-soft-deleted-contact
+        text: an unknown or soft-deleted contact returns not-found (404)
+      - key: valid-request-returns-updated
+        text: a valid request returns the updated contact (200)
     provenance: [ContactHandler.UpdateContact, UpdateContactRequest]
     notes: >
       Methods are not validated on this path: a methods key on the update body
@@ -640,10 +697,14 @@ behaviors:
     given: a DELETE for a contact
     when: the request is handled
     then:
-      - a malformed id returns a validation error (400)
-      - an unknown or already-deleted contact returns not-found (404)
-      - a successful delete returns no content (204) with an empty body
-      - no hard-delete operation is exposed through the API
+      - key: malformed-id-returns-validation
+        text: a malformed id returns a validation error (400)
+      - key: unknown-already-deleted-contact
+        text: an unknown or already-deleted contact returns not-found (404)
+      - key: successful-delete-returns-204
+        text: a successful delete returns no content (204) with an empty body
+      - key: no-hard-delete-operation
+        text: no hard-delete operation is exposed through the API
     provenance: [ContactHandler.DeleteContact]
     notes: Delete persistence semantics in CON-010.
 
@@ -669,9 +730,12 @@ behaviors:
     given: a contact detail page
     when: the user logs an interaction through the Log Interaction modal
     then:
-      - a direction is chosen from outbound, inbound, and mutual, defaulting to mutual
-      - an optional backdated date can be set for the interaction
-      - the interaction is posted with the chosen direction and the modal closes on success
+      - key: direction-chosen-outbound-inbound
+        text: a direction is chosen from outbound, inbound, and mutual, defaulting to mutual
+      - key: optional-backdated-date
+        text: an optional backdated date can be set for the interaction
+      - key: interaction-posted-chosen-direction
+        text: the interaction is posted with the chosen direction and the modal closes on success
     provenance: [log-interaction-modal.tsx, contacts.spec.ts Log Interaction tests]
     notes: Direction-aware cadence timestamp math (which columns each direction bumps) is CAD-006, backend-owned.
 
@@ -683,8 +747,10 @@ behaviors:
     given: the contact list
     when: a cadence filter option is selected
     then:
-      - has-cadence and no-cadence selections drive a cadence_filter list query and only matching rows remain
-      - clearing the filter restores the unfiltered list
+      - key: has-cadence-no-cadence
+        text: has-cadence and no-cadence selections drive a cadence_filter list query and only matching rows remain
+      - key: clearing-filter-restores-unfiltered
+        text: clearing the filter restores the unfiltered list
     provenance: [contacts page cadence filter select, ListContacts cadence_filter]
 
   - id: CON-055
@@ -695,7 +761,8 @@ behaviors:
     given: the new-contact form
     when: it is submitted with a full name
     then:
-      - the contact is created and the user lands on its detail page
+      - key: contact-created-user-lands
+        text: the contact is created and the user lands on its detail page
     provenance: [contacts/new page, useCreateContact]
 
   - id: CON-056
@@ -706,9 +773,12 @@ behaviors:
     given: a contact with several methods across types
     when: the detail page renders
     then:
-      - the contact's methods are displayed with normalized values
-      - the primary method is marked, and only one method carries the mark
-      - a method type without an external link surface (such as Google Chat) renders its value as plain text with its type label, not as a link
+      - key: methods-displayed-normalized
+        text: the contact's methods are displayed with normalized values
+      - key: primary-method-marked-only
+        text: the primary method is marked, and only one method carries the mark
+      - key: no-link-surface-plain-text
+        text: a method type without an external link surface (such as Google Chat) renders its value as plain text with its type label, not as a link
     provenance: ["contacts/[id]/page.tsx methods block", getPrimaryAndSecondaryMethods, getContactMethodHref]
     notes: Identifier normalization rules themselves are CON-012, backend-owned.
 
@@ -720,7 +790,8 @@ behaviors:
     given: the contact list
     when: a sortable column header is clicked
     then:
-      - the list refetches with that column's sort field, toggling the direction on repeated clicks
+      - key: list-refetches-column-sort-field
+        text: the list refetches with that column's sort field, toggling the direction on repeated clicks
     serves: [CON-051]
     provenance: [contacts page handleSort, ListContacts ORDER BY ladder]
 
@@ -732,10 +803,14 @@ behaviors:
     given: a contact list spanning multiple pages
     when: the pagination controls are used
     then:
-      - page-number buttons move between pages, with the current page marked
-      - the previous/next controls disable at the list boundaries
-      - the current page is reflected in the list URL, so a deep-linked or refreshed list restores that same page
-      - a URL asking for a page past the end of a non-empty list (stale deep-link or a shrunk result set) clamps to the last valid page rather than stranding the user on an empty list
+      - key: page-number-buttons-move
+        text: page-number buttons move between pages, with the current page marked
+      - key: previous-next-controls-disable
+        text: the previous/next controls disable at the list boundaries
+      - key: current-page-reflected-in-url
+        text: the current page is reflected in the list URL, so a deep-linked or refreshed list restores that same page
+      - key: page-past-end-clamps
+        text: a URL asking for a page past the end of a non-empty list (stale deep-link or a shrunk result set) clamps to the last valid page rather than stranding the user on an empty list
     provenance: [pagination.tsx, contacts page]
 
   - id: CON-059
@@ -746,8 +821,10 @@ behaviors:
     given: a contact detail page opened with list context
     when: the navigation bar's prev/next buttons are clicked
     then:
-      - the buttons move to the adjacent contact in the carried list order
-      - a position indicator reports the contact's place in the list
+      - key: buttons-move-adjacent-contact
+        text: the buttons move to the adjacent contact in the carried list order
+      - key: position-indicator-reports-contact
+        text: a position indicator reports the contact's place in the list
     serves: [CON-051]
     provenance: [ContactNavigationBar, useContactIDs]
     notes: The keyboard half of detail traversal is CON-040; this row covers the on-screen buttons so CON-040's then-list (and its citing tests' indexes) stays untouched.
@@ -760,7 +837,8 @@ behaviors:
     given: a contact detail page opened with sort, order, and search context
     when: the user moves to an adjacent contact
     then:
-      - the sort, order, and search context is carried in the destination URL
+      - key: sort-order-search-context
+        text: the sort, order, and search context is carried in the destination URL
     serves: [CON-051]
     provenance: [buildContactDetailUrl, contact detail listContext]
     notes: The current-status half of CON-039, which stays proposed for the tie-determinism claim.
@@ -773,8 +851,10 @@ behaviors:
     given: the contact list
     when: rows render
     then:
-      - a contact's cadence renders as its formatted label
-      - a contact with a computed next-contact date renders that date, and one without renders a placeholder
+      - key: cadence-renders-formatted-label
+        text: a contact's cadence renders as its formatted label
+      - key: next-contact-date-or-placeholder
+        text: a contact with a computed next-contact date renders that date, and one without renders a placeholder
     provenance: [contacts page table cells, formatCadence, contact_by]
     notes: The contact_by computation itself is backend-owned (CON-001); this row pins only the list's rendering of the derived values.
 
@@ -786,13 +866,20 @@ behaviors:
     given: a contact edit form opened on a contact that has contact methods
     when: the user edits and saves
     then:
-      - a method added by another writer since the form opened is still present after the save, including when the user edited a different method in the same save
-      - a method the user explicitly deleted in the form is removed
-      - if part of the save fails, the user is told which parts were saved rather than being shown a generic failure
-      - retrying after a partial failure does not undo what already saved
-      - a method added in a save whose later step failed can still be removed by a follow-up save
-      - a method added in a save whose later step failed can still be edited by a follow-up save, keeping the same method
-      - reverting a method's value after a partially failed save restores the original value on the server
+      - key: method-added-another-writer
+        text: a method added by another writer since the form opened is still present after the save, including when the user edited a different method in the same save
+      - key: method-user-explicitly-deleted
+        text: a method the user explicitly deleted in the form is removed
+      - key: partial-failure-names-saved-parts
+        text: if part of the save fails, the user is told which parts were saved rather than being shown a generic failure
+      - key: retrying-after-partial-failure
+        text: retrying after a partial failure does not undo what already saved
+      - key: partial-save-add-can-be-removed
+        text: a method added in a save whose later step failed can still be removed by a follow-up save
+      - key: partial-save-add-can-be-edited
+        text: a method added in a save whose later step failed can still be edited by a follow-up save, keeping the same method
+      - key: reverting-method-value-restores
+        text: reverting a method's value after a partially failed save restores the original value on the server
     provenance: [deriveMethodOperations, ContactMethodService.ApplyOperations]
     notes: >
       The form derives operations against a client-known acknowledged state,
@@ -814,9 +901,12 @@ behaviors:
     given: an update request for an existing contact
     when: the request body carries a methods key
     then:
-      - the request is rejected, naming the operations endpoint that does accept methods
-      - an explicit null and an empty list are rejected the same as a populated list
-      - none of the request's other fields are applied
+      - key: request-rejected-naming-operations
+        text: the request is rejected, naming the operations endpoint that does accept methods
+      - key: explicit-null-empty-list
+        text: an explicit null and an empty list are rejected the same as a populated list
+      - key: no-other-fields-applied
+        text: none of the request's other fields are applied
     provenance: [ContactHandler.UpdateContact, legacyContactMethodsProbe]
     notes: >
       Rejected rather than ignored. Dropping the now-unknown key would let a
@@ -834,20 +924,34 @@ behaviors:
     given: a contact with existing methods
     when: a method operations request is applied
     then:
-      - a method that no operation names is neither removed nor altered, except that promoting a primary demotes the previous primary
-      - the whole request applies in one transaction, or none of it applies
-      - the outcome does not depend on the order operations appear in the request
-      - adding a method that already exists succeeds without duplicating it
-      - removing a method that is already absent succeeds
-      - a request whose resulting method set would contain a duplicate type and value is rejected
-      - a request designating more than one primary is rejected
-      - an operation naming a method id owned by a different contact is rejected
-      - a named primary can be cleared, leaving the contact with no primary
-      - a request whose operations conflict with each other is rejected rather than resolved by their order
-      - updating a method's value takes effect even when the change does not alter how the value is normalized
-      - updating the primary method's value leaves it still the primary
-      - the response reports one result for every operation the request submitted, in the same order
-      - each result identifies the method its operation addressed, and reports the resulting method's stored state when the operation leaves one
+      - key: unnamed-method-untouched
+        text: a method that no operation names is neither removed nor altered, except that promoting a primary demotes the previous primary
+      - key: whole-request-applies-atomically
+        text: the whole request applies in one transaction, or none of it applies
+      - key: outcome-not-order-dependent
+        text: the outcome does not depend on the order operations appear in the request
+      - key: adding-method-already-exists
+        text: adding a method that already exists succeeds without duplicating it
+      - key: removing-method-already-absent
+        text: removing a method that is already absent succeeds
+      - key: duplicate-resulting-set-rejected
+        text: a request whose resulting method set would contain a duplicate type and value is rejected
+      - key: multiple-primaries-rejected
+        text: a request designating more than one primary is rejected
+      - key: operation-naming-method-id
+        text: an operation naming a method id owned by a different contact is rejected
+      - key: named-primary-can-be-cleared
+        text: a named primary can be cleared, leaving the contact with no primary
+      - key: request-whose-operations-conflict
+        text: a request whose operations conflict with each other is rejected rather than resolved by their order
+      - key: updating-method-value-takes-effect
+        text: updating a method's value takes effect even when the change does not alter how the value is normalized
+      - key: updating-primary-keeps-primary
+        text: updating the primary method's value leaves it still the primary
+      - key: response-reports-one-result
+        text: the response reports one result for every operation the request submitted, in the same order
+      - key: each-result-identifies-method
+        text: each result identifies the method its operation addressed, and reports the resulting method's stored state when the operation leaves one
     provenance: [ContactMethodService.ApplyOperations, ContactMethodHandler.ApplyOperations]
     notes: >
       The first then-item is the acceptance bar for the lost-update defect: a
@@ -871,8 +975,10 @@ behaviors:
     given: a contact detail page opened from a filtered, sorted, or searched list
     when: the user returns to the list via the visible back control or the keyboard
     then:
-      - a visible return-to-list control returns to the contact list with the sort, order, search, and filter context preserved
-      - returning lands on the list page that contains the contact that was open, rather than page 1
+      - key: visible-return-list-control
+        text: a visible return-to-list control returns to the contact list with the sort, order, search, and filter context preserved
+      - key: returning-lands-list-page
+        text: returning lands on the list page that contains the contact that was open, rather than page 1
     serves: [CON-051]
     provenance: [ContactNavigationBar back control, buildBackToListUrl, 'contacts page ?page URL sync', contact-navigation.spec.ts, '.ai/spec/2026-07-21-contact-list-back-navigation-design.md']
 
@@ -884,7 +990,8 @@ behaviors:
     given: the contact list showing a page other than the first
     when: the sort, order, search, or a filter is changed
     then:
-      - the list returns to the first page rather than carrying the prior page position into the new view
+      - key: list-returns-first-page
+        text: the list returns to the first page rather than carrying the prior page position into the new view
     provenance: [contacts page applyContext/handleSearchInput, buildContactListUrl page arg]
 
   # --- Intents (judged experience goals — Track B agentic judge only) ---

--- a/spec/dashboard.yaml
+++ b/spec/dashboard.yaml
@@ -85,11 +85,11 @@ behaviors:
       - key: refocus-refetches-only-when-stale
         text: returning focus to the window re-checks freshness, but refetches only once the list has gone stale (a 5-minute staleTime); refocusing sooner does not refetch
     waivers:
-      - then: 1
+      - then: covers-logging-interaction-merging
         reason: the per-flow freshness matrix is not deterministically provable in one browser test (documented at the DSH verifier→E2E migration); holistic freshness is judged under DSH-012
-      - then: 2
+      - then: purely-cosmetic-contact-edits
         reason: proving a negative (no refetch on a cosmetic edit) means asserting the absence of a background request — inherently racy in a browser test; judge-owned under DSH-012
-      - then: 3
+      - then: refocus-refetches-only-when-stale
         reason: the 5-minute staleTime gate depends on wall-clock query staleness the E2E harness cannot control deterministically; judge-owned under DSH-012
     serves: [DSH-012]
     provenance: [query-invalidation.ts overdue invalidation rules, use-contacts.ts useOverdueContacts]

--- a/spec/dashboard.yaml
+++ b/spec/dashboard.yaml
@@ -11,7 +11,8 @@ behaviors:
     given: the application root is opened
     when: the entry route resolves
     then:
-      - the user is taken to the dashboard as the default destination
+      - key: user-taken-dashboard-default
+        text: the user is taken to the dashboard as the default destination
     serves: [DSH-011]
     provenance: [app/page.tsx, dashboard.spec.ts]
     notes: The dashboard's overdue content is CAD-026; this behavior only pins that the dashboard is where the app opens. A former second clause pinned the redirect's interim presentation (not broken/blank while resolving); the maintainer retired it at the first label session — the interim is imperceptibly brief in practice, so its presentation is not worth pinning at item level. Interim-surface quality remains judgeable holistically under the DSH-011 intent this behavior serves.
@@ -24,9 +25,12 @@ behaviors:
     given: any primary application surface, including the dashboard
     when: the global navigation renders
     then:
-      - at wide (>= sm) viewports, links to the dashboard, contacts, birthdays, imports, and settings sections are present
-      - the link matching the current section is visually marked active
-      - the navigation bar stays visible while the page scrolls (sticky)
+      - key: wide-sm-viewports-links
+        text: at wide (>= sm) viewports, links to the dashboard, contacts, birthdays, imports, and settings sections are present
+      - key: link-matching-current-section
+        text: the link matching the current section is visually marked active
+      - key: navigation-bar-stays-visible
+        text: the navigation bar stays visible while the page scrolls (sticky)
     provenance: [components/layout/navigation.tsx, dashboard.spec.ts]
     notes: The bar also hosts a time-acceleration control and an aggregate sync-status indicator on the imports link — those belong to the settings and imports domains respectively. The birthdays surface itself is CON-045. App-shell nav renders on every primary surface, not only the dashboard; it is captured here because no dedicated navigation domain exists. Scoped to wide (>= sm) viewports deliberately — at narrow (below-sm) widths the link list is hidden (`hidden sm:flex`) and collapses to a menu button that is currently non-functional (no open/close state, no menu panel rendered), so navigation is not reachable on mobile. That mobile gap is a known bug, not claimed as working here.
 
@@ -38,8 +42,10 @@ behaviors:
     given: the dashboard is open
     when: the surface renders in any state
     then:
-      - an add-contact action is always available from the header
-      - the caught-up state additionally offers a path to add a contact and to view the full contact list
+      - key: add-contact-action-always
+        text: an add-contact action is always available from the header
+      - key: caught-up-offers-add-and-list
+        text: the caught-up state additionally offers a path to add a contact and to view the full contact list
     serves: [DSH-011]
     provenance: [dashboard/page.tsx header CTA, EmptyState]
     notes: The caught-up (all-clear) state itself is CAD-026; this pins the follow-on affordances it offers.
@@ -52,9 +58,12 @@ behaviors:
     given: the overdue widget is loading or its request has failed
     when: the dashboard renders
     then:
-      - while loading, placeholder content is shown rather than an empty or caught-up state
-      - on request failure, an error state with a failure reason is shown rather than an empty or caught-up state
-      - the shown failure reason faithfully reflects the actual failure
+      - key: while-loading-placeholder-content
+        text: while loading, placeholder content is shown rather than an empty or caught-up state
+      - key: request-failure-error-state
+        text: on request failure, an error state with a failure reason is shown rather than an empty or caught-up state
+      - key: shown-failure-reason-faithfully
+        text: the shown failure reason faithfully reflects the actual failure
     serves: [DSH-011]
     provenance: [dashboard/page.tsx loading and error branches]
     notes: The populated and caught-up states are CAD-026; this fills the loading and error states CAD does not cover.
@@ -67,10 +76,14 @@ behaviors:
     given: an open dashboard whose overdue list has been fetched
     when: an action elsewhere changes who is overdue
     then:
-      - the overdue list refreshes to reflect the change without a manual page reload
-      - this covers logging an interaction, merging contacts, and resolving a meeting note that touches a contact's cadence
-      - purely cosmetic contact edits that do not change overdue membership do not disturb the list
-      - returning focus to the window re-checks freshness, but refetches only once the list has gone stale (a 5-minute staleTime); refocusing sooner does not refetch
+      - key: overdue-list-refreshes-reflect
+        text: the overdue list refreshes to reflect the change without a manual page reload
+      - key: covers-logging-interaction-merging
+        text: this covers logging an interaction, merging contacts, and resolving a meeting note that touches a contact's cadence
+      - key: purely-cosmetic-contact-edits
+        text: purely cosmetic contact edits that do not change overdue membership do not disturb the list
+      - key: refocus-refetches-only-when-stale
+        text: returning focus to the window re-checks freshness, but refetches only once the list has gone stale (a 5-minute staleTime); refocusing sooner does not refetch
     waivers:
       - then: 1
         reason: the per-flow freshness matrix is not deterministically provable in one browser test (documented at the DSH verifier→E2E migration); holistic freshness is judged under DSH-012
@@ -102,8 +115,10 @@ behaviors:
     given: a user wanting to find a contact by text
     when: they look for a search affordance
     then:
-      - contact text search is provided through the contact list's search input
-      - no dedicated dashboard-level or app-global search surface exists (no top-bar search box or command palette)
+      - key: contact-text-search-provided
+        text: contact text search is provided through the contact list's search input
+      - key: no-global-search-surface
+        text: no dedicated dashboard-level or app-global search surface exists (no top-bar search box or command palette)
     provenance: [components/layout/navigation.tsx, contacts/page.tsx search input, contacts-api.ts]
     notes: Full-text matching semantics and relevance ordering are CON-023; this behavior records that the domain's "search" scope resolves to the contact list rather than a distinct surface, so the boundary is explicit.
 

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -89,10 +89,14 @@ behaviors:
     given: an external contact row
     when: its match status changes
     then:
-      - unmatched rows await review in the queue
-      - imported marks rows resolved with human curation (import-as-new, or a curated link)
-      - matched marks rows linked without curation (bare link, or source auto-match)
-      - ignored is terminal and sticky; the row never resurfaces in the queue
+      - key: unmatched-rows-await-review
+        text: unmatched rows await review in the queue
+      - key: imported-marks-rows-resolved
+        text: imported marks rows resolved with human curation (import-as-new, or a curated link)
+      - key: matched-marks-rows-linked
+        text: matched marks rows linked without curation (bare link, or source auto-match)
+      - key: ignored-terminal-sticky-row
+        text: ignored is terminal and sticky; the row never resurfaces in the queue
     provenance: [external_contact match_status CHECK, LinkContact curated signal, Ignore]
     notes: imported-vs-matched is the discriminator that drives auto-propagate vs suggest in reconciliation (IMP-017) — imported means a human curated the method set.
     waivers:
@@ -148,10 +152,14 @@ behaviors:
     given: an import request for a candidate
     when: the request is validated
     then:
-      - an already-processed candidate is rejected (400)
-      - a link-only source is forbidden from importing (403), enforced server-side
-      - an import without a name is rejected (400)
-      - an unknown candidate is not-found (404)
+      - key: already-processed-candidate-rejected
+        text: an already-processed candidate is rejected (400)
+      - key: link-only-source-forbidden
+        text: a link-only source is forbidden from importing (403), enforced server-side
+      - key: import-without-name-rejected
+        text: an import without a name is rejected (400)
+      - key: unknown-candidate-not-found
+        text: an unknown candidate is not-found (404)
     provenance: [ImportContact guards, IsLinkOnlySource]
 
   - id: IMP-012
@@ -162,10 +170,14 @@ behaviors:
     given: a valid import of an unmatched candidate
     when: the import runs
     then:
-      - a CRM contact is created through the normal creation path (person node, knowledge routing, methods)
-      - methods come from the user's selection when provided, else from the external record
-      - the candidate row is marked imported and linked to the new contact
-      - the response reports the new contact and a rematch job id
+      - key: crm-contact-created-normal-path
+        text: a CRM contact is created through the normal creation path (person node, knowledge routing, methods)
+      - key: methods-come-from-selection
+        text: methods come from the user's selection when provided, else from the external record
+      - key: candidate-row-marked-imported
+        text: the candidate row is marked imported and linked to the new contact
+      - key: response-reports-new-contact
+        text: the response reports the new contact and a rematch job id
     provenance: [ImportContact, buildMethodsFromSelection, BuildMethodsFromExternal]
 
   - id: IMP-013
@@ -176,8 +188,10 @@ behaviors:
     given: a link of a candidate to an existing contact
     when: the link is recorded
     then:
-      - any curation signal (method selection, conflict resolution, cadence, name, or an explicit curated flag) marks the row imported
-      - a bare link with no curation marks the row matched
+      - key: any-curation-signal-imports
+        text: any curation signal (method selection, conflict resolution, cadence, name, or an explicit curated flag) marks the row imported
+      - key: bare-link-no-curation
+        text: a bare link with no curation marks the row matched
     provenance: [LinkContact curated signal, EnrichContactFromExternalWithSelections]
     notes: Method-value conflicts neither block nor prompt today — a same-type different-value method is simply offered as an addition (IMP-027) — and the server does not reject links over conflicts; conflict resolutions still count as a curation signal at the API level.
     waivers:
@@ -242,10 +256,14 @@ behaviors:
     given: pending method suggestions on a linked external contact
     when: the user resolves or dismisses them
     then:
-      - resolve confirms the requested methods (or all when unspecified), adds them via enrichment, and clears them from pending
-      - dismiss is sticky per method (type and value) and appends to the dismissed set
-      - entries already on the contact or no longer offered by the source are pruned without being dismissed
-      - actions re-check live state under lock and tolerate repeats; a soft-deleted contact reports gone (410)
+      - key: resolve-confirms-requested-methods
+        text: resolve confirms the requested methods (or all when unspecified), adds them via enrichment, and clears them from pending
+      - key: dismiss-sticky-per-method
+        text: dismiss is sticky per method (type and value) and appends to the dismissed set
+      - key: stale-entries-pruned-not-dismissed
+        text: entries already on the contact or no longer offered by the source are pruned without being dismissed
+      - key: actions-re-check-live
+        text: actions re-check live state under lock and tolerate repeats; a soft-deleted contact reports gone (410)
     provenance: [ResolveMethodSuggestions, DismissMethodSuggestions, ErrSuggestionContactGone]
 
   # --- Rematch ---
@@ -258,9 +276,12 @@ behaviors:
     given: new methods appearing on a CRM contact (create, a method operations request, enrichment, or suggestion resolve)
     when: the write commits
     then:
-      - a rematch event is published for the methods that have a registered handler
-      - the caller receives the rematch job id
-      - no job is minted when no handler covers any of the methods
+      - key: rematch-event-published-methods
+        text: a rematch event is published for the methods that have a registered handler
+      - key: caller-receives-rematch-job
+        text: the caller receives the rematch job id
+      - key: no-job-minted-without-handler
+        text: no job is minted when no handler covers any of the methods
     provenance: [rematchRegistry.EligibleMethods, contact_methods.added publishers, RematchDispatcher]
 
   - id: IMP-020
@@ -301,9 +322,12 @@ behaviors:
     given: pending method suggestions and unmatched candidates
     when: the suggestions feed is requested
     then:
-      - method suggestions ride on top as a group (first page only)
-      - contact candidates follow, confidence-ranked and paginated
-      - each candidate declares its server-decided allowed actions
+      - key: method-suggestions-ride-top
+        text: method suggestions ride on top as a group (first page only)
+      - key: contact-candidates-follow-confidence
+        text: contact candidates follow, confidence-ranked and paginated
+      - key: each-candidate-declares-server
+        text: each candidate declares its server-decided allowed actions
     provenance: [GET /imports/suggestions, SuggestionItem, buildMethodSuggestionItems]
 
   - id: IMP-023
@@ -358,10 +382,14 @@ behaviors:
     given: pending imports and interaction reviews
     when: the imports page renders
     then:
-      - a People tab (default) holds method suggestions on top, then confidence-ranked candidates with source filters and pagination
-      - an Interactions tab holds conflicts and orphans, with an attention badge counting only those (discovery items excluded)
-      - manual sync triggers are offered for contact and calendar sources
-      - a low-confidence names section appears at the bottom only when title-derived tokens exist
+      - key: people-tab-default-holds
+        text: a People tab (default) holds method suggestions on top, then confidence-ranked candidates with source filters and pagination
+      - key: interactions-tab-holds-conflicts
+        text: an Interactions tab holds conflicts and orphans, with an attention badge counting only those (discovery items excluded)
+      - key: manual-sync-triggers-offered
+        text: manual sync triggers are offered for contact and calendar sources
+      - key: low-confidence-names-section
+        text: a low-confidence names section appears at the bottom only when title-derived tokens exist
     provenance: [imports/page.tsx, SubTabs, NameCandidateSection]
 
   - id: IMP-027
@@ -372,11 +400,16 @@ behaviors:
     given: a candidate opened for resolution
     when: the modal renders
     then:
-      - everything is one scrollable view — no multi-step wizard
-      - the user chooses import-as-new or link-to-existing; link-only sources are locked to link
-      - the name is editable inline, and an empty name blocks resolution; an unresolved telegram peer requires a name edit before import
-      - methods are individually selectable with at most one marked primary; link mode distinguishes to-add from already-present methods (already-present ones cannot be re-selected), and a same-type different-value method is offered as an addition alongside the CRM value
-      - a cadence can be chosen; link mode pre-fills it from the existing contact
+      - key: everything-one-scrollable-view
+        text: everything is one scrollable view — no multi-step wizard
+      - key: user-chooses-import-new
+        text: the user chooses import-as-new or link-to-existing; link-only sources are locked to link
+      - key: name-editable-empty-blocks
+        text: the name is editable inline, and an empty name blocks resolution; an unresolved telegram peer requires a name edit before import
+      - key: methods-selectable-one-primary
+        text: methods are individually selectable with at most one marked primary; link mode distinguishes to-add from already-present methods (already-present ones cannot be re-selected), and a same-type different-value method is offered as an addition alongside the CRM value
+      - key: cadence-chosen-or-prefilled
+        text: a cadence can be chosen; link mode pre-fills it from the existing contact
     provenance: [suggestion-modal.tsx, method-selector.tsx, detectMethodConflicts]
     notes: A conflict-resolution affordance (keep-CRM vs use-external toggle) exists in the code but is currently unreachable — the detector never emits a conflict state.
     waivers:
@@ -391,10 +424,14 @@ behaviors:
     given: several candidates in the queue
     when: the modal is open
     then:
-      - a position pager and arrow keys (inert while typing) move between candidates independent of list pagination (bounded at 1000 candidates)
-      - after resolving a candidate the modal advances to the next one, closing only when the queue is exhausted
-      - the suggested match, when present, is pre-selected in link mode
-      - opening a candidate from its card opens that candidate — the modal tracks it by id, not list position, so while it remains in the queue a background list refetch or reorder cannot swap in a different candidate (once it is resolved and gone, the modal advances in place as above)
+      - key: position-pager-arrow-keys
+        text: a position pager and arrow keys (inert while typing) move between candidates independent of list pagination (bounded at 1000 candidates)
+      - key: modal-advances-to-next
+        text: after resolving a candidate the modal advances to the next one, closing only when the queue is exhausted
+      - key: suggested-match-when-present
+        text: the suggested match, when present, is pre-selected in link mode
+      - key: card-opens-that-candidate
+        text: opening a candidate from its card opens that candidate — the modal tracks it by id, not list position, so while it remains in the queue a background list refetch or reorder cannot swap in a different candidate (once it is resolved and gone, the modal advances in place as above)
     provenance: [ContactCandidateResolver pager, currentId tracking]
 
   - id: IMP-029
@@ -405,9 +442,12 @@ behaviors:
     given: a candidate with a suggested match
     when: its card renders
     then:
-      - the link action names the suggested contact with its confidence percentage
-      - without a suggestion, the link action asks the user to select a contact
-      - import is not offered on link-only sources
+      - key: link-action-names-suggested
+        text: the link action names the suggested contact with its confidence percentage
+      - key: without-suggestion-link-action
+        text: without a suggestion, the link action asks the user to select a contact
+      - key: import-not-offered-link
+        text: import is not offered on link-only sources
     provenance: [CandidateCard, sourceAllowsImport]
 
   - id: IMP-030
@@ -418,9 +458,12 @@ behaviors:
     given: a pending method suggestion opened for review
     when: the resolver renders
     then:
-      - the target contact is fixed — no contact selection, no import mode
-      - methods already on the contact are shown disabled
-      - confirming requires at least one selected method; dismissing dismisses all pending ones stickily
+      - key: target-fixed-no-selection
+        text: the target contact is fixed — no contact selection, no import mode
+      - key: methods-already-contact-shown
+        text: methods already on the contact are shown disabled
+      - key: confirm-requires-one-method
+        text: confirming requires at least one selected method; dismissing dismisses all pending ones stickily
     provenance: [method-suggestion-resolver.tsx]
     waivers:
       - then: 1
@@ -434,9 +477,12 @@ behaviors:
     given: a resolution action on any review surface (import, link, ignore, suggestion, conflict, orphan, name token)
     when: the action succeeds
     then:
-      - the item leaves its queue and dependent counts update immediately
-      - dependent surfaces refresh through query invalidation scoped to the action (queue surfaces always; contact surfaces as affected by the action)
-      - a returned rematch job is registered for polling
+      - key: item-leaves-queue-counts-update
+        text: the item leaves its queue and dependent counts update immediately
+      - key: dependent-surfaces-invalidated
+        text: dependent surfaces refresh through query invalidation scoped to the action (queue surfaces always; contact surfaces as affected by the action)
+      - key: returned-rematch-job-registered
+        text: a returned rematch job is registered for polling
     provenance: [query-invalidation.ts import events, use-imports.ts]
 
   - id: IMP-036
@@ -447,8 +493,10 @@ behaviors:
     given: a telegram candidate carrying a username
     when: its card renders
     then:
-      - the @username appears as a chip deep-linking to the t.me profile
-      - when the candidate has no name fields the @username becomes the display name and the chip is suppressed
+      - key: username-appears-chip-deep
+        text: the @username appears as a chip deep-linking to the t.me profile
+      - key: no-name-fields-username-used
+        text: when the candidate has no name fields the @username becomes the display name and the chip is suppressed
     provenance: [imports/page.tsx CandidateCard telegram chip, getCandidateDisplayName]
 
   - id: IMP-037
@@ -459,7 +507,8 @@ behaviors:
     given: a gmail-correspondence candidate with correspondence metadata
     when: its card renders
     then:
-      - an evidence badge names the co-occurring contact and shows the message count
+      - key: evidence-badge-names-cooccurring
+        text: an evidence badge names the co-occurring contact and shows the message count
     provenance: [imports/page.tsx CandidateCard correspondenceLabel, gmail_correspondence metadata]
 
   - id: IMP-038
@@ -470,8 +519,10 @@ behaviors:
     given: a deep link into the imports page carrying a session id
     when: the Interactions tab loads with the session param
     then:
-      - the session's card is present on the Interactions tab
-      - the one-time session param is stripped from the URL so a refresh does not re-trigger the highlight
+      - key: session-card-present
+        text: the session's card is present on the Interactions tab
+      - key: one-time-session-param
+        text: the one-time session param is stripped from the URL so a refresh does not re-trigger the highlight
     provenance: [imports/page.tsx sessionParam effect, InteractionsTab highlightedSession]
     notes: The scroll-into-view and highlight styling are judge-owned presentation; the deterministic contract is card-present plus param-strip.
 
@@ -483,10 +534,14 @@ behaviors:
     given: a candidate open in the resolution modal
     when: the user dismisses it without resolving
     then:
-      - pressing Escape closes the modal
-      - clicking the backdrop closes the modal
-      - the Cancel action closes the modal
-      - dismissal resolves nothing — the candidate stays unmatched in its queue, and an uncommitted name edit is discarded
+      - key: pressing-escape-closes-modal
+        text: pressing Escape closes the modal
+      - key: clicking-backdrop-closes-modal
+        text: clicking the backdrop closes the modal
+      - key: cancel-action-closes-modal
+        text: the Cancel action closes the modal
+      - key: dismissal-resolves-nothing
+        text: dismissal resolves nothing — the candidate stays unmatched in its queue, and an uncommitted name edit is discarded
     provenance: [suggestion-modal.tsx onClose paths, Escape keydown handler, handleCancelNameEdit]
 
   - id: IMP-040
@@ -497,7 +552,8 @@ behaviors:
     given: a contact whose detail view has already been viewed in this session
     when: an import candidate is linked to that contact, adding a method
     then:
-      - returning to the contact's detail view shows the newly added method, with no manual refresh or hard reload
+      - key: returning-detail-shows-method
+        text: returning to the contact's detail view shows the newly added method, with no manual refresh or hard reload
     provenance: ['invalidationRules import:linked', 'useLinkCandidate onSuccess']
     notes: >
       The detail view is cached for five minutes in production, so the linked

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -100,7 +100,7 @@ behaviors:
     provenance: [external_contact match_status CHECK, LinkContact curated signal, Ignore]
     notes: imported-vs-matched is the discriminator that drives auto-propagate vs suggest in reconciliation (IMP-017) — imported means a human curated the method set.
     waivers:
-      - then: 2
+      - then: matched-marks-rows-linked
         reason: the matched (uncurated bare-link) state needs a link with NO curation signal — a zero-method candidate against a cadence-less contact with the name untouched — a degenerate path the modal offers no stable affordance for; the discriminator is owned by the Go integration test TestLinkContact_Bare_LandsMatched
 
   - id: IMP-008
@@ -195,7 +195,7 @@ behaviors:
     provenance: [LinkContact curated signal, EnrichContactFromExternalWithSelections]
     notes: Method-value conflicts neither block nor prompt today — a same-type different-value method is simply offered as an addition (IMP-027) — and the server does not reject links over conflicts; conflict resolutions still count as a curation signal at the API level.
     waivers:
-      - then: 1
+      - then: bare-link-no-curation
         reason: a bare link (no method curation, no cadence, no name change) is a degenerate UI path — the modal curates whenever the candidate offers methods or the contact carries a cadence to pre-fill; owned by the Go integration test TestLinkContact_Bare_LandsMatched
 
   - id: IMP-014
@@ -413,7 +413,7 @@ behaviors:
     provenance: [suggestion-modal.tsx, method-selector.tsx, detectMethodConflicts]
     notes: A conflict-resolution affordance (keep-CRM vs use-external toggle) exists in the code but is currently unreachable — the detector never emits a conflict state.
     waivers:
-      - then: 0
+      - then: everything-one-scrollable-view
         reason: single-view/no-wizard is a structural-absence property with no deterministic observable; the citing tests for the other then-items all drive one dialog with no step transitions, and visual composition is judge-owned
 
   - id: IMP-028
@@ -466,7 +466,7 @@ behaviors:
         text: confirming requires at least one selected method; dismissing dismisses all pending ones stickily
     provenance: [method-suggestion-resolver.tsx]
     waivers:
-      - then: 1
+      - then: methods-already-contact-shown
         reason: the suggestions feed prunes already-on-contact entries server-side (buildMethodSuggestionItems drift defense), so the disabled already-present row is unreachable and unseedable in E2E; the render-time state is covered by the method-suggestion-resolver component test
 
   - id: IMP-031

--- a/spec/ingest.yaml
+++ b/spec/ingest.yaml
@@ -13,9 +13,12 @@ behaviors:
     given: the daemon ingest events endpoint
     when: a batch is posted to the ingest endpoint
     then:
-      - the endpoint is registered only when event-bus ingest is enabled
-      - a request carrying the Mac-host header is authenticated as a daemon host and that host identity is threaded into batch processing
-      - a request without the host header is authenticated by the global API key and carries no host identity
+      - key: endpoint-registered-when-enabled
+        text: the endpoint is registered only when event-bus ingest is enabled
+      - key: request-carrying-mac-host
+        text: a request carrying the Mac-host header is authenticated as a daemon host and that host identity is threaded into batch processing
+      - key: request-without-host-header
+        text: a request without the host header is authenticated by the global API key and carries no host identity
     provenance: [IngestHandler.IngestEvents, IngestAuthMiddleware, auth.MacHostIDFromContext, EnableEventBusIngest]
 
   - id: ING-002
@@ -26,10 +29,14 @@ behaviors:
     given: a POST to the ingest endpoint
     when: the request envelope is checked before per-event processing
     then:
-      - a body over the size cap is rejected as payload-too-large (413)
-      - a malformed JSON body is rejected with a validation error (400)
-      - an empty events array is rejected with a validation error (400)
-      - a batch exceeding the maximum event count is rejected with a validation error (400)
+      - key: body-over-size-cap
+        text: a body over the size cap is rejected as payload-too-large (413)
+      - key: malformed-json-body-rejected
+        text: a malformed JSON body is rejected with a validation error (400)
+      - key: empty-events-array-rejected
+        text: an empty events array is rejected with a validation error (400)
+      - key: batch-over-max-count-rejected
+        text: a batch exceeding the maximum event count is rejected with a validation error (400)
     provenance: [IngestHandler.IngestEvents, maxIngestBodyBytes, maxBatchSize]
 
   - id: ING-003
@@ -40,9 +47,12 @@ behaviors:
     given: a batch of events that pass request-level checks
     when: the batch is processed
     then:
-      - the HTTP response is success (200) even when every event in the batch is rejected
-      - each rejected event appears in an errors list with its original request-array index and a stable error code
-      - the response reports separate accepted, duplicate, and rejected counts and is deliberately not wrapped in the standard API envelope
+      - key: http-response-success-200
+        text: the HTTP response is success (200) even when every event in the batch is rejected
+      - key: each-rejected-event-appears
+        text: each rejected event appears in an errors list with its original request-array index and a stable error code
+      - key: response-reports-separate-accepted
+        text: the response reports separate accepted, duplicate, and rejected counts and is deliberately not wrapped in the standard API envelope
     provenance: [IngestHandler.IngestEvents, IngestResponse, IngestError]
     notes: Attention items for sessions needing review are surfaced separately (ING-035).
 
@@ -54,10 +64,14 @@ behaviors:
     given: a single event in the batch
     when: the event is validated
     then:
-      - source is required and length-bounded, and source_id is length-bounded
-      - kind is required and must be a known event kind
-      - observed_at is required and must be a non-zero timestamp
-      - payload is required, size-bounded, and must pass structural validation for its kind (a literal JSON null is rejected)
+      - key: source-required-length-bounded
+        text: source is required and length-bounded, and source_id is length-bounded
+      - key: kind-required-must-known
+        text: kind is required and must be a known event kind
+      - key: observed-at-required-non-zero
+        text: observed_at is required and must be a non-zero timestamp
+      - key: payload-required-size-bounded
+        text: payload is required, size-bounded, and must pass structural validation for its kind (a literal JSON null is rejected)
     provenance: [validateIngestEvent, events.IsKnownKind, events.ValidatePayload]
 
   - id: ING-005
@@ -68,8 +82,10 @@ behaviors:
     given: a daemon-emitted event (message, external-contact, meeting-note, or call)
     when: the payload version is checked
     then:
-      - a version below the supported minimum is rejected as an invalid payload
-      - a version above the highest known version is rejected as an invalid payload with an upgrade signal
+      - key: version-below-supported-minimum
+        text: a version below the supported minimum is rejected as an invalid payload
+      - key: version-above-highest-known
+        text: a version above the highest known version is rejected as an invalid payload with an upgrade signal
     provenance: [validateRawMessagePayload, validateCallPayloadVersion, validateExternalContactPayloadVersion, validateMeetingNotePayloadVersion]
     notes: The "upgrade Pi" rejection makes an out-of-range daemon build fail loudly instead of silently dropping unknown fields on a lenient decode.
 
@@ -81,8 +97,10 @@ behaviors:
     given: a daemon batch whose host is revoked between authentication and commit
     when: the batch reaches its in-transaction host-liveness check
     then:
-      - the whole batch is rolled back with nothing persisted
-      - the response is unauthorized (401) so the daemon stops retrying
+      - key: whole-batch-rolled-back
+        text: the whole batch is rolled back with nothing persisted
+      - key: unauthorized-401-stops-retries
+        text: the response is unauthorized (401) so the daemon stops retrying
     provenance: [IngestHandler.IngestEvents, service.ErrHostRevokedDuringBatch]
 
   # --- Auth-path allowlist ---
@@ -95,9 +113,12 @@ behaviors:
     given: an authenticated ingest request
     when: each event's kind is checked against the auth path it arrived on
     then:
-      - daemon-push kinds are accepted only on the host-auth path
-      - internally-published kinds are accepted only on the global-key path
-      - a kind on the wrong path is rejected for that event without failing the batch
+      - key: daemon-push-kinds-accepted
+        text: daemon-push kinds are accepted only on the host-auth path
+      - key: internally-published-kinds-accepted
+        text: internally-published kinds are accepted only on the global-key path
+      - key: kind-wrong-path-rejected
+        text: a kind on the wrong path is rejected for that event without failing the batch
     provenance: [isHostOnlyKind, IngestService.IngestBatch]
     notes: A daemon-push kind is one that belongs to a registered ingest family (ING-024); these kinds have exactly one legitimate producer.
 
@@ -433,8 +454,10 @@ behaviors:
     given: a batch containing meeting-note recordings
     when: a recording lands in a conflict or orphan state
     then:
-      - the response carries a needs-attention entry naming the session and the reason
-      - the field is omitted for daemons that predate it
+      - key: response-carries-needs-attention
+        text: the response carries a needs-attention entry naming the session and the reason
+      - key: field-omitted-daemons-predate
+        text: the field is omitted for daemons that predate it
     provenance: [IngestResponse.NeedsAttention, NeedsAttentionItem]
     notes: What makes a session a conflict or an orphan is imports-matching scope (IMP-025).
 

--- a/spec/knowledge.yaml
+++ b/spec/knowledge.yaml
@@ -465,8 +465,10 @@ behaviors:
     given: a contact detail page
     when: the profile section renders
     then:
-      - a known location appears as a labeled row; an unknown location renders no row at all
-      - a known birthday appears as a labeled, human-readable date row; an unknown birthday renders no row
+      - key: known-location-appears-labeled
+        text: a known location appears as a labeled row; an unknown location renders no row at all
+      - key: known-birthday-appears-labeled
+        text: a known birthday appears as a labeled, human-readable date row; an unknown birthday renders no row
     provenance: ["contacts/[id]/page.tsx knowledge rows"]
 
   - id: KNW-035
@@ -477,7 +479,9 @@ behaviors:
     given: a contact whose birthday was stored with the placeholder year that marks a year-less (imported) birthday
     when: the birthday is displayed on any surface
     then:
-      - the date renders as month and day only, with the placeholder year never shown
-      - no age is computed or displayed for it
+      - key: date-renders-month-day
+        text: the date renders as month and day only, with the placeholder year never shown
+      - key: no-age-computed-displayed
+        text: no age is computed or displayed for it
     provenance: [formatBirthday, isPlaceholderBirthday, birthdays.spec.ts placeholder assertions]
     notes: The placeholder-year sentinel convention and the year-less rendering (formatBirthday drops the year on every surface — contact detail per KNW-034, the birthdays page, etc.) are the knowledge-domain derived-data concern owned here. Because no real year is stored there is no year to derive an age from; the landed CON-045 owns the birthdays-page display of that age-suppression outcome. The two are consistent, not competing — this row does not claim authority over CON-045.

--- a/spec/mac-host.yaml
+++ b/spec/mac-host.yaml
@@ -275,9 +275,9 @@ behaviors:
         text: an admin can mint a fresh pairing token and revoke a host
     provenance: [MacHostHandler.ListHosts/GetHostAdmin/GetSourceCounts/CreatePairingToken/DeleteHost, RegisterMacHostAdminRoutes]
     waivers:
-      - then: 1
+      - then: detail-view-returns-single
         reason: the host detail read (including revoked hosts and the unknown-id 404) is HTTP contract with no browser surface — the settings/mac page consumes only the list endpoint; owned by the Go API test mac_host_get_admin_test.go
-      - then: 2
+      - then: per-source-live-counts
         reason: the 404-vs-empty-count-map distinction is response-shape contract invisible in the browser (the UI renders only the happy-path counts); owned by the Go API tests in mac_host_source_counts_test.go (UnknownHost_404, NoRowsReturnsEmpty)
 
   # --- Daemon read endpoints ---

--- a/spec/mac-host.yaml
+++ b/spec/mac-host.yaml
@@ -39,10 +39,14 @@ behaviors:
     given: a request to the pairing endpoint
     when: it is handled
     then:
-      - a valid token pairs the host and returns the host id, plaintext api key, and current cursor epoch, with the api key shown only once
-      - an invalid, already-consumed, or expired token all collapse to a single opaque gone response (410) that does not reveal which condition failed
-      - a second pairing attempt while a host is already live is rejected as a conflict (409)
-      - a missing pairing token or hostname is a validation error (400)
+      - key: valid-token-pairs-host
+        text: a valid token pairs the host and returns the host id, plaintext api key, and current cursor epoch, with the api key shown only once
+      - key: invalid-already-consumed-expired
+        text: an invalid, already-consumed, or expired token all collapse to a single opaque gone response (410) that does not reveal which condition failed
+      - key: second-pairing-attempt-conflict
+        text: a second pairing attempt while a host is already live is rejected as a conflict (409)
+      - key: missing-pairing-token-hostname
+        text: a missing pairing token or hostname is a validation error (400)
     provenance: [MacHostHandler.Pair, pairResponse]
     notes: The opaque 410 is deliberate — distinct token-state codes would let a caller probe whether a guessed token ever existed. Rotation deliberately does the opposite (MAC-010).
 
@@ -90,12 +94,18 @@ behaviors:
     given: a request to a daemon-authenticated endpoint
     when: authentication runs
     then:
-      - a missing or malformed host-id header is rejected (401)
-      - presenting global-api-key auth alongside daemon auth is rejected as ambiguous (400)
-      - a missing or empty bearer token is rejected (401)
-      - an unknown or revoked host is rejected (401)
-      - a bearer token that fails the constant-time key comparison is rejected (401)
-      - a route id parameter that does not match the header host id is rejected as an authorization failure (403), distinct from an authentication failure
+      - key: missing-malformed-host-id
+        text: a missing or malformed host-id header is rejected (401)
+      - key: presenting-global-api-key
+        text: presenting global-api-key auth alongside daemon auth is rejected as ambiguous (400)
+      - key: missing-empty-bearer-token
+        text: a missing or empty bearer token is rejected (401)
+      - key: unknown-revoked-host-rejected
+        text: an unknown or revoked host is rejected (401)
+      - key: bearer-token-fails-constant
+        text: a bearer token that fails the constant-time key comparison is rejected (401)
+      - key: route-id-mismatch-forbidden
+        text: a route id parameter that does not match the header host id is rejected as an authorization failure (403), distinct from an authentication failure
     provenance: [MacHostAuthMiddleware, abortAuth]
     notes: The then[4] constant-time qualifier is a timing property no test can observe — the cited test proves only the rejection (401 on a wrong bearer for a known host). The middleware's comparison is bcrypt.CompareHashAndPassword behind the injectable PasswordComparator seam (DefaultPasswordComparator in mac_host_middleware.go); timing safety is owned by code review of that seam.
 
@@ -137,10 +147,14 @@ behaviors:
     given: a rotate-key request
     when: it is handled
     then:
-      - success returns the new plaintext key and rotation timestamp (200), with the key shown only once
-      - token-state failures return distinct client-error codes for invalid, already-used, and expired, because the caller has already proven control of the current key
-      - a key rotated out from under the caller returns stale-auth (401)
-      - a missing or revoked host returns not-found (404)
+      - key: success-returns-new-plaintext
+        text: success returns the new plaintext key and rotation timestamp (200), with the key shown only once
+      - key: token-state-failures-distinct
+        text: token-state failures return distinct client-error codes for invalid, already-used, and expired, because the caller has already proven control of the current key
+      - key: rotated-out-key-stale-auth
+        text: a key rotated out from under the caller returns stale-auth (401)
+      - key: missing-revoked-host
+        text: a missing or revoked host returns not-found (404)
     provenance: [MacHostHandler.RotateKey, rotateKeyResponse]
     notes: The distinct token-state codes are the opposite choice from pairing (MAC-003) — leaking token state is safe here because the caller already holds the current key.
 
@@ -154,10 +168,14 @@ behaviors:
     given: an authenticated daemon heartbeat
     when: it is handled
     then:
-      - the host's last-heartbeat time, daemon version, protocol version, permissions, and source health are recorded
-      - the response echoes the current cursor epoch so the daemon can detect a backend backup-restore
-      - the response reports the server's current and minimum protocol versions
-      - a host revoked between authentication and the write returns unknown-host (401)
+      - key: heartbeat-fields-recorded
+        text: the host's last-heartbeat time, daemon version, protocol version, permissions, and source health are recorded
+      - key: response-echoes-current-cursor
+        text: the response echoes the current cursor epoch so the daemon can detect a backend backup-restore
+      - key: response-reports-protocol-versions
+        text: the response reports the server's current and minimum protocol versions
+      - key: host-revoked-between-authentication
+        text: a host revoked between authentication and the write returns unknown-host (401)
     provenance: [MacHostHandler.Heartbeat, UpdateMacHostHeartbeat, heartbeatResponse]
 
   - id: MAC-012
@@ -168,8 +186,10 @@ behaviors:
     given: a heartbeat whose protocol version is below the server minimum
     when: it is handled
     then:
-      - the request is rejected with an upgrade-required response (412) before any database write
-      - the response carries the minimum acceptable protocol version
+      - key: request-rejected-upgrade-required
+        text: the request is rejected with an upgrade-required response (412) before any database write
+      - key: response-carries-minimum-acceptable
+        text: the response carries the minimum acceptable protocol version
     provenance: [MacHostHandler.Heartbeat protocol gate, mac.MinProtocolVersion]
     notes: Newer additive versions are accepted (older daemons simply do not emit newer event kinds), so the floor moves only on breaking contract changes.
 
@@ -206,9 +226,12 @@ behaviors:
     given: a daemon reading its cursor for a source
     when: the read is handled
     then:
-      - a committed cursor is returned along with the daemon-owned backfill-complete flag
-      - before any commit, an empty cursor and the host's current epoch are returned
-      - the backfill-complete flag is opaque to the backend and defaults to false when absent or malformed
+      - key: committed-cursor-returned-along
+        text: a committed cursor is returned along with the daemon-owned backfill-complete flag
+      - key: before-commit-empty-cursor
+        text: before any commit, an empty cursor and the host's current epoch are returned
+      - key: backfill-complete-flag-opaque
+        text: the backfill-complete flag is opaque to the backend and defaults to false when absent or malformed
     provenance: [MacHostHandler.GetCursor, extractBackfillComplete, cursorResponse]
 
   # --- Admin & revoke ---
@@ -242,10 +265,14 @@ behaviors:
     given: admin requests (global api key) against the hosts collection
     when: they are handled
     then:
-      - the list returns the live hosts
-      - the detail view returns a single host including revoked ones, and not-found (404) for an unknown id
-      - per-source live counts distinguish a missing host (404) from a host with no rows (an empty count map)
-      - an admin can mint a fresh pairing token and revoke a host
+      - key: list-returns-live-hosts
+        text: the list returns the live hosts
+      - key: detail-view-returns-single
+        text: the detail view returns a single host including revoked ones, and not-found (404) for an unknown id
+      - key: per-source-live-counts
+        text: per-source live counts distinguish a missing host (404) from a host with no rows (an empty count map)
+      - key: admin-can-mint-fresh
+        text: an admin can mint a fresh pairing token and revoke a host
     provenance: [MacHostHandler.ListHosts/GetHostAdmin/GetSourceCounts/CreatePairingToken/DeleteHost, RegisterMacHostAdminRoutes]
     waivers:
       - then: 1
@@ -503,7 +530,9 @@ behaviors:
     given: a paired host whose source health includes a contacts source
     when: the source-health view renders that source's cursor state
     then:
-      - once the source reports backfill complete, the live contact count for the host and source is shown in place of the raw change-token cursor
-      - while backfill is still in progress, a neutral placeholder is shown — the raw change-token cursor is never displayed and no count is substituted
+      - key: backfill-complete-shows-count
+        text: once the source reports backfill complete, the live contact count for the host and source is shown in place of the raw change-token cursor
+      - key: backfill-in-progress-placeholder
+        text: while backfill is still in progress, a neutral placeholder is shown — the raw change-token cursor is never displayed and no count is substituted
     provenance: [settings/mac/cursor-cell.ts renderCursorCell/cursorCellState, useMacHostSourceCounts, MacHostHandler.GetSourceCounts]
     notes: 'The regression guard for issue #327: an iCloud change-token cursor is meaningless to the operator, so the cell shows a live count only when the count is trustworthy (backfill complete) and otherwise the neutral placeholder — never the raw change-token. The counts endpoint contract is MAC-018.'

--- a/spec/notes-meetings.yaml
+++ b/spec/notes-meetings.yaml
@@ -50,10 +50,14 @@ behaviors:
     given: a GET for a contact's notepad
     when: the request is handled
     then:
-      - a live contact with a notepad returns it (200)
-      - a live contact without a notepad returns no content (204)
-      - a malformed contact id returns a validation error (400)
-      - an unknown or soft-deleted contact returns not-found (404)
+      - key: live-contact-notepad
+        text: a live contact with a notepad returns it (200)
+      - key: live-contact-without-notepad
+        text: a live contact without a notepad returns no content (204)
+      - key: malformed-contact-id
+        text: a malformed contact id returns a validation error (400)
+      - key: unknown-soft-deleted-contact
+        text: an unknown or soft-deleted contact returns not-found (404)
     provenance: [NoteHandler.GetContactNotepad, NoteResponse]
 
   - id: NTS-005
@@ -64,11 +68,16 @@ behaviors:
     given: a PUT of a contact's notepad body
     when: the request is handled
     then:
-      - a non-empty body returns the saved note (200)
-      - an empty or whitespace-only body deletes the note and returns no content (204)
-      - the body is limited to 50000 characters, else a validation error (400)
-      - a malformed contact id or unparseable body returns a validation error (400)
-      - an unknown or soft-deleted contact returns not-found (404)
+      - key: non-empty-body
+        text: a non-empty body returns the saved note (200)
+      - key: empty-whitespace-only-body
+        text: an empty or whitespace-only body deletes the note and returns no content (204)
+      - key: body-limited-50000-characters
+        text: the body is limited to 50000 characters, else a validation error (400)
+      - key: malformed-contact-id-unparseable
+        text: a malformed contact id or unparseable body returns a validation error (400)
+      - key: unknown-soft-deleted-contact
+        text: an unknown or soft-deleted contact returns not-found (404)
     provenance: [NoteHandler.SaveContactNotepad, SaveNoteRequest]
     notes: The length cap is validated on the raw body before trimming, so an over-length whitespace-only body is rejected rather than treated as an empty delete.
 
@@ -93,9 +102,12 @@ behaviors:
     given: a contact detail page
     when: the notepad renders
     then:
-      - the notepad appears only when it has content; an empty or absent notepad shows nothing
-      - the body preserves the user's line breaks
-      - long content is clamped with an expand and collapse control that appears only when the content overflows
+      - key: notepad-appears-only-with-content
+        text: the notepad appears only when it has content; an empty or absent notepad shows nothing
+      - key: body-preserves-line-breaks
+        text: the body preserves the user's line breaks
+      - key: long-content-clamped-expand
+        text: long content is clamped with an expand and collapse control that appears only when the content overflows
     provenance: [contact detail notes block, contacts.spec.ts]
 
   - id: NTS-008
@@ -106,9 +118,12 @@ behaviors:
     given: the contact edit or create form
     when: the notepad field is edited and the form is submitted
     then:
-      - the notepad is saved as its own operation alongside the contact update, both completing before edit mode closes
-      - clearing the notepad field removes the note
-      - the displayed notepad reflects the new content after a successful save
+      - key: notepad-saved-own-operation
+        text: the notepad is saved as its own operation alongside the contact update, both completing before edit mode closes
+      - key: clearing-notepad-field-removes
+        text: clearing the notepad field removes the note
+      - key: displayed-notepad-reflects-new
+        text: the displayed notepad reflects the new content after a successful save
     provenance: [contact-form.tsx notes field, contact detail submit, new contact page]
 
   # --- Meeting-note linkage states and user-driven resolution ---
@@ -233,13 +248,20 @@ behaviors:
     given: a POST to resolve-link for a meeting_note
     when: the request is handled
     then:
-      - action is required and must be link or none_of_these
-      - action=link requires kind in event or phone_call and an id parseable as a UUID, else a validation error (400)
-      - a successful resolve returns the updated meeting note and the interactions created (200)
-      - a missing row, or a snapshot target that no longer exists, returns not-found (404)
-      - a row not in an attention state returns conflict (409)
-      - a chosen id absent from the snapshot returns a validation error (400)
-      - a conflict_pending row missing its snapshot returns unprocessable content (422)
+      - key: action-required-must-link
+        text: action is required and must be link or none_of_these
+      - key: action-link-requires-kind
+        text: action=link requires kind in event or phone_call and an id parseable as a UUID, else a validation error (400)
+      - key: successful-resolve-returns-updated
+        text: a successful resolve returns the updated meeting note and the interactions created (200)
+      - key: missing-row-snapshot-target
+        text: a missing row, or a snapshot target that no longer exists, returns not-found (404)
+      - key: row-not-attention-state
+        text: a row not in an attention state returns conflict (409)
+      - key: chosen-id-absent-snapshot
+        text: a chosen id absent from the snapshot returns a validation error (400)
+      - key: conflict-pending-row-missing
+        text: a conflict_pending row missing its snapshot returns unprocessable content (422)
     provenance: [MeetingNoteHandler.ResolveLink, mapResolveError]
 
   - id: NTS-019
@@ -327,10 +349,15 @@ behaviors:
     given: a GET to needs-attention for meeting notes
     when: the request is handled
     then:
-      - a malformed host_id query parameter returns a validation error (400)
-      - the response returns every live meeting note in an attention state, newest first, optionally scoped to a host_id (200)
-      - each conflict_pending row carries a candidates array projecting each snapshot candidate with a per-kind preview; an orphan_needs_review row carries no candidates
-      - a snapshot candidate whose target row has been deleted is marked target-missing with a null preview rather than dropped from the response
-      - each candidate's overlap count is carried independently of the per-attendee matched flags, which drive only visual emphasis
+      - key: malformed-host-id-query
+        text: a malformed host_id query parameter returns a validation error (400)
+      - key: returns-attention-notes-newest-first
+        text: the response returns every live meeting note in an attention state, newest first, optionally scoped to a host_id (200)
+      - key: each-conflict-pending-row
+        text: each conflict_pending row carries a candidates array projecting each snapshot candidate with a per-kind preview; an orphan_needs_review row carries no candidates
+      - key: deleted-target-marked-missing
+        text: a snapshot candidate whose target row has been deleted is marked target-missing with a null preview rather than dropped from the response
+      - key: candidate-overlap-count-independent
+        text: each candidate's overlap count is carried independently of the per-attendee matched flags, which drive only visual emphasis
     provenance: [MeetingNoteHandler.ListNeedsAttention, MeetingNoteService.ListNeedsAttention, projectCandidates, candidatePreview, ListMeetingNotesNeedingAttention]
     notes: The business-logic of what makes a session a conflict versus an orphan is cross-ref IMP-025; this pins the read endpoint's API and projection contract, mirroring NTS-018 for the resolve-link write endpoint.

--- a/spec/settings.yaml
+++ b/spec/settings.yaml
@@ -22,9 +22,12 @@ behaviors:
     given: a configured OAuth provider
     when: the frontend requests that provider's authorization URL
     then:
-      - a random CSRF state is generated and stored server-side
-      - the stored state expires after ten minutes
-      - the response returns the provider authorization URL and the state
+      - key: random-csrf-state-generated
+        text: a random CSRF state is generated and stored server-side
+      - key: stored-state-expires-ten-minutes
+        text: the stored state expires after ten minutes
+      - key: returns-authorization-url-and-state
+        text: the response returns the provider authorization URL and the state
     provenance: [OAuthHandler.GetGoogleAuthURL, OAuthHandler.GetTodoistAuthURL, storeState, google.GenerateState]
     notes: The state store is in-process and not persisted, so a backend restart between issuance and callback invalidates outstanding states (they then fail as invalid_state). Google and Todoist share one state namespace with no provider tag; states are 32 random bytes so cross-provider collision is not a practical concern.
 
@@ -36,10 +39,14 @@ behaviors:
     given: a provider redirect back to the callback route
     when: the callback is processed
     then:
-      - a provider-supplied error parameter short-circuits before any state check or code exchange
-      - the CSRF state is validated and consumed before the authorization code is exchanged
-      - a state is accepted at most once, so replaying the same state fails validation
-      - an expired, unknown, or already-used state aborts the flow without exchanging the code
+      - key: provider-supplied-error-parameter
+        text: a provider-supplied error parameter short-circuits before any state check or code exchange
+      - key: csrf-state-validated-consumed
+        text: the CSRF state is validated and consumed before the authorization code is exchanged
+      - key: state-accepted-at-most-once
+        text: a state is accepted at most once, so replaying the same state fails validation
+      - key: expired-unknown-already-used
+        text: an expired, unknown, or already-used state aborts the flow without exchanging the code
     provenance: [OAuthHandler.GoogleCallback, OAuthHandler.TodoistCallback, validateState]
 
   - id: SET-004
@@ -50,10 +57,14 @@ behaviors:
     given: a completed or failed OAuth callback
     when: the callback responds
     then:
-      - the response is a redirect back to the settings surface, never a rendered page or JSON body
-      - a success carries an outcome of success plus the provider name
-      - a failure carries an outcome of error plus the provider name and a typed reason (the provider error, invalid_state, or exchange_failed)
-      - all redirect query parameters are URL-encoded rather than string-concatenated
+      - key: response-redirect-back-settings
+        text: the response is a redirect back to the settings surface, never a rendered page or JSON body
+      - key: success-carries-outcome-success
+        text: a success carries an outcome of success plus the provider name
+      - key: failure-carries-outcome-error
+        text: a failure carries an outcome of error plus the provider name and a typed reason (the provider error, invalid_state, or exchange_failed)
+      - key: redirect-params-url-encoded
+        text: all redirect query parameters are URL-encoded rather than string-concatenated
     provenance: [OAuthHandler.GoogleCallback, OAuthHandler.TodoistCallback, url.Values.Encode]
     notes: Google's callback additionally runs email/gchat sync reconciliation post-exchange (SET-013); those steps are non-fatal and do not change the redirect outcome.
 
@@ -76,10 +87,14 @@ behaviors:
     given: a request to an API-key-protected route
     when: the API key is checked
     then:
-      - the key is read from an X-API-Key header, falling back to an Authorization header of the form ApiKey <key>
-      - a missing key is rejected with 401 and a missing-key error code
-      - a key that does not match the configured key is rejected with 401 and an invalid-key error code
-      - a matching key allows the request to proceed
+      - key: key-read-from-api-key-header
+        text: the key is read from an X-API-Key header, falling back to an Authorization header of the form ApiKey <key>
+      - key: missing-key-rejected-401
+        text: a missing key is rejected with 401 and a missing-key error code
+      - key: key-does-not-match
+        text: a key that does not match the configured key is rejected with 401 and an invalid-key error code
+      - key: matching-key-allows-request
+        text: a matching key allows the request to proceed
     provenance: [auth.APIKeyMiddleware]
 
   - id: SET-007
@@ -101,10 +116,14 @@ behaviors:
     given: a request to one of a provider's connected-account management routes (list, status read, or revoke)
     when: the request is handled
     then:
-      - listing returns an array of connected accounts (200)
-      - a malformed account id returns a validation error (400)
-      - an unknown account id returns not-found (404)
-      - a successful status read returns the account (200) and a successful revoke returns a confirmation (200)
+      - key: listing-returns-array-connected
+        text: listing returns an array of connected accounts (200)
+      - key: malformed-account-id
+        text: a malformed account id returns a validation error (400)
+      - key: unknown-account-id
+        text: an unknown account id returns not-found (404)
+      - key: status-and-revoke-return-200
+        text: a successful status read returns the account (200) and a successful revoke returns a confirmation (200)
     provenance: [OAuthHandler.ListGoogleAccounts, OAuthHandler.GetGoogleAccountStatus, OAuthHandler.RevokeGoogleAccount, OAuthHandler Todoist counterparts]
 
   - id: SET-009
@@ -230,9 +249,12 @@ behaviors:
     given: a connected Todoist account
     when: the available projects or labels are requested
     then:
-      - with no account connected the request returns not-found (404)
-      - the live provider is queried and deleted entries are filtered out of the result
-      - a token or provider-API failure surfaces as a server error (500)
+      - key: no-account-connected-404
+        text: with no account connected the request returns not-found (404)
+      - key: deleted-entries-filtered-out
+        text: the live provider is queried and deleted entries are filtered out of the result
+      - key: token-provider-api-failure
+        text: a token or provider-API failure surfaces as a server error (500)
     provenance: [TodoistHandler.ListProjects, TodoistHandler.ListLabels]
 
   # --- Settings surfaces (Track B) ---
@@ -245,9 +267,12 @@ behaviors:
     given: the settings page
     when: it renders
     then:
-      - each supported provider has its own section showing whether an account is connected
-      - a connected account shows its identity and when it was connected
-      - each section offers a way to connect an account and to disconnect a connected one
+      - key: each-provider-section-shows-state
+        text: each supported provider has its own section showing whether an account is connected
+      - key: connected-account-shows-identity
+        text: a connected account shows its identity and when it was connected
+      - key: section-offers-connect-disconnect
+        text: each section offers a way to connect an account and to disconnect a connected one
     provenance: [settings/page.tsx, google-accounts-section.tsx, todoist-accounts-section.tsx]
 
   - id: SET-020
@@ -258,7 +283,8 @@ behaviors:
     given: a provider section with a connect affordance
     when: the user starts connecting
     then:
-      - the app fetches the provider authorization URL and navigates the whole page to the provider's consent screen
+      - key: app-fetches-provider-authorization
+        text: the app fetches the provider authorization URL and navigates the whole page to the provider's consent screen
     provenance: [startGoogleOAuthFlow, startTodoistOAuthFlow, oauth-api.ts]
 
   - id: SET-021
@@ -269,9 +295,12 @@ behaviors:
     given: a redirect back to the settings surface carrying a connect outcome
     when: the settings page mounts
     then:
-      - a success outcome shows a success indication and refreshes the account list
-      - an error outcome shows the failure reason to the user
-      - the one-time outcome parameters are stripped from the URL so a refresh does not re-trigger the notification
+      - key: success-outcome-shows-success
+        text: a success outcome shows a success indication and refreshes the account list
+      - key: error-outcome-shows-failure
+        text: an error outcome shows the failure reason to the user
+      - key: one-time-outcome-parameters
+        text: the one-time outcome parameters are stripped from the URL so a refresh does not re-trigger the notification
     provenance: [google-accounts-section.tsx auth-param effect, todoist-accounts-section.tsx, .ai/rules/core.md one-time action gotcha]
 
   - id: SET-022
@@ -282,9 +311,12 @@ behaviors:
     given: a connected provider account
     when: the user asks to disconnect it
     then:
-      - a confirmation prompt identifies the account and warns what access is revoked
-      - only on confirmation is the account revoked
-      - the outcome is reported and the account list reflects the removal
+      - key: confirmation-identifies-account
+        text: a confirmation prompt identifies the account and warns what access is revoked
+      - key: only-confirmation-account-revoked
+        text: only on confirmation is the account revoked
+      - key: outcome-reported-account-list
+        text: the outcome is reported and the account list reflects the removal
     provenance: [google-accounts-section.tsx handleDisconnect, todoist-accounts-section.tsx handleDisconnect]
 
   - id: SET-023
@@ -295,8 +327,10 @@ behaviors:
     given: a provider whose credentials are not configured or whose account list failed to load
     when: its section renders
     then:
-      - the section shows a not-connected empty state rather than an error stack
-      - the section lists the configuration the deployment must supply to enable the provider
+      - key: section-shows-not-connected
+        text: the section shows a not-connected empty state rather than an error stack
+      - key: lists-required-configuration
+        text: the section lists the configuration the deployment must supply to enable the provider
     provenance: [google-accounts-section.tsx showEmptyState, todoist-accounts-section.tsx, Configuration Required panels]
     notes: Treating a not-configured provider (a 4xx from its routes per SET-005) as an empty state is deliberate — the surface degrades gracefully on a deployment that never set the provider up.
 
@@ -308,8 +342,10 @@ behaviors:
     given: a connected Google account with a stored scope set
     when: its section renders
     then:
-      - a per-source sync affordance appears only when the account holds the scope that source requires
-      - the Google Chat affordance appears only when all of the chat scopes are held; a partial grant shows a reconnect prompt instead
+      - key: per-source-sync-affordance
+        text: a per-source sync affordance appears only when the account holds the scope that source requires
+      - key: google-chat-affordance-appears
+        text: the Google Chat affordance appears only when all of the chat scopes are held; a partial grant shows a reconnect prompt instead
     provenance: [google-accounts-section.tsx accountHasChatScopes/GCHAT_REQUIRED_SCOPES, SyncBadge]
     notes: The badges key off the stored requested-scope list as a proxy, not a live grant check. What each triggered sync source does once run is calendar/contacts/gmail/gchat-domain scope.
 
@@ -321,8 +357,10 @@ behaviors:
     given: a connected account whose sync state is in an auth-related error
     when: its section renders
     then:
-      - a reconnect affordance appears for that account
-      - the prompt is suppressed once the account credential is newer than the failing sync state
+      - key: reconnect-affordance-appears-account
+        text: a reconnect affordance appears for that account
+      - key: prompt-suppressed-once-account
+        text: the prompt is suppressed once the account credential is newer than the failing sync state
     provenance: [use-sync-states.ts accountNeedsReconnection, google-accounts-section.tsx, todoist-accounts-section.tsx]
     notes: The error strings this keys on are produced by the sync providers (calendar/gmail/gchat/todoist domains); settings owns only the reconnect affordance the errored state drives.
 
@@ -334,9 +372,12 @@ behaviors:
     given: a connected Todoist account
     when: the Todoist configuration is shown
     then:
-      - project and label pickers are offered, each populated from the live provider lists
-      - selecting a project or label persists that choice and reports the outcome
-      - the surface indicates that both a project and a label must be chosen before cadence sync is active
+      - key: project-label-pickers-offered
+        text: project and label pickers are offered, each populated from the live provider lists
+      - key: selecting-project-label-persists
+        text: selecting a project or label persists that choice and reports the outcome
+      - key: both-project-and-label-required
+        text: the surface indicates that both a project and a label must be chosen before cadence sync is active
     provenance: [todoist-accounts-section.tsx Sync Configuration, use-todoist-settings.ts]
 
   - id: SET-027
@@ -347,8 +388,10 @@ behaviors:
     given: the settings page
     when: the Telegram section renders
     then:
-      - the section is present on the settings surface
-      - when the Telegram feature is not enabled on the backend, the section shows a not-configured state naming the configuration required to enable it
+      - key: section-present-settings-surface
+        text: the section is present on the settings surface
+      - key: not-configured-state-when-disabled
+        text: when the Telegram feature is not enabled on the backend, the section shows a not-configured state naming the configuration required to enable it
     provenance: [telegram-section.tsx not_configured state, use-telegram.ts status 404 handling]
     notes: The connect / code-verification / two-factor / disconnect flow and group-chat tracking live under this section but are telegram-domain scope; settings owns only that the section renders and its not-configured empty state.
 
@@ -362,9 +405,12 @@ behaviors:
     given: the settings page
     when: the data backup and restore section renders
     then:
-      - an export affordance downloads the user's data as a JSON backup file
-      - an import affordance accepts a backup file to restore from
-      - the surface communicates that import does not yet modify stored data
+      - key: export-affordance-downloads-user
+        text: an export affordance downloads the user's data as a JSON backup file
+      - key: import-affordance-accepts-backup
+        text: an import affordance accepts a backup file to restore from
+      - key: import-not-yet-functional
+        text: the surface communicates that import does not yet modify stored data
     provenance: [settings/page.tsx Data Backup & Restore section, handleExportData, handleImportData]
     notes: Export is live and its HTTP contract is SET-030; it streams the current dataset — contacts only today — as a JSON download, even though the surface copy frames it as a complete backup. The restore path itself is not yet implemented and is recorded as proposed (SET-029).
 
@@ -390,10 +436,14 @@ behaviors:
     given: a request to the data export endpoint
     when: the export is requested
     then:
-      - the response is a JSON attachment (a Content-Disposition download) wrapping an export envelope
-      - the envelope carries a version tag and an export timestamp
-      - the exported dataset contains the contact records only — interactions and notes are not included
-      - a failure to read the contacts returns a server error (500)
+      - key: response-json-attachment-content
+        text: the response is a JSON attachment (a Content-Disposition download) wrapping an export envelope
+      - key: envelope-carries-version-tag
+        text: the envelope carries a version tag and an export timestamp
+      - key: exported-dataset-contacts-only
+        text: the exported dataset contains the contact records only — interactions and notes are not included
+      - key: contacts-read-failure-500
+        text: a failure to read the contacts returns a server error (500)
     provenance: [SystemHandler.ExportData, system_routes.go RegisterDataExchangeRoutes]
     notes: The settings surface (SET-028) frames export as a complete backup, but today the endpoint serializes contacts only; widening the payload to interactions and notes is unbuilt and recorded as proposed (SET-033). The contacts read is bounded by a large fixed limit rather than true pagination.
 
@@ -464,7 +514,9 @@ behaviors:
     given: the settings page
     when: the system information section renders
     then:
-      - a system information section is present on the settings surface
-      - a non-empty application version is shown
+      - key: system-information-section-present
+        text: a system information section is present on the settings surface
+      - key: non-empty-application-version
+        text: a non-empty application version is shown
     provenance: [settings/page.tsx System Information section]
     notes: The version string is build-stamped (NEXT_PUBLIC_BUILD_VERSION, with a dev fallback when unstamped); the backend build stamp is covered separately by TestHealthEndpoint_StampedBuildInfo. Pinning the exact fallback copy is deliberately avoided.

--- a/spec/telegram.yaml
+++ b/spec/telegram.yaml
@@ -131,13 +131,13 @@ behaviors:
         text: status always returns 200 with the current connection state
     provenance: [TelegramHandler.StartAuth, TelegramHandler.VerifyCode, TelegramHandler.VerifyPassword, TelegramHandler.CancelAuth, TelegramHandler.Disconnect, TelegramHandler.GetStatus]
     waivers:
-      - then: 1
+      - then: in-progress-or-connected-409
         reason: the already-connected 409 half is proven by an uncited groundwork test (TestTelegramAuthAPI_StartConflictWhenAlreadyConnected — the conflict is decided from the stored session row before any client is built); the auth-already-in-progress 409 half is the genuine impossibility — it requires AuthSessionManager's unexported live session state, which only a real StartAuth sets, and StartAuth blocks inside a gotd MTProto client.Run dialing Telegram's production DCs; no stub seam exists and adding one is a production change out of a coverage arc's scope
-      - then: 2
+      - then: invalid-token-client-error
         reason: the invalid-token 400 half is proven by an uncited groundwork test (TestTelegramAuthAPI_ValidationErrors area); the expired-token 410 half is deterministically unreachable — cleanup closes the session and nils it atomically under one mutex, so any post-TTL request takes the invalid-token 400 path; ErrAuthTokenExpired fires only in a race window on a live MTProto-backed session (candidate for a spec correction rather than a test)
-      - then: 3
+      - then: wrong-code-password-unauthorized
         reason: the 401 wrong-code/password and 500 internal-error branches require an AuthResult delivered on the session's result channel, written exclusively by the live client.Run goroutine after real Telegram RPC attempts; no seam exists to stub the MTProto client or feed the channel
-      - then: 4
+      - then: cancel-always-succeeds-200
         reason: the cancel-always-succeeds half is proven by an uncited groundwork test (TestTelegramAuthAPI_CancelAlwaysSucceeds); the successful-step-returns-200 half requires a live or stubbed MTProto auth flow reaching awaiting_code/awaiting_password — no seam exists (see then 3)
 
   - id: TGM-008

--- a/spec/telegram.yaml
+++ b/spec/telegram.yaml
@@ -115,13 +115,20 @@ behaviors:
     given: requests to the Telegram auth endpoints
     when: they are handled
     then:
-      - an empty or malformed phone number, or a missing token, code, or password, is a validation error (400)
-      - an auth-already-in-progress or already-connected start is a conflict (409)
-      - an invalid token is a client error (400) and an expired token is gone (410)
-      - a wrong code or password is unauthorized (401) and an internal auth error is a server error (500)
-      - cancel always succeeds (200) and a successful step returns 200 with the flow status
-      - disconnect succeeds (200) unless the session-row delete fails, which is a server error (500)
-      - status always returns 200 with the current connection state
+      - key: empty-malformed-phone-number
+        text: an empty or malformed phone number, or a missing token, code, or password, is a validation error (400)
+      - key: in-progress-or-connected-409
+        text: an auth-already-in-progress or already-connected start is a conflict (409)
+      - key: invalid-token-client-error
+        text: an invalid token is a client error (400) and an expired token is gone (410)
+      - key: wrong-code-password-unauthorized
+        text: a wrong code or password is unauthorized (401) and an internal auth error is a server error (500)
+      - key: cancel-always-succeeds-200
+        text: cancel always succeeds (200) and a successful step returns 200 with the flow status
+      - key: disconnect-200-unless-delete-fails
+        text: disconnect succeeds (200) unless the session-row delete fails, which is a server error (500)
+      - key: status-always-returns-200
+        text: status always returns 200 with the current connection state
     provenance: [TelegramHandler.StartAuth, TelegramHandler.VerifyCode, TelegramHandler.VerifyPassword, TelegramHandler.CancelAuth, TelegramHandler.Disconnect, TelegramHandler.GetStatus]
     waivers:
       - then: 1
@@ -245,9 +252,12 @@ behaviors:
     given: requests to the Telegram chats endpoints
     when: they are handled
     then:
-      - the list returns only group chats, each with its effective-tracked flag
-      - a status update accepts only auto, ignored, or tracked, else a validation error (400)
-      - a non-numeric chat id is a validation error (400) and an unknown chat on update is not-found (404)
+      - key: list-returns-only-group
+        text: the list returns only group chats, each with its effective-tracked flag
+      - key: status-update-closed-set
+        text: a status update accepts only auto, ignored, or tracked, else a validation error (400)
+      - key: non-numeric-chat-id
+        text: a non-numeric chat id is a validation error (400) and an unknown chat on update is not-found (404)
     provenance: [TelegramHandler.ListChats, TelegramHandler.UpdateChatStatus]
 
   # --- Message ingest & parsing ---
@@ -502,11 +512,16 @@ behaviors:
     given: the Telegram settings section in a disconnected state
     when: the user connects an account
     then:
-      - starting a connect reveals a phone-number entry with submit and cancel affordances
-      - a started flow advances to code entry, reflecting the delivery channel the code was sent through
-      - a valid code either connects the account or, for a two-factor account, advances to a password entry step
-      - a valid password connects the account
-      - the connected state shows the account username
+      - key: starting-connect-reveals-phone
+        text: starting a connect reveals a phone-number entry with submit and cancel affordances
+      - key: started-flow-advances-code
+        text: a started flow advances to code entry, reflecting the delivery channel the code was sent through
+      - key: valid-code-either-connects
+        text: a valid code either connects the account or, for a two-factor account, advances to a password entry step
+      - key: valid-password-connects-account
+        text: a valid password connects the account
+      - key: connected-state-shows-account
+        text: the connected state shows the account username
     provenance: [telegram-section.tsx phone_input/awaiting_code/awaiting_password/connected steps, use-telegram.ts]
     notes: The browser half of the auth flow; the backend session/step logic it drives is TGM-004/TGM-005 (surface none). E2E proves this against route-mocked auth endpoints — the mock is the external boundary (MTProto cannot run in E2E), the surface branches are real.
 
@@ -518,9 +533,12 @@ behaviors:
     given: a connected Telegram account
     when: the Telegram settings section renders
     then:
-      - the account username and phone number are shown
-      - while a backfill is in progress, its completed and total counts are shown
-      - a disconnect affordance is offered, and confirming it returns the section to the disconnected state
+      - key: account-username-phone-number
+        text: the account username and phone number are shown
+      - key: backfill-progress-counts-shown
+        text: while a backfill is in progress, its completed and total counts are shown
+      - key: disconnect-offered-and-confirmed
+        text: a disconnect affordance is offered, and confirming it returns the section to the disconnected state
     provenance: [telegram-section.tsx connected step, handleDisconnect, backfill progress block]
     notes: The status values rendered here are resolved by the backend per TGM-010 (surface none).
 
@@ -532,8 +550,10 @@ behaviors:
     given: an in-progress connect flow awaiting a verification code
     when: the backend rejects the submitted code
     then:
-      - the failure reason is shown to the user
-      - the flow stays on the code entry step so the user can retry
+      - key: failure-reason-shown-user
+        text: the failure reason is shown to the user
+      - key: flow-stays-code-entry
+        text: the flow stays on the code entry step so the user can retry
     provenance: [telegram-section.tsx handleVerifyCode error path]
     notes: Which rejections are retryable versus aborting is backend scope (TGM-006).
 
@@ -545,8 +565,11 @@ behaviors:
     given: a connected Telegram account
     when: the group-chat list renders
     then:
-      - discovered group chats are listed with their member counts
-      - before any chats are discovered an empty state is shown
-      - changing a chat's tracking choice persists it and the list reflects the persisted choice
+      - key: discovered-group-chats-listed
+        text: discovered group chats are listed with their member counts
+      - key: before-any-chats-discovered
+        text: before any chats are discovered an empty state is shown
+      - key: changing-tracking-choice-persists
+        text: changing a chat's tracking choice persists it and the list reflects the persisted choice
     provenance: [telegram-section.tsx TelegramChatList, use-telegram.ts useUpdateTelegramChatStatus]
     notes: How the tracking choice feeds effective tracking is TGM-011 (surface none); the tracked/untracked dot is judge-owned presentation.

--- a/spec/todoist.yaml
+++ b/spec/todoist.yaml
@@ -418,7 +418,7 @@ behaviors:
       - key: cadence-due-not-surfaced
         text: the cadence-due projection is not surfaced on the contact page (cadence is surfaced through the overdue and recent-activity surfaces instead)
     waivers:
-      - then: 2
+      - then: cadence-due-not-surfaced
         reason: a structural-absence property with no deterministic browser observable — the provider-less E2E env cannot seed a real cadence_due row (the contact-page task routes are OAuth-gated and route-mocked in E2E, so an absence assertion would only prove the mock), and the exclusion is enforced by the contact page's lifecycle-scoped task queries (manual + followup_loop only), which structurally omit cadence_due projections
     provenance: [tasks-section.tsx, contact detail task queries]
     notes: The tasks-section layout, badges, and completed-toggle are CAD-030; unlinking (which keeps the task alive in Todoist) is CAD-033. This pins the Todoist-projection-specific display concerns.

--- a/spec/todoist.yaml
+++ b/spec/todoist.yaml
@@ -396,8 +396,10 @@ behaviors:
     given: a connected Todoist account
     when: the user triggers a manual task sync
     then:
-      - a sync is requested for that account and its success or failure is indicated
-      - the account's read/write permission state is visible
+      - key: sync-requested-account-success
+        text: a sync is requested for that account and its success or failure is indicated
+      - key: read-write-permission-visible
+        text: the account's read/write permission state is visible
     provenance: [todoist-accounts-section.tsx sync badge, useTriggerSync]
     notes: The Todoist projection-target settings surface — the read/write settings endpoints, the project and label pickers, and the sync-configuration UI — is owned by the settings domain (SET-015, SET-016, SET-017, SET-018, SET-026), not re-minted here. This row pins only the on-demand sync trigger.
 
@@ -409,9 +411,12 @@ behaviors:
     given: a contact with tasks projected into Todoist
     when: the contact's tasks are shown
     then:
-      - the CRM link markers are stripped so the task shows human-readable content, falling back to a placeholder when empty
-      - each linked task offers a deep link that opens it in the Todoist app
-      - the cadence-due projection is not surfaced on the contact page (cadence is surfaced through the overdue and recent-activity surfaces instead)
+      - key: crm-link-markers-stripped
+        text: the CRM link markers are stripped so the task shows human-readable content, falling back to a placeholder when empty
+      - key: linked-task-deep-link
+        text: each linked task offers a deep link that opens it in the Todoist app
+      - key: cadence-due-not-surfaced
+        text: the cadence-due projection is not surfaced on the contact page (cadence is surfaced through the overdue and recent-activity surfaces instead)
     waivers:
       - then: 2
         reason: a structural-absence property with no deterministic browser observable — the provider-less E2E env cannot seed a real cadence_due row (the contact-page task routes are OAuth-gated and route-mocked in E2E, so an absence assertion would only prove the mock), and the exclusion is enforced by the contact page's lifecycle-scoped task queries (manual + followup_loop only), which structurally omit cadence_due projections


### PR DESCRIPTION
PR2 of 3 for #760 — the mechanical rewrite. Mints **393 permanent keys** and rewrites **616 positional references** (597 in-root citations + 2 out-of-root markers + 17 waivers). Green throughout because PR1 accepts both forms; PR3 retires the indexed form.

A single mis-repointed reference here is a silently-wrong migration — the exact failure class #760 exists to eliminate. So the review artifact is not the diff (unreviewable at 90 files) but a set of mechanical guards, each demonstrated to fail on its own defect.

## Commits — four boundaries, load-bearing for the guards

| | SHA | |
|---|---|---|
| base | `1dd9b72` | PR1 |
| tool | `5584816` | `backend/cmd/specmigrate/` + one `test-unit` Makefile entry |
| passA | `ac07ae0` | 393 then-items keyed (122 hand-edited) |
| passB | `2d3e11d` | 616 positional references rewritten |
| head | `d6bdbdc` | carry-forward tests (fixtures/tests only) |

Two passes with a **hard human checkpoint between them** — keys are permanent, so a fused pass would bake 393 unreviewed names into 616 references.

## Guards (all run from a built binary; exit codes read directly)

| Guard | Proves | Result |
|---|---|---|
| **G1** | `index_of_key(behavior, new_key) == old_index` for every rewritten reference | **616** checked → 0 |
| **G2a** | citation diff shape + **substitution exactness** against the ledger | 68 files, 510+510 lines → 0 |
| **G2b** | nothing outside the scan roots + corpus changed | 1 path, 84 M / 6 A / 0 D → 0 |
| **G2c** | corpus diff is exactly the keying transform | 393+17 conversions, **0 unclassified** → 0 |
| **disjointness** | no edit hidden by splitting across commits | **3 of 3 pairs live** → 0 |
| **G3** | no `then`/`given` text altered | 430 behaviors / 1075 items → 0 |

**11 failure demonstrations**, each injected, `grep`-confirmed to land, exit code read directly, reverted with a clean tree: G1 permutation / I4 re-point / waiver swap; G3 text edit; G2a shape *and* exactness (the exactness demo re-points a marker to another **valid** key — the shape clause still printed correct counts, proving it is not decorative); G2b production edit; G2c `notes:` reflow; both disjointness vectors; and the `cite`-abort.

Two controls confirmed as **non-substitutes**: the waiver swap and the marker re-point both leave `spec-lint` *and* `spec-coverage` at exit 0. G1/G2a are the only things that see them. This is why the coverage-report diff is a smoke check only — it is provably blind to a permutation inside a fully-covered behavior.

## The correctness claim, verified two independent ways

Review verified the 616 rewrites with an **independent re-implementation** sharing no code with the tool, asserting the stronger property — that each reference still names the same *assertion string*, not merely the same index. **Zero mismatches**, and the verifier was proved discriminating by permuting `CON-002` (a fully-covered behavior) → 3 mis-repointings reported.

**Corpus fidelity by inverse transform**: undoing every `key:`/`text:` pair and mapping every waiver key back to its index reproduces all 12 corpus files **byte-identical** to `1dd9b72`. No text altered, no `notes:` reflowed, no comment relocated, no anchors introduced — the rewrite is line-oriented, never a `yaml.Node` re-encode.

Running `keys` against the migrated corpus reports `393 already keyed (skipped); 0 corpus files to rewrite` — key stability (§3.6) demonstrated as a byte-level no-op rather than asserted.

## The slug checkpoint — 122 of 393 hand-edited

The generated slug for `CAD-033[1]` was `linked-task-row-offers`, for an item reading *"the linked task row offers **no** in-CRM complete or dismiss control"*. The negation sits past the take-4 cutoff, so the algorithm produced a permanent key asserting the **inverse of the behavior**. Now `no-in-crm-complete-or-dismiss`. No mechanical guard can catch that class, which is the entire reason the checkpoint exists.

Review then ran a targeted probe for survivors of that class — text matching `(is|are|does|can|…) (not|never) <verb>` where the key carries the verb stem without a negation — and found **0 candidates**.

An 18-key consistency sweep followed review: seven dangling `-returns` keys fixed **as a family** (fixing one would have made the corpus less consistent than fixing none), four `-when`/`-while`, plus `named-primary-can-be-cleared` (`be` is a stopword, so "can be cleared" had collapsed to "can cleared"), and two keys that dropped the discriminating half of a negative claim (`placeholder-year-birthdays-no-age`, `exported-dataset-contacts-only`). `CON-018` avoided mid-name identifier truncation by matching the corpus's existing `status-update-closed-set` precedent. Zero `-returns|-when|-while|-must|-through` endings remain.

The sweep was applied **at Pass A and Pass B regenerated by the tool**, not hand-patched at HEAD — a parallel edit would have left the ledger naming pre-sweep keys, so G2a's exactness clause would have replayed stale evidence while still passing. G1 and G2a therefore re-prove faithfulness from freshly derived evidence, and two discrimination probes were re-run afterwards to confirm the guards still fail on bad input.

## Two defects found and fixed during implementation

- **`go run` masks exit codes exactly like `make` does.** Verified on go1.25: it collapses any non-zero program exit to `1`, so the 1-vs-2 distinction the `cite`-abort criterion turns on is *invisible through it* — and the plan mandated `go run …; echo $?`. Every exit-code-sensitive assertion was re-run from a built binary; documented in the tool's README.
- **Two unchecked `f.Close()` calls in the guard tooling.** A guard that under-counts its own inputs is the worst failure mode available here, so this was fixed rather than suppressed. (The originally-stated truncated-tar rationale does not actually hold — `os/exec` hands the descriptor to the child — so the comment was corrected to name the real fail-closed chain.)

## Verification

`make lint` 0 · `make test-unit` 0 · `make test-integration` 0 · `make test-frontend` / `bun run test` 0 (74 files, 1248 tests — proves the judge harness is unaffected) · `spec-lint` 0 · `spec-coverage` 0 · **`spec-drift` 0 with zero output** (a keying-only edit must not read as an assertion change).

Coverage smoke diff vs baseline: 34 changed lines = the 17 `waived` lines only, **0 non-waived** — landing at Pass A and byte-identical across Pass B, exactly as planned.

## Scope

Zero production source files **modified**. Added paths are the one-shot tool (5 files, deleted by PR3) and one lint fixture. `frontend/tests/tours/judge/**` untouched (its indexes address its own transcribed array and are embedded in shipped Langfuse trace IDs). `.ai/spec/**` historical docs untouched. Normative docs are PR3's scope.

Part of #760; closes after PR3.
