### PR TITLE
refactor(messaging): extract shared comms_message aggregation adapters

### DIFF
--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -119,8 +119,12 @@ Three sources call the engine today: `telegram`, `messages`, and `gchat`.
 
 **`comms_message` is the default staging store for a new chat-like source.** It
 is the shared cross-source content table (`backend/migrations/058_comms_message.up.sql`),
-already carrying Gmail and Google Chat, and every read path over it is
-source-scoped. Do NOT mint a per-source staging table.
+already carrying Gmail and Google Chat. Every aggregation read path over it is
+source-scoped — the `*ForSource` queries take the source as a parameter, so two
+sources sharing the table never see each other's rows. (Source-neutral reads do
+exist and are deliberate: `GetCommsMessageByID` and `ListCommsMessagesByContact`
+serve by-id and per-contact timeline reads across all sources.) Do NOT mint a
+per-source staging table.
 
 `telegram_message` and `messages_message` are the legacy shape, retained for the
 two sources that predate `comms_message`. They are not the template.

--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -106,35 +106,72 @@ bodies OUTSIDE `IngestBatch` legitimately name kinds and are out of scope.
 
 ## Shared Message Aggregation (`messaging/aggregation`)
 
-Per-source message staging tables (`telegram_message` today; `messages_message`,
-`whatsapp_message` in later PRs) feed a single source-parametric burst/session
-aggregator at `backend/internal/messaging/aggregation`. The shared engine
-implements the burst → session → interaction pipeline (groupIntoBursts,
-resolveSessions, time-based + explicit reply bridging, same-direction
-coalescing) and depends only on interfaces — `SourceAdapter`, `MessageStore`,
-`InteractionFinder`, `InteractionPromoter`, `InteractionExtender`,
-`EventPublisher`.
+Staged message rows feed a single source-parametric burst/session aggregator at
+`backend/internal/messaging/aggregation`. The shared engine implements the
+burst → session → interaction pipeline (groupIntoBursts, resolveSessions,
+time-based + explicit reply bridging, same-direction coalescing) and depends
+only on interfaces — `SourceAdapter`, `MessageStore`, `InteractionFinder`,
+`InteractionPromoter`, `InteractionExtender`, `EventPublisher`.
 
-Each source provides a thin adapter in its package that:
+Three sources call the engine today: `telegram`, `messages`, and `gchat`.
 
-1. Implements `SourceAdapter` (returns the `interaction.source` constant,
-   formats `source_ref`/`peer_ref` strings, builds description labels).
-2. Implements `MessageStore` by wrapping its per-source staging repository
-   and mapping rows into the source-neutral `aggregation.Message` struct.
-   The staging-row → Message mapping MUST carry `InteractionID` through so
-   cross-batch explicit reply bridging works.
-3. Constructs `aggregation.Engine` via `aggregation.NewEngine(...)`. The
-   `EventPublisher` argument MUST be the untyped-nil interface when no
-   bus is configured — typed-nil concrete pointers (`(*events.Bus)(nil)`)
-   bypass the engine's `publisher == nil` guard.
+### Where new chat-like sources stage content
 
-Telegram's `*telegram.AggregationEngine` is currently the only caller; it is
-a thin shim around the shared engine, preserving its exported signature so
-manager/handlers/rematch wiring and integration tests compile unchanged.
+**`comms_message` is the default staging store for a new chat-like source.** It
+is the shared cross-source content table (`backend/migrations/058_comms_message.up.sql`),
+already carrying Gmail and Google Chat, and every read path over it is
+source-scoped. Do NOT mint a per-source staging table.
+
+`telegram_message` and `messages_message` are the legacy shape, retained for the
+two sources that predate `comms_message`. They are not the template.
+
+### The new-source recipe
+
+1. **`SourceAdapter`** — call `commsadapter.NewAdapter(source, label)`
+   (`backend/internal/messaging/commsadapter`). It derives `SourceRef`,
+   `SourceRefPrefix` (LIKE-escaped) and `PeerRef` from the one source string,
+   which is what keeps the ref prefix equal to `SourceName()`. That equality is
+   REQUIRED: `consumer.CommsAggregatorReenqueuer` recovers the chat id by
+   stripping `source + ":"` from the event `PeerRef`, so a source with a
+   different prefix silently loses post-record re-aggregation. (Telegram's
+   prefix is `tg:` while its source is `telegram`, which is exactly why it keeps
+   its own hand-written adapter rather than using this one.)
+2. **Engine** — call `commsadapter.NewEngine(adapter, burst, replyBridge, ...)`.
+   It supplies the `MessageStore` over `comms_message`
+   (`commsadapter.NewStore`), the `InteractionFinder`
+   (`commsadapter.NewInteractionFinder`), and the bus wrappers. Declare the
+   burst/reply-bridge windows as constants beside the source's own constructor,
+   not as wiring literals — the synthetic seed sizes its input to them.
+3. **Source constant + CHECK** — add a `repository.InteractionSource*` constant
+   and widen the `interaction_source_check` CHECK in a migration.
+   `TestInteractionSourceCheck_AgreesWithDescriptorAndConstants` fails until
+   both move together.
+4. **Wiring** — a source-keyed entry at each site that fans out by source:
+   the staging-processor registry and venue-container-reader registry
+   (`backend/cmd/crm-api/wire_core.go`), the engine construction and
+   aggregator-reenqueuer registry (`wire_aggregation.go`), the chat-lister
+   registry, `ChatAwareAggregator` worker map and sweeper-lister map
+   (`wire_scheduler.go`), and `consumer.messageInteractionSources`
+   (`backend/internal/consumer/interaction_recorder.go`). A missing staging
+   registry entry shows up as the recorder's zero-rows rollback; a missing
+   lister/reenqueuer entry leaves rows unprocessed. One integration test that
+   stages a row and asserts an interaction appears discriminates all of them.
+
+A source that genuinely cannot use `comms_message` writes its own
+`SourceAdapter` and `MessageStore` in its own package, mapping its staging rows
+into `aggregation.Message`. Two contracts bind it either way:
+
+- The staging-row → `Message` mapping MUST carry `InteractionID` through, or
+  cross-batch explicit reply bridging silently fails.
+- The `EventPublisher` argument MUST be the untyped-nil interface when no bus is
+  configured — a typed-nil concrete pointer (`(*events.Bus)(nil)`) bypasses the
+  engine's `publisher == nil` guard. `commsadapter.Publisher` and
+  `commsadapter.EventLookup` perform that conversion, so a constructor that goes
+  through them cannot get it wrong; a hand-rolled one must do it explicitly.
 
 The `MessageStore` ordering contract requires adapters to emit rows ordered
 by `SentAt ASC`; the engine sorts defensively, but adapters should keep the
-`ORDER BY sent_at` idiom that the Telegram sqlc queries already use.
+`ORDER BY sent_at` idiom the sqlc queries already use.
 
 ---
 

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -797,7 +797,7 @@ type MarkCommsMessagesProcessedParams struct {
 //     no-op for email rows. There is NO session-scope predicate here (unlike
 //     messages_message): the @session_ref arg is part of the shared
 //     StagingProcessor signature but intentionally unused in the email path.
-//   - chat non-tx engine path (commsMessageStoreAdapter.MarkProcessed, used by
+//   - chat non-tx engine path (commsadapter.StoreAdapter.MarkProcessed, used by
 //     the engine's extend/promote/bridge paths): those paths do not claim rows
 //     or publish events, so the claim-clear keeps any leftover claim from a
 //     prior pass from re-blocking the row. Mirrors MarkMessagesMessagesProcessed.

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1484,7 +1484,7 @@ type Querier interface {
 	//     no-op for email rows. There is NO session-scope predicate here (unlike
 	//     messages_message): the @session_ref arg is part of the shared
 	//     StagingProcessor signature but intentionally unused in the email path.
-	//   - chat non-tx engine path (commsMessageStoreAdapter.MarkProcessed, used by
+	//   - chat non-tx engine path (commsadapter.StoreAdapter.MarkProcessed, used by
 	//     the engine's extend/promote/bridge paths): those paths do not claim rows
 	//     or publish events, so the claim-clear keeps any leftover claim from a
 	//     prior pass from re-blocking the row. Mirrors MarkMessagesMessagesProcessed.

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -140,7 +140,7 @@ ORDER BY sent_at DESC, id;
 --     no-op for email rows. There is NO session-scope predicate here (unlike
 --     messages_message): the @session_ref arg is part of the shared
 --     StagingProcessor signature but intentionally unused in the email path.
---   - chat non-tx engine path (commsMessageStoreAdapter.MarkProcessed, used by
+--   - chat non-tx engine path (commsadapter.StoreAdapter.MarkProcessed, used by
 --     the engine's extend/promote/bridge paths): those paths do not claim rows
 --     or publish events, so the claim-clear keeps any leftover claim from a
 --     prior pass from re-blocking the row. Mirrors MarkMessagesMessagesProcessed.

--- a/backend/internal/google/gchat_aggregation.go
+++ b/backend/internal/google/gchat_aggregation.go
@@ -1,20 +1,10 @@
 package google
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
-	"time"
-
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/messaging/commsadapter"
 	"personal-crm/backend/internal/repository"
-
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 )
 
 // GChatSourceName is the source string written into interaction.source,
@@ -23,12 +13,10 @@ import (
 // repository.InteractionSourceGChat constant.
 const GChatSourceName = repository.InteractionSourceGChat
 
-// replyTargetMetadataKey is the source_metadata key under which an explicit
-// reply's target message resource name is stored (spec §5.X.3). No provider
-// writes this key yet (explicit-reply bridging is deferred), so the
-// projection's ReplyTargetID is currently always nil — but wiring the field
-// here means a later explicit-reply provider need not touch the adapter.
-const replyTargetMetadataKey = "reply_target_external_id"
+// gchatLabel is the human product name that appears in interaction
+// descriptions ("GChat outreach (3 messages)"). Declared beside the source name
+// because the pair is the whole of GChat's adapter configuration.
+const gchatLabel = "GChat"
 
 // GChatBurstWindowHours / GChatReplyBridgeHours are the aggregation windows the
 // GChat engine runs on: consecutive same-direction messages inside the burst
@@ -46,13 +34,20 @@ const (
 	GChatReplyBridgeHours = 48
 )
 
+// gchatSourceAdapter returns the shared comms adapter configured for Google
+// Chat. Both NewGChatAggregationEngine and the wire-format test call it, so the
+// bytes the test pins are the bytes production writes.
+func gchatSourceAdapter() commsadapter.Adapter {
+	return commsadapter.NewAdapter(GChatSourceName, gchatLabel)
+}
+
 // NewGChatAggregationEngine constructs a shared aggregator engine configured
-// for the Google Chat source over the comms_message table. Mirror of
-// messages.NewAggregationEngine — same nil-safety conventions. Returns the
-// shared *aggregation.Engine directly (NO facade): GChat's chat ID is the
-// opaque space resource name (a string), so the engine's native
+// for the Google Chat source over the comms_message table. Returns the shared
+// *aggregation.Engine directly (NO facade): GChat's chat ID is the opaque space
+// resource name (a string), so the engine's native
 // AggregateForContact(ctx, contactID, chatID string) signature already takes a
-// string. Production wiring passes all of (pool, eventBus, enqueuer).
+// string. Production wiring passes all of (pool, eventBus, enqueuer); nil bus /
+// pool / enqueuer are safe (see commsadapter.NewEngine).
 func NewGChatAggregationEngine(
 	burstWindowHours, replyBridgeHours int,
 	commsRepo *repository.CommsMessageRepository,
@@ -63,257 +58,16 @@ func NewGChatAggregationEngine(
 	pool aggregation.TxBeginner,
 	enqueuer aggregation.ConsumerJobEnqueuer,
 ) *aggregation.Engine {
-	adapter := gchatAdapter{}
-	store := &commsMessageStoreAdapter{repo: commsRepo, source: GChatSourceName}
-	finder := &interactionFinderAdapter{repo: interactionRepo}
-
-	// Untyped-nil propagation — a typed-nil concrete pointer would silently
-	// bypass the engine's publisher == nil guard. See
-	// messaging/aggregation/interfaces.go EventPublisher note.
-	var pub aggregation.EventPublisher
-	if eventBus != nil {
-		pub = eventBus
-	}
-	var lookup aggregation.EventLookup
-	if eventBus != nil {
-		lookup = &busEventLookup{bus: eventBus}
-	}
-
-	return aggregation.NewEngine(
-		adapter,
-		store,
-		finder,
-		promoter,
-		extender,
-		pub,
+	return commsadapter.NewEngine(
+		gchatSourceAdapter(),
 		burstWindowHours,
 		replyBridgeHours,
+		commsRepo,
+		interactionRepo,
+		promoter,
+		extender,
+		eventBus,
 		pool,
-		lookup,
 		enqueuer,
 	)
-}
-
-// --- adapters --------------------------------------------------------
-
-// gchatAdapter binds source-name + format hooks for the Google Chat source.
-// Wire format:
-//   - SourceRef:   "gchat:<space_resource>:<first_message_resource>"
-//   - PeerRef:     "gchat:<space_resource>"
-//   - Description: "GChat <label> (<n> messages)"
-//
-// The chat ID is the opaque Chat space resource name (e.g. "spaces/AAAA9876"),
-// a string, so this mirrors the Messages adapter (string chat IDs), not
-// Telegram (int64).
-type gchatAdapter struct{}
-
-// SourceName returns the source string written into interaction.source.
-func (gchatAdapter) SourceName() string {
-	return GChatSourceName
-}
-
-// SourceRef formats the deterministic burst sourceRef.
-func (gchatAdapter) SourceRef(chatID, firstExternalID string) string {
-	return GChatSourceName + ":" + chatID + ":" + firstExternalID
-}
-
-// SourceRefPrefix returns the LIKE pattern for scoped "recent interaction in
-// this chat" queries.
-//
-// Chat space resource names (e.g. "spaces/AAAA9876") do not legitimately
-// contain LIKE wildcards (`_`, `%`) today, but the format is opaque and could
-// drift. We escape the chat ID UNCONDITIONALLY (spec §5.X.4 defensive) so the
-// prefix is correct even if Chat ever ships a `_`/`%` in a resource name. The
-// underlying InteractionFinder queries use `LIKE pattern ESCAPE '\'`, so the
-// explicit escape takes effect end-to-end. The replacer also escapes a literal
-// `\` in the chat ID — belt-and-suspenders for forward compatibility.
-func (gchatAdapter) SourceRefPrefix(chatID string) string {
-	escaped := strings.NewReplacer(
-		`\`, `\\`,
-		`%`, `\%`,
-		`_`, `\_`,
-	).Replace(chatID)
-	return GChatSourceName + ":" + escaped + ":%"
-}
-
-// PeerRef formats the event-payload PeerRef field. NOT a LIKE pattern — escape
-// is not applied because the consumer's reenqueuer parses this field with a
-// literal string strip.
-func (gchatAdapter) PeerRef(chatID string) string {
-	return GChatSourceName + ":" + chatID
-}
-
-// Description formats the human-readable interaction description. Label
-// phrasing mirrors Telegram/Messages (outreach/response/exchange) so UI
-// surfaces stay consistent across sources.
-func (gchatAdapter) Description(direction string, msgCount int) string {
-	label := "exchange"
-	switch direction {
-	case repository.InteractionDirectionOutbound:
-		label = "outreach"
-	case repository.InteractionDirectionInbound:
-		label = "response"
-	}
-	return fmt.Sprintf("GChat %s (%d messages)", label, msgCount)
-}
-
-// commsMessageStoreAdapter projects repository.CommsMessage rows into
-// aggregation.Message, pinning a source. Lives in the google package (not
-// repository) so the repository package stays free of aggregation-package
-// imports — the same boundary the telegram/messages adapters honor. The 7
-// MessageStore methods delegate to the source-parameterized repo methods,
-// passing a.source; the ForSource suffix on the repo methods is erased here.
-type commsMessageStoreAdapter struct {
-	repo   *repository.CommsMessageRepository
-	source string
-}
-
-func (a *commsMessageStoreAdapter) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
-	return a.repo.ListUnprocessedContactIDsForSource(ctx, a.source)
-}
-
-func (a *commsMessageStoreAdapter) ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]aggregation.Message, error) {
-	rows, err := a.repo.ListUnprocessedByContactForSource(ctx, a.source, contactID)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]aggregation.Message, len(rows))
-	for i := range rows {
-		out[i] = mapCommsMessage(rows[i])
-	}
-	return out, nil
-}
-
-func (a *commsMessageStoreAdapter) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]aggregation.Message, error) {
-	rows, err := a.repo.ListUnprocessedByContactAndChatForSource(ctx, a.source, contactID, chatID)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]aggregation.Message, len(rows))
-	for i := range rows {
-		out[i] = mapCommsMessage(rows[i])
-	}
-	return out, nil
-}
-
-// GetMessageByReplyTarget resolves the message referenced by a reply. The
-// reply target is itself a stored comms_message row, looked up by its own
-// external_id within the same (source, contact, chat) scope. comms_message is
-// per-contact (a shared address fans out to one row per matched contact), so
-// the lookup MUST be scoped to contactID — otherwise it could return another
-// contact's row whose interaction would then be wrongly bridged.
-func (a *commsMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, contactID uuid.UUID, chatID, replyTargetID string) (aggregation.Message, bool, error) {
-	row, err := a.repo.GetMessageByReplyTargetForSource(ctx, a.source, contactID, chatID, replyTargetID)
-	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return aggregation.Message{}, false, nil
-		}
-		return aggregation.Message{}, false, err
-	}
-	return mapCommsMessage(*row), true, nil
-}
-
-func (a *commsMessageStoreAdapter) MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
-	return a.repo.MarkMessagesProcessed(ctx, messageIDs, interactionID)
-}
-
-func (a *commsMessageStoreAdapter) ClaimRowsTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, sessionRef string) ([]uuid.UUID, error) {
-	return a.repo.ClaimMessagesTx(ctx, tx, messageIDs, sessionRef)
-}
-
-func (a *commsMessageStoreAdapter) ClearStaleClaimTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, expectedSessionRef string) error {
-	return a.repo.ClearStaleClaimTx(ctx, tx, messageIDs, expectedSessionRef)
-}
-
-// mapCommsMessage projects a repository.CommsMessage into the source-neutral
-// aggregation.Message. ChatID comes from thread_id (the space resource name);
-// a nil thread_id defensively yields ChatID == "" (chat sources always write
-// it non-null). Preserving InteractionID / ClaimedAt / ClaimedSessionRef is
-// required for cross-batch explicit reply bridging and stale-claim /
-// boundary-shift recovery. ReplyTargetID is parsed from
-// source_metadata.reply_target_external_id when present as a non-empty string.
-func mapCommsMessage(m repository.CommsMessage) aggregation.Message {
-	out := aggregation.Message{
-		ID:                m.ID,
-		IsOutgoing:        m.Direction == repository.InteractionDirectionOutbound,
-		SentAt:            m.SentAt,
-		ExternalID:        m.ExternalID,
-		InteractionID:     m.InteractionID,
-		ClaimedAt:         m.ClaimedAt,
-		ClaimedSessionRef: m.ClaimedSessionRef,
-	}
-	if m.ThreadID != nil {
-		out.ChatID = *m.ThreadID
-	}
-	if rt := parseReplyTargetID(m.SourceMetadata); rt != "" {
-		out.ReplyTargetID = &rt
-	}
-	return out
-}
-
-// parseReplyTargetID extracts source_metadata.reply_target_external_id as a
-// non-empty string, or "" when the key is absent, empty, or the wrong type.
-func parseReplyTargetID(raw []byte) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var meta map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &meta); err != nil {
-		return ""
-	}
-	v, ok := meta[replyTargetMetadataKey]
-	if !ok {
-		return ""
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return ""
-	}
-	return s
-}
-
-// busEventLookup adapts *events.Bus to aggregation.EventLookup. Same shape as
-// the messages/telegram adapters' busEventLookup; re-declared package-private
-// here so the google package owns its own copy (the repository package stays
-// free of aggregation imports).
-type busEventLookup struct{ bus *events.Bus }
-
-func (l *busEventLookup) FindEventBySourceRef(ctx context.Context, source, sourceID string) (uuid.UUID, bool, error) {
-	env, err := l.bus.FindEventBySource(ctx, source, sourceID)
-	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return uuid.Nil, false, nil
-		}
-		return uuid.Nil, false, err
-	}
-	return env.ID, true, nil
-}
-
-// interactionFinderAdapter wraps *repository.InteractionRepository and exposes
-// the source-neutral aggregation.InteractionFinder surface. Same shape as the
-// messages/telegram adapters' interactionFinderAdapter.
-type interactionFinderAdapter struct {
-	repo *repository.InteractionRepository
-}
-
-func (a *interactionFinderAdapter) FindRecentBySourceAndDirection(
-	ctx context.Context,
-	contactID uuid.UUID,
-	source, direction, sourceRefPrefix string,
-	windowStart, windowEnd time.Time,
-) (*repository.Interaction, error) {
-	return a.repo.FindRecentInteractionBySourceAndDirection(ctx, contactID, source, direction, sourceRefPrefix, windowStart, windowEnd)
-}
-
-func (a *interactionFinderAdapter) FindRecentOutboundBySource(
-	ctx context.Context,
-	contactID uuid.UUID,
-	source, sourceRefPrefix string,
-	windowStart, windowEnd time.Time,
-) (*repository.Interaction, error) {
-	return a.repo.FindRecentOutboundInteractionBySource(ctx, contactID, source, sourceRefPrefix, windowStart, windowEnd)
-}
-
-func (a *interactionFinderAdapter) GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error) {
-	return a.repo.GetInteraction(ctx, id)
 }

--- a/backend/internal/google/gchat_aggregation_unit_test.go
+++ b/backend/internal/google/gchat_aggregation_unit_test.go
@@ -1,29 +1,34 @@
 package google
 
 import (
-	"encoding/json"
 	"testing"
-	"time"
 
-	"personal-crm/backend/internal/accelerated"
-	"personal-crm/backend/internal/messaging/aggregation"
 	"personal-crm/backend/internal/repository"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// TestGChatAdapter_Formatting pins the wire-format hooks: SourceName, SourceRef,
-// PeerRef, and Description for each direction.
-func TestGChatAdapter_Formatting(t *testing.T) {
-	a := gchatAdapter{}
+// TestGChatSourceAdapter_WireFormat pins the GChat-specific bytes the shared
+// commsadapter.Adapter produces once configured with GChat's source name and
+// label. The projection, LIKE-escape and nil-propagation behaviour now live in
+// backend/internal/messaging/commsadapter and are tested there; what stays
+// GChat's own is WHICH source string and label the engine is wired with, since
+// changing either rewrites interaction.source_ref and interaction.description
+// for this source.
+//
+// It asserts against gchatSourceAdapter(), the same call
+// NewGChatAggregationEngine makes, so the adapter under test is the adapter in
+// production.
+func TestGChatSourceAdapter_WireFormat(t *testing.T) {
+	a := gchatSourceAdapter()
 
 	assert.Equal(t, "gchat", a.SourceName())
+	assert.Equal(t, repository.InteractionSourceGChat, a.SourceName())
 	assert.Equal(t,
 		"gchat:spaces/AAA:spaces/AAA/messages/1",
 		a.SourceRef("spaces/AAA", "spaces/AAA/messages/1"),
 	)
+	assert.Equal(t, `gchat:spaces/AAA:%`, a.SourceRefPrefix("spaces/AAA"))
 	assert.Equal(t, "gchat:spaces/AAA", a.PeerRef("spaces/AAA"))
 
 	assert.Equal(t, "GChat outreach (3 messages)",
@@ -32,185 +37,16 @@ func TestGChatAdapter_Formatting(t *testing.T) {
 		a.Description(repository.InteractionDirectionInbound, 1))
 	assert.Equal(t, "GChat exchange (5 messages)",
 		a.Description(repository.InteractionDirectionMutual, 5))
-	// Unknown direction falls back to "exchange".
-	assert.Equal(t, "GChat exchange (2 messages)",
-		a.Description("something-else", 2))
 }
 
-// TestGChatAdapter_SourceRefPrefixEscape proves the LIKE-escape fires
-// UNCONDITIONALLY (spec §5.X.4): benign inputs pass through unchanged, while
-// `_`, `%`, and `\` are escaped so they cannot act as LIKE wildcards.
-func TestGChatAdapter_SourceRefPrefixEscape(t *testing.T) {
-	a := gchatAdapter{}
-
-	cases := []struct {
-		name string
-		chat string
-		want string
-	}{
-		{
-			name: "benign space resource name unchanged",
-			chat: "spaces/AAA",
-			want: `gchat:spaces/AAA:%`,
-		},
-		{
-			name: "underscore and percent escaped",
-			chat: "a_b%c",
-			want: `gchat:a\_b\%c:%`,
-		},
-		{
-			name: "backslash doubled",
-			chat: `a\b`,
-			want: `gchat:a\\b:%`,
-		},
-		{
-			name: "all special chars together",
-			chat: `x_%\y`,
-			want: `gchat:x\_\%\\y:%`,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, a.SourceRefPrefix(tc.chat))
-		})
-	}
-}
-
-// TestMapCommsMessage_Projection covers the repository.CommsMessage →
-// aggregation.Message projection: ChatID from thread_id, IsOutgoing from
-// direction, ExternalID passthrough, claim/interaction fields preserved, and
-// the defensive nil thread_id case.
-func TestMapCommsMessage_Projection(t *testing.T) {
-	id := uuid.New()
-	interactionID := uuid.New()
-	claimedAt := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
-	sessionRef := "gchat:spaces/AAA:spaces/AAA/messages/1"
-	sentAt := accelerated.GetCurrentTime().UTC().Add(-time.Hour).Truncate(time.Microsecond)
-	thread := "spaces/AAA"
-
-	t.Run("outbound row with all fields", func(t *testing.T) {
-		m := repository.CommsMessage{
-			ID:                id,
-			Source:            "gchat",
-			ExternalID:        "spaces/AAA/messages/1",
-			ThreadID:          &thread,
-			Direction:         repository.InteractionDirectionOutbound,
-			SentAt:            sentAt,
-			InteractionID:     &interactionID,
-			ClaimedAt:         &claimedAt,
-			ClaimedSessionRef: &sessionRef,
-		}
-		got := mapCommsMessage(m)
-		assert.Equal(t, id, got.ID)
-		assert.Equal(t, "spaces/AAA", got.ChatID)
-		assert.True(t, got.IsOutgoing)
-		assert.Equal(t, sentAt, got.SentAt)
-		assert.Equal(t, "spaces/AAA/messages/1", got.ExternalID)
-		require.NotNil(t, got.InteractionID)
-		assert.Equal(t, interactionID, *got.InteractionID)
-		require.NotNil(t, got.ClaimedAt)
-		assert.Equal(t, claimedAt, *got.ClaimedAt)
-		require.NotNil(t, got.ClaimedSessionRef)
-		assert.Equal(t, sessionRef, *got.ClaimedSessionRef)
-		assert.Nil(t, got.ReplyTargetID)
-	})
-
-	t.Run("inbound row, nil claim/interaction fields preserved as nil", func(t *testing.T) {
-		m := repository.CommsMessage{
-			ID:         id,
-			Source:     "gchat",
-			ExternalID: "spaces/AAA/messages/2",
-			ThreadID:   &thread,
-			Direction:  repository.InteractionDirectionInbound,
-			SentAt:     sentAt,
-		}
-		got := mapCommsMessage(m)
-		assert.False(t, got.IsOutgoing)
-		assert.Nil(t, got.InteractionID)
-		assert.Nil(t, got.ClaimedAt)
-		assert.Nil(t, got.ClaimedSessionRef)
-	})
-
-	t.Run("nil thread_id yields empty ChatID (defensive)", func(t *testing.T) {
-		m := repository.CommsMessage{
-			ID:         id,
-			Source:     "gchat",
-			ExternalID: "spaces/AAA/messages/3",
-			ThreadID:   nil,
-			Direction:  repository.InteractionDirectionInbound,
-			SentAt:     sentAt,
-		}
-		got := mapCommsMessage(m)
-		assert.Equal(t, "", got.ChatID)
-	})
-}
-
-// TestMapCommsMessage_ReplyTargetID covers parsing the reply target external id
-// from source_metadata: present non-empty string → set; absent/empty/wrong-type
-// → nil.
-func TestMapCommsMessage_ReplyTargetID(t *testing.T) {
-	base := repository.CommsMessage{
-		ID:         uuid.New(),
-		Source:     "gchat",
-		ExternalID: "spaces/AAA/messages/9",
-		ThreadID:   strPtr("spaces/AAA"),
-		Direction:  repository.InteractionDirectionInbound,
-		SentAt:     accelerated.GetCurrentTime().UTC(),
-	}
-
-	withMeta := func(m map[string]any) []byte {
-		b, err := json.Marshal(m)
-		require.NoError(t, err)
-		return b
-	}
-
-	t.Run("present non-empty string", func(t *testing.T) {
-		m := base
-		m.SourceMetadata = withMeta(map[string]any{
-			replyTargetMetadataKey: "spaces/AAA/messages/parent",
-		})
-		got := mapCommsMessage(m)
-		require.NotNil(t, got.ReplyTargetID)
-		assert.Equal(t, "spaces/AAA/messages/parent", *got.ReplyTargetID)
-	})
-
-	t.Run("key absent", func(t *testing.T) {
-		m := base
-		m.SourceMetadata = withMeta(map[string]any{"other": "x"})
-		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
-	})
-
-	t.Run("key present but empty string", func(t *testing.T) {
-		m := base
-		m.SourceMetadata = withMeta(map[string]any{replyTargetMetadataKey: ""})
-		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
-	})
-
-	t.Run("key present but wrong type", func(t *testing.T) {
-		m := base
-		m.SourceMetadata = withMeta(map[string]any{replyTargetMetadataKey: 123})
-		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
-	})
-
-	t.Run("nil/empty metadata", func(t *testing.T) {
-		m := base
-		m.SourceMetadata = nil
-		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
-		m.SourceMetadata = []byte{}
-		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
-	})
-
-	t.Run("malformed JSON", func(t *testing.T) {
-		m := base
-		m.SourceMetadata = []byte("{not json")
-		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
-	})
-}
-
-// TestGChatStoreAdapter_SatisfiesMessageStore is a compile-time assertion that
-// commsMessageStoreAdapter implements the aggregation.MessageStore interface
-// (catches a signature drift on either side).
-func TestGChatStoreAdapter_SatisfiesMessageStore(t *testing.T) {
-	var _ aggregation.MessageStore = (*commsMessageStoreAdapter)(nil)
-	var _ aggregation.SourceAdapter = gchatAdapter{}
+// TestNewGChatAggregationEngine_AcceptsNilDependencies is the construction-level
+// smoke test for the migrated constructor: nil repos / bus / pool / enqueuer
+// must not panic, matching the nil-safety contract the wiring and the gchat
+// tests rely on.
+func TestNewGChatAggregationEngine_AcceptsNilDependencies(t *testing.T) {
+	e := NewGChatAggregationEngine(
+		GChatBurstWindowHours, GChatReplyBridgeHours,
+		nil, nil, nil, nil, nil, nil, nil,
+	)
+	assert.NotNil(t, e)
 }

--- a/backend/internal/messages/aggregation_adapter.go
+++ b/backend/internal/messages/aggregation_adapter.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/messaging/commsadapter"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
@@ -43,31 +43,22 @@ func NewAggregationEngine(
 ) *aggregation.Engine {
 	adapter := messagesAdapter{}
 	store := &messagesMessageStoreAdapter{repo: messageRepo}
-	finder := &interactionFinderAdapter{repo: interactionRepo}
 
-	// Untyped-nil propagation — see telegram/aggregation.go for the
-	// rationale (typed-nil concrete pointer would silently bypass
-	// engine guards on publisher == nil).
-	var pub aggregation.EventPublisher
-	if eventBus != nil {
-		pub = eventBus
-	}
-	var lookup aggregation.EventLookup
-	if eventBus != nil {
-		lookup = &busEventLookup{bus: eventBus}
-	}
-
+	// Untyped-nil propagation for a nil bus is handled by
+	// commsadapter.Publisher / commsadapter.EventLookup — a typed-nil
+	// concrete pointer would silently bypass the engine's
+	// publisher == nil guard.
 	return aggregation.NewEngine(
 		adapter,
 		store,
-		finder,
+		commsadapter.NewInteractionFinder(interactionRepo),
 		promoter,
 		extender,
-		pub,
+		commsadapter.Publisher(eventBus),
 		burstWindowHours,
 		replyBridgeHours,
 		pool,
-		lookup,
+		commsadapter.EventLookup(eventBus),
 		enqueuer,
 	)
 }
@@ -219,48 +210,4 @@ func mapMessagesMessage(m repository.MessagesMessage) aggregation.Message {
 		out.ReplyTargetID = &s
 	}
 	return out
-}
-
-// busEventLookup adapts *events.Bus to aggregation.EventLookup. Same
-// shape as the telegram adapter's busEventLookup.
-type busEventLookup struct{ bus *events.Bus }
-
-func (l *busEventLookup) FindEventBySourceRef(ctx context.Context, source, sourceID string) (uuid.UUID, bool, error) {
-	env, err := l.bus.FindEventBySource(ctx, source, sourceID)
-	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return uuid.Nil, false, nil
-		}
-		return uuid.Nil, false, err
-	}
-	return env.ID, true, nil
-}
-
-// interactionFinderAdapter wraps *repository.InteractionRepository and
-// exposes the source-neutral aggregation.InteractionFinder surface.
-// Same shape as the telegram adapter's interactionFinderAdapter.
-type interactionFinderAdapter struct {
-	repo *repository.InteractionRepository
-}
-
-func (a *interactionFinderAdapter) FindRecentBySourceAndDirection(
-	ctx context.Context,
-	contactID uuid.UUID,
-	source, direction, sourceRefPrefix string,
-	windowStart, windowEnd time.Time,
-) (*repository.Interaction, error) {
-	return a.repo.FindRecentInteractionBySourceAndDirection(ctx, contactID, source, direction, sourceRefPrefix, windowStart, windowEnd)
-}
-
-func (a *interactionFinderAdapter) FindRecentOutboundBySource(
-	ctx context.Context,
-	contactID uuid.UUID,
-	source, sourceRefPrefix string,
-	windowStart, windowEnd time.Time,
-) (*repository.Interaction, error) {
-	return a.repo.FindRecentOutboundInteractionBySource(ctx, contactID, source, sourceRefPrefix, windowStart, windowEnd)
-}
-
-func (a *interactionFinderAdapter) GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error) {
-	return a.repo.GetInteraction(ctx, id)
 }

--- a/backend/internal/messaging/commsadapter/adapter.go
+++ b/backend/internal/messaging/commsadapter/adapter.go
@@ -1,0 +1,93 @@
+package commsadapter
+
+import (
+	"fmt"
+	"strings"
+
+	"personal-crm/backend/internal/repository"
+)
+
+// Adapter is a source-parameterized aggregation.SourceAdapter for any source
+// whose interaction ref prefix equals its interaction.source string. Wire
+// format, for source "gchat" with label "GChat":
+//
+//   - SourceRef:       "gchat:<chatID>:<firstExternalID>"
+//   - SourceRefPrefix: "gchat:<escaped chatID>:%"
+//   - PeerRef:         "gchat:<chatID>"
+//   - Description:     "GChat <label> (<n> messages)"
+//
+// The source==prefix equality is REQUIRED by consumer.CommsAggregatorReenqueuer,
+// which recovers the chat id by stripping source + ":" from the event PeerRef.
+// Deriving every format from the single source field is what makes that
+// equality structural rather than a convention a new source could miss.
+//
+// Adapter is a value type: it satisfies aggregation.SourceAdapter when passed by
+// value, so callers pass the NewAdapter result directly.
+type Adapter struct {
+	source string // interaction.source constant, e.g. "gchat", "whatsapp"
+	label  string // human product name used in Description, e.g. "GChat", "WhatsApp"
+}
+
+// NewAdapter returns the SourceAdapter for a comms_message-backed source.
+// source is the interaction.source constant (which is also the ref prefix);
+// label is the human product name that appears in interaction descriptions.
+func NewAdapter(source, label string) Adapter {
+	return Adapter{source: source, label: label}
+}
+
+// SourceName returns the source string written into interaction.source.
+func (a Adapter) SourceName() string {
+	return a.source
+}
+
+// SourceRef formats the deterministic burst sourceRef.
+func (a Adapter) SourceRef(chatID, firstExternalID string) string {
+	return a.source + ":" + chatID + ":" + firstExternalID
+}
+
+// SourceRefPrefix returns the LIKE pattern for scoped "recent interaction in
+// this chat" queries.
+//
+// Chat ids are opaque per-source strings that may legitimately contain the
+// PostgreSQL LIKE wildcards `_` and `%` (Apple Messages guids empirically do).
+// We escape UNCONDITIONALLY so the prefix stays correct for any source, present
+// or future. The underlying InteractionFinder queries use
+// `LIKE pattern ESCAPE '\'`, so the explicit escape takes effect end-to-end.
+func (a Adapter) SourceRefPrefix(chatID string) string {
+	return a.source + ":" + escapeLike(chatID) + ":%"
+}
+
+// PeerRef formats the event-payload PeerRef field. NOT a LIKE pattern — the
+// escape is deliberately NOT applied because the consumer's reenqueuer parses
+// this field with a literal string strip.
+func (a Adapter) PeerRef(chatID string) string {
+	return a.source + ":" + chatID
+}
+
+// Description formats the human-readable interaction description. Label
+// phrasing (outreach/response/exchange) is shared across every source so UI
+// surfaces stay consistent.
+func (a Adapter) Description(direction string, msgCount int) string {
+	label := "exchange"
+	switch direction {
+	case repository.InteractionDirectionOutbound:
+		label = "outreach"
+	case repository.InteractionDirectionInbound:
+		label = "response"
+	}
+	return fmt.Sprintf("%s %s (%d messages)", a.label, label, msgCount)
+}
+
+// likeEscaper escapes the three LIKE metacharacters. The literal `\` is escaped
+// too — belt-and-suspenders for a source whose chat ids ever contain one.
+var likeEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`%`, `\%`,
+	`_`, `\_`,
+)
+
+// escapeLike escapes the LIKE metacharacters so SourceRefPrefix is a correct
+// pattern for `LIKE ... ESCAPE '\'`.
+func escapeLike(s string) string {
+	return likeEscaper.Replace(s)
+}

--- a/backend/internal/messaging/commsadapter/commsadapter_test.go
+++ b/backend/internal/messaging/commsadapter/commsadapter_test.go
@@ -1,0 +1,285 @@
+package commsadapter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdapter_WireFormat pins the wire-format hooks for a configured source:
+// SourceName, SourceRef, PeerRef, and Description for each direction. These
+// bytes are the interaction.source_ref / event PeerRef / interaction.description
+// values every comms source writes, so a change here is a data-format change.
+func TestAdapter_WireFormat(t *testing.T) {
+	a := NewAdapter("gchat", "GChat")
+
+	assert.Equal(t, "gchat", a.SourceName())
+	assert.Equal(t,
+		"gchat:spaces/AAA:spaces/AAA/messages/1",
+		a.SourceRef("spaces/AAA", "spaces/AAA/messages/1"),
+	)
+	assert.Equal(t, "gchat:spaces/AAA", a.PeerRef("spaces/AAA"))
+
+	assert.Equal(t, "GChat outreach (3 messages)",
+		a.Description(repository.InteractionDirectionOutbound, 3))
+	assert.Equal(t, "GChat response (1 messages)",
+		a.Description(repository.InteractionDirectionInbound, 1))
+	assert.Equal(t, "GChat exchange (5 messages)",
+		a.Description(repository.InteractionDirectionMutual, 5))
+	// Unknown direction falls back to "exchange".
+	assert.Equal(t, "GChat exchange (2 messages)",
+		a.Description("something-else", 2))
+}
+
+// TestAdapter_SourceRefPrefixEscapesLikeWildcards proves the LIKE-escape fires
+// UNCONDITIONALLY: benign inputs pass through unchanged, while `_`, `%`, and `\`
+// are escaped so they cannot act as LIKE wildcards. PeerRef of the same chat id
+// is deliberately NOT escaped — the reenqueuer strips it literally.
+func TestAdapter_SourceRefPrefixEscapesLikeWildcards(t *testing.T) {
+	a := NewAdapter("gchat", "GChat")
+
+	cases := []struct {
+		name string
+		chat string
+		want string
+	}{
+		{
+			name: "benign space resource name unchanged",
+			chat: "spaces/AAA",
+			want: `gchat:spaces/AAA:%`,
+		},
+		{
+			name: "underscore and percent escaped",
+			chat: "a_b%c",
+			want: `gchat:a\_b\%c:%`,
+		},
+		{
+			name: "backslash doubled",
+			chat: `a\b`,
+			want: `gchat:a\\b:%`,
+		},
+		{
+			name: "all special chars together",
+			chat: `x_%\y`,
+			want: `gchat:x\_\%\\y:%`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, a.SourceRefPrefix(tc.chat))
+			// PeerRef must NOT escape: the consumer reenqueuer recovers the
+			// chat id with a literal strip, so an escaped peer ref would
+			// yield a chat id that matches no row.
+			assert.Equal(t, "gchat:"+tc.chat, a.PeerRef(tc.chat))
+		})
+	}
+}
+
+// TestAdapter_PrefixEqualsSourceName is the mechanical guard for the package's
+// central invariant: every ref an Adapter emits is prefixed with its own
+// SourceName plus ":". consumer.CommsAggregatorReenqueuer recovers the chat id
+// by stripping exactly that, so a source whose prefix drifts from its source
+// string silently loses post-record re-aggregation.
+func TestAdapter_PrefixEqualsSourceName(t *testing.T) {
+	for _, a := range []Adapter{
+		NewAdapter("gchat", "GChat"),
+		NewAdapter("whatsapp", "WhatsApp"),
+	} {
+		t.Run(a.SourceName(), func(t *testing.T) {
+			want := a.SourceName() + ":"
+			assert.True(t, strings.HasPrefix(a.SourceRef("chat-1", "msg-1"), want),
+				"SourceRef must start with %q, got %q", want, a.SourceRef("chat-1", "msg-1"))
+			assert.True(t, strings.HasPrefix(a.SourceRefPrefix("chat-1"), want),
+				"SourceRefPrefix must start with %q, got %q", want, a.SourceRefPrefix("chat-1"))
+			assert.True(t, strings.HasPrefix(a.PeerRef("chat-1"), want),
+				"PeerRef must start with %q, got %q", want, a.PeerRef("chat-1"))
+			// The reenqueuer's exact recovery step, reproduced.
+			assert.Equal(t, "chat-1", strings.TrimPrefix(a.PeerRef("chat-1"), want))
+		})
+	}
+}
+
+// TestMapMessage_Projection covers the repository.CommsMessage →
+// aggregation.Message projection: ChatID from thread_id, IsOutgoing from
+// direction, ExternalID passthrough, claim/interaction fields preserved, and the
+// defensive nil thread_id case.
+func TestMapMessage_Projection(t *testing.T) {
+	id := uuid.New()
+	interactionID := uuid.New()
+	claimedAt := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
+	sessionRef := "gchat:spaces/AAA:spaces/AAA/messages/1"
+	sentAt := accelerated.GetCurrentTime().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	thread := "spaces/AAA"
+
+	t.Run("outbound row with all fields", func(t *testing.T) {
+		m := repository.CommsMessage{
+			ID:                id,
+			Source:            "gchat",
+			ExternalID:        "spaces/AAA/messages/1",
+			ThreadID:          &thread,
+			Direction:         repository.InteractionDirectionOutbound,
+			SentAt:            sentAt,
+			InteractionID:     &interactionID,
+			ClaimedAt:         &claimedAt,
+			ClaimedSessionRef: &sessionRef,
+		}
+		got := MapMessage(m)
+		assert.Equal(t, id, got.ID)
+		assert.Equal(t, "spaces/AAA", got.ChatID)
+		assert.True(t, got.IsOutgoing)
+		assert.Equal(t, sentAt, got.SentAt)
+		assert.Equal(t, "spaces/AAA/messages/1", got.ExternalID)
+		require.NotNil(t, got.InteractionID)
+		assert.Equal(t, interactionID, *got.InteractionID)
+		require.NotNil(t, got.ClaimedAt)
+		assert.Equal(t, claimedAt, *got.ClaimedAt)
+		require.NotNil(t, got.ClaimedSessionRef)
+		assert.Equal(t, sessionRef, *got.ClaimedSessionRef)
+		assert.Nil(t, got.ReplyTargetID)
+	})
+
+	t.Run("inbound row, nil claim/interaction fields preserved as nil", func(t *testing.T) {
+		m := repository.CommsMessage{
+			ID:         id,
+			Source:     "gchat",
+			ExternalID: "spaces/AAA/messages/2",
+			ThreadID:   &thread,
+			Direction:  repository.InteractionDirectionInbound,
+			SentAt:     sentAt,
+		}
+		got := MapMessage(m)
+		assert.False(t, got.IsOutgoing)
+		assert.Nil(t, got.InteractionID)
+		assert.Nil(t, got.ClaimedAt)
+		assert.Nil(t, got.ClaimedSessionRef)
+	})
+
+	t.Run("nil thread_id yields empty ChatID (defensive)", func(t *testing.T) {
+		m := repository.CommsMessage{
+			ID:         id,
+			Source:     "gchat",
+			ExternalID: "spaces/AAA/messages/3",
+			ThreadID:   nil,
+			Direction:  repository.InteractionDirectionInbound,
+			SentAt:     sentAt,
+		}
+		got := MapMessage(m)
+		assert.Equal(t, "", got.ChatID)
+	})
+}
+
+// TestMapMessage_ReplyTargetID covers parsing the reply target external id from
+// source_metadata: present non-empty string → set; absent/empty/wrong-type →
+// nil.
+func TestMapMessage_ReplyTargetID(t *testing.T) {
+	thread := "spaces/AAA"
+	base := repository.CommsMessage{
+		ID:         uuid.New(),
+		Source:     "gchat",
+		ExternalID: "spaces/AAA/messages/9",
+		ThreadID:   &thread,
+		Direction:  repository.InteractionDirectionInbound,
+		SentAt:     accelerated.GetCurrentTime().UTC(),
+	}
+
+	withMeta := func(m map[string]any) []byte {
+		b, err := json.Marshal(m)
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("present non-empty string", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{
+			ReplyTargetMetadataKey: "spaces/AAA/messages/parent",
+		})
+		got := MapMessage(m)
+		require.NotNil(t, got.ReplyTargetID)
+		assert.Equal(t, "spaces/AAA/messages/parent", *got.ReplyTargetID)
+	})
+
+	t.Run("key absent", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{"other": "x"})
+		assert.Nil(t, MapMessage(m).ReplyTargetID)
+	})
+
+	t.Run("key present but empty string", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{ReplyTargetMetadataKey: ""})
+		assert.Nil(t, MapMessage(m).ReplyTargetID)
+	})
+
+	t.Run("key present but wrong type", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{ReplyTargetMetadataKey: 123})
+		assert.Nil(t, MapMessage(m).ReplyTargetID)
+	})
+
+	t.Run("nil/empty metadata", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = nil
+		assert.Nil(t, MapMessage(m).ReplyTargetID)
+		m.SourceMetadata = []byte{}
+		assert.Nil(t, MapMessage(m).ReplyTargetID)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = []byte("{not json")
+		assert.Nil(t, MapMessage(m).ReplyTargetID)
+	})
+}
+
+// TestStore_SatisfiesMessageStore is a compile-time assertion that StoreAdapter
+// implements aggregation.MessageStore and Adapter implements
+// aggregation.SourceAdapter (catches a signature drift on either side).
+func TestStore_SatisfiesMessageStore(t *testing.T) {
+	var _ aggregation.MessageStore = (*StoreAdapter)(nil)
+	var _ aggregation.SourceAdapter = NewAdapter("x", "X")
+}
+
+// TestEventLookup_NilBusReturnsNilInterface is the typed-nil trap the
+// aggregation package's EventPublisher note warns about: returning
+// (*busEventLookup)(nil) would make the engine's `lookup == nil` guard see a
+// NON-nil interface and take the wrong branch. The `== nil` comparison is the
+// assertion a typed-nil regression fails.
+func TestEventLookup_NilBusReturnsNilInterface(t *testing.T) {
+	got := EventLookup(nil)
+	assert.Nil(t, got)
+	assert.True(t, got == nil, "EventLookup(nil) must be the untyped-nil interface value, got %#v", got)
+}
+
+// TestPublisher_NilBusReturnsNilInterface — same contract for the publisher
+// side; a typed-nil here would silently bypass the engine's publisher==nil
+// guard in the session-create path.
+func TestPublisher_NilBusReturnsNilInterface(t *testing.T) {
+	got := Publisher(nil)
+	assert.Nil(t, got)
+	assert.True(t, got == nil, "Publisher(nil) must be the untyped-nil interface value, got %#v", got)
+}
+
+// TestNewEngine_AcceptsNilBusPoolEnqueuer is the construction-level smoke test:
+// pure construction with nil repos/bus/pool/enqueuer must not panic and must
+// return a usable engine. Mirrors telegram's
+// TestNewAggregationEngine_AcceptsNilEventBus / _AcceptsNilPool.
+func TestNewEngine_AcceptsNilBusPoolEnqueuer(t *testing.T) {
+	require.NotPanics(t, func() {
+		e := NewEngine(
+			NewAdapter("gchat", "GChat"),
+			2, 48,
+			nil, nil, nil, nil,
+			nil, nil, nil,
+		)
+		require.NotNil(t, e)
+	})
+}

--- a/backend/internal/messaging/commsadapter/doc.go
+++ b/backend/internal/messaging/commsadapter/doc.go
@@ -1,0 +1,33 @@
+// Package commsadapter holds the source-parameterized glue that binds a
+// comms_message-backed chat source to the shared burst/session aggregator in
+// personal-crm/backend/internal/messaging/aggregation.
+//
+// What belongs here: anything a comms_message-backed source needs that differs
+// from another such source ONLY by its source string and its human label. That
+// is the Adapter (wire formats), the StoreAdapter (comms_message →
+// aggregation.Message projection), the InteractionFinder/EventLookup/Publisher
+// wrappers, and the engine constructor. What does NOT belong here: per-source
+// staging tables, per-source parsing, or anything that reads a column no other
+// comms source writes.
+//
+// Two rules this package exists to enforce structurally rather than by
+// convention:
+//
+//  1. SourceName() == the SourceRef/SourceRefPrefix/PeerRef prefix. The
+//     consumer's CommsAggregatorReenqueuer recovers a chat id by stripping
+//     source + ":" from the event PeerRef, so a source whose ref prefix differs
+//     from its source string silently loses post-record re-aggregation. Adapter
+//     derives all three from one field, so they cannot drift. (Telegram's ref
+//     prefix is "tg:" while its source is "telegram", which is exactly why
+//     Telegram cannot use Adapter and keeps its own.)
+//
+//  2. An unavailable *events.Bus must reach the engine as the UNTYPED-nil
+//     interface value. A typed-nil concrete pointer satisfies the engine's
+//     `publisher == nil` guard as non-nil and silently bypasses it — see the
+//     EventPublisher note in messaging/aggregation/interfaces.go. EventLookup
+//     and Publisher return a literal nil interface for a nil bus, so no caller
+//     has to re-implement the conversion.
+//
+// The repository package stays free of aggregation-package imports; that is why
+// the row projection lives here rather than beside repository.CommsMessage.
+package commsadapter

--- a/backend/internal/messaging/commsadapter/engine.go
+++ b/backend/internal/messaging/commsadapter/engine.go
@@ -1,0 +1,123 @@
+package commsadapter
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// NewInteractionFinder wraps *repository.InteractionRepository and exposes the
+// source-neutral aggregation.InteractionFinder surface. Lives here (not in the
+// repository package) so the repository type stays free of aggregation-package
+// imports.
+func NewInteractionFinder(repo *repository.InteractionRepository) aggregation.InteractionFinder {
+	return &interactionFinderAdapter{repo: repo}
+}
+
+// EventLookup adapts *events.Bus to aggregation.EventLookup, returning the
+// UNTYPED-nil interface value when bus is nil.
+//
+// Returning nil here rather than at each call site is the point: a typed-nil
+// concrete pointer satisfies the engine's nil guard as non-nil and silently
+// bypasses it (see the EventPublisher note in
+// messaging/aggregation/interfaces.go).
+func EventLookup(bus *events.Bus) aggregation.EventLookup {
+	if bus == nil {
+		return nil
+	}
+	return &busEventLookup{bus: bus}
+}
+
+// Publisher adapts *events.Bus to aggregation.EventPublisher with the same
+// untyped-nil contract as EventLookup.
+func Publisher(bus *events.Bus) aggregation.EventPublisher {
+	if bus == nil {
+		return nil
+	}
+	return bus
+}
+
+// NewEngine constructs the shared aggregation engine for a comms_message-backed
+// source. Callers supply their own SourceAdapter (normally NewAdapter) and their
+// own burst/reply windows; everything else is uniform across comms sources.
+//
+// A nil eventBus, pool, or enqueuer is safe: eventBus is converted to the
+// untyped-nil interface by Publisher/EventLookup, and pool/enqueuer are already
+// interface-typed parameters the engine nil-guards itself.
+func NewEngine(
+	adapter aggregation.SourceAdapter,
+	burstWindowHours, replyBridgeHours int,
+	commsRepo *repository.CommsMessageRepository,
+	interactionRepo *repository.InteractionRepository,
+	promoter aggregation.InteractionPromoter,
+	extender aggregation.InteractionExtender,
+	eventBus *events.Bus,
+	pool aggregation.TxBeginner,
+	enqueuer aggregation.ConsumerJobEnqueuer,
+) *aggregation.Engine {
+	return aggregation.NewEngine(
+		adapter,
+		NewStore(commsRepo, adapter.SourceName()),
+		NewInteractionFinder(interactionRepo),
+		promoter,
+		extender,
+		Publisher(eventBus),
+		burstWindowHours,
+		replyBridgeHours,
+		pool,
+		EventLookup(eventBus),
+		enqueuer,
+	)
+}
+
+// busEventLookup adapts *events.Bus to aggregation.EventLookup:
+// (uuid.Nil, false, nil) on db.ErrNotFound; (id, true, nil) on hit; non-nil
+// error on infrastructure failure. Constructed only by EventLookup.
+type busEventLookup struct{ bus *events.Bus }
+
+func (l *busEventLookup) FindEventBySourceRef(ctx context.Context, source, sourceID string) (uuid.UUID, bool, error) {
+	env, err := l.bus.FindEventBySource(ctx, source, sourceID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return uuid.Nil, false, nil
+		}
+		return uuid.Nil, false, err
+	}
+	return env.ID, true, nil
+}
+
+// interactionFinderAdapter wraps *repository.InteractionRepository and exposes
+// the source-neutral aggregation.InteractionFinder surface. Constructed only by
+// NewInteractionFinder.
+type interactionFinderAdapter struct {
+	repo *repository.InteractionRepository
+}
+
+func (a *interactionFinderAdapter) FindRecentBySourceAndDirection(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, direction, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentInteractionBySourceAndDirection(ctx, contactID, source, direction, sourceRefPrefix, windowStart, windowEnd)
+}
+
+func (a *interactionFinderAdapter) FindRecentOutboundBySource(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentOutboundInteractionBySource(ctx, contactID, source, sourceRefPrefix, windowStart, windowEnd)
+}
+
+func (a *interactionFinderAdapter) GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error) {
+	return a.repo.GetInteraction(ctx, id)
+}

--- a/backend/internal/messaging/commsadapter/store.go
+++ b/backend/internal/messaging/commsadapter/store.go
@@ -1,0 +1,144 @@
+package commsadapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ReplyTargetMetadataKey is the source_metadata key under which an explicit
+// reply's target external message id is stored. No provider writes this key yet
+// (explicit-reply bridging is deferred), so the projection's ReplyTargetID is
+// currently always nil — but wiring the field here means a later explicit-reply
+// provider need not touch the adapter.
+const ReplyTargetMetadataKey = "reply_target_external_id"
+
+// StoreAdapter projects repository.CommsMessage rows into aggregation.Message,
+// pinning a source. Lives here (not in repository) so the repository package
+// stays free of aggregation-package imports. The 7 MessageStore methods
+// delegate to the source-parameterized repo methods, passing a.source; the
+// ForSource suffix on the repo methods is erased here.
+type StoreAdapter struct {
+	repo   *repository.CommsMessageRepository
+	source string
+}
+
+// NewStore returns an aggregation.MessageStore over comms_message scoped to
+// source.
+func NewStore(repo *repository.CommsMessageRepository, source string) aggregation.MessageStore {
+	return &StoreAdapter{repo: repo, source: source}
+}
+
+func (a *StoreAdapter) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return a.repo.ListUnprocessedContactIDsForSource(ctx, a.source)
+}
+
+func (a *StoreAdapter) ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]aggregation.Message, error) {
+	rows, err := a.repo.ListUnprocessedByContactForSource(ctx, a.source, contactID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = MapMessage(rows[i])
+	}
+	return out, nil
+}
+
+func (a *StoreAdapter) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]aggregation.Message, error) {
+	rows, err := a.repo.ListUnprocessedByContactAndChatForSource(ctx, a.source, contactID, chatID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = MapMessage(rows[i])
+	}
+	return out, nil
+}
+
+// GetMessageByReplyTarget resolves the message referenced by a reply. The reply
+// target is itself a stored comms_message row, looked up by its own external_id
+// within the same (source, contact, chat) scope. comms_message can fan a shared
+// address out to one row per matched contact, so the lookup MUST be scoped to
+// contactID — otherwise it could return another contact's row whose interaction
+// would then be wrongly bridged.
+func (a *StoreAdapter) GetMessageByReplyTarget(ctx context.Context, contactID uuid.UUID, chatID, replyTargetID string) (aggregation.Message, bool, error) {
+	row, err := a.repo.GetMessageByReplyTargetForSource(ctx, a.source, contactID, chatID, replyTargetID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return aggregation.Message{}, false, nil
+		}
+		return aggregation.Message{}, false, err
+	}
+	return MapMessage(*row), true, nil
+}
+
+func (a *StoreAdapter) MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	return a.repo.MarkMessagesProcessed(ctx, messageIDs, interactionID)
+}
+
+func (a *StoreAdapter) ClaimRowsTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, sessionRef string) ([]uuid.UUID, error) {
+	return a.repo.ClaimMessagesTx(ctx, tx, messageIDs, sessionRef)
+}
+
+func (a *StoreAdapter) ClearStaleClaimTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, expectedSessionRef string) error {
+	return a.repo.ClearStaleClaimTx(ctx, tx, messageIDs, expectedSessionRef)
+}
+
+// MapMessage projects a repository.CommsMessage into the source-neutral
+// aggregation.Message. ChatID comes from thread_id (the chat scope key); a nil
+// thread_id defensively yields ChatID == "" (chat sources always write it
+// non-null). Preserving InteractionID / ClaimedAt / ClaimedSessionRef is
+// required for cross-batch explicit reply bridging and stale-claim /
+// boundary-shift recovery. ReplyTargetID is parsed from
+// source_metadata.reply_target_external_id when present as a non-empty string.
+//
+// Exported so per-source tests can assert the projection against their own
+// rows.
+func MapMessage(m repository.CommsMessage) aggregation.Message {
+	out := aggregation.Message{
+		ID:                m.ID,
+		IsOutgoing:        m.Direction == repository.InteractionDirectionOutbound,
+		SentAt:            m.SentAt,
+		ExternalID:        m.ExternalID,
+		InteractionID:     m.InteractionID,
+		ClaimedAt:         m.ClaimedAt,
+		ClaimedSessionRef: m.ClaimedSessionRef,
+	}
+	if m.ThreadID != nil {
+		out.ChatID = *m.ThreadID
+	}
+	if rt := parseReplyTargetID(m.SourceMetadata); rt != "" {
+		out.ReplyTargetID = &rt
+	}
+	return out
+}
+
+// parseReplyTargetID extracts source_metadata.reply_target_external_id as a
+// non-empty string, or "" when the key is absent, empty, or the wrong type.
+func parseReplyTargetID(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return ""
+	}
+	v, ok := meta[ReplyTargetMetadataKey]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return ""
+	}
+	return s
+}

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -10,6 +10,7 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/messaging/commsadapter"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
@@ -46,11 +47,11 @@ type AggregationEngine struct {
 // error — equivalent to the off/shadow modes documented in
 // EventBusConfig (spec §3.9).
 //
-// CRITICAL: nil *events.Bus / nil aggregation.TxBeginner /
-// nil aggregation.ConsumerJobEnqueuer must be converted to the
-// untyped-nil interface value explicitly. Assigning a typed-nil
-// pointer to an interface variable produces a non-nil interface, which
-// would silently bypass the engine's nil-guards.
+// CRITICAL: a nil *events.Bus must reach the engine as the untyped-nil
+// interface value. Assigning a typed-nil pointer to an interface
+// variable produces a non-nil interface, which would silently bypass
+// the engine's nil-guards. commsadapter.Publisher / commsadapter.EventLookup
+// perform that conversion, so this constructor must not re-implement it.
 //
 // pool is the TxBeginner for the engine's atomic claim+publish step.
 // Pass nil to fall back to the legacy non-tx publish path (test mode).
@@ -70,32 +71,18 @@ func NewAggregationEngine(
 ) *AggregationEngine {
 	adapter := telegramAdapter{}
 	store := &telegramMessageStoreAdapter{repo: messageRepo}
-	finder := &interactionFinderAdapter{repo: interactionRepo}
-
-	var pub aggregation.EventPublisher
-	if eventBus != nil {
-		pub = eventBus
-	}
-
-	// EventLookup is satisfied by *events.Bus.FindEventBySource via the
-	// busEventLookup adapter — declared as a typed nil so the engine
-	// guard correctly sees nil when eventBus is nil.
-	var lookup aggregation.EventLookup
-	if eventBus != nil {
-		lookup = &busEventLookup{bus: eventBus}
-	}
 
 	eng := aggregation.NewEngine(
 		adapter,
 		store,
-		finder,
+		commsadapter.NewInteractionFinder(interactionRepo),
 		promoter,
 		extender,
-		pub,
+		commsadapter.Publisher(eventBus),
 		burstWindowHours,
 		replyBridgeHours,
 		pool,
-		lookup,
+		commsadapter.EventLookup(eventBus),
 		enqueuer,
 	)
 	return &AggregationEngine{engine: eng}
@@ -256,55 +243,4 @@ func mapTelegramMessage(m repository.TelegramMessage) aggregation.Message {
 		out.ReplyTargetID = &s
 	}
 	return out
-}
-
-// busEventLookup adapts *events.Bus to the aggregation.EventLookup
-// interface. (uuid.Nil, false, nil) on db.ErrNotFound; (id, true, nil)
-// on hit; non-nil error on infrastructure failure.
-//
-// Lives in the telegram package (not the shared aggregation package)
-// because the aggregation package must not import `db` or
-// `repository`. The same pattern repeats for any future per-source
-// shim (messages, whatsapp).
-type busEventLookup struct{ bus *events.Bus }
-
-func (l *busEventLookup) FindEventBySourceRef(ctx context.Context, source, sourceID string) (uuid.UUID, bool, error) {
-	env, err := l.bus.FindEventBySource(ctx, source, sourceID)
-	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return uuid.Nil, false, nil
-		}
-		return uuid.Nil, false, err
-	}
-	return env.ID, true, nil
-}
-
-// interactionFinderAdapter wraps *repository.InteractionRepository and
-// exposes the source-neutral aggregation.InteractionFinder surface.
-// Lives in the telegram package (not the repository package) so the
-// repository type stays free of aggregation-package imports.
-type interactionFinderAdapter struct {
-	repo *repository.InteractionRepository
-}
-
-func (a *interactionFinderAdapter) FindRecentBySourceAndDirection(
-	ctx context.Context,
-	contactID uuid.UUID,
-	source, direction, sourceRefPrefix string,
-	windowStart, windowEnd time.Time,
-) (*repository.Interaction, error) {
-	return a.repo.FindRecentInteractionBySourceAndDirection(ctx, contactID, source, direction, sourceRefPrefix, windowStart, windowEnd)
-}
-
-func (a *interactionFinderAdapter) FindRecentOutboundBySource(
-	ctx context.Context,
-	contactID uuid.UUID,
-	source, sourceRefPrefix string,
-	windowStart, windowEnd time.Time,
-) (*repository.Interaction, error) {
-	return a.repo.FindRecentOutboundInteractionBySource(ctx, contactID, source, sourceRefPrefix, windowStart, windowEnd)
-}
-
-func (a *interactionFinderAdapter) GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error) {
-	return a.repo.GetInteraction(ctx, id)
 }

--- a/backend/internal/telegram/aggregation_test.go
+++ b/backend/internal/telegram/aggregation_test.go
@@ -12,15 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNewAggregationEngine_AcceptsNilEventBus is a defensive shim-level
-// smoke test that confirms the explicit "if bus != nil { pub = bus }"
-// nil-iface conversion is wired correctly. Without it, passing a nil
-// *events.Bus would defeat the engine's publisher==nil guard.
+// TestNewAggregationEngine_AcceptsNilEventBus is a shim-level smoke test:
+// constructing with a nil *events.Bus must not panic. It asserts
+// construction ONLY — it does not inspect the interface value, so it
+// cannot detect a typed-nil publisher on its own.
 //
-// The behavioural contract (createInteractionForSession returns the
-// publisher-required error when publisher is the nil interface value)
-// is locked in by TestEngine_FakeSource_NilPublisher_Errors in the
-// shared package.
+// The nil-iface conversion itself now lives in commsadapter.Publisher /
+// commsadapter.EventLookup, and the assertions that a typed-nil
+// regression fails are TestPublisher_NilBusReturnsNilInterface and
+// TestEventLookup_NilBusReturnsNilInterface in that package. The
+// behavioural contract downstream (createInteractionForSession returns
+// the publisher-required error when publisher is the nil interface
+// value) is locked in by TestEngine_FakeSource_NilPublisher_Errors in
+// the shared aggregation package.
 func TestNewAggregationEngine_AcceptsNilEventBus(t *testing.T) {
 	// Pure construction: no method invoked, so nil concrete repos are
 	// safe. The shim simply wraps them in adapter structs.

--- a/backend/internal/telegram/aggregation_test.go
+++ b/backend/internal/telegram/aggregation_test.go
@@ -93,8 +93,8 @@ func TestMapTelegramMessage(t *testing.T) {
 }
 
 // Compile-time guard: telegramMessageStoreAdapter satisfies
-// aggregation.MessageStore and interactionFinderAdapter satisfies
-// aggregation.InteractionFinder. The test references the interface
-// types so go vet flags mismatches at build time.
+// aggregation.MessageStore. The test references the interface type so
+// go vet flags mismatches at build time. The InteractionFinder side is
+// no longer telegram's own — commsadapter.NewInteractionFinder returns
+// the interface, so its conformance is a compile error in that package.
 var _ aggregation.MessageStore = (*telegramMessageStoreAdapter)(nil)
-var _ aggregation.InteractionFinder = (*interactionFinderAdapter)(nil)

--- a/backend/tests/commsadapter_store_integration_test.go
+++ b/backend/tests/commsadapter_store_integration_test.go
@@ -1,0 +1,175 @@
+// Live-store coverage for backend/internal/messaging/commsadapter's
+// StoreAdapter. The package's own unit tests cover the row projection and
+// interface conformance but cannot reach the database, so two behaviours are
+// untestable there and are the ones that break silently:
+//
+//   - the store must pass ITS OWN source to every *ForSource repository call.
+//     A store constructed for one source that reads another's rows would still
+//     satisfy the interface, still compile, and still pass the unit suite; it
+//     would simply aggregate the wrong source's messages. ListUnprocessedContactIDs
+//     is the entry point AggregateAll drives, so a wrong source there silently
+//     changes which contacts a whole sweep touches.
+//   - GetMessageByReplyTarget must translate the repository's db.ErrNotFound
+//     into (zero, false, nil). Returning the error instead would abort the
+//     explicit-reply bridge for every non-reply message rather than falling
+//     through to the time-window bridge.
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/messaging/commsadapter"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommsAdapterStore_ReadsAreScopedToItsOwnSource seeds one gchat row and one
+// email row for the same contact, then proves a gchat-pinned StoreAdapter sees
+// exactly the gchat row on all three list paths and an email-pinned one sees
+// exactly the email row. A store that ignored its source, or was handed the
+// wrong one, fails here.
+func TestCommsAdapterStore_ReadsAreScopedToItsOwnSource(t *testing.T) {
+	t.Parallel()
+	ctx, commsRepo, contactRepo, _ := setupCommsMessageTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := newEmailContact(t, ctx, commsRepo, contactRepo, "Store Scope "+suffix)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	space := "spaces/STORE-" + suffix
+	gchatRow := upsertGChatRow(t, ctx, commsRepo, contact.ID,
+		space, "gchat-store-"+suffix, repository.InteractionDirectionInbound, base)
+
+	emailThread := "thread-store-" + suffix
+	emailBody := "email body"
+	emailRow, err := commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+		Source:           repository.InteractionSourceEmail,
+		ExternalID:       "email-store-" + suffix,
+		ThreadID:         &emailThread,
+		Body:             &emailBody,
+		Direction:        repository.InteractionDirectionInbound,
+		SentAt:           base,
+		MatchedContactID: contact.ID,
+	})
+	require.NoError(t, err)
+
+	gchatStore := commsadapter.NewStore(commsRepo, repository.InteractionSourceGChat)
+	emailStore := commsadapter.NewStore(commsRepo, repository.InteractionSourceEmail)
+
+	// AggregateAll's entry point: the contact appears for both sources here
+	// (it has an unprocessed row in each), so the discriminating assertion is
+	// the per-contact read below — this one only proves the call reaches the DB.
+	gchatContacts, err := gchatStore.ListUnprocessedContactIDs(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, gchatContacts, contact.ID)
+
+	// Per-contact reads are where a wrong source shows up as wrong rows.
+	gchatMsgs, err := gchatStore.ListUnprocessedByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.Len(t, gchatMsgs, 1, "gchat store must see exactly its own row")
+	assert.Equal(t, gchatRow.ID, gchatMsgs[0].ID)
+	assert.Equal(t, space, gchatMsgs[0].ChatID, "ChatID is projected from thread_id")
+	assert.False(t, gchatMsgs[0].IsOutgoing)
+
+	emailMsgs, err := emailStore.ListUnprocessedByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.Len(t, emailMsgs, 1, "email store must see exactly its own row")
+	assert.Equal(t, emailRow.ID, emailMsgs[0].ID)
+
+	// Chat-scoped read: the gchat store finds its row in the space; the email
+	// store finds nothing there, because the row it could match is not its source.
+	inSpace, err := gchatStore.ListUnprocessedByContactAndChat(ctx, contact.ID, space)
+	require.NoError(t, err)
+	require.Len(t, inSpace, 1)
+	assert.Equal(t, gchatRow.ID, inSpace[0].ID)
+
+	emailInSpace, err := emailStore.ListUnprocessedByContactAndChat(ctx, contact.ID, space)
+	require.NoError(t, err)
+	assert.Empty(t, emailInSpace, "email store must not read the gchat row's chat")
+}
+
+// TestCommsAdapterStore_GetMessageByReplyTargetHitAndMiss covers the store's
+// error translation: a hit returns (msg, true, nil); a miss returns
+// (zero, false, nil) with NO error, because db.ErrNotFound is the expected
+// "this message is not a reply to anything we staged" case rather than a
+// failure. A store pinned to another source must also miss.
+func TestCommsAdapterStore_GetMessageByReplyTargetHitAndMiss(t *testing.T) {
+	t.Parallel()
+	ctx, commsRepo, contactRepo, _ := setupCommsMessageTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := newEmailContact(t, ctx, commsRepo, contactRepo, "Store Reply "+suffix)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	space := "spaces/STORERT-" + suffix
+	targetExtID := "gchat-storert-" + suffix
+	target := upsertGChatRow(t, ctx, commsRepo, contact.ID,
+		space, targetExtID, repository.InteractionDirectionInbound, base)
+
+	gchatStore := commsadapter.NewStore(commsRepo, repository.InteractionSourceGChat)
+
+	t.Run("hit resolves the row within (source, contact, chat) scope", func(t *testing.T) {
+		got, found, err := gchatStore.GetMessageByReplyTarget(ctx, contact.ID, space, targetExtID)
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, target.ID, got.ID)
+		assert.Equal(t, targetExtID, got.ExternalID)
+		assert.Equal(t, space, got.ChatID)
+	})
+
+	t.Run("miss returns not-found without an error", func(t *testing.T) {
+		got, found, err := gchatStore.GetMessageByReplyTarget(ctx, contact.ID, space, "no-such-id-"+suffix)
+		require.NoError(t, err, "db.ErrNotFound must be translated, not propagated")
+		assert.False(t, found)
+		assert.Equal(t, uuid.Nil, got.ID)
+	})
+
+	t.Run("another chat in the same source misses", func(t *testing.T) {
+		_, found, err := gchatStore.GetMessageByReplyTarget(ctx, contact.ID, "spaces/OTHER-"+suffix, targetExtID)
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("a store pinned to another source misses", func(t *testing.T) {
+		emailStore := commsadapter.NewStore(commsRepo, repository.InteractionSourceEmail)
+		_, found, err := emailStore.GetMessageByReplyTarget(ctx, contact.ID, space, targetExtID)
+		require.NoError(t, err)
+		assert.False(t, found, "the row belongs to gchat; an email-pinned store must not resolve it")
+	})
+}
+
+// TestGChatEngine_AggregateAllProducesInteraction drives the sweep entry point
+// the other engine tests skip: AggregateAll discovers its contacts through the
+// store's ListUnprocessedContactIDs rather than being handed one. It runs on an
+// ephemeral database clone, so "all contacts" is exactly this test's contact.
+func TestGChatEngine_AggregateAllProducesInteraction(t *testing.T) {
+	t.Parallel()
+	e := setupGChatEngineTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newGChatContact(t, "GChat AggregateAll "+suffix)
+	space := "spaces/AGGALL-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	r1 := e.seedGChatRow(t, contact.ID, space, "gchat-aggall1-"+suffix, repository.InteractionDirectionInbound, base)
+	r2 := e.seedGChatRow(t, contact.ID, space, "gchat-aggall2-"+suffix, repository.InteractionDirectionInbound, base.Add(10*time.Minute))
+
+	require.NoError(t, e.engine.AggregateAll(e.ctx))
+
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, repository.InteractionSourceGChat, interactions[0].Source)
+	assert.Equal(t, repository.InteractionDirectionInbound, interactions[0].Direction)
+	require.NotNil(t, interactions[0].Description)
+	assert.Equal(t, "GChat response (2 messages)", *interactions[0].Description)
+
+	waitForGChatRowsProcessed(t, e, []uuid.UUID{r1.ID, r2.ID}, interactions[0].ID)
+}

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -633,6 +633,10 @@
     "tags": ["@area:imports", "@area:contacts"]
   },
   {
+    "pattern": "^backend/internal/messaging/commsadapter/",
+    "tags": ["@area:imports", "@area:contacts"]
+  },
+  {
     "pattern": "^backend/internal/scheduler/messaging_aggregate.*\\.go$",
     "tags": ["@area:imports", "@area:contacts"]
   },


### PR DESCRIPTION
Closes #456.

PR1 (pilot) of the WhatsApp integration arc (spec: `.ai/spec/whatsapp-integration.md`, landed in #786).

## What

- New `backend/internal/messaging/commsadapter` package: a source-parameterized `Adapter` (all wire formats derived from one source field, so `SourceName()` and the `source:`-prefixed refs cannot drift — the property the comms reenqueuer depends on), a `StoreAdapter` over `comms_message`, shared interaction-finder/event-bus wrappers that return untyped-nil for a nil bus, and `NewEngine`.
- GChat migrated onto the whole package (public constructor `NewGChatAggregationEngine` unchanged in name and signature); Telegram and Messages migrated onto the two byte-identical finder/lookup adapters.
- `.ai/patterns/sync.md` rewritten: `comms_message` is the default staging store for chat-like sources (it previously prescribed per-source tables and named `whatsapp_message`).

Zero behavior change; the existing suites are the acceptance instrument.

## Deviations from plan (declared)

- `make sqlc` ran after renaming one query comment that referenced a deleted symbol; regeneration touched exactly that comment line in `db/comms_message.sql.go` + `db/querier.go`.
- The surviving gchat adapter assertion goes through an unexported `gchatSourceAdapter()` helper (the engine field is unexported, so the plan's "through the exported constructor" was unreachable); nil-dependency coverage still goes through the exported constructor.
- The five moved GChat unit tests were added in one commit and deleted from `google` in the next, not in a single commit as the plan stated. Safe rather than promissory: replacements land before the deletion, so every commit on the branch has the coverage.
- One stale conformance line (`var _ aggregation.InteractionFinder = ...`) removed from `telegram/aggregation_test.go`; the conformance is now a compile-time check inside `commsadapter`.
- `frontend/tests/e2e/test-map.json` gained an entry for the new package to keep diff-selection accurate.

## Ephemeral defect-injection record (second-order verification, nothing committed)

Six `/tmp`-overlay mutants, each observed red then discarded:
- `Description` outreach/response swap → `TestAdapter_WireFormat` FAIL, exit 1
- `PeerRef` escaping the chat id → `TestAdapter_SourceRefPrefixEscapesLikeWildcards` FAIL, exit 1
- hardcoded `"wa:"` prefix in `SourceRef` → `TestAdapter_WireFormat` + `TestAdapter_PrefixEqualsSourceName` FAIL, exit 1
- removed `bus == nil` early return → `TestEventLookup_NilBusReturnsNilInterface` FAIL, exit 1
- hardcoded `"gchat"` store source → `TestCommsAdapterStore_ReadsAreScopedToItsOwnSource` FAIL, exit 1
- propagated `ErrNotFound` from reply lookup → `TestCommsAdapterStore_GetMessageByReplyTargetHitAndMiss` FAIL, exit 1

## Verification

`make lint` 0 issues; `make test` green (27 Go packages, frontend 1159 tests); `make test-e2e-diff` 195 passed; `go build ./...` clean (import-cycle proof); `grep -rn "busEventLookup\|interactionFinderAdapter" backend/internal/{telegram,messages,google}` → no matches.