### PR TITLE
feat(whatsapp): live message ingest with fail-closed group gate (PR4)

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -306,7 +306,10 @@ func run() int {
 		if telegramManager != nil {
 			importHandler.RegisterPostImportHook(telegram.NewPostImportHook(telegramManager))
 		}
-		if waIngestor != nil {
+		// The matcher check is not redundant with the ingestor one: the hook
+		// constructor takes an interface, so handing it a nil *PeerMatcher
+		// would produce a non-nil interface that panics on use.
+		if waIngestor != nil && waIngestor.PeerMatcher() != nil {
 			importHandler.RegisterPostImportHook(wapkg.NewPostImportHook(waIngestor.PeerMatcher()))
 		}
 	}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -40,6 +40,8 @@ import (
 	"personal-crm/backend/internal/health"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/telegram"
+	wapkg "personal-crm/backend/internal/whatsapp"
 
 	"github.com/gin-gonic/gin"
 	"github.com/riverqueue/river"
@@ -173,6 +175,11 @@ func run() int {
 
 	// Message-store repos + staging registry + venue resolver.
 	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
+	// The pool is a property of the repository, not of any feature: without it
+	// AttachUnmatchedByPeer — whose two statements must commit together — fails
+	// at runtime. Unconditional and outside every feature gate, matching the
+	// contact repository's precedent.
+	messaging.CommsMessageRepo.SetPool(database.Pool)
 
 	// Event-bus consumers (Cadence / Knowledge / FollowUp) + their shared
 	// collaborators, built BEFORE ContactService so they can be passed to
@@ -258,12 +265,32 @@ func run() int {
 	// external-sync-off configuration, so no second gate is needed here. A zero
 	// whatsappStack reproduces the nil manager/handler when disabled.
 	var whatsappStk whatsappStack
+	// Declared outside the gated block because the post-import hook wiring
+	// below is outside it and must reference the same instance.
+	var waIngestor *wapkg.Ingestor
 	if cfg.Features.EnableWhatsAppSync {
-		// The prerequisite set the readiness gate reads. It is deliberately
-		// partial: the ingestor and the drain worker are not built yet, so the
+		// Config validation refuses WhatsApp-on / external-sync-off, so a nil
+		// external contact repository here is a validation escape rather than a
+		// supported configuration: it leaves the ingestor nil, which keeps the
+		// readiness gate reporting not_ready.
+		if externalContactRepo == nil {
+			logger.Error().Msg("whatsapp: external contact repository is absent; ingest stays unwired")
+		} else {
+			waIngestor = buildWhatsAppIngestor(cfg, database, messaging.CommsMessageRepo, ingest.IdentityService, externalContactRepo, domain.EnrichmentService)
+		}
+		// The prerequisite set the readiness gate reads. It is still
+		// deliberately partial: the drain worker is not built yet, so the
 		// manager reports not_ready and never connects. Filling the remaining
-		// fields is what turns WhatsApp on.
-		whatsappStk = buildWhatsApp(ctx, cfg, database, whatsappPrereqs{})
+		// field is what turns WhatsApp on.
+		//
+		// The nil check is load-bearing: assigning a nil *Ingestor into the
+		// interface field would produce a non-nil interface holding a nil
+		// pointer, which the readiness gate would read as "wired".
+		prereqs := whatsappPrereqs{}
+		if waIngestor != nil {
+			prereqs.Ingestor = waIngestor
+		}
+		whatsappStk = buildWhatsApp(ctx, cfg, database, prereqs)
 	}
 	whatsappManager := whatsappStk.Manager
 	whatsappHandler := whatsappStk.Handler
@@ -273,9 +300,15 @@ func run() int {
 		defer whatsappManager.Stop()
 	}
 
-	// Wire Telegram post-import hook (if both Telegram and imports are enabled)
-	if telegramManager != nil && importHandler != nil {
-		importHandler.SetPostImportHook(telegramManager)
+	// Wire the per-source post-import hooks (message back-linking). Each is
+	// registered only when its integration is built.
+	if importHandler != nil {
+		if telegramManager != nil {
+			importHandler.RegisterPostImportHook(telegram.NewPostImportHook(telegramManager))
+		}
+		if waIngestor != nil {
+			importHandler.RegisterPostImportHook(wapkg.NewPostImportHook(waIngestor.PeerMatcher()))
+		}
 	}
 
 	// Aggregation engines (messages + gchat) + reenqueuer registry.

--- a/backend/cmd/crm-api/wire_whatsapp.go
+++ b/backend/cmd/crm-api/wire_whatsapp.go
@@ -8,6 +8,7 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	wapkg "personal-crm/backend/internal/whatsapp"
 )
 
@@ -84,6 +85,37 @@ func buildWhatsApp(ctx context.Context, cfg *config.Config, database *db.Databas
 		Manager: manager,
 		Handler: handlers.NewWhatsAppHandler(manager),
 	}
+}
+
+// buildWhatsAppIngestor constructs the live-message ingest path.
+//
+// It is built by the caller rather than inside buildWhatsApp because its
+// dependencies — the identity and enrichment services — are composed earlier
+// than the WhatsApp stack, and it reaches the manager through
+// whatsappPrereqs.Ingestor, the readiness field it satisfies. Its manager seam
+// (the group-info source) is bound by Manager.SetIngestor, before Start.
+//
+// The WhatsAppRepository built here is a stateless wrapper over the shared
+// db.Querier, so the second instance buildWhatsApp constructs for the manager is
+// the same thing; there is no state to share.
+func buildWhatsAppIngestor(
+	cfg *config.Config,
+	database *db.Database,
+	commsMessageRepo *repository.CommsMessageRepository,
+	identityService *service.IdentityService,
+	externalContactRepo *repository.ExternalContactRepository,
+	enricher *service.EnrichmentService,
+) *wapkg.Ingestor {
+	whatsappRepo := repository.NewWhatsAppRepository(database.Queries)
+	gate := wapkg.NewChatGate(whatsappRepo, cfg.WhatsApp.GroupMaxMembers)
+	matcher := wapkg.NewPeerMatcher(
+		identityService,
+		commsMessageRepo,
+		externalContactRepo,
+		enricher,
+		cfg.WhatsApp.DiscoveryMinMessages,
+	)
+	return wapkg.NewIngestor(commsMessageRepo, gate, matcher)
 }
 
 // activateWhatsApp installs every prerequisite that is present and THEN calls

--- a/backend/cmd/crm-api/wire_whatsapp_test.go
+++ b/backend/cmd/crm-api/wire_whatsapp_test.go
@@ -173,11 +173,15 @@ func TestWhatsAppWiring_IngestorIsWiredAndDrainerIsNot(t *testing.T) {
 	assert.Equal(t, wapkg.ReasonIngestNotWired, status.Reason)
 }
 
-// TestWhatsAppWiring_GroupInfoSourceBoundBeforeStart pins the ordering the group
-// gate depends on: the seam is bound by SetIngestor, which the activation
-// sequence runs before the single Start, so no connected client can reach an
-// ingestor whose group-info source is still nil.
-func TestWhatsAppWiring_GroupInfoSourceBoundBeforeStart(t *testing.T) {
+// TestWhatsAppWiring_ActivationBindsTheGroupInfoSource asserts exactly what it
+// can see: that driving the real activation sequence leaves the ingestor's
+// group-info seam BOUND rather than nil. It does NOT assert the bind happened
+// before Start — the real manager gives a fake ingestor no way to observe
+// Start — and the name says so. The ordering half is
+// TestBuildWhatsApp_StartIsCalledAfterEverySetter, which pins SetIngestor ahead
+// of Start on the same sequence, plus TestSetIngestor_BindsGroupInfoSource in
+// the whatsapp package, which pins that SetIngestor is where the bind happens.
+func TestWhatsAppWiring_ActivationBindsTheGroupInfoSource(t *testing.T) {
 	m := wapkg.NewManager(nil, wapkg.NewWALogger("whatsapp-test"), &config.WhatsAppConfig{}, nil, nil)
 	t.Cleanup(m.Stop)
 

--- a/backend/cmd/crm-api/wire_whatsapp_test.go
+++ b/backend/cmd/crm-api/wire_whatsapp_test.go
@@ -145,3 +145,54 @@ func countCalls(haystack []string, needle string) int {
 	}
 	return n
 }
+
+// TestWhatsAppWiring_IngestorIsWiredAndDrainerIsNot is the D18 guard: this PR
+// genuinely satisfies the ingest prerequisite, and the feature is STILL off.
+//
+// It drives the real activation sequence with the real ingestor shape, so it
+// discriminates between "the ingestor is wired" and "the manager will connect".
+func TestWhatsAppWiring_IngestorIsWiredAndDrainerIsNot(t *testing.T) {
+	m := wapkg.NewManager(nil, wapkg.NewWALogger("whatsapp-test"), &config.WhatsAppConfig{}, nil, nil)
+	t.Cleanup(m.Stop)
+
+	ingestor := wapkg.NewIngestor(nil, wapkg.NewChatGate(nil, 10), nil)
+	activateWhatsApp(context.Background(), m, whatsappPrereqs{
+		Ingestor: ingestor,
+		Recorder: stubRecorder{},
+		// DrainReady deliberately false: the drain worker is the next PR's.
+	})
+
+	ready, missing := m.Ready()
+	assert.False(t, ready, "the feature must still be off")
+	assert.Contains(t, missing, "history drain worker",
+		"the ingest prerequisite is genuinely satisfied, so the NEXT missing piece must be the drainer")
+	assert.NotContains(t, missing, "message ingestor")
+
+	status := m.Status()
+	assert.Equal(t, wapkg.StateNotReady, status.State)
+	assert.Equal(t, wapkg.ReasonIngestNotWired, status.Reason)
+}
+
+// TestWhatsAppWiring_GroupInfoSourceBoundBeforeStart pins the ordering the group
+// gate depends on: the seam is bound by SetIngestor, which the activation
+// sequence runs before the single Start, so no connected client can reach an
+// ingestor whose group-info source is still nil.
+func TestWhatsAppWiring_GroupInfoSourceBoundBeforeStart(t *testing.T) {
+	m := wapkg.NewManager(nil, wapkg.NewWALogger("whatsapp-test"), &config.WhatsAppConfig{}, nil, nil)
+	t.Cleanup(m.Stop)
+
+	binder := &bindOrderIngestor{}
+	activateWhatsApp(context.Background(), m, whatsappPrereqs{
+		Ingestor:   binder,
+		Recorder:   stubRecorder{},
+		DrainReady: true,
+	})
+
+	assert.True(t, binder.bound, "the group-info source must be bound, not left nil")
+}
+
+// bindOrderIngestor records whether the group-info seam was bound.
+type bindOrderIngestor struct{ bound bool }
+
+func (b *bindOrderIngestor) IngestMessage(context.Context, wapkg.IngestedMessage) error { return nil }
+func (b *bindOrderIngestor) BindGroupInfoSource(func() wapkg.GroupInfoFetcher)          { b.bound = true }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -6532,7 +6532,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "unresolved_lid_peers": {
-                    "description": "UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the\nintegration could not recover from their WhatsApp-internal id. Such a\npeer cannot be matched to a contact automatically, so any message of\ntheirs that is stored is stored without one and can reach a contact only\nthrough the import queue.\n\nIt counts peers observed, not peers whose messages were stored — a sender\nin a group the size gate declines to track is counted too — so it is a\nmeasure of how much of the conversation graph cannot be attributed\nautomatically, not a count of unattributed records or of messages.",
+                    "description": "UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the\nintegration could not recover from their WhatsApp-internal id. Such a\npeer cannot be matched to a contact automatically, so any message of\ntheirs that is stored is stored without one and can reach a contact only\nthrough the import queue.\n\nIt counts peers observed, not peers whose messages were stored — a sender\nin a group the size gate declines to track is counted too — so it is a\nmeasure of how much of the conversation graph cannot be attributed\nautomatically, not a count of unattributed records or of messages.\n\nThe count SATURATES at an internal cap (5000) rather than growing without\nbound, so a value at the cap means \"at least this many\" rather than\nexactly this many. The cap is far above any plausible personal address\nbook, so in practice the number is exact.",
                     "type": "integer"
                 }
             }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -5077,7 +5077,7 @@ const docTemplate = `{
         },
         "/whatsapp/auth/status": {
             "get": {
-                "description": "Report the WhatsApp connection state, the linked account when paired, any in-flight pairing code, and the history-backfill counts. Absent (404) when the feature is disabled.",
+                "description": "Report the WhatsApp connection state, the linked account when paired, any in-flight pairing code, the history-backfill counts, and what the live message path observed. Absent (404) when the feature is disabled.",
                 "produces": [
                     "application/json"
                 ],
@@ -6528,6 +6528,15 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.WhatsAppIngestResponse": {
+            "type": "object",
+            "properties": {
+                "unresolved_lid_peers": {
+                    "description": "UnresolvedLIDPeers counts distinct peers whose phone number the\nintegration could not recover from their WhatsApp-internal id. Their\nmessages are stored without a contact and can reach one only through the\nimport queue, so this is the visible size of that gap — not a message\nvolume.",
+                    "type": "integer"
+                }
+            }
+        },
         "handlers.WhatsAppPairRequest": {
             "type": "object",
             "required": [
@@ -6584,6 +6593,9 @@ const docTemplate = `{
                 "connected_at": {
                     "type": "string",
                     "format": "date-time"
+                },
+                "ingest": {
+                    "$ref": "#/definitions/handlers.WhatsAppIngestResponse"
                 },
                 "jid": {
                     "type": "string"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -6532,7 +6532,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "unresolved_lid_peers": {
-                    "description": "UnresolvedLIDPeers counts distinct peers whose phone number the\nintegration could not recover from their WhatsApp-internal id. Their\nmessages are stored without a contact and can reach one only through the\nimport queue, so this is the visible size of that gap — not a message\nvolume.",
+                    "description": "UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the\nintegration could not recover from their WhatsApp-internal id. Such a\npeer cannot be matched to a contact automatically, so any message of\ntheirs that is stored is stored without one and can reach a contact only\nthrough the import queue.\n\nIt counts peers observed, not peers whose messages were stored — a sender\nin a group the size gate declines to track is counted too — so it is a\nmeasure of how much of the conversation graph cannot be attributed\nautomatically, not a count of unattributed records or of messages.",
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6530,7 +6530,7 @@
             "type": "object",
             "properties": {
                 "unresolved_lid_peers": {
-                    "description": "UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the\nintegration could not recover from their WhatsApp-internal id. Such a\npeer cannot be matched to a contact automatically, so any message of\ntheirs that is stored is stored without one and can reach a contact only\nthrough the import queue.\n\nIt counts peers observed, not peers whose messages were stored — a sender\nin a group the size gate declines to track is counted too — so it is a\nmeasure of how much of the conversation graph cannot be attributed\nautomatically, not a count of unattributed records or of messages.",
+                    "description": "UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the\nintegration could not recover from their WhatsApp-internal id. Such a\npeer cannot be matched to a contact automatically, so any message of\ntheirs that is stored is stored without one and can reach a contact only\nthrough the import queue.\n\nIt counts peers observed, not peers whose messages were stored — a sender\nin a group the size gate declines to track is counted too — so it is a\nmeasure of how much of the conversation graph cannot be attributed\nautomatically, not a count of unattributed records or of messages.\n\nThe count SATURATES at an internal cap (5000) rather than growing without\nbound, so a value at the cap means \"at least this many\" rather than\nexactly this many. The cap is far above any plausible personal address\nbook, so in practice the number is exact.",
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5075,7 +5075,7 @@
         },
         "/whatsapp/auth/status": {
             "get": {
-                "description": "Report the WhatsApp connection state, the linked account when paired, any in-flight pairing code, and the history-backfill counts. Absent (404) when the feature is disabled.",
+                "description": "Report the WhatsApp connection state, the linked account when paired, any in-flight pairing code, the history-backfill counts, and what the live message path observed. Absent (404) when the feature is disabled.",
                 "produces": [
                     "application/json"
                 ],
@@ -6526,6 +6526,15 @@
                 }
             }
         },
+        "handlers.WhatsAppIngestResponse": {
+            "type": "object",
+            "properties": {
+                "unresolved_lid_peers": {
+                    "description": "UnresolvedLIDPeers counts distinct peers whose phone number the\nintegration could not recover from their WhatsApp-internal id. Their\nmessages are stored without a contact and can reach one only through the\nimport queue, so this is the visible size of that gap — not a message\nvolume.",
+                    "type": "integer"
+                }
+            }
+        },
         "handlers.WhatsAppPairRequest": {
             "type": "object",
             "required": [
@@ -6582,6 +6591,9 @@
                 "connected_at": {
                     "type": "string",
                     "format": "date-time"
+                },
+                "ingest": {
+                    "$ref": "#/definitions/handlers.WhatsAppIngestResponse"
                 },
                 "jid": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6530,7 +6530,7 @@
             "type": "object",
             "properties": {
                 "unresolved_lid_peers": {
-                    "description": "UnresolvedLIDPeers counts distinct peers whose phone number the\nintegration could not recover from their WhatsApp-internal id. Their\nmessages are stored without a contact and can reach one only through the\nimport queue, so this is the visible size of that gap — not a message\nvolume.",
+                    "description": "UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the\nintegration could not recover from their WhatsApp-internal id. Such a\npeer cannot be matched to a contact automatically, so any message of\ntheirs that is stored is stored without one and can reach a contact only\nthrough the import queue.\n\nIt counts peers observed, not peers whose messages were stored — a sender\nin a group the size gate declines to track is counted too — so it is a\nmeasure of how much of the conversation graph cannot be attributed\nautomatically, not a count of unattributed records or of messages.",
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1028,6 +1028,11 @@ definitions:
           in a group the size gate declines to track is counted too — so it is a
           measure of how much of the conversation graph cannot be attributed
           automatically, not a count of unattributed records or of messages.
+
+          The count SATURATES at an internal cap (5000) rather than growing without
+          bound, so a value at the cap means "at least this many" rather than
+          exactly this many. The cap is far above any plausible personal address
+          book, so in practice the number is exact.
         type: integer
     type: object
   handlers.WhatsAppPairRequest:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1018,11 +1018,16 @@ definitions:
     properties:
       unresolved_lid_peers:
         description: |-
-          UnresolvedLIDPeers counts distinct peers whose phone number the
-          integration could not recover from their WhatsApp-internal id. Their
-          messages are stored without a contact and can reach one only through the
-          import queue, so this is the visible size of that gap — not a message
-          volume.
+          UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the
+          integration could not recover from their WhatsApp-internal id. Such a
+          peer cannot be matched to a contact automatically, so any message of
+          theirs that is stored is stored without one and can reach a contact only
+          through the import queue.
+
+          It counts peers observed, not peers whose messages were stored — a sender
+          in a group the size gate declines to track is counted too — so it is a
+          measure of how much of the conversation graph cannot be attributed
+          automatically, not a count of unattributed records or of messages.
         type: integer
     type: object
   handlers.WhatsAppPairRequest:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1014,6 +1014,17 @@ definitions:
           phone.
         type: string
     type: object
+  handlers.WhatsAppIngestResponse:
+    properties:
+      unresolved_lid_peers:
+        description: |-
+          UnresolvedLIDPeers counts distinct peers whose phone number the
+          integration could not recover from their WhatsApp-internal id. Their
+          messages are stored without a contact and can reach one only through the
+          import queue, so this is the visible size of that gap — not a message
+          volume.
+        type: integer
+    type: object
   handlers.WhatsAppPairRequest:
     properties:
       method:
@@ -1055,6 +1066,8 @@ definitions:
       connected_at:
         format: date-time
         type: string
+      ingest:
+        $ref: '#/definitions/handlers.WhatsAppIngestResponse'
       jid:
         type: string
       link_selector_persisted:
@@ -4274,8 +4287,8 @@ paths:
   /whatsapp/auth/status:
     get:
       description: Report the WhatsApp connection state, the linked account when paired,
-        any in-flight pairing code, and the history-backfill counts. Absent (404)
-        when the feature is disabled.
+        any in-flight pairing code, the history-backfill counts, and what the live
+        message path observed. Absent (404) when the feature is disabled.
       produces:
       - application/json
       responses:

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -24,10 +24,15 @@ import (
 const MaxCandidatesForSorting = 10000
 
 // ImportHandler handles import candidate HTTP requests
-// PostImportHook is called after a Telegram candidate is imported/linked
+// PostImportHook is called after a chat-source candidate is imported or linked,
 // to back-fill message matching and trigger aggregation.
+//
+// It is keyed by Source() rather than assuming one source, and it receives the
+// whole external_contact row: every source keys its candidates differently, so
+// the field extraction belongs in the source's own adapter, not in this handler.
 type PostImportHook interface {
-	OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error
+	Source() string
+	OnPeerLinked(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) error
 }
 
 // ImportHandler holds the dependencies the import endpoints need. It
@@ -38,14 +43,14 @@ type PostImportHook interface {
 // routed through identitySvc so handler code does not call the
 // identity repository directly.
 type ImportHandler struct {
-	externalRepo   *repository.ExternalContactRepository
-	identitySvc    *service.IdentityService
-	contactSvc     *service.ContactService
-	matchSvc       *service.ImportMatchService
-	enricher       *service.EnrichmentService
-	suggestionSvc  *service.SuggestionService
-	validator      *validator.Validate
-	postImportHook PostImportHook
+	externalRepo    *repository.ExternalContactRepository
+	identitySvc     *service.IdentityService
+	contactSvc      *service.ContactService
+	matchSvc        *service.ImportMatchService
+	enricher        *service.EnrichmentService
+	suggestionSvc   *service.SuggestionService
+	validator       *validator.Validate
+	postImportHooks map[string]PostImportHook
 }
 
 // NewImportHandler creates a new import handler. identitySvc may be
@@ -72,9 +77,17 @@ func NewImportHandler(
 	}
 }
 
-// SetPostImportHook sets an optional hook for post-import processing (e.g., Telegram back-linking).
-func (h *ImportHandler) SetPostImportHook(hook PostImportHook) {
-	h.postImportHook = hook
+// RegisterPostImportHook registers an optional per-source hook for post-import
+// processing (message back-linking). Registering a second hook for the same
+// source replaces the first.
+func (h *ImportHandler) RegisterPostImportHook(hook PostImportHook) {
+	if hook == nil {
+		return
+	}
+	if h.postImportHooks == nil {
+		h.postImportHooks = make(map[string]PostImportHook)
+	}
+	h.postImportHooks[hook.Source()] = hook
 }
 
 // ImportCandidateResponse represents an import candidate for the API
@@ -569,22 +582,20 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	}, nil)
 }
 
-// triggerPostImportHook calls the post-import hook for Telegram candidates (best-effort).
+// triggerPostImportHook dispatches to the hook registered for the candidate's
+// source (best-effort). A source with no hook is a no-op.
 func (h *ImportHandler) triggerPostImportHook(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) {
-	if h.postImportHook == nil || external.Source != "telegram" {
+	if len(h.postImportHooks) == 0 || external == nil {
 		return
 	}
-	peerUserID, err := strconv.ParseInt(external.SourceID, 10, 64)
-	if err != nil {
-		logger.Warn().Err(err).Str("source_id", external.SourceID).Msg("failed to parse telegram peer user ID for post-import hook")
+	hook, ok := h.postImportHooks[external.Source]
+	if !ok {
 		return
 	}
-	var peerUsername string
-	if username, ok := external.Metadata["username"].(string); ok {
-		peerUsername = strings.TrimPrefix(username, "@")
-	}
-	if err := h.postImportHook.OnPeerLinked(ctx, peerUserID, peerUsername, contactID); err != nil {
-		logger.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: post-import hook failed")
+	if err := hook.OnPeerLinked(ctx, external, contactID); err != nil {
+		// No identifier value is logged: the source alone is enough to locate
+		// the failure, and the peer key is personal data.
+		logger.Warn().Err(err).Str("source", external.Source).Msg("post-import hook failed")
 	}
 }
 

--- a/backend/internal/api/handlers/import_post_hook_test.go
+++ b/backend/internal/api/handlers/import_post_hook_test.go
@@ -66,31 +66,137 @@ func TestPostImportDispatch_RoutesTelegramToTelegramHook(t *testing.T) {
 	assert.Zero(t, wa.calls)
 }
 
+// recordingTelegramLinker captures exactly what the Telegram adapter derived,
+// which is the only way the extraction can be asserted: with a concrete
+// *TelegramManager the sole reachable call is nil-constructed, and a
+// nil-constructed call observes nothing.
+type recordingTelegramLinker struct {
+	calls        int
+	peerUserID   int64
+	peerUsername string
+	contactID    uuid.UUID
+	err          error
+}
+
+func (r *recordingTelegramLinker) OnPeerLinked(_ context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error {
+	r.calls++
+	r.peerUserID = peerUserID
+	r.peerUsername = peerUsername
+	r.contactID = contactID
+	return r.err
+}
+
+type recordingWhatsAppLinker struct {
+	calls     int
+	peerJID   string
+	phoneE164 *string
+	contactID uuid.UUID
+	err       error
+}
+
+func (r *recordingWhatsAppLinker) OnPeerLinked(_ context.Context, peerJID string, phoneE164 *string, contactID uuid.UUID) error {
+	r.calls++
+	r.peerJID = peerJID
+	r.phoneE164 = phoneE164
+	r.contactID = contactID
+	return r.err
+}
+
 // TestPostImportDispatch_TelegramBehaviorUnchanged pins that the adapter derives
 // the SAME (peerUserID, peerUsername) pair the handler used to compute inline,
 // including the stripped leading '@'.
 func TestPostImportDispatch_TelegramBehaviorUnchanged(t *testing.T) {
-	hook := telegram.NewPostImportHook(nil)
+	linker := &recordingTelegramLinker{}
+	hook := telegram.NewPostImportHook(linker)
 	assert.Equal(t, "telegram", hook.Source())
 
-	// A nil manager makes the delegation a no-op, so what is under test here is
-	// the extraction: an unparseable source id must be tolerated, exactly as the
-	// handler tolerated it before.
-	require.NoError(t, hook.OnPeerLinked(context.Background(),
-		&repository.ExternalContact{Source: "telegram", SourceID: "not-a-number"}, uuid.New()))
+	contactID := uuid.New()
 	require.NoError(t, hook.OnPeerLinked(context.Background(),
 		&repository.ExternalContact{
 			Source: "telegram", SourceID: "12345",
 			Metadata: map[string]any{"username": "@handle"},
-		}, uuid.New()))
+		}, contactID))
+
+	require.Equal(t, 1, linker.calls)
+	assert.Equal(t, int64(12345), linker.peerUserID, "the source id is the Telegram peer user id")
+	assert.Equal(t, "handle", linker.peerUsername, "the leading '@' is stripped, as the handler stripped it")
+	assert.Equal(t, contactID, linker.contactID)
 }
 
-func TestPostImportDispatch_WhatsAppHookSourceIsWhatsApp(t *testing.T) {
-	hook := whatsapp.NewPostImportHook(nil)
-	assert.Equal(t, "whatsapp", hook.Source())
+func TestPostImportDispatch_TelegramMissingUsernameIsEmpty(t *testing.T) {
+	linker := &recordingTelegramLinker{}
+	hook := telegram.NewPostImportHook(linker)
+
 	require.NoError(t, hook.OnPeerLinked(context.Background(),
-		&repository.ExternalContact{Source: "whatsapp", SourceID: "88800000002@lid"}, uuid.New()),
-		"an unwired matcher is a no-op, not a panic")
+		&repository.ExternalContact{Source: "telegram", SourceID: "999"}, uuid.New()))
+
+	require.Equal(t, 1, linker.calls)
+	assert.Equal(t, int64(999), linker.peerUserID)
+	assert.Empty(t, linker.peerUsername, "an absent handle is empty, not a panic and not a literal '<nil>'")
+}
+
+func TestPostImportDispatch_TelegramUnparseableSourceIDIsTolerated(t *testing.T) {
+	linker := &recordingTelegramLinker{}
+	hook := telegram.NewPostImportHook(linker)
+
+	require.NoError(t, hook.OnPeerLinked(context.Background(),
+		&repository.ExternalContact{Source: "telegram", SourceID: "not-a-number"}, uuid.New()),
+		"an unparseable source id logs and returns nil, exactly as the handler did")
+	assert.Zero(t, linker.calls, "and nothing is delegated with a garbage peer id")
+}
+
+// TestPostImportDispatch_WhatsAppDerivesJIDAndPhone is the WhatsApp half of the
+// same guard: the candidate's source_id IS the raw peer JID, and the resolved
+// phone rides in metadata.
+func TestPostImportDispatch_WhatsAppDerivesJIDAndPhone(t *testing.T) {
+	linker := &recordingWhatsAppLinker{}
+	hook := whatsapp.NewPostImportHook(linker)
+	assert.Equal(t, "whatsapp", hook.Source())
+
+	contactID := uuid.New()
+	require.NoError(t, hook.OnPeerLinked(context.Background(),
+		&repository.ExternalContact{
+			Source: "whatsapp", SourceID: "88800000002@lid",
+			Metadata: map[string]any{"phone_e164": "+15559876543"},
+		}, contactID))
+
+	require.Equal(t, 1, linker.calls)
+	assert.Equal(t, "88800000002@lid", linker.peerJID)
+	require.NotNil(t, linker.phoneE164)
+	assert.Equal(t, "+15559876543", *linker.phoneE164)
+	assert.Equal(t, contactID, linker.contactID)
+}
+
+func TestPostImportDispatch_WhatsAppWithoutPhonePassesNil(t *testing.T) {
+	linker := &recordingWhatsAppLinker{}
+	hook := whatsapp.NewPostImportHook(linker)
+
+	require.NoError(t, hook.OnPeerLinked(context.Background(),
+		&repository.ExternalContact{Source: "whatsapp", SourceID: "88800000002@lid"}, uuid.New()))
+
+	require.Equal(t, 1, linker.calls)
+	assert.Equal(t, "88800000002@lid", linker.peerJID)
+	assert.Nil(t, linker.phoneE164, "a peer whose number was never recovered attaches by handle alone")
+
+	// An empty-string phone is absent, not a selector: passing "" would match
+	// no staged row and would look like a deliberate narrowing.
+	linker2 := &recordingWhatsAppLinker{}
+	hook2 := whatsapp.NewPostImportHook(linker2)
+	require.NoError(t, hook2.OnPeerLinked(context.Background(),
+		&repository.ExternalContact{
+			Source: "whatsapp", SourceID: "88800000002@lid",
+			Metadata: map[string]any{"phone_e164": ""},
+		}, uuid.New()))
+	require.Equal(t, 1, linker2.calls)
+	assert.Nil(t, linker2.phoneE164)
+}
+
+func TestPostImportDispatch_UnwiredDelegateIsNoop(t *testing.T) {
+	require.NoError(t, telegram.NewPostImportHook(nil).OnPeerLinked(context.Background(),
+		&repository.ExternalContact{Source: "telegram", SourceID: "12345"}, uuid.New()),
+		"an unwired delegate is a no-op, not a panic")
+	require.NoError(t, whatsapp.NewPostImportHook(nil).OnPeerLinked(context.Background(),
+		&repository.ExternalContact{Source: "whatsapp", SourceID: "88800000002@lid"}, uuid.New()))
 }
 
 func TestPostImportDispatch_UnknownSourceIsNoop(t *testing.T) {

--- a/backend/internal/api/handlers/import_post_hook_test.go
+++ b/backend/internal/api/handlers/import_post_hook_test.go
@@ -1,0 +1,137 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/telegram"
+	"personal-crm/backend/internal/whatsapp"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingHook is a PostImportHook that records what it was handed.
+type recordingHook struct {
+	source   string
+	err      error
+	calls    int
+	external *repository.ExternalContact
+	contact  uuid.UUID
+}
+
+func (h *recordingHook) Source() string { return h.source }
+
+func (h *recordingHook) OnPeerLinked(_ context.Context, external *repository.ExternalContact, contactID uuid.UUID) error {
+	h.calls++
+	h.external = external
+	h.contact = contactID
+	return h.err
+}
+
+func TestPostImportDispatch_RoutesWhatsAppToWhatsAppHook(t *testing.T) {
+	wa := &recordingHook{source: "whatsapp"}
+	tg := &recordingHook{source: "telegram"}
+	h := &ImportHandler{}
+	h.RegisterPostImportHook(wa)
+	h.RegisterPostImportHook(tg)
+
+	contactID := uuid.New()
+	external := &repository.ExternalContact{
+		Source: "whatsapp", SourceID: "88800000002@lid",
+		Metadata: map[string]any{"phone_e164": "+15559876543"},
+	}
+	h.triggerPostImportHook(context.Background(), external, contactID)
+
+	assert.Equal(t, 1, wa.calls)
+	assert.Zero(t, tg.calls, "a candidate reaches exactly one hook")
+	assert.Same(t, external, wa.external, "the hook receives the whole row, not extracted fields")
+	assert.Equal(t, contactID, wa.contact)
+}
+
+func TestPostImportDispatch_RoutesTelegramToTelegramHook(t *testing.T) {
+	wa := &recordingHook{source: "whatsapp"}
+	tg := &recordingHook{source: "telegram"}
+	h := &ImportHandler{}
+	h.RegisterPostImportHook(wa)
+	h.RegisterPostImportHook(tg)
+
+	h.triggerPostImportHook(context.Background(),
+		&repository.ExternalContact{Source: "telegram", SourceID: "12345"}, uuid.New())
+
+	assert.Equal(t, 1, tg.calls)
+	assert.Zero(t, wa.calls)
+}
+
+// TestPostImportDispatch_TelegramBehaviorUnchanged pins that the adapter derives
+// the SAME (peerUserID, peerUsername) pair the handler used to compute inline,
+// including the stripped leading '@'.
+func TestPostImportDispatch_TelegramBehaviorUnchanged(t *testing.T) {
+	hook := telegram.NewPostImportHook(nil)
+	assert.Equal(t, "telegram", hook.Source())
+
+	// A nil manager makes the delegation a no-op, so what is under test here is
+	// the extraction: an unparseable source id must be tolerated, exactly as the
+	// handler tolerated it before.
+	require.NoError(t, hook.OnPeerLinked(context.Background(),
+		&repository.ExternalContact{Source: "telegram", SourceID: "not-a-number"}, uuid.New()))
+	require.NoError(t, hook.OnPeerLinked(context.Background(),
+		&repository.ExternalContact{
+			Source: "telegram", SourceID: "12345",
+			Metadata: map[string]any{"username": "@handle"},
+		}, uuid.New()))
+}
+
+func TestPostImportDispatch_WhatsAppHookSourceIsWhatsApp(t *testing.T) {
+	hook := whatsapp.NewPostImportHook(nil)
+	assert.Equal(t, "whatsapp", hook.Source())
+	require.NoError(t, hook.OnPeerLinked(context.Background(),
+		&repository.ExternalContact{Source: "whatsapp", SourceID: "88800000002@lid"}, uuid.New()),
+		"an unwired matcher is a no-op, not a panic")
+}
+
+func TestPostImportDispatch_UnknownSourceIsNoop(t *testing.T) {
+	tg := &recordingHook{source: "telegram"}
+	h := &ImportHandler{}
+	h.RegisterPostImportHook(tg)
+
+	h.triggerPostImportHook(context.Background(),
+		&repository.ExternalContact{Source: "google", SourceID: "abc"}, uuid.New())
+	assert.Zero(t, tg.calls)
+}
+
+func TestPostImportDispatch_NoHooksRegisteredIsNoop(t *testing.T) {
+	h := &ImportHandler{}
+	assert.NotPanics(t, func() {
+		h.triggerPostImportHook(context.Background(),
+			&repository.ExternalContact{Source: "whatsapp", SourceID: "x"}, uuid.New())
+	})
+}
+
+func TestPostImportDispatch_HookErrorIsNonFatal(t *testing.T) {
+	wa := &recordingHook{source: "whatsapp", err: errors.New("attach failed")}
+	h := &ImportHandler{}
+	h.RegisterPostImportHook(wa)
+
+	assert.NotPanics(t, func() {
+		h.triggerPostImportHook(context.Background(),
+			&repository.ExternalContact{Source: "whatsapp", SourceID: "x"}, uuid.New())
+	}, "the import already succeeded; the back-link is best-effort")
+	assert.Equal(t, 1, wa.calls)
+}
+
+func TestPostImportDispatch_RegisteringTwiceReplaces(t *testing.T) {
+	first := &recordingHook{source: "whatsapp"}
+	second := &recordingHook{source: "whatsapp"}
+	h := &ImportHandler{}
+	h.RegisterPostImportHook(first)
+	h.RegisterPostImportHook(second)
+
+	h.triggerPostImportHook(context.Background(),
+		&repository.ExternalContact{Source: "whatsapp", SourceID: "x"}, uuid.New())
+	assert.Zero(t, first.calls)
+	assert.Equal(t, 1, second.calls)
+}

--- a/backend/internal/api/handlers/whatsapp.go
+++ b/backend/internal/api/handlers/whatsapp.go
@@ -196,7 +196,7 @@ func (h *WhatsAppHandler) Disconnect(c *gin.Context) {
 
 // GetStatus returns the WhatsApp connection status
 // @Summary Get WhatsApp status
-// @Description Report the WhatsApp connection state, the linked account when paired, any in-flight pairing code, and the history-backfill counts. Absent (404) when the feature is disabled.
+// @Description Report the WhatsApp connection state, the linked account when paired, any in-flight pairing code, the history-backfill counts, and what the live message path observed. Absent (404) when the feature is disabled.
 // @Tags whatsapp
 // @Produce json
 // @Success 200 {object} api.APIResponse{data=WhatsAppStatusResponse}
@@ -233,6 +233,9 @@ func whatsAppStatusResponse(status wapkg.Status) WhatsAppStatusResponse {
 			DroppedInlineChunks: status.Backfill.DroppedInlineChunks,
 			ObservedFloorAt:     formatTimePtr(status.Backfill.ObservedFloorAt),
 			Stale:               status.Backfill.Stale,
+		},
+		Ingest: WhatsAppIngestResponse{
+			UnresolvedLIDPeers: status.Ingest.UnresolvedLIDPeers,
 		},
 	}
 	if status.Pairing != nil {

--- a/backend/internal/api/handlers/whatsapp_dto.go
+++ b/backend/internal/api/handlers/whatsapp_dto.go
@@ -53,6 +53,11 @@ type WhatsAppIngestResponse struct {
 	// in a group the size gate declines to track is counted too — so it is a
 	// measure of how much of the conversation graph cannot be attributed
 	// automatically, not a count of unattributed records or of messages.
+	//
+	// The count SATURATES at an internal cap (5000) rather than growing without
+	// bound, so a value at the cap means "at least this many" rather than
+	// exactly this many. The cap is far above any plausible personal address
+	// book, so in practice the number is exact.
 	UnresolvedLIDPeers int `json:"unresolved_lid_peers"`
 }
 

--- a/backend/internal/api/handlers/whatsapp_dto.go
+++ b/backend/internal/api/handlers/whatsapp_dto.go
@@ -39,6 +39,18 @@ type WhatsAppBackfillResponse struct {
 	Stale bool `json:"stale,omitempty"`
 }
 
+// WhatsAppIngestResponse reports what the live message path observed. The
+// counts are a PROCESS-LIFETIME observation, not a persisted total: a restart
+// resets them to zero.
+type WhatsAppIngestResponse struct {
+	// UnresolvedLIDPeers counts distinct peers whose phone number the
+	// integration could not recover from their WhatsApp-internal id. Their
+	// messages are stored without a contact and can reach one only through the
+	// import queue, so this is the visible size of that gap — not a message
+	// volume.
+	UnresolvedLIDPeers int `json:"unresolved_lid_peers"`
+}
+
 // WhatsAppStatusResponse mirrors whatsapp.Status on the wire.
 type WhatsAppStatusResponse struct {
 	Configured bool `json:"configured"`
@@ -76,6 +88,7 @@ type WhatsAppStatusResponse struct {
 	// itself is real and is deliberately not torn down.
 	LinkSelectorPersisted *bool                    `json:"link_selector_persisted,omitempty"`
 	Backfill              WhatsAppBackfillResponse `json:"backfill"`
+	Ingest                WhatsAppIngestResponse   `json:"ingest"`
 }
 
 // WhatsAppDisconnectResponse reports how an unlink resolved. Disconnect returns

--- a/backend/internal/api/handlers/whatsapp_dto.go
+++ b/backend/internal/api/handlers/whatsapp_dto.go
@@ -43,11 +43,16 @@ type WhatsAppBackfillResponse struct {
 // counts are a PROCESS-LIFETIME observation, not a persisted total: a restart
 // resets them to zero.
 type WhatsAppIngestResponse struct {
-	// UnresolvedLIDPeers counts distinct peers whose phone number the
-	// integration could not recover from their WhatsApp-internal id. Their
-	// messages are stored without a contact and can reach one only through the
-	// import queue, so this is the visible size of that gap — not a message
-	// volume.
+	// UnresolvedLIDPeers counts distinct peers OBSERVED whose phone number the
+	// integration could not recover from their WhatsApp-internal id. Such a
+	// peer cannot be matched to a contact automatically, so any message of
+	// theirs that is stored is stored without one and can reach a contact only
+	// through the import queue.
+	//
+	// It counts peers observed, not peers whose messages were stored — a sender
+	// in a group the size gate declines to track is counted too — so it is a
+	// measure of how much of the conversation graph cannot be attributed
+	// automatically, not a count of unattributed records or of messages.
 	UnresolvedLIDPeers int `json:"unresolved_lid_peers"`
 }
 

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -285,6 +285,29 @@ func (q *Queries) ClearStaleCommsClaim(ctx context.Context, arg ClearStaleCommsC
 	return err
 }
 
+const CountLiveMatchedChatMessage = `-- name: CountLiveMatchedChatMessage :one
+SELECT COUNT(*) FROM comms_message
+WHERE source = $1
+  AND external_id = $2
+  AND matched_contact_id IS NOT NULL
+  AND deleted_at IS NULL
+`
+
+type CountLiveMatchedChatMessageParams struct {
+	Source     string `json:"source"`
+	ExternalID string `json:"external_id"`
+}
+
+// Reports whether the message is ALREADY staged against a contact, so the
+// unmatched insert path can decline rather than mint the duplicate pair with
+// nothing to tombstone it. O(1) on idx_comms_message_dedup.
+func (q *Queries) CountLiveMatchedChatMessage(ctx context.Context, arg CountLiveMatchedChatMessageParams) (int64, error) {
+	row := q.db.QueryRow(ctx, CountLiveMatchedChatMessage, arg.Source, arg.ExternalID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const GetCommsMessage = `-- name: GetCommsMessage :one
 SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
 WHERE source = $1
@@ -1151,6 +1174,32 @@ func (q *Queries) SoftDeleteDuplicateUnmatchedCommsMessages(ctx context.Context,
 		arg.PeerNormalized,
 		arg.ContactID,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const SoftDeleteUnmatchedChatMessageTwin = `-- name: SoftDeleteUnmatchedChatMessageTwin :execrows
+UPDATE comms_message
+SET deleted_at = NOW()
+WHERE source = $1
+  AND external_id = $2
+  AND matched_contact_id IS NULL
+  AND deleted_at IS NULL
+`
+
+type SoftDeleteUnmatchedChatMessageTwinParams struct {
+	Source     string `json:"source"`
+	ExternalID string `json:"external_id"`
+}
+
+// Tombstones the unmatched staging row for a message that has just been staged
+// WITH a contact. The matched and unmatched chat upserts have DISJOINT conflict
+// targets, so both rows can exist for one message; the matched row is the
+// survivor. O(1) on idx_comms_message_dedup_unmatched.
+func (q *Queries) SoftDeleteUnmatchedChatMessageTwin(ctx context.Context, arg SoftDeleteUnmatchedChatMessageTwinParams) (int64, error) {
+	result, err := q.db.Exec(ctx, SoftDeleteUnmatchedChatMessageTwin, arg.Source, arg.ExternalID)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -1714,6 +1714,78 @@ func (q *Queries) UpdateExternalContactMatch(ctx context.Context, arg UpdateExte
 	return &i, err
 }
 
+const UpsertDiscoveryCandidate = `-- name: UpsertDiscoveryCandidate :one
+INSERT INTO external_contact (
+    source, source_id, display_name, first_name, last_name, metadata, synced_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
+    display_name = COALESCE(EXCLUDED.display_name, external_contact.display_name),
+    first_name   = COALESCE(EXCLUDED.first_name,   external_contact.first_name),
+    last_name    = COALESCE(EXCLUDED.last_name,    external_contact.last_name),
+    metadata     = external_contact.metadata || EXCLUDED.metadata,
+    synced_at    = EXCLUDED.synced_at,
+    updated_at   = NOW()
+RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at, host_id, last_content_hash, pending_method_suggestions, dismissed_method_suggestions
+`
+
+type UpsertDiscoveryCandidateParams struct {
+	Source      string             `json:"source"`
+	SourceID    string             `json:"source_id"`
+	DisplayName pgtype.Text        `json:"display_name"`
+	FirstName   pgtype.Text        `json:"first_name"`
+	LastName    pgtype.Text        `json:"last_name"`
+	Metadata    []byte             `json:"metadata"`
+	SyncedAt    pgtype.Timestamptz `json:"synced_at"`
+}
+
+// Source-parameterized discovery upsert that preserves populated peer fields
+// when a later message arrives with null entity data. Never clears a
+// name/handle that was previously captured. Metadata is merged (|| operator) so
+// keys from earlier writes (e.g. username) are retained when the new map omits
+// them.
+func (q *Queries) UpsertDiscoveryCandidate(ctx context.Context, arg UpsertDiscoveryCandidateParams) (*ExternalContact, error) {
+	row := q.db.QueryRow(ctx, UpsertDiscoveryCandidate,
+		arg.Source,
+		arg.SourceID,
+		arg.DisplayName,
+		arg.FirstName,
+		arg.LastName,
+		arg.Metadata,
+		arg.SyncedAt,
+	)
+	var i ExternalContact
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.SourceID,
+		&i.AccountID,
+		&i.DisplayName,
+		&i.FirstName,
+		&i.LastName,
+		&i.Emails,
+		&i.Phones,
+		&i.Addresses,
+		&i.Organization,
+		&i.JobTitle,
+		&i.Birthday,
+		&i.PhotoUrl,
+		&i.CrmContactID,
+		&i.MatchStatus,
+		&i.DuplicateOfID,
+		&i.Etag,
+		&i.Metadata,
+		&i.SyncedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.HostID,
+		&i.LastContentHash,
+		&i.PendingMethodSuggestions,
+		&i.DismissedMethodSuggestions,
+	)
+	return &i, err
+}
+
 const UpsertExternalContact = `-- name: UpsertExternalContact :one
 INSERT INTO external_contact (
     source, source_id, account_id, host_id, display_name, first_name, last_name,
@@ -1825,75 +1897,6 @@ func (q *Queries) UpsertExternalContact(ctx context.Context, arg UpsertExternalC
 		arg.Metadata,
 		arg.SyncedAt,
 		arg.LastContentHash,
-	)
-	var i ExternalContact
-	err := row.Scan(
-		&i.ID,
-		&i.Source,
-		&i.SourceID,
-		&i.AccountID,
-		&i.DisplayName,
-		&i.FirstName,
-		&i.LastName,
-		&i.Emails,
-		&i.Phones,
-		&i.Addresses,
-		&i.Organization,
-		&i.JobTitle,
-		&i.Birthday,
-		&i.PhotoUrl,
-		&i.CrmContactID,
-		&i.MatchStatus,
-		&i.DuplicateOfID,
-		&i.Etag,
-		&i.Metadata,
-		&i.SyncedAt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.DeletedAt,
-		&i.HostID,
-		&i.LastContentHash,
-		&i.PendingMethodSuggestions,
-		&i.DismissedMethodSuggestions,
-	)
-	return &i, err
-}
-
-const UpsertTelegramDiscoveryCandidate = `-- name: UpsertTelegramDiscoveryCandidate :one
-INSERT INTO external_contact (
-    source, source_id, display_name, first_name, last_name, metadata, synced_at
-) VALUES ('telegram', $1, $2, $3, $4, $5, $6)
-ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
-    display_name = COALESCE(EXCLUDED.display_name, external_contact.display_name),
-    first_name   = COALESCE(EXCLUDED.first_name,   external_contact.first_name),
-    last_name    = COALESCE(EXCLUDED.last_name,    external_contact.last_name),
-    metadata     = external_contact.metadata || EXCLUDED.metadata,
-    synced_at    = EXCLUDED.synced_at,
-    updated_at   = NOW()
-RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at, host_id, last_content_hash, pending_method_suggestions, dismissed_method_suggestions
-`
-
-type UpsertTelegramDiscoveryCandidateParams struct {
-	SourceID    string             `json:"source_id"`
-	DisplayName pgtype.Text        `json:"display_name"`
-	FirstName   pgtype.Text        `json:"first_name"`
-	LastName    pgtype.Text        `json:"last_name"`
-	Metadata    []byte             `json:"metadata"`
-	SyncedAt    pgtype.Timestamptz `json:"synced_at"`
-}
-
-// Telegram-specific upsert that preserves populated peer fields when a later
-// message arrives with null entity data. Never clears a name/handle that was
-// previously captured. Metadata is merged (|| operator) so keys from earlier
-// writes (e.g. username) are retained when the new map omits them.
-func (q *Queries) UpsertTelegramDiscoveryCandidate(ctx context.Context, arg UpsertTelegramDiscoveryCandidateParams) (*ExternalContact, error) {
-	row := q.db.QueryRow(ctx, UpsertTelegramDiscoveryCandidate,
-		arg.SourceID,
-		arg.DisplayName,
-		arg.FirstName,
-		arg.LastName,
-		arg.Metadata,
-		arg.SyncedAt,
 	)
 	var i ExternalContact
 	err := row.Scan(

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -270,6 +270,10 @@ type Querier interface {
 	// end-to-end test to verify Stage 3 created the row the staging
 	// table's interaction_id points to.
 	CountInteractionsByIDContactAndSource(ctx context.Context, arg CountInteractionsByIDContactAndSourceParams) (int64, error)
+	// Reports whether the message is ALREADY staged against a contact, so the
+	// unmatched insert path can decline rather than mint the duplicate pair with
+	// nothing to tombstone it. O(1) on idx_comms_message_dedup.
+	CountLiveMatchedChatMessage(ctx context.Context, arg CountLiveMatchedChatMessageParams) (int64, error)
 	// Count calendar events involving a contact (for merge preview)
 	CountMergeCalendarEvents(ctx context.Context, dollar_1 pgtype.UUID) (int64, error)
 	// Count contact methods for a contact (for merge preview)
@@ -1935,6 +1939,11 @@ type Querier interface {
 	SoftDeleteNode(ctx context.Context, id pgtype.UUID) error
 	SoftDeleteTelegramChannelMessages(ctx context.Context, arg SoftDeleteTelegramChannelMessagesParams) error
 	SoftDeleteTelegramMessages(ctx context.Context, messageIds []int32) error
+	// Tombstones the unmatched staging row for a message that has just been staged
+	// WITH a contact. The matched and unmatched chat upserts have DISJOINT conflict
+	// targets, so both rows can exist for one message; the matched row is the
+	// survivor. O(1) on idx_comms_message_dedup_unmatched.
+	SoftDeleteUnmatchedChatMessageTwin(ctx context.Context, arg SoftDeleteUnmatchedChatMessageTwinParams) (int64, error)
 	// Test setup — drop ALL river_job rows, but ONLY when connected to a
 	// per-package clone DB (current_database() matching the clone-name prefix).
 	// The rescue-on-crash test calls this to clear foreign-kind leftovers (e.g.
@@ -2945,6 +2954,12 @@ type Querier interface {
 	UpsertContactNoteByCategory(ctx context.Context, arg UpsertContactNoteByCategoryParams) (*Note, error)
 	// Upsert a contact task by external_task_id (Todoist task IDs are globally unique)
 	UpsertContactTask(ctx context.Context, arg UpsertContactTaskParams) (*ContactTask, error)
+	// Source-parameterized discovery upsert that preserves populated peer fields
+	// when a later message arrives with null entity data. Never clears a
+	// name/handle that was previously captured. Metadata is merged (|| operator) so
+	// keys from earlier writes (e.g. username) are retained when the new map omits
+	// them.
+	UpsertDiscoveryCandidate(ctx context.Context, arg UpsertDiscoveryCandidateParams) (*ExternalContact, error)
 	// Embedding storage queries (graph foundation, derived storage).
 	//
 	// The embedding table is a disposable projection: a vector(1536) keyed by a
@@ -3038,11 +3053,6 @@ type Querier interface {
 	UpsertTelegramChannelAccessHash(ctx context.Context, arg UpsertTelegramChannelAccessHashParams) (*TelegramChannelState, error)
 	UpsertTelegramChannelState(ctx context.Context, arg UpsertTelegramChannelStateParams) (*TelegramChannelState, error)
 	UpsertTelegramChatConfig(ctx context.Context, arg UpsertTelegramChatConfigParams) (*TelegramChatConfig, error)
-	// Telegram-specific upsert that preserves populated peer fields when a later
-	// message arrives with null entity data. Never clears a name/handle that was
-	// previously captured. Metadata is merged (|| operator) so keys from earlier
-	// writes (e.g. username) are retained when the new map omits them.
-	UpsertTelegramDiscoveryCandidate(ctx context.Context, arg UpsertTelegramDiscoveryCandidateParams) (*ExternalContact, error)
 	UpsertTelegramMessage(ctx context.Context, arg UpsertTelegramMessageParams) (*TelegramMessage, error)
 	UpsertTelegramSession(ctx context.Context, arg UpsertTelegramSessionParams) (*TelegramSession, error)
 	// Used by gotd/td session.Storage — only updates encrypted session data,

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -654,3 +654,25 @@ WHERE source = @source
 DELETE FROM comms_message
 WHERE source = @source
   AND external_id LIKE @external_id_prefix;
+
+-- name: SoftDeleteUnmatchedChatMessageTwin :execrows
+-- Tombstones the unmatched staging row for a message that has just been staged
+-- WITH a contact. The matched and unmatched chat upserts have DISJOINT conflict
+-- targets, so both rows can exist for one message; the matched row is the
+-- survivor. O(1) on idx_comms_message_dedup_unmatched.
+UPDATE comms_message
+SET deleted_at = NOW()
+WHERE source = @source
+  AND external_id = @external_id
+  AND matched_contact_id IS NULL
+  AND deleted_at IS NULL;
+
+-- name: CountLiveMatchedChatMessage :one
+-- Reports whether the message is ALREADY staged against a contact, so the
+-- unmatched insert path can decline rather than mint the duplicate pair with
+-- nothing to tombstone it. O(1) on idx_comms_message_dedup.
+SELECT COUNT(*) FROM comms_message
+WHERE source = @source
+  AND external_id = @external_id
+  AND matched_contact_id IS NOT NULL
+  AND deleted_at IS NULL;

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -495,14 +495,15 @@ WHERE source = $1 AND COALESCE(account_id, '') = COALESCE($2, '');
 -- name: DeleteExternalContact :exec
 DELETE FROM external_contact WHERE id = $1;
 
--- name: UpsertTelegramDiscoveryCandidate :one
--- Telegram-specific upsert that preserves populated peer fields when a later
--- message arrives with null entity data. Never clears a name/handle that was
--- previously captured. Metadata is merged (|| operator) so keys from earlier
--- writes (e.g. username) are retained when the new map omits them.
+-- name: UpsertDiscoveryCandidate :one
+-- Source-parameterized discovery upsert that preserves populated peer fields
+-- when a later message arrives with null entity data. Never clears a
+-- name/handle that was previously captured. Metadata is merged (|| operator) so
+-- keys from earlier writes (e.g. username) are retained when the new map omits
+-- them.
 INSERT INTO external_contact (
     source, source_id, display_name, first_name, last_name, metadata, synced_at
-) VALUES ('telegram', $1, $2, $3, $4, $5, $6)
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
     display_name = COALESCE(EXCLUDED.display_name, external_contact.display_name),
     first_name   = COALESCE(EXCLUDED.first_name,   external_contact.first_name),

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -1098,6 +1098,35 @@ func (r *CommsMessageRepository) ListUnmatchedPeerCounts(ctx context.Context, so
 	return out, nil
 }
 
+// SoftDeleteUnmatchedTwin tombstones the unmatched staging row for a message
+// that has just been staged WITH a contact, and returns how many rows it
+// touched (zero in the overwhelmingly common case).
+//
+// The two chat upserts have disjoint conflict targets, so a matched and an
+// unmatched row for ONE message can coexist. This is the matched-row-wins half
+// of the reconciliation that keeps a flip from stranding a permanent duplicate.
+func (r *CommsMessageRepository) SoftDeleteUnmatchedTwin(ctx context.Context, source, externalID string) (int64, error) {
+	return r.queries.SoftDeleteUnmatchedChatMessageTwin(ctx, db.SoftDeleteUnmatchedChatMessageTwinParams{
+		Source:     source,
+		ExternalID: externalID,
+	})
+}
+
+// HasMatchedChatMessage reports whether the message is already staged against a
+// contact. It is the reverse-direction guard: an unmatched insert for a message
+// that already has a matched row would mint the duplicate pair with nothing to
+// tombstone it.
+func (r *CommsMessageRepository) HasMatchedChatMessage(ctx context.Context, source, externalID string) (bool, error) {
+	count, err := r.queries.CountLiveMatchedChatMessage(ctx, db.CountLiveMatchedChatMessageParams{
+		Source:     source,
+		ExternalID: externalID,
+	})
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 // HardDeleteBySourceAndExternalIDPrefix is a test-only helper that hard-deletes
 // staging rows by (source, external_id LIKE prefix). It exists for the chat
 // staging tests, whose UNMATCHED rows have no contact for

--- a/backend/internal/repository/external_contact.go
+++ b/backend/internal/repository/external_contact.go
@@ -155,10 +155,11 @@ type KnownExternalContactID struct {
 	LastContentHash *string `json:"last_content_hash"`
 }
 
-// UpsertTelegramDiscoveryCandidateRequest carries the Telegram-specific fields
-// used by the peer matcher. Nil name fields are preserved (never overwrite a
+// UpsertDiscoveryCandidateRequest carries the fields a chat source's peer
+// matcher discovers. Nil name fields are preserved (never overwrite a
 // previously-captured name). Metadata is merged with existing stored metadata.
-type UpsertTelegramDiscoveryCandidateRequest struct {
+type UpsertDiscoveryCandidateRequest struct {
+	Source      string         `json:"source"`
 	SourceID    string         `json:"source_id"`
 	DisplayName *string        `json:"display_name,omitempty"`
 	FirstName   *string        `json:"first_name,omitempty"`
@@ -537,15 +538,18 @@ func buildUpsertExternalContactParams(req UpsertExternalContactRequest) db.Upser
 	return params
 }
 
-// UpsertTelegramDiscoveryCandidate inserts or updates a Telegram discovery
-// candidate via the dedicated SQL query. Unlike the shared Upsert, nil name
-// fields are preserved (never overwrite a stored value) and metadata is merged
-// with the existing stored map instead of replacing it. Unrelated columns
-// (emails, phones, addresses, organization, job_title, birthday, photo_url,
-// etag, account_id) are not touched on update.
-func (r *ExternalContactRepository) UpsertTelegramDiscoveryCandidate(
+// UpsertDiscoveryCandidate inserts or updates a discovery candidate via the
+// dedicated SQL query. Unlike the shared Upsert, nil name fields are preserved
+// (never overwrite a stored value) and metadata is merged with the existing
+// stored map instead of replacing it. Unrelated columns (emails, phones,
+// addresses, organization, job_title, birthday, photo_url, etag, account_id)
+// are not touched on update, and match_status is never overwritten.
+//
+// It is source-parameterized rather than twinned per source, so the preserve
+// semantics cannot drift between the sources that share them.
+func (r *ExternalContactRepository) UpsertDiscoveryCandidate(
 	ctx context.Context,
-	req UpsertTelegramDiscoveryCandidateRequest,
+	req UpsertDiscoveryCandidateRequest,
 ) (*ExternalContact, error) {
 	metadata := req.Metadata
 	if metadata == nil {
@@ -556,7 +560,8 @@ func (r *ExternalContactRepository) UpsertTelegramDiscoveryCandidate(
 		return nil, fmt.Errorf("marshal metadata: %w", err)
 	}
 
-	params := db.UpsertTelegramDiscoveryCandidateParams{
+	params := db.UpsertDiscoveryCandidateParams{
+		Source:      req.Source,
 		SourceID:    req.SourceID,
 		DisplayName: stringToPgText(req.DisplayName),
 		FirstName:   stringToPgText(req.FirstName),
@@ -564,9 +569,9 @@ func (r *ExternalContactRepository) UpsertTelegramDiscoveryCandidate(
 		Metadata:    metadataBytes,
 		SyncedAt:    timeToPgTimestamptz(req.SyncedAt),
 	}
-	dbContact, err := r.queries.UpsertTelegramDiscoveryCandidate(ctx, params)
+	dbContact, err := r.queries.UpsertDiscoveryCandidate(ctx, params)
 	if err != nil {
-		return nil, fmt.Errorf("upsert telegram discovery candidate: %w", err)
+		return nil, fmt.Errorf("upsert discovery candidate: %w", err)
 	}
 	return convertDbExternalContact(dbContact)
 }

--- a/backend/internal/service/external_methods.go
+++ b/backend/internal/service/external_methods.go
@@ -13,7 +13,8 @@ import (
 //
 // Callers are responsible for deduplicating against existing contact methods
 // on the target contact — this function returns everything the external
-// contact carries, in a stable order: emails, then phones, then telegram.
+// contact carries, in a stable order: emails, then phones, then the
+// source-specific handle.
 func BuildMethodsFromExternal(external *repository.ExternalContact) []ContactMethodInput {
 	if external == nil {
 		return nil
@@ -36,14 +37,30 @@ func BuildMethodsFromExternal(external *repository.ExternalContact) []ContactMet
 		}
 	}
 
+	// WhatsApp candidates are keyed by their raw peer JID, and only the
+	// resolved E.164 is a usable contact method. A peer whose number was never
+	// recovered therefore emits nothing — correct, and silent rather than
+	// wrong: there is no identifier type for a WhatsApp-internal id, and the
+	// raw JID is an unusable string in a user-facing field.
+	if external.Source == "whatsapp" {
+		if phone, ok := external.Metadata["phone_e164"].(string); ok {
+			canonical := canonicalizeMethodValue("whatsapp", phone)
+			if canonical != "" {
+				methods = append(methods, ContactMethodInput{Type: "whatsapp", Value: canonical})
+			}
+		}
+	}
+
 	return methods
 }
 
 // canonicalizeMethodValue converts a user- or frontend-supplied raw method
 // value into the canonical form stored in contact_method.value. For
 // handle-based types (telegram/twitter/discord), strips leading '@' and
-// trims whitespace. Does NOT lowercase — storage preserves user casing;
-// value_normalized in the DB carries the lowercased form via the trigger.
+// trims whitespace. Every other type — including whatsapp, whose value is an
+// already-normalized E.164 — passes through unchanged. Does NOT lowercase:
+// storage preserves user casing; value_normalized in the DB carries the
+// lowercased form via the trigger.
 func canonicalizeMethodValue(methodType, rawValue string) string {
 	switch methodType {
 	case "telegram", "twitter", "discord":

--- a/backend/internal/service/external_methods_test.go
+++ b/backend/internal/service/external_methods_test.go
@@ -122,6 +122,70 @@ func TestBuildMethodsFromExternal_AllCombined_StableOrder(t *testing.T) {
 	}, got)
 }
 
+func TestBuildMethodsFromExternal_WhatsAppEmitsWhatsAppMethod(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "whatsapp",
+		Metadata: map[string]any{"phone_e164": "+15559876543"},
+	}
+	assert.Equal(t, []ContactMethodInput{
+		{Type: "whatsapp", Value: "+15559876543"},
+	}, BuildMethodsFromExternal(ext))
+}
+
+// TestBuildMethodsFromExternal_WhatsAppWithoutPhoneEmitsNothing: a LID-only peer
+// has no phone, and the arc rejected minting a lid identifier — so an imported
+// LID-only peer gains no WhatsApp method. Silent rather than wrong; emitting the
+// raw JID would put an unusable string in a user-facing field.
+func TestBuildMethodsFromExternal_WhatsAppWithoutPhoneEmitsNothing(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "whatsapp",
+		Metadata: map[string]any{"peer_jid": "88800000002@lid"},
+	}
+	assert.Empty(t, BuildMethodsFromExternal(ext))
+}
+
+func TestBuildMethodsFromExternal_WhatsAppMetadataNonStringIgnored(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "whatsapp",
+		Metadata: map[string]any{"phone_e164": 15559876543},
+	}
+	assert.Empty(t, BuildMethodsFromExternal(ext))
+}
+
+func TestBuildMethodsFromExternal_WhatsAppEmptyPhoneEmitsNothing(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "whatsapp",
+		Metadata: map[string]any{"phone_e164": ""},
+	}
+	assert.Empty(t, BuildMethodsFromExternal(ext))
+}
+
+// TestBuildMethodsFromExternal_TelegramUnchangedByWhatsAppArm guards the arm
+// that was already there against the one just added.
+func TestBuildMethodsFromExternal_TelegramUnchangedByWhatsAppArm(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Metadata: map[string]any{"username": "@handle", "phone_e164": "+15559876543"},
+	}
+	assert.Equal(t, []ContactMethodInput{
+		{Type: "telegram", Value: "handle"},
+	}, BuildMethodsFromExternal(ext), "a telegram row must not grow a whatsapp method")
+}
+
+func TestBuildMethodsFromExternal_WhatsAppOrderIsEmailsThenPhonesThenHandle(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "whatsapp",
+		Emails:   []repository.EmailEntry{{Value: "a@example.com"}},
+		Phones:   []repository.PhoneEntry{{Value: "+15551234"}},
+		Metadata: map[string]any{"phone_e164": "+15559876543"},
+	}
+	assert.Equal(t, []ContactMethodInput{
+		{Type: "email", Value: "a@example.com"},
+		{Type: "phone", Value: "+15551234"},
+		{Type: "whatsapp", Value: "+15559876543"},
+	}, BuildMethodsFromExternal(ext))
+}
+
 func TestIsUniqueViolation(t *testing.T) {
 	tests := []struct {
 		name string

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -563,7 +563,8 @@ func (h *Harness) SeedTelegramDiscoveryCandidate(ctx context.Context, spec facto
 	if spec.Username != "" {
 		metadata["username"] = spec.Username
 	}
-	req := repository.UpsertTelegramDiscoveryCandidateRequest{
+	req := repository.UpsertDiscoveryCandidateRequest{
+		Source:      "telegram",
 		SourceID:    strconv.FormatInt(spec.PeerUserID, 10),
 		DisplayName: nilIfBlank(spec.DisplayName),
 		FirstName:   nilIfBlank(spec.FirstName),
@@ -571,7 +572,7 @@ func (h *Harness) SeedTelegramDiscoveryCandidate(ctx context.Context, spec facto
 		Metadata:    metadata,
 		SyncedAt:    &now,
 	}
-	ec, err := h.externalRepo.UpsertTelegramDiscoveryCandidate(ctx, req)
+	ec, err := h.externalRepo.UpsertDiscoveryCandidate(ctx, req)
 	if err != nil {
 		return uuid.Nil, "", fmt.Errorf("seed telegram discovery candidate: %w", err)
 	}

--- a/backend/internal/telegram/import_hook.go
+++ b/backend/internal/telegram/import_hook.go
@@ -35,6 +35,12 @@ type PostImportHook struct {
 }
 
 // NewPostImportHook wraps a Telegram manager.
+//
+// The parameter is an interface, so a TYPED nil (a nil *TelegramManager) makes
+// it non-nil and defeats the guard in OnPeerLinked, panicking on the nil
+// receiver. Passing an untyped nil is safe and is what the tests do; passing a
+// typed nil is the caller's responsibility, and the composition root avoids it
+// by registering the hook only when it built a manager.
 func NewPostImportHook(mgr telegramPeerLinker) *PostImportHook {
 	return &PostImportHook{mgr: mgr}
 }

--- a/backend/internal/telegram/import_hook.go
+++ b/backend/internal/telegram/import_hook.go
@@ -11,20 +11,31 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// telegramPeerLinker is the slice of *TelegramManager this adapter delegates to.
+//
+// It is an interface rather than the concrete manager so the EXTRACTION — which
+// is the only logic this adapter owns — can be asserted against a recording
+// fake. With a concrete dependency the sole reachable test call is a
+// nil-constructed one, and a nil-constructed call cannot observe what was
+// derived, so a wrong extraction would pass.
+type telegramPeerLinker interface {
+	OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error
+}
+
 // PostImportHook back-links a Telegram candidate's message history after the
 // user imports or links it.
 //
-// It exists because the import handler's hook is now source-keyed and passes the
+// It exists because the import handler's hook is source-keyed and passes the
 // whole external_contact row, while TelegramManager.OnPeerLinked keeps its
 // existing (peerUserID, peerUsername) shape — it is also called by the rematch
 // path. The adapter owns the interface and the field extraction; the manager
 // method is untouched.
 type PostImportHook struct {
-	mgr *TelegramManager
+	mgr telegramPeerLinker
 }
 
 // NewPostImportHook wraps a Telegram manager.
-func NewPostImportHook(mgr *TelegramManager) *PostImportHook {
+func NewPostImportHook(mgr telegramPeerLinker) *PostImportHook {
 	return &PostImportHook{mgr: mgr}
 }
 
@@ -34,8 +45,12 @@ func (h *PostImportHook) Source() string { return "telegram" }
 // OnPeerLinked extracts the peer user id and handle from the candidate row and
 // delegates. A source_id that is not a Telegram user id logs and returns nil,
 // exactly as the handler did before the hook was source-keyed.
+//
+// The extraction runs BEFORE the delegate nil-check deliberately: putting the
+// check first would make every test that constructs the hook without a manager
+// skip the only logic this type has.
 func (h *PostImportHook) OnPeerLinked(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) error {
-	if h.mgr == nil || external == nil {
+	if external == nil {
 		return nil
 	}
 	peerUserID, err := strconv.ParseInt(external.SourceID, 10, 64)
@@ -46,6 +61,9 @@ func (h *PostImportHook) OnPeerLinked(ctx context.Context, external *repository.
 	var peerUsername string
 	if username, ok := external.Metadata["username"].(string); ok {
 		peerUsername = strings.TrimPrefix(username, "@")
+	}
+	if h.mgr == nil {
+		return nil
 	}
 	return h.mgr.OnPeerLinked(ctx, peerUserID, peerUsername, contactID)
 }

--- a/backend/internal/telegram/import_hook.go
+++ b/backend/internal/telegram/import_hook.go
@@ -1,0 +1,51 @@
+package telegram
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// PostImportHook back-links a Telegram candidate's message history after the
+// user imports or links it.
+//
+// It exists because the import handler's hook is now source-keyed and passes the
+// whole external_contact row, while TelegramManager.OnPeerLinked keeps its
+// existing (peerUserID, peerUsername) shape — it is also called by the rematch
+// path. The adapter owns the interface and the field extraction; the manager
+// method is untouched.
+type PostImportHook struct {
+	mgr *TelegramManager
+}
+
+// NewPostImportHook wraps a Telegram manager.
+func NewPostImportHook(mgr *TelegramManager) *PostImportHook {
+	return &PostImportHook{mgr: mgr}
+}
+
+// Source is the external_contact.source this hook handles.
+func (h *PostImportHook) Source() string { return "telegram" }
+
+// OnPeerLinked extracts the peer user id and handle from the candidate row and
+// delegates. A source_id that is not a Telegram user id logs and returns nil,
+// exactly as the handler did before the hook was source-keyed.
+func (h *PostImportHook) OnPeerLinked(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) error {
+	if h.mgr == nil || external == nil {
+		return nil
+	}
+	peerUserID, err := strconv.ParseInt(external.SourceID, 10, 64)
+	if err != nil {
+		log.Warn().Err(err).Msg("telegram: failed to parse peer user ID for post-import hook")
+		return nil
+	}
+	var peerUsername string
+	if username, ok := external.Metadata["username"].(string); ok {
+		peerUsername = strings.TrimPrefix(username, "@")
+	}
+	return h.mgr.OnPeerLinked(ctx, peerUserID, peerUsername, contactID)
+}

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -23,7 +23,7 @@ type identityMatcher interface {
 
 // externalContactUpserter defines the interface for upserting/updating external contacts.
 type externalContactUpserter interface {
-	UpsertTelegramDiscoveryCandidate(ctx context.Context, req repository.UpsertTelegramDiscoveryCandidateRequest) (*repository.ExternalContact, error)
+	UpsertDiscoveryCandidate(ctx context.Context, req repository.UpsertDiscoveryCandidateRequest) (*repository.ExternalContact, error)
 	GetBySource(ctx context.Context, source, sourceID string, accountID *string) (*repository.ExternalContact, error)
 	UpdateMatch(ctx context.Context, id uuid.UUID, crmContactID *uuid.UUID, status repository.MatchStatus) (*repository.ExternalContact, error)
 }
@@ -229,7 +229,8 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 			metadata["username"] = "@" + *username
 		}
 
-		_, err := m.externalContactRepo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		_, err := m.externalContactRepo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+			Source:      "telegram",
 			SourceID:    sourceID,
 			DisplayName: displayName,
 			FirstName:   firstName,
@@ -285,7 +286,8 @@ func (m *PeerMatcher) UpdateDiscoveryCandidatesForPeer(ctx context.Context, peer
 	}
 
 	now := accelerated.GetCurrentTime()
-	if _, err := m.externalContactRepo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	if _, err := m.externalContactRepo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:      "telegram",
 		SourceID:    sourceID,
 		DisplayName: displayName,
 		FirstName:   firstName,

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -34,12 +34,12 @@ type updateMatchCall struct {
 }
 
 type mockExternalContactUpserter struct {
-	upsertCalls      []repository.UpsertTelegramDiscoveryCandidateRequest
+	upsertCalls      []repository.UpsertDiscoveryCandidateRequest
 	getResult        *repository.ExternalContact
 	updateMatchCalls []updateMatchCall
 }
 
-func (m *mockExternalContactUpserter) UpsertTelegramDiscoveryCandidate(_ context.Context, req repository.UpsertTelegramDiscoveryCandidateRequest) (*repository.ExternalContact, error) {
+func (m *mockExternalContactUpserter) UpsertDiscoveryCandidate(_ context.Context, req repository.UpsertDiscoveryCandidateRequest) (*repository.ExternalContact, error) {
 	m.upsertCalls = append(m.upsertCalls, req)
 	return &repository.ExternalContact{ID: uuid.New(), Source: "telegram", SourceID: req.SourceID}, nil
 }
@@ -331,7 +331,7 @@ func TestUpdateDiscoveryCandidatesForPeer_AtThreshold(t *testing.T) {
 // TestUpdateDiscoveryCandidatesForPeer_NilNames_StillSendsUpsert documents the
 // Go-layer contract after the null-overwrite fix: the live path keeps passing
 // whatever names it has (including all-nil). The SQL COALESCE in the dedicated
-// UpsertTelegramDiscoveryCandidate query is what actually preserves stored
+// UpsertDiscoveryCandidate query is what actually preserves stored
 // values. The metadata map must not carry a "username" key when peerUsername
 // is nil — otherwise the JSONB merge would overwrite an earlier non-null handle
 // with a bogus null-ish entry.

--- a/backend/internal/whatsapp/actor.go
+++ b/backend/internal/whatsapp/actor.go
@@ -1374,6 +1374,7 @@ func (m *Manager) Status() Status {
 	// leave the loop holding aliases into what it published.
 	out := s.status.clone()
 	out.Backfill = m.backfillStatus(context.Background())
+	out.Ingest = m.ingestStatus()
 	return out
 }
 

--- a/backend/internal/whatsapp/actor_test.go
+++ b/backend/internal/whatsapp/actor_test.go
@@ -110,7 +110,12 @@ func TestPackageHasNoMutex(t *testing.T) {
 	allowed := map[string]int{
 		"sync.Once":      2, // the process-wide device props, and Manager.stopOnce
 		"sync.WaitGroup": 1, // Manager.effects, the effect-goroutine census
-		"atomic.Pointer": 2, // the published snapshot, and the backfill cache
+		// The published snapshot, the backfill cache, and the unresolved-LID
+		// peer set. The third is a COPY-ON-WRITE map: it is off-loop shared
+		// state, and this is how the package holds such state without a lock —
+		// every published map is immutable and a writer installs a replacement
+		// by CAS, so a reader can never observe a half-built set.
+		"atomic.Pointer": 3,
 		// dialSettled: the dial and its watchdog race to decide one outcome.
 		// They share no state beyond this flag and the channel it guards, and
 		// the CAS is the decision itself, so there is nothing for a lock to make

--- a/backend/internal/whatsapp/chatconfig.go
+++ b/backend/internal/whatsapp/chatconfig.go
@@ -1,0 +1,221 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+)
+
+// Per-chat gate statuses. "auto" is the insert default; the other two are the
+// user's explicit override, which no automatic write ever clears.
+const (
+	ChatStatusAuto    = "auto"
+	ChatStatusTracked = "tracked"
+	ChatStatusIgnored = "ignored"
+)
+
+// ErrChatGateUndecided means the gate could not decide right now. The caller
+// must NOT acknowledge the message: WhatsApp never redelivers an acked message,
+// and the next delivery will plausibly find the count resolved.
+//
+// Only TRANSIENT causes may enter this bucket. A permanent answer — we are not
+// in the group, the group does not exist, the server reports no size — is a
+// decision, because "ask again later" against an unchanging answer is an
+// unbounded redelivery loop, each iteration paying a config read and a network
+// IQ on the library's serialized handler queue.
+var ErrChatGateUndecided = errors.New("whatsapp: group tracking could not be decided")
+
+// EffectiveTracked decides whether a chat's messages are stored, from its
+// persisted state alone.
+//
+// It fails CLOSED on an unknown member count — a deliberate divergence from
+// Telegram, which tracks by default when the size is unknown. A non-positive
+// count is treated as unknown, never as a small group: the wire's size
+// attribute is optional and yields 0 when absent.
+func EffectiveTracked(status string, memberCount *int, groupMaxMembers int) bool {
+	switch status {
+	case ChatStatusTracked:
+		return true
+	case ChatStatusIgnored:
+		return false
+	default:
+		if memberCount == nil || *memberCount <= 0 {
+			return false
+		}
+		return *memberCount <= groupMaxMembers
+	}
+}
+
+// whatsAppChatConfigStore is the slice of WhatsAppRepository the gate needs.
+type whatsAppChatConfigStore interface {
+	GetChatConfig(ctx context.Context, chatJID string) (*repository.WhatsAppChatConfig, error)
+	UpsertChatConfig(ctx context.Context, cfg repository.WhatsAppChatConfig) (*repository.WhatsAppChatConfig, error)
+}
+
+// ChatGate is the persisted group-size gate. It is owned by the Ingestor rather
+// than the manager because the DB read must come FIRST — the library's group
+// lookup is uncached, so an ungated call would be a network round trip per
+// message — and because the history drainer projects through the same ingest
+// choke point, giving both paths one implementation.
+type ChatGate struct {
+	repo            whatsAppChatConfigStore
+	groupInfoSource func() GroupInfoFetcher
+	groupMaxMembers int
+}
+
+// NewChatGate builds the gate. The group-info source is bound later, by
+// Manager.SetIngestor, because the ingestor is constructed before the manager.
+func NewChatGate(repo whatsAppChatConfigStore, groupMaxMembers int) *ChatGate {
+	return &ChatGate{repo: repo, groupMaxMembers: groupMaxMembers}
+}
+
+// BindGroupInfoSource installs the late-bound accessor for the live client.
+func (g *ChatGate) BindGroupInfoSource(src func() GroupInfoFetcher) {
+	g.groupInfoSource = src
+}
+
+// ShouldTrack resolves and persists the chat's config, then decides whether its
+// messages are stored.
+//
+// A non-nil error wrapping ErrChatGateUndecided means the caller must NOT
+// acknowledge. "Do not track" and "fail closed" are STORAGE rules, not ack
+// rules: they say an unresolved group's messages must not be stored, never that
+// they must be acknowledged as handled.
+func (g *ChatGate) ShouldTrack(ctx context.Context, chatJID, chatType string) (bool, error) {
+	// The gate is the group-SIZE gate. A private chat has already passed the
+	// person-to-person allowlist upstream.
+	if chatType != ChatTypeGroup {
+		return true, nil
+	}
+
+	cfg, err := g.repo.GetChatConfig(ctx, chatJID)
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		return false, fmt.Errorf("%w: read chat config: %v", ErrChatGateUndecided, err)
+	}
+	if errors.Is(err, db.ErrNotFound) {
+		cfg = nil
+	}
+
+	// An explicit user override needs no member count, and consulting it first
+	// is what stops an ignored group paying a network IQ per message for a
+	// number its own decision discards.
+	if cfg != nil && (cfg.Status == ChatStatusTracked || cfg.Status == ChatStatusIgnored) {
+		return cfg.Status == ChatStatusTracked, nil
+	}
+
+	var (
+		count  *int
+		title  *string
+		lookup *time.Time
+	)
+	if cfg != nil {
+		count = int32PtrToIntPtr(cfg.MemberCount)
+		title = cfg.ChatTitle
+	}
+
+	// A lookup runs only when the row is absent or its count is still
+	// unresolved, and a successful one is always something new to persist.
+	looked := false
+	if cfg == nil || count == nil {
+		info, err := g.lookupGroup(ctx, chatJID)
+		if err != nil {
+			return false, err
+		}
+		if info == nil {
+			// A decided-permanent lookup failure: nothing is stored, nothing is
+			// written, and the message is consumed.
+			return false, nil
+		}
+		resolved := info.MemberCount
+		count = &resolved
+		if info.Title != "" {
+			title = &info.Title
+		}
+		now := accelerated.GetCurrentTime()
+		lookup = &now
+		looked = true
+	}
+
+	// Re-writing an unchanged row on every group message is a pointless write
+	// on the message-handling path, so only a fresh resolution is persisted —
+	// which is also the only way a row can be absent by this point.
+	if looked {
+		if _, err := g.repo.UpsertChatConfig(ctx, repository.WhatsAppChatConfig{
+			ChatJID:      chatJID,
+			ChatTitle:    title,
+			ChatType:     chatType,
+			MemberCount:  intPtrToInt32Ptr(count),
+			LastLookupAt: lookup,
+		}); err != nil {
+			// Undecided rather than decided: without the write the count would
+			// be re-fetched on every message from this chat.
+			return false, fmt.Errorf("%w: persist chat config: %v", ErrChatGateUndecided, err)
+		}
+	}
+
+	status := ChatStatusAuto
+	if cfg != nil && cfg.Status != "" {
+		status = cfg.Status
+	}
+	return EffectiveTracked(status, count, g.groupMaxMembers), nil
+}
+
+// lookupGroup resolves the group's metadata, splitting failures by whether a
+// later delivery could plausibly answer differently.
+//
+// (nil, nil) means DECIDED-not-tracked: the server answered, and its answer
+// does not change on redelivery. A non-nil error is undecided.
+func (g *ChatGate) lookupGroup(ctx context.Context, chatJID string) (*ChatGroupInfo, error) {
+	if g.groupInfoSource == nil {
+		return nil, fmt.Errorf("%w: no group info source", ErrChatGateUndecided)
+	}
+	fetcher := g.groupInfoSource()
+	if fetcher == nil {
+		return nil, fmt.Errorf("%w: no connected client", ErrChatGateUndecided)
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, groupInfoTimeout)
+	defer cancel()
+
+	info, err := fetcher.GroupInfo(lookupCtx, chatJID)
+	if err == nil {
+		return info, nil
+	}
+	if errors.Is(err, ErrGroupUnavailable) || errors.Is(err, ErrGroupSizeUnknown) {
+		// We are not in the group, it does not exist, or it has no reportable
+		// size. Withholding here would redeliver forever.
+		logger.Debug().Err(err).Msg("whatsapp: group is permanently unsizable; not tracking")
+		return nil, nil
+	}
+	logger.Warn().Err(err).Msg("whatsapp: group lookup failed; withholding the ack")
+	return nil, fmt.Errorf("%w: %v", ErrChatGateUndecided, err)
+}
+
+// int32PtrToIntPtr converts the repository's column width to the gate's.
+func int32PtrToIntPtr(v *int32) *int {
+	if v == nil {
+		return nil
+	}
+	out := int(*v)
+	return &out
+}
+
+// intPtrToInt32Ptr converts the gate's width back to the repository's.
+func intPtrToInt32Ptr(v *int) *int32 {
+	if v == nil {
+		return nil
+	}
+	if *v > math.MaxInt32 {
+		out := int32(math.MaxInt32)
+		return &out
+	}
+	out := int32(*v)
+	return &out
+}

--- a/backend/internal/whatsapp/chatconfig.go
+++ b/backend/internal/whatsapp/chatconfig.go
@@ -68,12 +68,17 @@ type ChatGate struct {
 	repo            whatsAppChatConfigStore
 	groupInfoSource func() GroupInfoFetcher
 	groupMaxMembers int
+	// lookupTimeout bounds the group metadata call. It is a field rather than
+	// the package constant read directly so tests can shrink it without a
+	// mutable global — two tests otherwise spend the full production bound in
+	// real wall-clock time proving the bound exists.
+	lookupTimeout time.Duration
 }
 
 // NewChatGate builds the gate. The group-info source is bound later, by
 // Manager.SetIngestor, because the ingestor is constructed before the manager.
 func NewChatGate(repo whatsAppChatConfigStore, groupMaxMembers int) *ChatGate {
-	return &ChatGate{repo: repo, groupMaxMembers: groupMaxMembers}
+	return &ChatGate{repo: repo, groupMaxMembers: groupMaxMembers, lookupTimeout: groupInfoTimeout}
 }
 
 // BindGroupInfoSource installs the late-bound accessor for the live client.
@@ -84,11 +89,17 @@ func (g *ChatGate) BindGroupInfoSource(src func() GroupInfoFetcher) {
 // ShouldTrack resolves and persists the chat's config, then decides whether its
 // messages are stored.
 //
+// accountJID is the linked account the MESSAGE was observed by, in the non-AD
+// form the parser stamps. It is compared against the account the connected
+// client belongs to, because the two can differ mid-re-pair; an empty value
+// skips the comparison, which is what a caller that cannot know its account
+// gets.
+//
 // A non-nil error wrapping ErrChatGateUndecided means the caller must NOT
 // acknowledge. "Do not track" and "fail closed" are STORAGE rules, not ack
 // rules: they say an unresolved group's messages must not be stored, never that
 // they must be acknowledged as handled.
-func (g *ChatGate) ShouldTrack(ctx context.Context, chatJID, chatType string) (bool, error) {
+func (g *ChatGate) ShouldTrack(ctx context.Context, chatJID, chatType, accountJID string) (bool, error) {
 	// The gate is the group-SIZE gate. A private chat has already passed the
 	// person-to-person allowlist upstream.
 	if chatType != ChatTypeGroup {
@@ -124,7 +135,7 @@ func (g *ChatGate) ShouldTrack(ctx context.Context, chatJID, chatType string) (b
 	// unresolved, and a successful one is always something new to persist.
 	looked := false
 	if cfg == nil || count == nil {
-		info, err := g.lookupGroup(ctx, chatJID)
+		info, err := g.lookupGroup(ctx, chatJID, accountJID)
 		if err != nil {
 			return false, err
 		}
@@ -146,6 +157,14 @@ func (g *ChatGate) ShouldTrack(ctx context.Context, chatJID, chatType string) (b
 	// Re-writing an unchanged row on every group message is a pointless write
 	// on the message-handling path, so only a fresh resolution is persisted —
 	// which is also the only way a row can be absent by this point.
+	//
+	// LastLookupAt is written for OBSERVABILITY only: nothing reads it, and
+	// nothing re-resolves on a TTL, so once a size is recorded it is frozen
+	// until the row's member_count is cleared. A group that grows past the
+	// threshold therefore keeps being tracked. That is a deliberate limit of
+	// this PR, not an oversight — a TTL re-resolve would put a network round
+	// trip back on the message path, and the settings surface that will let a
+	// user override the decision is where a re-resolve belongs.
 	if looked {
 		if _, err := g.repo.UpsertChatConfig(ctx, repository.WhatsAppChatConfig{
 			ChatJID:      chatJID,
@@ -172,7 +191,7 @@ func (g *ChatGate) ShouldTrack(ctx context.Context, chatJID, chatType string) (b
 //
 // (nil, nil) means DECIDED-not-tracked: the server answered, and its answer
 // does not change on redelivery. A non-nil error is undecided.
-func (g *ChatGate) lookupGroup(ctx context.Context, chatJID string) (*ChatGroupInfo, error) {
+func (g *ChatGate) lookupGroup(ctx context.Context, chatJID, accountJID string) (*ChatGroupInfo, error) {
 	if g.groupInfoSource == nil {
 		return nil, fmt.Errorf("%w: no group info source", ErrChatGateUndecided)
 	}
@@ -181,7 +200,19 @@ func (g *ChatGate) lookupGroup(ctx context.Context, chatJID string) (*ChatGroupI
 		return nil, fmt.Errorf("%w: no connected client", ErrChatGateUndecided)
 	}
 
-	lookupCtx, cancel := context.WithTimeout(ctx, groupInfoTimeout)
+	// The fetcher comes from the PUBLISHED session; the message came from its
+	// EMITTING one. Mid-re-pair those are different accounts, and asking the new
+	// account about a group only the old one was in returns "not in that group"
+	// — a PERMANENT answer, which this gate would consume and acknowledge,
+	// losing the message for good. A mismatch is transient by construction (the
+	// re-pair settles), so it is undecided, and no lookup is made at all.
+	if accountJID != "" {
+		if live := fetcher.AccountJID(); live != "" && live != accountJID {
+			return nil, fmt.Errorf("%w: the connected client is a different account than the one that observed this message", ErrChatGateUndecided)
+		}
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, g.lookupTimeout)
 	defer cancel()
 
 	info, err := fetcher.GroupInfo(lookupCtx, chatJID)

--- a/backend/internal/whatsapp/chatconfig_test.go
+++ b/backend/internal/whatsapp/chatconfig_test.go
@@ -46,9 +46,10 @@ func (f *fakeChatConfigStore) UpsertChatConfig(_ context.Context, cfg repository
 }
 
 type fakeGroupInfoFetcher struct {
-	info  *ChatGroupInfo
-	err   error
-	calls int
+	info    *ChatGroupInfo
+	err     error
+	calls   int
+	account string
 }
 
 func (f *fakeGroupInfoFetcher) GroupInfo(_ context.Context, _ string) (*ChatGroupInfo, error) {
@@ -56,16 +57,26 @@ func (f *fakeGroupInfoFetcher) GroupInfo(_ context.Context, _ string) (*ChatGrou
 	return f.info, f.err
 }
 
+func (f *fakeGroupInfoFetcher) AccountJID() string { return f.account }
+
+// testLookupTimeout keeps the bounded-lookup test off the production 5s bound.
+const testLookupTimeout = 50 * time.Millisecond
+
 func gateWith(store *fakeChatConfigStore, fetcher GroupInfoFetcher, maxMembers int) *ChatGate {
 	g := NewChatGate(store, maxMembers)
 	g.BindGroupInfoSource(func() GroupInfoFetcher { return fetcher })
+	g.lookupTimeout = testLookupTimeout
 	return g
 }
 
 func int32p(v int32) *int32 { return &v }
 func intp(v int) *int       { return &v }
 
-const testGroupChatJID = "120363000000000001@g.us"
+const (
+	testGroupChatJID = "120363000000000001@g.us"
+	// testAccountJID is the account the fixtures' messages were observed by.
+	testAccountJID = "15550000001@s.whatsapp.net"
+)
 
 // --- EffectiveTracked -------------------------------------------------------
 
@@ -110,7 +121,7 @@ func TestEffectiveTracked_ZeroMemberCountIsUnresolved(t *testing.T) {
 func TestGroupGate_PrivateChatSkipsTheGateEntirely(t *testing.T) {
 	store := &fakeChatConfigStore{}
 	fetcher := &fakeGroupInfoFetcher{}
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), "x@s.whatsapp.net", ChatTypePrivate)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), "x@s.whatsapp.net", ChatTypePrivate, testAccountJID)
 
 	require.NoError(t, err)
 	assert.True(t, tracked)
@@ -122,7 +133,7 @@ func TestGroupGate_ResolvesAndPersistsANewGroup(t *testing.T) {
 	store := &fakeChatConfigStore{}
 	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{Title: "Book Club", MemberCount: 4}}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err)
 	assert.True(t, tracked)
 
@@ -142,7 +153,7 @@ func TestGroupGate_UnknownMemberCountIsUndecided(t *testing.T) {
 	store := &fakeChatConfigStore{}
 	fetcher := &fakeGroupInfoFetcher{err: context.DeadlineExceeded}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	assert.False(t, tracked, "fail closed on storage")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrChatGateUndecided, "a timeout is a transient failure, not a decision")
@@ -152,7 +163,7 @@ func TestGroupGate_LookupFailureWritesNoConfig(t *testing.T) {
 	store := &fakeChatConfigStore{}
 	fetcher := &fakeGroupInfoFetcher{err: errors.New("transport down")}
 
-	_, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	_, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.ErrorIs(t, err, ErrChatGateUndecided)
 	assert.Empty(t, store.upserts, "nothing may record a false resolution")
 }
@@ -162,13 +173,13 @@ func TestGroupGate_RetriesLookupOnNextMessage(t *testing.T) {
 	fetcher := &fakeGroupInfoFetcher{err: errors.New("transport down")}
 	gate := gateWith(store, fetcher, 10)
 
-	_, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	_, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.ErrorIs(t, err, ErrChatGateUndecided)
 
 	// Because the failure wrote nothing, the next message re-enters the lookup.
 	fetcher.err = nil
 	fetcher.info = &ChatGroupInfo{Title: "Book Club", MemberCount: 4}
-	tracked, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err)
 	assert.True(t, tracked)
 	assert.Equal(t, 2, fetcher.calls)
@@ -179,13 +190,13 @@ func TestGroupGate_NilFetcherIsUndecided(t *testing.T) {
 	gate := NewChatGate(store, 10)
 	gate.BindGroupInfoSource(func() GroupInfoFetcher { return nil })
 
-	tracked, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	assert.False(t, tracked)
 	assert.ErrorIs(t, err, ErrChatGateUndecided, "no connected client is transient, not a decision")
 }
 
 func TestGroupGate_UnboundSourceIsUndecided(t *testing.T) {
-	tracked, err := NewChatGate(&fakeChatConfigStore{}, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := NewChatGate(&fakeChatConfigStore{}, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	assert.False(t, tracked)
 	assert.ErrorIs(t, err, ErrChatGateUndecided)
 }
@@ -194,7 +205,7 @@ func TestGroupGate_ConfigReadErrorIsUndecided(t *testing.T) {
 	store := &fakeChatConfigStore{getErr: errors.New("database down")}
 	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 4}}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	assert.False(t, tracked)
 	require.ErrorIs(t, err, ErrChatGateUndecided,
 		"a database blip must withhold the ack, exactly as the same blip on the staging write does")
@@ -205,7 +216,7 @@ func TestGroupGate_UpsertErrorIsUndecided(t *testing.T) {
 	store := &fakeChatConfigStore{upsertErr: errors.New("database down")}
 	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 4}}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	assert.False(t, tracked)
 	assert.ErrorIs(t, err, ErrChatGateUndecided,
 		"without the write the count would be re-fetched on every message")
@@ -217,7 +228,7 @@ func TestGroupGate_UserIgnoredOverrideSurvivesLookup(t *testing.T) {
 	}}
 	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 3}}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err)
 	assert.False(t, tracked, "a small group the user ignored stays ignored")
 }
@@ -235,7 +246,7 @@ func TestGroupGate_ExplicitStatusSkipsLookup(t *testing.T) {
 			}}
 			fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 4}}
 
-			tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+			tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 			require.NoError(t, err)
 			assert.Equal(t, status == ChatStatusTracked, tracked)
 			assert.Zero(t, fetcher.calls, "an override needs no member count")
@@ -252,7 +263,7 @@ func TestGroupGate_UnchangedRowIsNotRewritten(t *testing.T) {
 	}}
 	fetcher := &fakeGroupInfoFetcher{}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err)
 	assert.True(t, tracked)
 	assert.Zero(t, fetcher.calls, "a resolved count needs no lookup")
@@ -268,7 +279,7 @@ func TestGroupGate_NotInGroupIsDecidedNotUndecided(t *testing.T) {
 	fetcher := &fakeGroupInfoFetcher{err: errors.New("wrapped: " + ErrGroupUnavailable.Error())}
 	fetcher.err = errors.Join(ErrGroupUnavailable, errors.New("status 403"))
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err, "we are not in the group; that answer does not change on redelivery")
 	assert.False(t, tracked)
 	assert.Empty(t, store.upserts)
@@ -278,7 +289,7 @@ func TestGroupGate_GroupNotFoundIsDecidedNotUndecided(t *testing.T) {
 	store := &fakeChatConfigStore{}
 	fetcher := &fakeGroupInfoFetcher{err: errors.Join(ErrGroupUnavailable, errors.New("status 404"))}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err)
 	assert.False(t, tracked)
 }
@@ -287,7 +298,7 @@ func TestGroupGate_UnknownSizeIsDecidedNotUndecided(t *testing.T) {
 	store := &fakeChatConfigStore{}
 	fetcher := &fakeGroupInfoFetcher{err: ErrGroupSizeUnknown}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err, "the server answered; retrying re-asks a question already answered")
 	assert.False(t, tracked)
 }
@@ -296,7 +307,7 @@ func TestGroupGate_LargeGroupIsDecidedNotTracked(t *testing.T) {
 	store := &fakeChatConfigStore{}
 	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{Title: "Big", MemberCount: 42}}
 
-	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 	require.NoError(t, err, "a resolved count above the threshold is a real decision")
 	assert.False(t, tracked)
 	require.Len(t, store.upserts, 1, "the resolution is persisted so the next message needs no lookup")
@@ -353,22 +364,25 @@ func TestGroupGate_LookupIsTimeBounded(t *testing.T) {
 	t.Cleanup(func() { close(blocked) })
 	gate := NewChatGate(store, 10)
 	gate.BindGroupInfoSource(func() GroupInfoFetcher { return blockingGroupInfoFetcher{blocked} })
+	gate.lookupTimeout = testLookupTimeout
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+		_, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
 		done <- err
 	}()
 
 	select {
 	case err := <-done:
 		assert.ErrorIs(t, err, ErrChatGateUndecided)
-	case <-time.After(groupInfoTimeout + 5*time.Second):
+	case <-time.After(testLookupTimeout + 5*time.Second):
 		t.Fatal("the group lookup was not bounded; it would block whatsmeow's handler goroutine")
 	}
 }
 
 type blockingGroupInfoFetcher struct{ block chan struct{} }
+
+func (b blockingGroupInfoFetcher) AccountJID() string { return "" }
 
 func (b blockingGroupInfoFetcher) GroupInfo(ctx context.Context, _ string) (*ChatGroupInfo, error) {
 	select {
@@ -376,5 +390,59 @@ func (b blockingGroupInfoFetcher) GroupInfo(ctx context.Context, _ string) (*Cha
 		return nil, nil
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	}
+}
+
+// TestGroupGate_DifferentAccountIsUndecided is the re-pair guard. The group
+// fetcher is resolved from the PUBLISHED session while the message was parsed
+// against its EMITTING one; mid-re-pair those are different accounts, and asking
+// the new account about a group only the old one was in answers "not in that
+// group" — a PERMANENT answer this gate would otherwise consume and acknowledge,
+// losing the message for good.
+func TestGroupGate_DifferentAccountIsUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{
+		account: "15559999999@s.whatsapp.net",
+		err:     errors.Join(ErrGroupUnavailable, errors.New("status 403")),
+	}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
+	assert.False(t, tracked, "fail closed on storage")
+	require.ErrorIs(t, err, ErrChatGateUndecided,
+		"a wrong-account answer is transient by construction — the re-pair settles — so it must not be consumed")
+	assert.Zero(t, fetcher.calls, "and the wrong client is never asked at all")
+	assert.Empty(t, store.upserts)
+}
+
+func TestGroupGate_SameAccountProceeds(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{
+		account: testAccountJID,
+		info:    &ChatGroupInfo{Title: "Book Club", MemberCount: 4},
+	}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, testAccountJID)
+	require.NoError(t, err)
+	assert.True(t, tracked)
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+// TestGroupGate_UnknownAccountSkipsTheComparison keeps a caller that cannot know
+// its own account (a fetcher with no store, a projection built by hand) working
+// exactly as before rather than permanently undecided.
+func TestGroupGate_UnknownAccountSkipsTheComparison(t *testing.T) {
+	for _, tc := range []struct{ name, msgAccount, liveAccount string }{
+		{"message account unknown", "", "15559999999@s.whatsapp.net"},
+		{"client account unknown", testAccountJID, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeChatConfigStore{}
+			fetcher := &fakeGroupInfoFetcher{account: tc.liveAccount, info: &ChatGroupInfo{MemberCount: 4}}
+
+			tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup, tc.msgAccount)
+			require.NoError(t, err)
+			assert.True(t, tracked)
+			assert.Equal(t, 1, fetcher.calls)
+		})
 	}
 }

--- a/backend/internal/whatsapp/chatconfig_test.go
+++ b/backend/internal/whatsapp/chatconfig_test.go
@@ -1,0 +1,380 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"go.mau.fi/whatsmeow/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ------------------------------------------------------------------
+
+type fakeChatConfigStore struct {
+	cfg       *repository.WhatsAppChatConfig
+	getErr    error
+	upsertErr error
+	upserts   []repository.WhatsAppChatConfig
+	gets      int
+}
+
+func (f *fakeChatConfigStore) GetChatConfig(_ context.Context, _ string) (*repository.WhatsAppChatConfig, error) {
+	f.gets++
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.cfg == nil {
+		return nil, db.ErrNotFound
+	}
+	out := *f.cfg
+	return &out, nil
+}
+
+func (f *fakeChatConfigStore) UpsertChatConfig(_ context.Context, cfg repository.WhatsAppChatConfig) (*repository.WhatsAppChatConfig, error) {
+	f.upserts = append(f.upserts, cfg)
+	if f.upsertErr != nil {
+		return nil, f.upsertErr
+	}
+	return &cfg, nil
+}
+
+type fakeGroupInfoFetcher struct {
+	info  *ChatGroupInfo
+	err   error
+	calls int
+}
+
+func (f *fakeGroupInfoFetcher) GroupInfo(_ context.Context, _ string) (*ChatGroupInfo, error) {
+	f.calls++
+	return f.info, f.err
+}
+
+func gateWith(store *fakeChatConfigStore, fetcher GroupInfoFetcher, maxMembers int) *ChatGate {
+	g := NewChatGate(store, maxMembers)
+	g.BindGroupInfoSource(func() GroupInfoFetcher { return fetcher })
+	return g
+}
+
+func int32p(v int32) *int32 { return &v }
+func intp(v int) *int       { return &v }
+
+const testGroupChatJID = "120363000000000001@g.us"
+
+// --- EffectiveTracked -------------------------------------------------------
+
+func TestEffectiveTracked_TrackedOverridesLarge(t *testing.T) {
+	assert.True(t, EffectiveTracked(ChatStatusTracked, intp(500), 10),
+		"an explicit track is the user's decision, whatever the size")
+}
+
+func TestEffectiveTracked_IgnoredOverridesSmall(t *testing.T) {
+	assert.False(t, EffectiveTracked(ChatStatusIgnored, intp(2), 10))
+}
+
+func TestEffectiveTracked_AutoSmallGroup(t *testing.T) {
+	assert.True(t, EffectiveTracked(ChatStatusAuto, intp(4), 10))
+}
+
+func TestEffectiveTracked_AutoLargeGroup(t *testing.T) {
+	assert.False(t, EffectiveTracked(ChatStatusAuto, intp(11), 10))
+}
+
+func TestEffectiveTracked_AutoExactThresholdTracked(t *testing.T) {
+	assert.True(t, EffectiveTracked(ChatStatusAuto, intp(10), 10), "the bound is inclusive")
+}
+
+// TestEffectiveTracked_AutoNilMemberCountFailsClosed is the deliberate
+// divergence from Telegram, which tracks by default when the size is unknown.
+func TestEffectiveTracked_AutoNilMemberCountFailsClosed(t *testing.T) {
+	assert.False(t, EffectiveTracked(ChatStatusAuto, nil, 10),
+		"an unknown size must not be treated as a small group")
+}
+
+// TestEffectiveTracked_ZeroMemberCountIsUnresolved guards the wire's optional
+// size attribute: an absent size yields 0 with no error, and 0 satisfies any
+// "<= threshold" test, so a resolved-looking 0 would fail OPEN forever.
+func TestEffectiveTracked_ZeroMemberCountIsUnresolved(t *testing.T) {
+	assert.False(t, EffectiveTracked(ChatStatusAuto, intp(0), 10))
+	assert.False(t, EffectiveTracked(ChatStatusAuto, intp(-3), 10))
+}
+
+// --- ShouldTrack ------------------------------------------------------------
+
+func TestGroupGate_PrivateChatSkipsTheGateEntirely(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{}
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), "x@s.whatsapp.net", ChatTypePrivate)
+
+	require.NoError(t, err)
+	assert.True(t, tracked)
+	assert.Zero(t, store.gets, "the gate is the group-SIZE gate")
+	assert.Zero(t, fetcher.calls)
+}
+
+func TestGroupGate_ResolvesAndPersistsANewGroup(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{Title: "Book Club", MemberCount: 4}}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err)
+	assert.True(t, tracked)
+
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, testGroupChatJID, store.upserts[0].ChatJID)
+	require.NotNil(t, store.upserts[0].MemberCount)
+	assert.EqualValues(t, 4, *store.upserts[0].MemberCount)
+	require.NotNil(t, store.upserts[0].ChatTitle)
+	assert.Equal(t, "Book Club", *store.upserts[0].ChatTitle)
+	assert.Empty(t, store.upserts[0].Status, "an automatic write never sets a status")
+	require.NotNil(t, store.upserts[0].LastLookupAt)
+}
+
+// TestGroupGate_UnknownMemberCountIsUndecided is the P0: a group whose size
+// cannot be resolved right now stores nothing AND is not acknowledged.
+func TestGroupGate_UnknownMemberCountIsUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{err: context.DeadlineExceeded}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	assert.False(t, tracked, "fail closed on storage")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChatGateUndecided, "a timeout is a transient failure, not a decision")
+}
+
+func TestGroupGate_LookupFailureWritesNoConfig(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{err: errors.New("transport down")}
+
+	_, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.ErrorIs(t, err, ErrChatGateUndecided)
+	assert.Empty(t, store.upserts, "nothing may record a false resolution")
+}
+
+func TestGroupGate_RetriesLookupOnNextMessage(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{err: errors.New("transport down")}
+	gate := gateWith(store, fetcher, 10)
+
+	_, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.ErrorIs(t, err, ErrChatGateUndecided)
+
+	// Because the failure wrote nothing, the next message re-enters the lookup.
+	fetcher.err = nil
+	fetcher.info = &ChatGroupInfo{Title: "Book Club", MemberCount: 4}
+	tracked, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err)
+	assert.True(t, tracked)
+	assert.Equal(t, 2, fetcher.calls)
+}
+
+func TestGroupGate_NilFetcherIsUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	gate := NewChatGate(store, 10)
+	gate.BindGroupInfoSource(func() GroupInfoFetcher { return nil })
+
+	tracked, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	assert.False(t, tracked)
+	assert.ErrorIs(t, err, ErrChatGateUndecided, "no connected client is transient, not a decision")
+}
+
+func TestGroupGate_UnboundSourceIsUndecided(t *testing.T) {
+	tracked, err := NewChatGate(&fakeChatConfigStore{}, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	assert.False(t, tracked)
+	assert.ErrorIs(t, err, ErrChatGateUndecided)
+}
+
+func TestGroupGate_ConfigReadErrorIsUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{getErr: errors.New("database down")}
+	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 4}}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	assert.False(t, tracked)
+	require.ErrorIs(t, err, ErrChatGateUndecided,
+		"a database blip must withhold the ack, exactly as the same blip on the staging write does")
+	assert.Zero(t, fetcher.calls)
+}
+
+func TestGroupGate_UpsertErrorIsUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{upsertErr: errors.New("database down")}
+	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 4}}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	assert.False(t, tracked)
+	assert.ErrorIs(t, err, ErrChatGateUndecided,
+		"without the write the count would be re-fetched on every message")
+}
+
+func TestGroupGate_UserIgnoredOverrideSurvivesLookup(t *testing.T) {
+	store := &fakeChatConfigStore{cfg: &repository.WhatsAppChatConfig{
+		ChatJID: testGroupChatJID, ChatType: ChatTypeGroup, Status: ChatStatusIgnored, MemberCount: int32p(3),
+	}}
+	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 3}}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err)
+	assert.False(t, tracked, "a small group the user ignored stays ignored")
+}
+
+// TestGroupGate_ExplicitStatusSkipsLookup is the short-circuit: an override
+// needs no member count, so consulting it first is what stops an ignored group
+// paying a network round trip per message for a number it discards.
+func TestGroupGate_ExplicitStatusSkipsLookup(t *testing.T) {
+	for _, status := range []string{ChatStatusTracked, ChatStatusIgnored} {
+		t.Run(status, func(t *testing.T) {
+			store := &fakeChatConfigStore{cfg: &repository.WhatsAppChatConfig{
+				ChatJID: testGroupChatJID, ChatType: ChatTypeGroup, Status: status,
+				// Deliberately unresolved: only the short-circuit can answer.
+				MemberCount: nil,
+			}}
+			fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{MemberCount: 4}}
+
+			tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+			require.NoError(t, err)
+			assert.Equal(t, status == ChatStatusTracked, tracked)
+			assert.Zero(t, fetcher.calls, "an override needs no member count")
+			assert.Empty(t, store.upserts, "and it writes nothing")
+		})
+	}
+}
+
+func TestGroupGate_UnchangedRowIsNotRewritten(t *testing.T) {
+	title := "Book Club"
+	store := &fakeChatConfigStore{cfg: &repository.WhatsAppChatConfig{
+		ChatJID: testGroupChatJID, ChatType: ChatTypeGroup, Status: ChatStatusAuto,
+		MemberCount: int32p(4), ChatTitle: &title,
+	}}
+	fetcher := &fakeGroupInfoFetcher{}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err)
+	assert.True(t, tracked)
+	assert.Zero(t, fetcher.calls, "a resolved count needs no lookup")
+	assert.Empty(t, store.upserts, "re-writing an unchanged row on every message is a pointless write")
+}
+
+// TestGroupGate_NotInGroupIsDecidedNotUndecided pins the permanent-vs-transient
+// split. Routing a 403 into the undecided bucket turns one poisoned message into
+// an unbounded redelivery loop, each iteration paying a config read and a
+// network round trip on the library's serialized handler queue.
+func TestGroupGate_NotInGroupIsDecidedNotUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{err: errors.New("wrapped: " + ErrGroupUnavailable.Error())}
+	fetcher.err = errors.Join(ErrGroupUnavailable, errors.New("status 403"))
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err, "we are not in the group; that answer does not change on redelivery")
+	assert.False(t, tracked)
+	assert.Empty(t, store.upserts)
+}
+
+func TestGroupGate_GroupNotFoundIsDecidedNotUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{err: errors.Join(ErrGroupUnavailable, errors.New("status 404"))}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err)
+	assert.False(t, tracked)
+}
+
+func TestGroupGate_UnknownSizeIsDecidedNotUndecided(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{err: ErrGroupSizeUnknown}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err, "the server answered; retrying re-asks a question already answered")
+	assert.False(t, tracked)
+}
+
+func TestGroupGate_LargeGroupIsDecidedNotTracked(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	fetcher := &fakeGroupInfoFetcher{info: &ChatGroupInfo{Title: "Big", MemberCount: 42}}
+
+	tracked, err := gateWith(store, fetcher, 10).ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+	require.NoError(t, err, "a resolved count above the threshold is a real decision")
+	assert.False(t, tracked)
+	require.Len(t, store.upserts, 1, "the resolution is persisted so the next message needs no lookup")
+}
+
+// --- the clientGroupInfoFetcher's count derivation --------------------------
+
+func TestManagerGroupInfoFetcher_NilWhenNotConnected(t *testing.T) {
+	m := newManagerForTest(t, newFakeSyncStore(), &fakeBackfillReader{})
+	assert.Nil(t, m.GroupInfoFetcher(), "no client means the count stays unresolved, which is undecidable")
+}
+
+// TestManagerGroupInfo_ZeroSizeIsNotAResolvedCount is the guard for the wire's
+// optional size attribute. A resolved-looking 0 would persist, satisfy any
+// "<= threshold" test, and make the fail-closed gate fail OPEN forever — the
+// retry never re-runs, because the count is no longer NULL.
+func TestManagerGroupInfo_ZeroSizeIsNotAResolvedCount(t *testing.T) {
+	_, err := projectGroupInfo(&types.GroupInfo{
+		GroupName:        types.GroupName{Name: "Silent"},
+		ParticipantCount: 0,
+	})
+	assert.ErrorIs(t, err, ErrGroupSizeUnknown)
+}
+
+func TestManagerGroupInfo_FallsBackToParticipantListLength(t *testing.T) {
+	got, err := projectGroupInfo(&types.GroupInfo{
+		GroupName:        types.GroupName{Name: "Book Club"},
+		ParticipantCount: 0,
+		Participants:     make([]types.GroupParticipant, 3),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, got.MemberCount, "the list is the answer the wire attribute omitted")
+	assert.Equal(t, "Book Club", got.Title)
+}
+
+func TestManagerGroupInfo_PrefersTheReportedCount(t *testing.T) {
+	got, err := projectGroupInfo(&types.GroupInfo{
+		ParticipantCount: 42,
+		// A truncated participant list is normal for a large group.
+		Participants: make([]types.GroupParticipant, 3),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 42, got.MemberCount)
+}
+
+func TestManagerGroupInfo_NilInfoIsUnknownSize(t *testing.T) {
+	_, err := projectGroupInfo(nil)
+	assert.ErrorIs(t, err, ErrGroupSizeUnknown)
+}
+
+func TestGroupGate_LookupIsTimeBounded(t *testing.T) {
+	store := &fakeChatConfigStore{}
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+	gate := NewChatGate(store, 10)
+	gate.BindGroupInfoSource(func() GroupInfoFetcher { return blockingGroupInfoFetcher{blocked} })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := gate.ShouldTrack(context.Background(), testGroupChatJID, ChatTypeGroup)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, ErrChatGateUndecided)
+	case <-time.After(groupInfoTimeout + 5*time.Second):
+		t.Fatal("the group lookup was not bounded; it would block whatsmeow's handler goroutine")
+	}
+}
+
+type blockingGroupInfoFetcher struct{ block chan struct{} }
+
+func (b blockingGroupInfoFetcher) GroupInfo(ctx context.Context, _ string) (*ChatGroupInfo, error) {
+	select {
+	case <-b.block:
+		return nil, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/backend/internal/whatsapp/fakes_test.go
+++ b/backend/internal/whatsapp/fakes_test.go
@@ -809,6 +809,18 @@ func newTestManagerFull(t testCleanup, cli *fakeClient, paired bool, waRepo back
 	return m, syncStore, ingestor, recorder, devices
 }
 
+// seedSelfJID publishes a linked-account JID so the message path can resolve an
+// own identity. Production reads it off the emitting session's device store and
+// falls back to this published value; a unit test has no real store, so it
+// exercises the fallback. It is an operation, so the publish is the loop's.
+func seedSelfJID(m *Manager, jid types.JID) {
+	m.runOp(func(st *actorState, reply chan opResult) {
+		s := jid.String()
+		st.status.JID = &s
+		reply <- opResult{}
+	})
+}
+
 // blockingSessionFactory builds a factory that blocks until the batch context
 // expires. It is how an effectDeadline expiry is driven without sleeping for the
 // production bound.

--- a/backend/internal/whatsapp/groupinfo.go
+++ b/backend/internal/whatsapp/groupinfo.go
@@ -1,0 +1,100 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+var (
+	// ErrGroupSizeUnknown means the server answered without a usable size. It
+	// is deliberately NOT the same as a small group: an absent size attribute
+	// yields 0 with no error from the library, and 0 satisfies any
+	// "<= threshold" test, so a resolved-looking 0 would make the fail-closed
+	// gate fail OPEN forever.
+	ErrGroupSizeUnknown = errors.New("whatsapp: group size unknown")
+
+	// ErrGroupUnavailable wraps the library's "not in the group" (403) and
+	// "group does not exist" (404) answers. Both are answers, not failures:
+	// neither changes on a redelivery.
+	ErrGroupUnavailable = errors.New("whatsapp: group unavailable")
+)
+
+// GroupInfoFetcher returns the seam bound to the live client, or nil when no
+// client is connected — in which case the member count stays unresolved and the
+// gate reports ErrChatGateUndecided rather than deciding.
+//
+// It reads the published snapshot rather than taking a turn, exactly as
+// HistoryFetcher does: a per-message lookup must never wait on the actor loop.
+func (m *Manager) GroupInfoFetcher() GroupInfoFetcher {
+	var sess *session
+	if s := m.snap.Load(); s != nil {
+		sess = s.sess
+	}
+
+	if sess == nil || sess.wa == nil || !sess.client.IsConnected() {
+		return nil
+	}
+	return &clientGroupInfoFetcher{cli: sess.wa}
+}
+
+// clientGroupInfoFetcher wraps the one group-metadata call this integration
+// makes.
+type clientGroupInfoFetcher struct {
+	cli *whatsmeow.Client
+}
+
+var _ GroupInfoFetcher = (*clientGroupInfoFetcher)(nil)
+
+// GroupInfo resolves a group's title and member count.
+//
+// The library's GetGroupInfo never reads its cache — it sends a group IQ every
+// call — so this is a network round trip and the caller must gate it on
+// persisted state.
+//
+// The count is derived DEFENSIVELY: ParticipantCount is an optional wire
+// attribute that yields 0 when absent, so a non-positive value falls back to
+// the participant list's length and, failing that, is reported as unknown
+// rather than as a resolved zero.
+func (f *clientGroupInfoFetcher) GroupInfo(ctx context.Context, chatJID string) (*ChatGroupInfo, error) {
+	jid, err := types.ParseJID(chatJID)
+	if err != nil {
+		return nil, fmt.Errorf("whatsapp: parse group JID: %w", err)
+	}
+
+	info, err := f.cli.GetGroupInfo(ctx, jid)
+	if err != nil {
+		if errors.Is(err, whatsmeow.ErrNotInGroup) || errors.Is(err, whatsmeow.ErrGroupNotFound) {
+			return nil, fmt.Errorf("%w: %w", ErrGroupUnavailable, err)
+		}
+		return nil, fmt.Errorf("whatsapp: get group info: %w", err)
+	}
+	return projectGroupInfo(info)
+}
+
+// projectGroupInfo derives the member count DEFENSIVELY, which is why it is a
+// pure function rather than four lines inline: it is the single place a
+// resolved-looking zero is refused, and it is unit-testable without a client.
+//
+// ParticipantCount is an OPTIONAL wire attribute — an absent size yields 0 with
+// no error — so a non-positive value falls back to the participant list's length
+// and, failing that, is reported as unknown. Without this, an absent size
+// persists as a resolved 0, satisfies any "<= threshold" test, and makes the
+// fail-closed gate fail OPEN forever, because the retry never re-runs once the
+// count is no longer NULL.
+func projectGroupInfo(info *types.GroupInfo) (*ChatGroupInfo, error) {
+	if info == nil {
+		return nil, fmt.Errorf("%w: empty group info", ErrGroupSizeUnknown)
+	}
+	count := info.ParticipantCount
+	if count <= 0 {
+		count = len(info.Participants)
+	}
+	if count <= 0 {
+		return nil, ErrGroupSizeUnknown
+	}
+	return &ChatGroupInfo{Title: info.Name, MemberCount: count}, nil
+}

--- a/backend/internal/whatsapp/groupinfo.go
+++ b/backend/internal/whatsapp/groupinfo.go
@@ -49,6 +49,22 @@ type clientGroupInfoFetcher struct {
 
 var _ GroupInfoFetcher = (*clientGroupInfoFetcher)(nil)
 
+// AccountJID reports the linked account this client belongs to, in the same
+// non-AD form the parser stamps onto each message.
+func (f *clientGroupInfoFetcher) AccountJID() string {
+	if f.cli == nil || f.cli.Store == nil {
+		return ""
+	}
+	jid := f.cli.Store.GetJID()
+	if jid.IsEmpty() {
+		jid = f.cli.Store.GetLID()
+	}
+	if jid.IsEmpty() {
+		return ""
+	}
+	return normalizeServer(jid).ToNonAD().String()
+}
+
 // GroupInfo resolves a group's title and member count.
 //
 // The library's GetGroupInfo never reads its cache — it sends a group IQ every

--- a/backend/internal/whatsapp/groupinfo.go
+++ b/backend/internal/whatsapp/groupinfo.go
@@ -49,20 +49,16 @@ type clientGroupInfoFetcher struct {
 
 var _ GroupInfoFetcher = (*clientGroupInfoFetcher)(nil)
 
-// AccountJID reports the linked account this client belongs to, in the same
-// non-AD form the parser stamps onto each message.
+// AccountJID reports the linked account this client belongs to.
+//
+// It goes through canonicalAccountJID — the SAME derivation the parser uses to
+// stamp each message — so the comparison in the gate cannot fail merely because
+// the two sides preferred different forms of one identity.
 func (f *clientGroupInfoFetcher) AccountJID() string {
 	if f.cli == nil || f.cli.Store == nil {
 		return ""
 	}
-	jid := f.cli.Store.GetJID()
-	if jid.IsEmpty() {
-		jid = f.cli.Store.GetLID()
-	}
-	if jid.IsEmpty() {
-		return ""
-	}
-	return normalizeServer(jid).ToNonAD().String()
+	return canonicalAccountJID(f.cli.Store.GetJID(), f.cli.Store.GetLID())
 }
 
 // GroupInfo resolves a group's title and member count.

--- a/backend/internal/whatsapp/import_hook.go
+++ b/backend/internal/whatsapp/import_hook.go
@@ -26,6 +26,12 @@ type PostImportHook struct {
 }
 
 // NewPostImportHook wraps the ingest path's peer matcher.
+//
+// The parameter is an interface, so a TYPED nil (a nil *PeerMatcher) makes it
+// non-nil and defeats the guard in OnPeerLinked, panicking on the nil receiver.
+// Passing an untyped nil is safe and is what the tests do; passing a typed nil
+// is the caller's responsibility, and the composition root avoids it by
+// registering the hook only when it built an ingestor with a matcher.
 func NewPostImportHook(matcher whatsappPeerLinker) *PostImportHook {
 	return &PostImportHook{matcher: matcher}
 }

--- a/backend/internal/whatsapp/import_hook.go
+++ b/backend/internal/whatsapp/import_hook.go
@@ -1,0 +1,38 @@
+package whatsapp
+
+import (
+	"context"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// PostImportHook back-links a WhatsApp candidate's staged messages after the
+// user imports or links it. It satisfies the import handler's hook interface
+// structurally, so this package never imports the handler package.
+type PostImportHook struct {
+	matcher *PeerMatcher
+}
+
+// NewPostImportHook wraps the ingest path's peer matcher.
+func NewPostImportHook(matcher *PeerMatcher) *PostImportHook {
+	return &PostImportHook{matcher: matcher}
+}
+
+// Source is the external_contact.source this hook handles.
+func (h *PostImportHook) Source() string { return syncSource }
+
+// OnPeerLinked reads the peer JID off the candidate's source_id — which is the
+// RAW peer JID, the same value comms_message.peer_handle carries — and the
+// resolved phone off its metadata, then attaches the staged messages.
+func (h *PostImportHook) OnPeerLinked(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) error {
+	if h.matcher == nil || external == nil {
+		return nil
+	}
+	var phone *string
+	if v, ok := external.Metadata["phone_e164"].(string); ok && v != "" {
+		phone = &v
+	}
+	return h.matcher.OnPeerLinked(ctx, external.SourceID, phone, contactID)
+}

--- a/backend/internal/whatsapp/import_hook.go
+++ b/backend/internal/whatsapp/import_hook.go
@@ -8,15 +8,25 @@ import (
 	"github.com/google/uuid"
 )
 
+// whatsappPeerLinker is the slice of *PeerMatcher this adapter delegates to.
+//
+// It is an interface rather than the concrete matcher so the EXTRACTION — the
+// only logic this type owns — can be asserted against a recording fake. With a
+// concrete dependency the sole reachable test call is a nil-constructed one,
+// which cannot observe what was derived, so a wrong extraction would pass.
+type whatsappPeerLinker interface {
+	OnPeerLinked(ctx context.Context, peerJID string, phoneE164 *string, contactID uuid.UUID) error
+}
+
 // PostImportHook back-links a WhatsApp candidate's staged messages after the
 // user imports or links it. It satisfies the import handler's hook interface
 // structurally, so this package never imports the handler package.
 type PostImportHook struct {
-	matcher *PeerMatcher
+	matcher whatsappPeerLinker
 }
 
 // NewPostImportHook wraps the ingest path's peer matcher.
-func NewPostImportHook(matcher *PeerMatcher) *PostImportHook {
+func NewPostImportHook(matcher whatsappPeerLinker) *PostImportHook {
 	return &PostImportHook{matcher: matcher}
 }
 
@@ -26,13 +36,19 @@ func (h *PostImportHook) Source() string { return syncSource }
 // OnPeerLinked reads the peer JID off the candidate's source_id — which is the
 // RAW peer JID, the same value comms_message.peer_handle carries — and the
 // resolved phone off its metadata, then attaches the staged messages.
+//
+// The extraction runs BEFORE the delegate nil-check, so every call exercises
+// it rather than short-circuiting past the only logic this type has.
 func (h *PostImportHook) OnPeerLinked(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) error {
-	if h.matcher == nil || external == nil {
+	if external == nil {
 		return nil
 	}
 	var phone *string
 	if v, ok := external.Metadata["phone_e164"].(string); ok && v != "" {
 		phone = &v
+	}
+	if h.matcher == nil {
+		return nil
 	}
 	return h.matcher.OnPeerLinked(ctx, external.SourceID, phone, contactID)
 }

--- a/backend/internal/whatsapp/ingest.go
+++ b/backend/internal/whatsapp/ingest.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"personal-crm/backend/internal/logger"
@@ -10,6 +11,12 @@ import (
 
 	"github.com/google/uuid"
 )
+
+// ErrIngestMissingMessageID is returned when a projected message carries no id.
+// It is the symmetric twin of the staging layer's missing-thread refusal: the
+// id is what dedup, the twin reconciliation and the reply bridge all key on, so
+// a row without one is staged and then permanently unreachable.
+var ErrIngestMissingMessageID = errors.New("whatsapp: ingest message has no message id")
 
 // commsChatStore is the slice of CommsMessageRepository the ingest path writes
 // through.
@@ -58,9 +65,33 @@ func (i *Ingestor) PeerMatcher() *PeerMatcher {
 // ack, so it is reserved for outcomes a redelivery can genuinely repair. The
 // one deliberate addition is the gate's ErrChatGateUndecided: an undecidable
 // group stores nothing AND is not treated as handled.
+//
+// CALLER PRECONDITION: MessageID and ChatJID must both be non-empty. They are
+// the message's identity and its chat scope; a row missing either is staged and
+// then permanently unreachable. Both are refused rather than stored, so a
+// caller that builds an IngestedMessage by hand — the history drainer — fails
+// loudly instead of writing rows nothing can ever find.
+//
+// Cost per message, since this runs inline on the library's serialized handler
+// goroutine:
+//   - group chats add one config read, plus one network lookup and one config
+//     write only while the size is unresolved;
+//   - a matched peer costs a match, one candidate read, and the tombstone probe
+//     — the candidate read's follow-up work is first-match-gated, so a known
+//     peer's steady state adds nothing beyond that read;
+//   - an unmatched peer costs a match attempt, the reverse probe, the staging
+//     write and the discovery upsert.
 func (i *Ingestor) IngestMessage(ctx context.Context, msg IngestedMessage) error {
+	if msg.MessageID == "" {
+		return ErrIngestMissingMessageID
+	}
+
 	if msg.ChatType == ChatTypeGroup && i.gate != nil {
-		tracked, err := i.gate.ShouldTrack(ctx, msg.ChatJID, msg.ChatType)
+		accountJID := ""
+		if msg.AccountJID != nil {
+			accountJID = *msg.AccountJID
+		}
+		tracked, err := i.gate.ShouldTrack(ctx, msg.ChatJID, msg.ChatType, accountJID)
 		if err != nil {
 			// Undecidable: withhold the ack so the next delivery can decide.
 			return err

--- a/backend/internal/whatsapp/ingest.go
+++ b/backend/internal/whatsapp/ingest.go
@@ -76,9 +76,10 @@ func (i *Ingestor) PeerMatcher() *PeerMatcher {
 // goroutine:
 //   - group chats add one config read, plus one network lookup and one config
 //     write only while the size is unresolved;
-//   - a matched peer costs a match, one candidate read, and the tombstone probe
-//     — the candidate read's follow-up work is first-match-gated, so a known
-//     peer's steady state adds nothing beyond that read;
+//   - a matched peer costs the identity match, the staging write and the
+//     tombstone probe. Marking the import candidate and syncing contact methods
+//     are first-match-gated on the identity being newly bound, so a peer that
+//     has matched before adds nothing beyond those;
 //   - an unmatched peer costs a match attempt, the reverse probe, the staging
 //     write and the discovery upsert.
 func (i *Ingestor) IngestMessage(ctx context.Context, msg IngestedMessage) error {

--- a/backend/internal/whatsapp/ingest.go
+++ b/backend/internal/whatsapp/ingest.go
@@ -1,0 +1,174 @@
+package whatsapp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// commsChatStore is the slice of CommsMessageRepository the ingest path writes
+// through.
+type commsChatStore interface {
+	UpsertChatMessage(ctx context.Context, params repository.UpsertChatMessageParams) (*repository.CommsMessage, error)
+	SoftDeleteUnmatchedTwin(ctx context.Context, source, externalID string) (int64, error)
+	HasMatchedChatMessage(ctx context.Context, source, externalID string) (bool, error)
+}
+
+// Ingestor stages projected messages into comms_message. It is the single choke
+// point the live handler uses today and the history drainer will reuse, so
+// backfill and live ingest cannot diverge.
+type Ingestor struct {
+	commsRepo commsChatStore
+	gate      *ChatGate
+	matcher   *PeerMatcher
+}
+
+var (
+	_ MessageIngestor = (*Ingestor)(nil)
+	_ GroupInfoBinder = (*Ingestor)(nil)
+)
+
+// NewIngestor builds the live-message ingest path.
+func NewIngestor(commsRepo commsChatStore, gate *ChatGate, matcher *PeerMatcher) *Ingestor {
+	return &Ingestor{commsRepo: commsRepo, gate: gate, matcher: matcher}
+}
+
+// BindGroupInfoSource forwards the seam to the gate. Manager.SetIngestor calls
+// it before Start, so the source is bound before any client can connect.
+func (i *Ingestor) BindGroupInfoSource(src func() GroupInfoFetcher) {
+	if i.gate != nil {
+		i.gate.BindGroupInfoSource(src)
+	}
+}
+
+// PeerMatcher exposes the matcher for the post-import hook, which needs the
+// same instance the ingest path uses.
+func (i *Ingestor) PeerMatcher() *PeerMatcher {
+	return i.matcher
+}
+
+// IngestMessage stages one projected message.
+//
+// Only the staging write's failure is returned — a returned error withholds the
+// ack, so it is reserved for outcomes a redelivery can genuinely repair. The
+// one deliberate addition is the gate's ErrChatGateUndecided: an undecidable
+// group stores nothing AND is not treated as handled.
+func (i *Ingestor) IngestMessage(ctx context.Context, msg IngestedMessage) error {
+	if msg.ChatType == ChatTypeGroup && i.gate != nil {
+		tracked, err := i.gate.ShouldTrack(ctx, msg.ChatJID, msg.ChatType)
+		if err != nil {
+			// Undecidable: withhold the ack so the next delivery can decide.
+			return err
+		}
+		if !tracked {
+			// A real decision: the message is handled, just not stored.
+			logger.Debug().Str("chat_jid", msg.ChatJID).Msg("whatsapp: group is not tracked; message not stored")
+			return nil
+		}
+	}
+
+	matched := i.resolveContact(ctx, msg)
+
+	// The matched and unmatched upserts have DISJOINT conflict targets, so both
+	// rows can exist for one message. The matched row is the survivor, in both
+	// directions.
+	if matched == nil && msg.PeerJID != nil {
+		already, err := i.commsRepo.HasMatchedChatMessage(ctx, syncSource, msg.MessageID)
+		if err != nil {
+			// Best-effort: the worst case is a duplicate the next attach
+			// reconciles, whereas returning would withhold an ack for content
+			// that is about to be stored anyway.
+			logger.Warn().Err(err).Str("message_id", msg.MessageID).
+				Msg("whatsapp: matched-row probe failed; staging unmatched anyway")
+		} else if already {
+			// Already stored against a contact. An unmatched insert here would
+			// mint the duplicate pair with nothing to tombstone it, and would
+			// fire discovery for a peer that already has a contact.
+			return nil
+		}
+	}
+
+	meta, err := buildSourceMetadata(msg)
+	if err != nil {
+		return fmt.Errorf("whatsapp: build source metadata: %w", err)
+	}
+
+	direction := repository.InteractionDirectionInbound
+	if msg.IsOutgoing {
+		direction = repository.InteractionDirectionOutbound
+	}
+
+	if _, err := i.commsRepo.UpsertChatMessage(ctx, repository.UpsertChatMessageParams{
+		Source:     syncSource,
+		ExternalID: msg.MessageID,
+		ThreadID:   msg.ChatJID,
+		Body:       msg.Body,
+		// Snippet stays nil: nothing on this route reads it, and a truncated
+		// copy of the body is a second copy of the same content.
+		Snippet:          nil,
+		PeerHandle:       msg.PeerJID,
+		PeerNormalized:   msg.PeerPhoneE164,
+		Direction:        direction,
+		SentAt:           msg.SentAt,
+		AccountID:        msg.AccountJID,
+		SourceMetadata:   meta,
+		MatchedContactID: matched,
+	}); err != nil {
+		return fmt.Errorf("stage whatsapp message: %w", err)
+	}
+
+	if matched != nil {
+		// Best-effort: failing to tombstone a duplicate must not withhold an
+		// ack for a message that is already stored.
+		if rows, err := i.commsRepo.SoftDeleteUnmatchedTwin(ctx, syncSource, msg.MessageID); err != nil {
+			logger.Warn().Err(err).Str("message_id", msg.MessageID).
+				Msg("whatsapp: failed to tombstone the unmatched twin")
+		} else if rows > 0 {
+			logger.Debug().Int64("rows", rows).Str("message_id", msg.MessageID).
+				Msg("whatsapp: tombstoned the unmatched twin of a matched message")
+		}
+		return nil
+	}
+
+	if msg.PeerJID != nil && i.matcher != nil {
+		if err := i.matcher.UpdateDiscoveryCandidates(ctx, msg.PeerJID); err != nil {
+			logger.Warn().Err(err).Msg("whatsapp: failed to update discovery candidates")
+		}
+	}
+	return nil
+}
+
+// resolveContact runs the peer match, tolerating both a nil peer (an outbound
+// group message, permanently unmatched by design) and a matcher failure.
+func (i *Ingestor) resolveContact(ctx context.Context, msg IngestedMessage) *uuid.UUID {
+	if msg.PeerJID == nil || i.matcher == nil {
+		return nil
+	}
+	matched, err := i.matcher.MatchPeer(ctx, *msg.PeerJID, msg.PeerPhoneE164, msg.PushName)
+	if err != nil {
+		logger.Warn().Err(err).Msg("whatsapp: peer matching failed")
+		return nil
+	}
+	return matched
+}
+
+// buildSourceMetadata assembles the JSONB the aggregation adapter reads.
+// reply_target_external_id is the key it already looks for.
+func buildSourceMetadata(msg IngestedMessage) ([]byte, error) {
+	meta := map[string]any{
+		"message_type": msg.MessageType,
+		"chat_type":    msg.ChatType,
+	}
+	if msg.PushName != nil {
+		meta["push_name"] = *msg.PushName
+	}
+	if msg.ReplyTargetID != nil {
+		meta["reply_target_external_id"] = *msg.ReplyTargetID
+	}
+	return json.Marshal(meta)
+}

--- a/backend/internal/whatsapp/manager.go
+++ b/backend/internal/whatsapp/manager.go
@@ -68,6 +68,20 @@ const (
 	// discipline as the terminal write, and for the same reason: one transient
 	// blip must not leave the store holding two sessions.
 	deviceDeleteAttempts = 2
+
+	// ingestTimeout bounds the WHOLE ingest of one message — the gate, the
+	// match and the staging write. It dominates the two inner bounds below, and
+	// is chosen to keep the worst case under the library's 30s handler warning.
+	// An expiry withholds the ack, so it is a redelivery rather than a loss.
+	ingestTimeout = 20 * time.Second
+
+	// groupInfoTimeout bounds the group metadata lookup. The library's group
+	// call is a network IQ with no cache, so it needs an explicit bound: the
+	// event dispatcher hands the handler an unbounded context.
+	groupInfoTimeout = 5 * time.Second
+
+	// altJIDTimeout bounds the device store's LID-to-phone lookup.
+	altJIDTimeout = 3 * time.Second
 )
 
 // syncSource is the external_sync_state source string. It is also the
@@ -209,6 +223,16 @@ type Manager struct {
 	backfill atomic.Pointer[cachedBackfill]
 	stopOnce sync.Once
 
+	// unresolvedLIDs is the set of peers seen this process whose phone number
+	// could not be recovered from their LID. It is written from the library's
+	// dispatching goroutine and read from the status endpoint's, so it cannot
+	// live in actorState — and it is a COPY-ON-WRITE map behind an atomic
+	// pointer rather than a sync.Map, because this package's design admits no
+	// shared MUTABLE state: every published map is immutable, and a new peer
+	// installs a replacement by CAS. The copy costs O(n) on the first sight of
+	// a peer only; every later message from that peer takes the read path.
+	unresolvedLIDs atomic.Pointer[map[string]struct{}]
+
 	// timeouts is fixed at construction. See managerTimeouts.
 	timeouts managerTimeouts
 }
@@ -291,7 +315,15 @@ func applyDeviceProps() {
 
 // SetIngestor installs the real message ingestor. Until it is called the
 // default REFUSES, which withholds the ack rather than dropping the message.
+//
+// The group-info seam is bound HERE, before the operation is queued, so an
+// ingestor cannot be installed without its source and the bind never runs on
+// the loop goroutine. Since every setter runs before the single Start, the seam
+// is bound before any client can connect.
 func (m *Manager) SetIngestor(i MessageIngestor) {
+	if b, ok := i.(GroupInfoBinder); ok {
+		b.BindGroupInfoSource(m.GroupInfoFetcher)
+	}
 	m.runOp(func(st *actorState, reply chan opResult) {
 		st.ingestor = i
 		reply <- opResult{}
@@ -856,7 +888,7 @@ func (m *Manager) handleEventFor(sess *session, evt any) bool {
 		if notif := e.RawMessage.GetProtocolMessage().GetHistorySyncNotification(); notif != nil {
 			return m.handleHistoryNotification(ctx, e, notif)
 		}
-		return m.handleMessage(ctx, e)
+		return m.handleMessage(ctx, sess, e)
 
 	case *events.HistorySync:
 		// Unreachable while manual mode holds: the automatic loop that
@@ -1172,25 +1204,43 @@ func (m *Manager) onTerminal(st *actorState, from *session, reason string, banne
 
 // --- data plane ------------------------------------------------------------
 
-// handleMessage forwards an ordinary message to the ingestor.
+// handleMessage parses an ordinary message and forwards it to the ingestor.
 //
 // It reads the published snapshot ONCE at entry and uses that seam for the whole
 // event, so a SetIngestor landing mid-event cannot make one event use two
-// ingestors. It is deliberately session-agnostic: attribution exists to stop a
-// dead client publishing state, and a real message is a real message.
+// ingestors. It takes the EMITTING session because the parser needs that
+// client's own JIDs (to reject a self-chat) and its device store (to recover a
+// peer's phone number from a LID). That is not a retreat from the data plane's
+// session-agnosticism, which is about state PUBLICATION: a retired session must
+// not publish status, but a real message is still a real message, and the
+// client that just delivered it is the right authority on its own store.
 //
-// The projection onto IngestedMessage is DELIBERATELY partial: it fills
-// MessageID, ChatJID, IsOutgoing and SentAt, and nothing else. Every remaining field is left at its
-// zero value, because the parser that fills them is the next PR's —
+// The projection fills every field the live path can know EXCEPT ChatTitle and
+// MemberCount, which stay nil pointers: each would cost a group-metadata round
+// trip per message, and the group's title and size live in whatsapp_chat_config
+// instead. Those two pointers are the remaining trap — a consumer that reads one
+// does not get an empty value, it dereferences nil.
 //
-//	strings, empty:   ChatType, MessageType
-//	pointers, NIL:    ChatTitle, Body, ReplyTargetID, PeerJID, PeerPhoneE164,
-//	                  PushName, MemberCount
+// The named return plus recover is what stops a panic on this path becoming an
+// ACK. The library's dispatcher recovers a panicking handler and returns its own
+// named result at its zero value, which reads as "handled successfully" — so the
+// message would be acknowledged and lost. A withheld ack is a redelivery, which
+// is recoverable; an ack is not.
 //
-// The pointers are the trap: a consumer that reads one today does not get an
-// empty value, it dereferences nil. Nothing downstream may read any field
-// outside the four above until that parser lands.
-func (m *Manager) handleMessage(ctx context.Context, e *events.Message) bool {
+// The return is named `handled` rather than `ok` deliberately: the body binds
+// `eligible` from the parser, and a same-named short declaration in any future
+// nested block would shadow the named return and silently defeat the guard.
+func (m *Manager) handleMessage(ctx context.Context, sess *session, e *events.Message) (handled bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error().
+				Interface("panic", r).
+				Str("message_id", e.Info.ID).
+				Msg("whatsapp: ingest panicked; withholding ack so WhatsApp redelivers")
+			handled = false
+		}
+	}()
+
 	var ingestor MessageIngestor
 	if s := m.snap.Load(); s != nil {
 		ingestor = s.ingestor
@@ -1201,18 +1251,98 @@ func (m *Manager) handleMessage(ctx context.Context, e *events.Message) bool {
 		return false
 	}
 
-	msg := IngestedMessage{
-		MessageID:  e.Info.ID,
-		ChatJID:    e.Info.Chat.ToNonAD().String(),
-		IsOutgoing: e.Info.IsFromMe,
-		SentAt:     e.Info.Timestamp,
+	own, resolver := m.ownIdentityFor(sess)
+	if !own.ok() {
+		// Without an own JID the parser can neither reject a self-chat nor
+		// decide a DM's direction safely. Dropping with a true ack would be an
+		// irreversible loss, because WhatsApp does not redeliver an acked
+		// message. Unreachable in a logged-in session.
+		logger.Error().Str("message_id", e.Info.ID).
+			Msg("whatsapp: own identity unknown; withholding ack")
+		return false
 	}
-	if err := ingestor.IngestMessage(ctx, msg); err != nil {
+
+	msg, unresolvedLID, eligible := parseMessage(ctx, e, own, resolver)
+	if unresolvedLID != "" {
+		m.noteUnresolvedLID(unresolvedLID)
+	}
+	if !eligible {
+		// Handled, just to no effect: an ineligible chat is not a failure, and
+		// withholding here would redeliver forever.
+		logger.Debug().Str("message_id", e.Info.ID).
+			Msg("whatsapp: message is not an ingestible person-to-person turn; acking without storing")
+		return true
+	}
+
+	ingestCtx, cancel := context.WithTimeout(ctx, ingestTimeout)
+	defer cancel()
+
+	if err := ingestor.IngestMessage(ingestCtx, msg); err != nil {
 		logger.Error().Err(err).Str("message_id", e.Info.ID).
 			Msg("whatsapp: message ingest failed; withholding ack so WhatsApp redelivers")
 		return false
 	}
 	return true
+}
+
+// ownIdentityFor resolves the emitting session's own JIDs, plus the device
+// store the peer ladder reads for its LID mapping.
+//
+// The fallback is SelfJID — a snapshot read — and never Status(), which runs two
+// database queries through backfillStatus and must not be on a per-message path.
+func (m *Manager) ownIdentityFor(sess *session) (ownIdentity, peerAltResolver) {
+	if sess != nil && sess.wa != nil && sess.wa.Store != nil {
+		device := sess.wa.Store
+		return ownIdentity{PN: device.GetJID(), LID: device.GetLID()}, device
+	}
+	if jid, ok := m.SelfJID(); ok {
+		if jid.Server == types.HiddenUserServer {
+			return ownIdentity{LID: jid}, nil
+		}
+		return ownIdentity{PN: jid}, nil
+	}
+	return ownIdentity{}, nil
+}
+
+// noteUnresolvedLID records a peer whose phone number could not be recovered.
+// DISTINCT peers, for the life of this process: a per-message counter would
+// report message volume under a field named for peers.
+//
+// The CAS loop is what makes the copy-on-write set correct under the concurrent
+// dispatch the library permits — a lost update would under-report the gap.
+func (m *Manager) noteUnresolvedLID(jid string) {
+	for {
+		current := m.unresolvedLIDs.Load()
+		if current != nil {
+			if _, seen := (*current)[jid]; seen {
+				return
+			}
+		}
+		next := make(map[string]struct{}, lenOfSet(current)+1)
+		if current != nil {
+			for k := range *current {
+				next[k] = struct{}{}
+			}
+		}
+		next[jid] = struct{}{}
+		if m.unresolvedLIDs.CompareAndSwap(current, &next) {
+			return
+		}
+	}
+}
+
+// ingestStatus reads the LID set on the CALLER's goroutine. It is not manager
+// state in the actor sense — an immutable map behind an atomic pointer, not a
+// loop-owned field — so the status endpoint never waits on a turn for it.
+func (m *Manager) ingestStatus() IngestStatus {
+	return IngestStatus{UnresolvedLIDPeers: lenOfSet(m.unresolvedLIDs.Load())}
+}
+
+func lenOfSet(set *map[string]struct{}) int {
+	if set == nil {
+		return 0
+	}
+	return len(*set)
 }
 
 // handleHistoryNotification does exactly one thing: strip any inline payload,

--- a/backend/internal/whatsapp/manager.go
+++ b/backend/internal/whatsapp/manager.go
@@ -82,6 +82,14 @@ const (
 
 	// altJIDTimeout bounds the device store's LID-to-phone lookup.
 	altJIDTimeout = 3 * time.Second
+
+	// maxUnresolvedLIDPeers caps the observed-peer set. The set is
+	// copy-on-write, so each newly seen peer costs O(n) on the library's
+	// serialized handler goroutine; the cap keeps that bounded. It is far above
+	// any plausible personal address book, so in practice the count is exact
+	// and the cap only exists so a pathological stream cannot degrade message
+	// handling.
+	maxUnresolvedLIDPeers = 5000
 )
 
 // syncSource is the external_sync_state source string. It is also the
@@ -1262,7 +1270,7 @@ func (m *Manager) handleMessage(ctx context.Context, sess *session, e *events.Me
 		return false
 	}
 
-	msg, unresolvedLID, eligible := parseMessage(ctx, e, own, resolver)
+	msg, unresolvedLID, eligible := parseMessage(ctx, e, own, resolver, altJIDTimeout)
 	if unresolvedLID != "" {
 		m.noteUnresolvedLID(unresolvedLID)
 	}
@@ -1305,20 +1313,34 @@ func (m *Manager) ownIdentityFor(sess *session) (ownIdentity, peerAltResolver) {
 }
 
 // noteUnresolvedLID records a peer whose phone number could not be recovered.
-// DISTINCT peers, for the life of this process: a per-message counter would
-// report message volume under a field named for peers.
+//
+// It counts DISTINCT peers OBSERVED, for the life of this process — not peers
+// whose messages were stored. It fires for every eligible message, which
+// includes messages the group gate then declines to store, so the count is a
+// measure of how much of the user's conversation graph the integration cannot
+// automatically attribute, not a count of unattributed rows. A per-message
+// counter would instead report message volume under a field named for peers.
 //
 // The CAS loop is what makes the copy-on-write set correct under the concurrent
 // dispatch the library permits — a lost update would under-report the gap.
+//
+// The set is CAPPED. Copy-on-write is O(n) per newly seen peer, which is O(n²)
+// over the life of a process, and it runs on the library's serialized handler
+// goroutine; the cap bounds that at a size far above any plausible personal
+// address book, after which the reported count saturates rather than growing.
 func (m *Manager) noteUnresolvedLID(jid string) {
 	for {
 		current := m.unresolvedLIDs.Load()
+		size := lenOfSet(current)
 		if current != nil {
 			if _, seen := (*current)[jid]; seen {
 				return
 			}
 		}
-		next := make(map[string]struct{}, lenOfSet(current)+1)
+		if size >= maxUnresolvedLIDPeers {
+			return
+		}
+		next := make(map[string]struct{}, size+1)
 		if current != nil {
 			for k := range *current {
 				next[k] = struct{}{}

--- a/backend/internal/whatsapp/manager.go
+++ b/backend/internal/whatsapp/manager.go
@@ -1298,6 +1298,20 @@ func (m *Manager) handleMessage(ctx context.Context, sess *session, e *events.Me
 //
 // The fallback is SelfJID — a snapshot read — and never Status(), which runs two
 // database queries through backfillStatus and must not be on a per-message path.
+//
+// COUPLING, because it is not local: the identity returned here decides the
+// account JID stamped on every message, and the group gate refuses to consult a
+// client reporting a DIFFERENT account. The session branch is safe by
+// construction — it hands both forms to canonicalAccountJID, exactly as
+// clientGroupInfoFetcher.AccountJID does, so the two cannot disagree. The
+// fallback branch has only ONE published JID to work with, so if it ever ran for
+// an account published in its internal-id form while the live client reported
+// the phone-number form, every group message would look like a foreign account:
+// permanently undecided, permanently redelivered. That is a livelock, not a
+// dropped message, and it is unreachable today because production always builds
+// its sessions through newClient, which always sets sess.wa. Anything that makes
+// the fallback reachable must publish both forms, or drop the account
+// comparison for messages resolved through it.
 func (m *Manager) ownIdentityFor(sess *session) (ownIdentity, peerAltResolver) {
 	if sess != nil && sess.wa != nil && sess.wa.Store != nil {
 		device := sess.wa.Store

--- a/backend/internal/whatsapp/manager_test.go
+++ b/backend/internal/whatsapp/manager_test.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1349,4 +1350,18 @@ func TestOnPairSuccess_SelectorWriteFailureStillDeletesTheReplacedDevice(t *test
 	eventually(t, "the replaced device is still deleted, which moves the store to the self-healing state", func() bool {
 		return indexOf(oldClient.callLog(), "delete_device") >= 0
 	})
+}
+
+// TestNoteUnresolvedLID_SaturatesAtTheCap pins the bound on the copy-on-write
+// set: it is O(n) per newly seen peer on the library's serialized handler
+// goroutine, so it cannot be allowed to grow without limit.
+func TestNoteUnresolvedLID_SaturatesAtTheCap(t *testing.T) {
+	m := newManagerForTest(t, newFakeSyncStore(), &fakeBackfillReader{})
+
+	for i := range maxUnresolvedLIDPeers + 25 {
+		m.noteUnresolvedLID(fmt.Sprintf("%d@lid", i))
+	}
+
+	assert.Equal(t, maxUnresolvedLIDPeers, m.ingestStatus().UnresolvedLIDPeers,
+		"the count saturates rather than growing without bound")
 }

--- a/backend/internal/whatsapp/manager_test.go
+++ b/backend/internal/whatsapp/manager_test.go
@@ -92,6 +92,7 @@ func TestManager_SynchronousAckEnabled(t *testing.T) {
 // here and the ack would be sent for a message we failed to store.
 func TestNewClient_HandlerFailureReachesDispatcher(t *testing.T) {
 	m, _, ingestor, _ := newTestManager(t, newFakeClient(), true)
+	seedSelfJID(m, testOwnPN)
 	cli := m.newClient(&store.Device{}, &session{})
 	require.NotNil(t, cli)
 
@@ -183,6 +184,11 @@ func TestDefaultIngestor_RefusesAndWithholdsAck(t *testing.T) {
 
 	m := newManagerForTest(t, newFakeSyncStore(), &fakeBackfillReader{})
 	m.SetHistoryRecorder(&fakeRecorder{})
+	// The own identity is seeded so the REFUSING INGESTOR is what withholds
+	// here: without it the handler would withhold one step earlier, for an
+	// unknown own identity, and this test would pass without exercising the
+	// default at all.
+	seedSelfJID(m, testOwnPN)
 	assert.False(t, m.handleEvent(newMessageEvent("msg-1")),
 		"the default ingestor must withhold the ack, not swallow the message")
 }
@@ -416,16 +422,153 @@ func TestHandleEvent_LoggedOutIsTerminalWithReason(t *testing.T) {
 
 func TestHandleEvent_MessageForwardsToIngestor(t *testing.T) {
 	m, _, ingestor, _ := newTestManager(t, newFakeClient(), true)
+	seedSelfJID(m, testOwnPN)
 
 	assert.True(t, m.handleEvent(newMessageEvent("msg-42")))
 	require.Equal(t, 1, ingestor.count())
 	assert.Equal(t, "msg-42", ingestor.first().MessageID)
 }
 
+// TestHandleEvent_MessageForwardsParsedFieldsToIngestor is the end-to-end check
+// that the handler hands the ingestor a REAL projection rather than the
+// four-field stub it used to.
+func TestHandleEvent_MessageForwardsParsedFieldsToIngestor(t *testing.T) {
+	m, _, ingestor, _ := newTestManager(t, newFakeClient(), true)
+	seedSelfJID(m, testOwnPN)
+
+	require.True(t, m.handleEvent(newMessageEvent("msg-42")))
+	require.Equal(t, 1, ingestor.count())
+
+	got := ingestor.first()
+	assert.Equal(t, ChatTypePrivate, got.ChatType)
+	assert.Equal(t, MessageTypeText, got.MessageType)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "hello", *got.Body)
+	require.NotNil(t, got.PeerJID)
+	assert.Equal(t, testPeerPN.String(), *got.PeerJID)
+	require.NotNil(t, got.PeerPhoneE164)
+	assert.Equal(t, "+15559876543", *got.PeerPhoneE164)
+	require.NotNil(t, got.PushName)
+	assert.Equal(t, "Peer", *got.PushName)
+	require.NotNil(t, got.AccountJID)
+	assert.Equal(t, testOwnPN.String(), *got.AccountJID)
+}
+
+// TestHandleEvent_UnknownOwnIdentityWithholdsAck: without an own JID the parser
+// can neither reject a self-chat nor decide a DM's direction, and WhatsApp does
+// not redeliver an acked message — so a drop here would be irreversible.
+func TestHandleEvent_UnknownOwnIdentityWithholdsAck(t *testing.T) {
+	m, _, ingestor, _ := newTestManager(t, newFakeClient(), true)
+	// Deliberately no seedSelfJID.
+
+	assert.False(t, m.handleEvent(newMessageEvent("msg-1")))
+	assert.Zero(t, ingestor.count(), "nothing may be staged against an unknown account")
+}
+
+// TestHandleEvent_IneligibleChatAcksWithoutIngesting: ineligible is not failure.
+func TestHandleEvent_IneligibleChatAcksWithoutIngesting(t *testing.T) {
+	for _, chat := range []types.JID{
+		types.StatusBroadcastJID,
+		types.NewJID("123", types.NewsletterServer),
+		testOwnPN, // the self-chat
+	} {
+		t.Run(chat.String(), func(t *testing.T) {
+			m, _, ingestor, _ := newTestManager(t, newFakeClient(), true)
+			seedSelfJID(m, testOwnPN)
+
+			evt := newMessageEvent("msg-1")
+			evt.Info.Chat = chat
+
+			assert.True(t, m.handleEvent(evt), "withholding here would redeliver forever")
+			assert.Zero(t, ingestor.count())
+		})
+	}
+}
+
+// TestHandleEvent_PanicWithholdsAck is the guard for the library's own
+// dispatcher behaviour: it recovers a panicking handler and returns its named
+// result at the zero value, which reads as "handled successfully" — so without
+// this recover a panic would ACK and lose the message.
+func TestHandleEvent_PanicWithholdsAck(t *testing.T) {
+	m, _, _, _ := newTestManager(t, newFakeClient(), true)
+	seedSelfJID(m, testOwnPN)
+	m.SetIngestor(panickingIngestor{})
+
+	assert.False(t, m.handleEvent(newMessageEvent("msg-boom")),
+		"a panic on the ingest path must withhold the ack, not silently acknowledge")
+}
+
+// TestSetIngestor_BindsGroupInfoSource pins the ordering the group gate depends
+// on: the seam is bound by SetIngestor, which runs before the single Start, so
+// there is no window in which a connected client has an ingestor with no
+// source.
+func TestSetIngestor_BindsGroupInfoSource(t *testing.T) {
+	m := newManagerForTest(t, newFakeSyncStore(), &fakeBackfillReader{})
+	binder := &recordingBinder{}
+
+	m.SetIngestor(binder)
+	require.NotNil(t, binder.src, "an ingestor cannot be installed without its group-info source")
+	assert.Nil(t, binder.src(), "and the bound source reports nil while nothing is connected")
+}
+
+func TestStatus_ReportsUnresolvedLIDCount(t *testing.T) {
+	m, _, _, _ := newTestManager(t, newFakeClient(), true)
+	seedSelfJID(m, testOwnPN)
+
+	assert.Zero(t, m.Status().Ingest.UnresolvedLIDPeers, "the count is meaningful as zero")
+
+	for _, peer := range []string{"88800000002@lid", "88800000003@lid", "88800000002@lid"} {
+		evt := newMessageEvent("msg-" + peer)
+		evt.Info.Chat = mustParseTestJID(t, peer)
+		require.True(t, m.handleEvent(evt))
+	}
+
+	assert.Equal(t, 2, m.Status().Ingest.UnresolvedLIDPeers,
+		"DISTINCT peers: a per-message counter would report volume under a field named for peers")
+}
+
+// TestPeerResolution_UnresolvedLIDIncrementsCounter is the manager-side half of
+// the counter: the parser reports the peer, the manager records it once.
+func TestPeerResolution_UnresolvedLIDIncrementsCounter(t *testing.T) {
+	m, _, _, _ := newTestManager(t, newFakeClient(), true)
+	seedSelfJID(m, testOwnPN)
+
+	m.noteUnresolvedLID("88800000002@lid")
+	m.noteUnresolvedLID("88800000002@lid")
+	assert.Equal(t, 1, m.ingestStatus().UnresolvedLIDPeers)
+
+	m.noteUnresolvedLID("88800000003@lid")
+	assert.Equal(t, 2, m.ingestStatus().UnresolvedLIDPeers)
+}
+
+func mustParseTestJID(t *testing.T, s string) types.JID {
+	t.Helper()
+	jid, err := types.ParseJID(s)
+	require.NoError(t, err)
+	return jid
+}
+
+// panickingIngestor is the deliberate defect the panic guard exists for.
+type panickingIngestor struct{}
+
+func (panickingIngestor) IngestMessage(context.Context, IngestedMessage) error {
+	panic("ingest exploded")
+}
+
+// recordingBinder is a MessageIngestor that also implements GroupInfoBinder, so
+// the bind can be observed.
+type recordingBinder struct {
+	src func() GroupInfoFetcher
+}
+
+func (b *recordingBinder) IngestMessage(context.Context, IngestedMessage) error { return nil }
+func (b *recordingBinder) BindGroupInfoSource(src func() GroupInfoFetcher)      { b.src = src }
+
 // TestHandleEvent_MessageIngestErrorWithholdsAck is what makes an unprocessable
 // message a redelivery rather than a silent drop.
 func TestHandleEvent_MessageIngestErrorWithholdsAck(t *testing.T) {
 	m, _, ingestor, _ := newTestManager(t, newFakeClient(), true)
+	seedSelfJID(m, testOwnPN)
 	ingestor.setErr(errors.New("database down"))
 
 	assert.False(t, m.handleEvent(newMessageEvent("msg-1")))
@@ -637,6 +780,9 @@ func countCalls(haystack []string, needle string) int {
 	return n
 }
 
+// newMessageEvent builds an inbound direct message. Message and RawMessage
+// carry the same content: the parser reads the UNWRAPPED Message, while the
+// history-notification branch upstream reads RawMessage.
 func newMessageEvent(id string) *events.Message {
 	body := "hello"
 	return &events.Message{
@@ -646,7 +792,9 @@ func newMessageEvent(id string) *events.Message {
 				Chat: types.NewJID("15559876543", types.DefaultUserServer),
 			},
 			Timestamp: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+			PushName:  "Peer",
 		},
+		Message:    &waE2E.Message{Conversation: proto.String(body)},
 		RawMessage: &waE2E.Message{Conversation: proto.String(body)},
 	}
 }

--- a/backend/internal/whatsapp/matcher.go
+++ b/backend/internal/whatsapp/matcher.go
@@ -99,7 +99,27 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerJID string, phoneE164, 
 		return nil, nil
 	}
 
-	m.reconcileOnMatch(ctx, *result.ContactID, peerJID, phoneE164)
+	// Reconciliation is FIRST-MATCH work: marking the import candidate matched
+	// and syncing the contact methods the peer implies each have to happen once,
+	// not on every message this peer ever sends.
+	//
+	// The gate is Cached, which the identity service sets when the identity row
+	// ALREADY existed and ALREADY pointed at a live contact — precisely "this
+	// peer was reconciled by an earlier message". Gating on the candidate row
+	// instead would not work: a peer whose phone matched a contact on its very
+	// FIRST message never gets a candidate row at all (discovery runs only on
+	// the unmatched branch), so the read would return nothing every time and the
+	// method sync would run forever, inline on the library's serialized handler
+	// goroutine. That is the dominant matched population, not an edge case.
+	//
+	// The cost of gating here rather than after the read: if the mark below
+	// fails transiently, no later message retries it, so the candidate can stay
+	// labelled unmatched while its contact is bound. That is cosmetic — the
+	// contact link itself is on the identity row — and it is the price of not
+	// paying a read per message forever.
+	if !result.Cached {
+		m.reconcileOnMatch(ctx, *result.ContactID, peerJID, phoneE164)
+	}
 	logger.Info().
 		Str("contact_id", result.ContactID.String()).
 		Str("match_type", string(result.MatchType)).
@@ -219,12 +239,15 @@ func discoveryDisplayName(row repository.UnmatchedPeerCount) string {
 // contact methods it implies. Errors are logged at warn and never fail the
 // match.
 //
-// This runs on the message-handling path, so it does exactly ONE candidate read
-// and then FIRST-MATCH-GATES the rest: a candidate already recorded as matched
-// or imported has been through both steps on an earlier message, so the steady
-// state for a known peer is one indexed read and nothing else. Reading twice —
-// once to mark and once to enrich — and re-running the method sync on every
-// message is what this shape exists to avoid.
+// The CALLER gates this on the first match for a peer, so a known peer's steady
+// state costs nothing here at all — no read, no write, no method sync. When it
+// does run it does ONE candidate read and reuses it for both steps; reading
+// twice, once to mark and once to enrich, is what this shape replaced.
+//
+// The already-matched/imported short-circuit below is a second, narrower guard
+// for the case the caller's gate cannot see: an identity that was bound by some
+// other flow (an import, a rematch) and is reaching the live path uncached for
+// the first time.
 func (m *PeerMatcher) reconcileOnMatch(ctx context.Context, contactID uuid.UUID, peerJID string, phoneE164 *string) {
 	external, err := m.externalContactRepo.GetBySource(ctx, syncSource, peerJID, nil)
 	if err != nil {

--- a/backend/internal/whatsapp/matcher.go
+++ b/backend/internal/whatsapp/matcher.go
@@ -99,8 +99,7 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerJID string, phoneE164, 
 		return nil, nil
 	}
 
-	m.markExternalContactMatched(ctx, peerJID, *result.ContactID)
-	m.ensureMethodsOnMatch(ctx, *result.ContactID, peerJID, phoneE164)
+	m.reconcileOnMatch(ctx, *result.ContactID, peerJID, phoneE164)
 	logger.Info().
 		Str("contact_id", result.ContactID.String()).
 		Str("match_type", string(result.MatchType)).
@@ -216,22 +215,42 @@ func discoveryDisplayName(row repository.UnmatchedPeerCount) string {
 	return "WhatsApp " + user
 }
 
-// ensureMethodsOnMatch syncs contact methods onto the matched contact. Errors
-// are logged at warn and never fail the match.
-func (m *PeerMatcher) ensureMethodsOnMatch(ctx context.Context, contactID uuid.UUID, peerJID string, phoneE164 *string) {
-	if m.enricher == nil {
-		return
-	}
-
+// reconcileOnMatch marks the peer's import candidate matched and syncs the
+// contact methods it implies. Errors are logged at warn and never fail the
+// match.
+//
+// This runs on the message-handling path, so it does exactly ONE candidate read
+// and then FIRST-MATCH-GATES the rest: a candidate already recorded as matched
+// or imported has been through both steps on an earlier message, so the steady
+// state for a known peer is one indexed read and nothing else. Reading twice —
+// once to mark and once to enrich — and re-running the method sync on every
+// message is what this shape exists to avoid.
+func (m *PeerMatcher) reconcileOnMatch(ctx context.Context, contactID uuid.UUID, peerJID string, phoneE164 *string) {
 	external, err := m.externalContactRepo.GetBySource(ctx, syncSource, peerJID, nil)
 	if err != nil {
 		// Transient repository error — bail out rather than synthesize, which
 		// would risk dropping persisted values and emitting a NULL
 		// external_contact_id audit row when a real one exists.
-		logger.Warn().Err(err).Msg("whatsapp: get external_contact for method sync failed")
+		logger.Warn().Err(err).Msg("whatsapp: get external_contact for match reconcile failed")
+		return
+	}
+
+	if external != nil {
+		if external.MatchStatus == repository.MatchStatusMatched || external.MatchStatus == repository.MatchStatusImported {
+			// Already reconciled by an earlier message from this peer.
+			return
+		}
+		if _, err := m.externalContactRepo.UpdateMatch(ctx, external.ID, &contactID, repository.MatchStatusMatched); err != nil {
+			logger.Warn().Err(err).Msg("whatsapp: failed to mark external contact as matched")
+		}
+	}
+
+	if m.enricher == nil {
 		return
 	}
 	if external == nil {
+		// No candidate row: the peer matched before ever crossing the discovery
+		// threshold. Synthesize the minimum the method builder reads.
 		external = &repository.ExternalContact{
 			Source:   syncSource,
 			SourceID: peerJID,
@@ -249,20 +268,5 @@ func (m *PeerMatcher) ensureMethodsOnMatch(ctx context.Context, contactID uuid.U
 		logger.Warn().Err(err).
 			Str("contact_id", contactID.String()).
 			Msg("whatsapp: sync methods from external failed")
-	}
-}
-
-// markExternalContactMatched updates any existing candidate for this peer to
-// "matched".
-func (m *PeerMatcher) markExternalContactMatched(ctx context.Context, peerJID string, contactID uuid.UUID) {
-	existing, err := m.externalContactRepo.GetBySource(ctx, syncSource, peerJID, nil)
-	if err != nil || existing == nil {
-		return // no existing candidate, nothing to update
-	}
-	if existing.MatchStatus == repository.MatchStatusMatched || existing.MatchStatus == repository.MatchStatusImported {
-		return
-	}
-	if _, err := m.externalContactRepo.UpdateMatch(ctx, existing.ID, &contactID, repository.MatchStatusMatched); err != nil {
-		logger.Warn().Err(err).Msg("whatsapp: failed to mark external contact as matched")
 	}
 }

--- a/backend/internal/whatsapp/matcher.go
+++ b/backend/internal/whatsapp/matcher.go
@@ -1,0 +1,268 @@
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+)
+
+// identityMatcher is the slice of service.IdentityService the matcher uses.
+type identityMatcher interface {
+	MatchOrCreate(ctx context.Context, req service.MatchRequest) (*service.MatchResult, error)
+}
+
+// commsPeerStore is the slice of CommsMessageRepository the peer paths use.
+type commsPeerStore interface {
+	AttachUnmatchedByPeer(ctx context.Context, source string, peerNormalized, peerHandle *string, contactID uuid.UUID) (int64, int64, error)
+	ListUnmatchedPeerCounts(ctx context.Context, source string, peerHandle *string, minMessages int) ([]repository.UnmatchedPeerCount, error)
+}
+
+// externalContactUpserter is the slice of ExternalContactRepository discovery
+// needs.
+type externalContactUpserter interface {
+	UpsertDiscoveryCandidate(ctx context.Context, req repository.UpsertDiscoveryCandidateRequest) (*repository.ExternalContact, error)
+	GetBySource(ctx context.Context, source, sourceID string, accountID *string) (*repository.ExternalContact, error)
+	UpdateMatch(ctx context.Context, id uuid.UUID, crmContactID *uuid.UUID, status repository.MatchStatus) (*repository.ExternalContact, error)
+}
+
+// contactEnricher performs narrow method-only enrichment on a bound CRM
+// contact. Satisfied by *service.EnrichmentService. May be nil in tests.
+type contactEnricher interface {
+	SyncMethodsFromExternal(ctx context.Context, crmContactID uuid.UUID, external *repository.ExternalContact) error
+}
+
+// PeerMatcher binds WhatsApp peers to CRM contacts and surfaces the frequent
+// unknown ones as import candidates.
+//
+// There is no two-tier ladder, unlike Telegram: identity.IdentifierTypeWhatsApp
+// already searches BOTH whatsapp and phone contact methods, so one
+// MatchOrCreate call covers what Telegram needs two for.
+type PeerMatcher struct {
+	identityService     identityMatcher
+	commsRepo           commsPeerStore
+	externalContactRepo externalContactUpserter
+	enricher            contactEnricher // may be nil (tests)
+	discoveryMinMsgs    int
+}
+
+// NewPeerMatcher creates a new peer matcher.
+func NewPeerMatcher(
+	identityService identityMatcher,
+	commsRepo commsPeerStore,
+	externalContactRepo externalContactUpserter,
+	enricher contactEnricher,
+	discoveryMinMsgs int,
+) *PeerMatcher {
+	return &PeerMatcher{
+		identityService:     identityService,
+		commsRepo:           commsRepo,
+		externalContactRepo: externalContactRepo,
+		enricher:            enricher,
+		discoveryMinMsgs:    discoveryMinMsgs,
+	}
+}
+
+// MatchPeer resolves a peer to a CRM contact. Returns (nil, nil) when the peer
+// is unknown — which is a normal outcome, not a failure: the message still
+// stages, unmatched, and the peer can reach a contact through the import queue.
+//
+// Matching is best-effort throughout: an identity error logs and yields nil
+// rather than failing the message, mirroring Telegram's discipline.
+func (m *PeerMatcher) MatchPeer(ctx context.Context, peerJID string, phoneE164, pushName *string) (*uuid.UUID, error) {
+	// A peer whose phone number was never recovered has nothing to match on:
+	// there is no identifier type for a WhatsApp-internal id, so there is
+	// nothing worth minting.
+	if phoneE164 == nil || *phoneE164 == "" {
+		return nil, nil
+	}
+
+	result, err := m.identityService.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier: *phoneE164,
+		Type:          identity.IdentifierTypeWhatsApp,
+		Source:        syncSource,
+		SourceID:      &peerJID,
+		DisplayName:   nilIfEmptyPtr(pushName),
+	})
+	if err != nil {
+		logger.Warn().Err(err).Msg("whatsapp: peer identity match failed")
+		return nil, nil
+	}
+	if result == nil || result.ContactID == nil {
+		return nil, nil
+	}
+
+	m.markExternalContactMatched(ctx, peerJID, *result.ContactID)
+	m.ensureMethodsOnMatch(ctx, *result.ContactID, peerJID, phoneE164)
+	logger.Info().
+		Str("contact_id", result.ContactID.String()).
+		Str("match_type", string(result.MatchType)).
+		Msg("whatsapp: peer matched")
+	return result.ContactID, nil
+}
+
+// OnPeerLinked back-fills after an import or a manual link: it binds the
+// identity and re-points every staged message for the peer onto the contact.
+//
+// phoneE164 is optional: a peer staged under a WhatsApp-internal id before its
+// phone number resolved is attachable only by the number, and the attach query
+// matches peer_handle OR peer_normalized. Passing nil narrows it to the handle.
+func (m *PeerMatcher) OnPeerLinked(ctx context.Context, peerJID string, phoneE164 *string, contactID uuid.UUID) error {
+	if phoneE164 != nil && *phoneE164 != "" {
+		if _, err := m.identityService.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier:  *phoneE164,
+			Type:           identity.IdentifierTypeWhatsApp,
+			Source:         syncSource,
+			SourceID:       &peerJID,
+			KnownContactID: &contactID,
+		}); err != nil {
+			// Non-fatal: the identity link is a convenience for future
+			// matches, while the attach below is the user-visible effect.
+			logger.Warn().Err(err).Msg("whatsapp: failed to link identity on import")
+		}
+	}
+
+	attached, deduped, err := m.commsRepo.AttachUnmatchedByPeer(ctx, syncSource, nilIfEmptyPtr(phoneE164), &peerJID, contactID)
+	if err != nil {
+		return fmt.Errorf("attach whatsapp staged messages: %w", err)
+	}
+
+	logger.Info().
+		Str("contact_id", contactID.String()).
+		Int64("attached", attached).
+		Int64("deduped", deduped).
+		Msg("whatsapp: peer linked, staged messages attached")
+	return nil
+}
+
+// UpdateDiscoveryCandidates upserts an import candidate for every unmatched
+// peer at or above the discovery threshold. peerJID nil means every peer.
+//
+// The candidate ALWAYS carries a display name — push name, else resolved phone,
+// else a "WhatsApp <user>" label — because the imports queue's unresolved-hiding
+// predicates are Telegram-scoped, so a WhatsApp candidate is always visible and
+// must therefore never be contentless. The ladder is monotone under the
+// upsert's COALESCE preserve: a later push name always upgrades an earlier
+// phone-or-JID label, because a non-nil incoming value wins.
+func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context, peerJID *string) error {
+	counts, err := m.commsRepo.ListUnmatchedPeerCounts(ctx, syncSource, peerJID, m.discoveryMinMsgs)
+	if err != nil {
+		return fmt.Errorf("list unmatched whatsapp peer counts: %w", err)
+	}
+
+	now := accelerated.GetCurrentTime()
+	created := 0
+	for _, row := range counts {
+		if row.PeerHandle == "" {
+			continue
+		}
+
+		metadata := map[string]any{
+			"message_count":  row.TotalCount,
+			"outbound_count": row.OutboundCount,
+			"inbound_count":  row.InboundCount,
+			"peer_jid":       row.PeerHandle,
+		}
+		if !row.LastMessageAt.IsZero() {
+			metadata["last_message_at"] = row.LastMessageAt.Format("2006-01-02T15:04:05Z")
+		}
+		if pushName := nilIfEmptyPtr(row.LastPushName); pushName != nil {
+			metadata["push_name"] = *pushName
+		}
+		if phone := nilIfEmptyPtr(row.PeerNormalized); phone != nil {
+			metadata["phone_e164"] = *phone
+		}
+
+		label := discoveryDisplayName(row)
+		if _, err := m.externalContactRepo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+			Source:      syncSource,
+			SourceID:    row.PeerHandle,
+			DisplayName: &label,
+			Metadata:    metadata,
+			SyncedAt:    &now,
+		}); err != nil {
+			logger.Warn().Err(err).Msg("whatsapp: failed to upsert discovery candidate")
+			continue
+		}
+		created++
+	}
+
+	if created > 0 {
+		logger.Info().Int("candidates", created).Msg("whatsapp: discovery candidates updated")
+	}
+	return nil
+}
+
+// discoveryDisplayName is the never-nil label ladder. FirstName/LastName stay
+// unset throughout: WhatsApp gives a push name, not a split name.
+func discoveryDisplayName(row repository.UnmatchedPeerCount) string {
+	if pushName := nilIfEmptyPtr(row.LastPushName); pushName != nil {
+		return *pushName
+	}
+	if phone := nilIfEmptyPtr(row.PeerNormalized); phone != nil {
+		return *phone
+	}
+	user := row.PeerHandle
+	if at := strings.Index(user, "@"); at >= 0 {
+		user = user[:at]
+	}
+	return "WhatsApp " + user
+}
+
+// ensureMethodsOnMatch syncs contact methods onto the matched contact. Errors
+// are logged at warn and never fail the match.
+func (m *PeerMatcher) ensureMethodsOnMatch(ctx context.Context, contactID uuid.UUID, peerJID string, phoneE164 *string) {
+	if m.enricher == nil {
+		return
+	}
+
+	external, err := m.externalContactRepo.GetBySource(ctx, syncSource, peerJID, nil)
+	if err != nil {
+		// Transient repository error — bail out rather than synthesize, which
+		// would risk dropping persisted values and emitting a NULL
+		// external_contact_id audit row when a real one exists.
+		logger.Warn().Err(err).Msg("whatsapp: get external_contact for method sync failed")
+		return
+	}
+	if external == nil {
+		external = &repository.ExternalContact{
+			Source:   syncSource,
+			SourceID: peerJID,
+			Metadata: map[string]any{},
+		}
+	} else if external.Metadata == nil {
+		external.Metadata = map[string]any{}
+	}
+	if phoneE164 != nil && *phoneE164 != "" {
+		// The current message is the freshest source of the peer's number.
+		external.Metadata["phone_e164"] = *phoneE164
+	}
+
+	if err := m.enricher.SyncMethodsFromExternal(ctx, contactID, external); err != nil {
+		logger.Warn().Err(err).
+			Str("contact_id", contactID.String()).
+			Msg("whatsapp: sync methods from external failed")
+	}
+}
+
+// markExternalContactMatched updates any existing candidate for this peer to
+// "matched".
+func (m *PeerMatcher) markExternalContactMatched(ctx context.Context, peerJID string, contactID uuid.UUID) {
+	existing, err := m.externalContactRepo.GetBySource(ctx, syncSource, peerJID, nil)
+	if err != nil || existing == nil {
+		return // no existing candidate, nothing to update
+	}
+	if existing.MatchStatus == repository.MatchStatusMatched || existing.MatchStatus == repository.MatchStatusImported {
+		return
+	}
+	if _, err := m.externalContactRepo.UpdateMatch(ctx, existing.ID, &contactID, repository.MatchStatusMatched); err != nil {
+		logger.Warn().Err(err).Msg("whatsapp: failed to mark external contact as matched")
+	}
+}

--- a/backend/internal/whatsapp/matcher_test.go
+++ b/backend/internal/whatsapp/matcher_test.go
@@ -20,7 +20,11 @@ import (
 type fakeIdentityMatcher struct {
 	contactID *uuid.UUID
 	err       error
-	requests  []service.MatchRequest
+	// cached mirrors what the identity service reports when the identity row
+	// already existed AND already pointed at a live contact — i.e. this peer
+	// was reconciled by an earlier message.
+	cached   bool
+	requests []service.MatchRequest
 }
 
 func (f *fakeIdentityMatcher) MatchOrCreate(_ context.Context, req service.MatchRequest) (*service.MatchResult, error) {
@@ -28,7 +32,7 @@ func (f *fakeIdentityMatcher) MatchOrCreate(_ context.Context, req service.Match
 	if f.err != nil {
 		return nil, f.err
 	}
-	return &service.MatchResult{ContactID: f.contactID, MatchType: repository.MatchTypeExact}, nil
+	return &service.MatchResult{ContactID: f.contactID, MatchType: repository.MatchTypeExact, Cached: f.cached}, nil
 }
 
 type fakeCommsPeerStore struct {
@@ -371,27 +375,94 @@ func TestDiscovery_UpsertErrorIsNonFatal(t *testing.T) {
 }
 
 // TestMatchPeer_ReconcileIsFirstMatchGated is the per-message cost guard: this
-// runs inline on the library's serialized handler goroutine, so a known peer's
-// steady state must be ONE candidate read and nothing else — not a read to mark,
-// a second read to enrich, and a method-sync transaction on every message.
+// runs inline on the library's serialized handler goroutine, so a peer that has
+// already matched must cost NOTHING beyond the identity match — not a read, not
+// a mark, and above all not a method-sync transaction.
+//
+// The no-candidate-row row is the one that matters most: a peer whose phone
+// matched a contact on its FIRST message never gets a candidate row at all,
+// because discovery only runs on the unmatched branch. Gating on the candidate
+// row instead of on the identity would leave exactly that population — the
+// majority of matched peers — synthesizing and re-enriching forever.
 func TestMatchPeer_ReconcileIsFirstMatchGated(t *testing.T) {
+	matchedCandidate := &repository.ExternalContact{
+		ID: uuid.New(), Source: "whatsapp", SourceID: "15559876543@s.whatsapp.net",
+		MatchStatus: repository.MatchStatusMatched, Metadata: map[string]any{},
+	}
+
+	tests := []struct {
+		name                                string
+		cached                              bool
+		candidate                           *repository.ExternalContact
+		wantGets, wantUpdates, wantEnriched int
+	}{
+		{
+			name:   "repeat message, no candidate row — the dominant matched case",
+			cached: true, candidate: nil,
+			wantGets: 0, wantUpdates: 0, wantEnriched: 0,
+		},
+		{
+			name:   "repeat message, candidate row exists",
+			cached: true, candidate: matchedCandidate,
+			wantGets: 0, wantUpdates: 0, wantEnriched: 0,
+		},
+		{
+			name:   "first match, no candidate row",
+			cached: false, candidate: nil,
+			wantGets: 1, wantUpdates: 0, wantEnriched: 1,
+		},
+		{
+			name:   "uncached but already reconciled elsewhere (an import, a rematch)",
+			cached: false, candidate: matchedCandidate,
+			wantGets: 1, wantUpdates: 0, wantEnriched: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := uuid.New()
+			ids := &fakeIdentityMatcher{contactID: &want, cached: tt.cached}
+			ext := &countingExternalContactUpserter{fakeExternalContactUpserter: fakeExternalContactUpserter{
+				getResult: tt.candidate,
+			}}
+			enricher := &fakeEnricher{}
+			m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, 3)
+
+			got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
+			require.NoError(t, err)
+			require.NotNil(t, got, "the match itself is unaffected by the gate")
+
+			assert.Equal(t, tt.wantGets, ext.getCalls, "candidate reads")
+			assert.Equal(t, tt.wantUpdates, ext.updateCalls, "candidate mark writes")
+			assert.Equal(t, tt.wantEnriched, enricher.calls, "method-sync transactions")
+		})
+	}
+}
+
+// TestMatchPeer_RepeatedMessagesFromAKnownPeerCostNothingExtra is the finding
+// stated as a scenario: five messages from a peer with no candidate row must not
+// produce five method-sync transactions.
+func TestMatchPeer_RepeatedMessagesFromAKnownPeerCostNothingExtra(t *testing.T) {
 	want := uuid.New()
 	ids := &fakeIdentityMatcher{contactID: &want}
-	ext := &countingExternalContactUpserter{fakeExternalContactUpserter: fakeExternalContactUpserter{
-		getResult: &repository.ExternalContact{
-			ID: uuid.New(), Source: "whatsapp", SourceID: "15559876543@s.whatsapp.net",
-			MatchStatus: repository.MatchStatusMatched, Metadata: map[string]any{},
-		},
-	}}
+	ext := &countingExternalContactUpserter{}
 	enricher := &fakeEnricher{}
 	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, 3)
 
+	// First message: the identity is newly bound, so it reconciles once.
 	_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
 	require.NoError(t, err)
+	require.Equal(t, 1, enricher.calls)
 
-	assert.Equal(t, 1, ext.getCalls, "one candidate read, not two")
-	assert.Zero(t, ext.updateCalls, "an already-matched candidate needs no re-marking")
-	assert.Zero(t, enricher.calls, "and no method-sync transaction per message")
+	// Every later message finds the identity cached.
+	ids.cached = true
+	for range 5 {
+		_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 1, enricher.calls, "one sync in total, not one per message")
+	assert.Equal(t, 1, ext.getCalls, "and one candidate read in total")
 }
 
 func TestMatchPeer_ReconcileRunsOnceForANewCandidate(t *testing.T) {

--- a/backend/internal/whatsapp/matcher_test.go
+++ b/backend/internal/whatsapp/matcher_test.go
@@ -369,3 +369,58 @@ func TestDiscovery_UpsertErrorIsNonFatal(t *testing.T) {
 	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil),
 		"discovery is best-effort; it must not withhold an ack for a message already staged")
 }
+
+// TestMatchPeer_ReconcileIsFirstMatchGated is the per-message cost guard: this
+// runs inline on the library's serialized handler goroutine, so a known peer's
+// steady state must be ONE candidate read and nothing else — not a read to mark,
+// a second read to enrich, and a method-sync transaction on every message.
+func TestMatchPeer_ReconcileIsFirstMatchGated(t *testing.T) {
+	want := uuid.New()
+	ids := &fakeIdentityMatcher{contactID: &want}
+	ext := &countingExternalContactUpserter{fakeExternalContactUpserter: fakeExternalContactUpserter{
+		getResult: &repository.ExternalContact{
+			ID: uuid.New(), Source: "whatsapp", SourceID: "15559876543@s.whatsapp.net",
+			MatchStatus: repository.MatchStatusMatched, Metadata: map[string]any{},
+		},
+	}}
+	enricher := &fakeEnricher{}
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, 3)
+
+	_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, ext.getCalls, "one candidate read, not two")
+	assert.Zero(t, ext.updateCalls, "an already-matched candidate needs no re-marking")
+	assert.Zero(t, enricher.calls, "and no method-sync transaction per message")
+}
+
+func TestMatchPeer_ReconcileRunsOnceForANewCandidate(t *testing.T) {
+	want := uuid.New()
+	ext := &countingExternalContactUpserter{fakeExternalContactUpserter: fakeExternalContactUpserter{
+		getResult: &repository.ExternalContact{
+			ID: uuid.New(), Source: "whatsapp", SourceID: "15559876543@s.whatsapp.net",
+			MatchStatus: repository.MatchStatusUnmatched, Metadata: map[string]any{},
+		},
+	}}
+	enricher := &fakeEnricher{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{contactID: &want}, &fakeCommsPeerStore{}, ext, enricher, 3)
+
+	_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, ext.getCalls)
+	assert.Equal(t, 1, ext.updateCalls, "an unmatched candidate is marked matched")
+	assert.Equal(t, 1, enricher.calls, "and enriched, once")
+}
+
+// countingExternalContactUpserter counts the candidate reads, which is the cost
+// the fold exists to halve.
+type countingExternalContactUpserter struct {
+	fakeExternalContactUpserter
+	getCalls int
+}
+
+func (c *countingExternalContactUpserter) GetBySource(ctx context.Context, source, sourceID string, accountID *string) (*repository.ExternalContact, error) {
+	c.getCalls++
+	return c.fakeExternalContactUpserter.GetBySource(ctx, source, sourceID, accountID)
+}

--- a/backend/internal/whatsapp/matcher_test.go
+++ b/backend/internal/whatsapp/matcher_test.go
@@ -1,0 +1,371 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ------------------------------------------------------------------
+
+type fakeIdentityMatcher struct {
+	contactID *uuid.UUID
+	err       error
+	requests  []service.MatchRequest
+}
+
+func (f *fakeIdentityMatcher) MatchOrCreate(_ context.Context, req service.MatchRequest) (*service.MatchResult, error) {
+	f.requests = append(f.requests, req)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &service.MatchResult{ContactID: f.contactID, MatchType: repository.MatchTypeExact}, nil
+}
+
+type fakeCommsPeerStore struct {
+	counts       []repository.UnmatchedPeerCount
+	countsErr    error
+	attachErr    error
+	attachCalls  []attachCall
+	countsCalls  []countsCall
+	attached     int64
+	dedupedCount int64
+}
+
+type attachCall struct {
+	source         string
+	peerNormalized *string
+	peerHandle     *string
+	contactID      uuid.UUID
+}
+
+type countsCall struct {
+	source      string
+	peerHandle  *string
+	minMessages int
+}
+
+func (f *fakeCommsPeerStore) AttachUnmatchedByPeer(_ context.Context, source string, peerNormalized, peerHandle *string, contactID uuid.UUID) (int64, int64, error) {
+	f.attachCalls = append(f.attachCalls, attachCall{source, peerNormalized, peerHandle, contactID})
+	if f.attachErr != nil {
+		return 0, 0, f.attachErr
+	}
+	return f.attached, f.dedupedCount, nil
+}
+
+func (f *fakeCommsPeerStore) ListUnmatchedPeerCounts(_ context.Context, source string, peerHandle *string, minMessages int) ([]repository.UnmatchedPeerCount, error) {
+	f.countsCalls = append(f.countsCalls, countsCall{source, peerHandle, minMessages})
+	return f.counts, f.countsErr
+}
+
+type fakeExternalContactUpserter struct {
+	upserts      []repository.UpsertDiscoveryCandidateRequest
+	getResult    *repository.ExternalContact
+	getErr       error
+	updateCalls  int
+	upsertErrOne error
+}
+
+func (f *fakeExternalContactUpserter) UpsertDiscoveryCandidate(_ context.Context, req repository.UpsertDiscoveryCandidateRequest) (*repository.ExternalContact, error) {
+	f.upserts = append(f.upserts, req)
+	if f.upsertErrOne != nil {
+		return nil, f.upsertErrOne
+	}
+	return &repository.ExternalContact{ID: uuid.New(), Source: req.Source, SourceID: req.SourceID}, nil
+}
+
+func (f *fakeExternalContactUpserter) GetBySource(_ context.Context, _, _ string, _ *string) (*repository.ExternalContact, error) {
+	return f.getResult, f.getErr
+}
+
+func (f *fakeExternalContactUpserter) UpdateMatch(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ repository.MatchStatus) (*repository.ExternalContact, error) {
+	f.updateCalls++
+	return nil, nil
+}
+
+type fakeEnricher struct {
+	calls    int
+	external *repository.ExternalContact
+	err      error
+}
+
+func (f *fakeEnricher) SyncMethodsFromExternal(_ context.Context, _ uuid.UUID, external *repository.ExternalContact) error {
+	f.calls++
+	f.external = external
+	return f.err
+}
+
+func strp(s string) *string { return &s }
+
+// --- MatchPeer --------------------------------------------------------------
+
+func TestMatchPeer_ResolvedPhoneMatchesContact(t *testing.T) {
+	want := uuid.New()
+	ids := &fakeIdentityMatcher{contactID: &want}
+	ext := &fakeExternalContactUpserter{}
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, nil, 3)
+
+	got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), strp("Their Name"))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, want, *got)
+
+	require.Len(t, ids.requests, 1, "one call covers both whatsapp and phone contact methods")
+	assert.Equal(t, identity.IdentifierTypeWhatsApp, ids.requests[0].Type)
+	assert.Equal(t, "+15559876543", ids.requests[0].RawIdentifier)
+	assert.Equal(t, "whatsapp", ids.requests[0].Source)
+	require.NotNil(t, ids.requests[0].SourceID)
+	assert.Equal(t, "15559876543@s.whatsapp.net", *ids.requests[0].SourceID, "keyed by the raw peer JID")
+	require.NotNil(t, ids.requests[0].DisplayName)
+	assert.Equal(t, "Their Name", *ids.requests[0].DisplayName)
+}
+
+func TestMatchPeer_NilPhoneIsUnmatchedWithoutIdentityCall(t *testing.T) {
+	ids := &fakeIdentityMatcher{}
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, 3)
+
+	got, err := m.MatchPeer(context.Background(), "88800000002@lid", nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, ids.requests, "a LID-only peer has no identifier worth minting")
+}
+
+func TestMatchPeer_IdentityErrorIsNonFatal(t *testing.T) {
+	ids := &fakeIdentityMatcher{err: errors.New("identity service down")}
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, 3)
+
+	got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
+	require.NoError(t, err, "matching is best-effort; the message still stages")
+	assert.Nil(t, got)
+}
+
+func TestMatchPeer_FiresEnricherOnMatch(t *testing.T) {
+	want := uuid.New()
+	ids := &fakeIdentityMatcher{contactID: &want}
+	ext := &fakeExternalContactUpserter{getResult: &repository.ExternalContact{
+		ID: uuid.New(), Source: "whatsapp", SourceID: "15559876543@s.whatsapp.net",
+		MatchStatus: repository.MatchStatusUnmatched, Metadata: map[string]any{},
+	}}
+	enricher := &fakeEnricher{}
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, 3)
+
+	_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, enricher.calls)
+	require.NotNil(t, enricher.external)
+	assert.Equal(t, "+15559876543", enricher.external.Metadata["phone_e164"],
+		"the current message is the freshest source of the peer's number")
+	assert.Equal(t, 1, ext.updateCalls, "an existing unmatched candidate is marked matched")
+}
+
+func TestMatchPeer_NilEnricherNoPanic(t *testing.T) {
+	want := uuid.New()
+	m := NewPeerMatcher(&fakeIdentityMatcher{contactID: &want}, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, 3)
+
+	got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+}
+
+// --- OnPeerLinked -----------------------------------------------------------
+
+func TestOnPeerLinked_PassesBothSelectors(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCommsPeerStore{attached: 4, dedupedCount: 1}
+	ids := &fakeIdentityMatcher{contactID: &contactID}
+	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, 3)
+
+	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", strp("+15559876543"), contactID))
+
+	require.Len(t, comms.attachCalls, 1)
+	assert.Equal(t, "whatsapp", comms.attachCalls[0].source)
+	require.NotNil(t, comms.attachCalls[0].peerHandle)
+	assert.Equal(t, "88800000002@lid", *comms.attachCalls[0].peerHandle)
+	require.NotNil(t, comms.attachCalls[0].peerNormalized)
+	assert.Equal(t, "+15559876543", *comms.attachCalls[0].peerNormalized,
+		"a peer staged under a LID before its phone resolved is attachable only by the phone")
+
+	require.Len(t, ids.requests, 1)
+	require.NotNil(t, ids.requests[0].KnownContactID)
+	assert.Equal(t, contactID, *ids.requests[0].KnownContactID)
+}
+
+func TestOnPeerLinked_NilPhoneReproducesTheContractedShape(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCommsPeerStore{}
+	ids := &fakeIdentityMatcher{}
+	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, 3)
+
+	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", nil, contactID))
+	assert.Empty(t, ids.requests, "with no phone there is nothing to link the identity by")
+	require.Len(t, comms.attachCalls, 1)
+	assert.Nil(t, comms.attachCalls[0].peerNormalized)
+}
+
+func TestOnPeerLinked_AttachErrorIsFatal(t *testing.T) {
+	comms := &fakeCommsPeerStore{attachErr: errors.New("database down")}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, &fakeExternalContactUpserter{}, nil, 3)
+
+	err := m.OnPeerLinked(context.Background(), "88800000002@lid", nil, uuid.New())
+	require.Error(t, err, "the attach IS the user-visible effect of linking; a silent failure loses it")
+}
+
+func TestOnPeerLinked_IdentityLinkFailureIsNonFatal(t *testing.T) {
+	comms := &fakeCommsPeerStore{attached: 2}
+	ids := &fakeIdentityMatcher{err: errors.New("identity service down")}
+	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, 3)
+
+	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", strp("+15559876543"), uuid.New()),
+		"the identity link is a convenience for future matches; the attach still has to run")
+	assert.Len(t, comms.attachCalls, 1)
+}
+
+// --- discovery --------------------------------------------------------------
+
+func peerCount(handle string, total int64, normalized, pushName *string) repository.UnmatchedPeerCount {
+	return repository.UnmatchedPeerCount{
+		PeerHandle:     handle,
+		PeerNormalized: normalized,
+		TotalCount:     total,
+		InboundCount:   total,
+		LastMessageAt:  time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		LastPushName:   pushName,
+	}
+}
+
+func TestDiscovery_ThresholdIsAppliedByTheQuery(t *testing.T) {
+	comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{
+		peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), strp("Their Name")),
+	}}
+	ext := &fakeExternalContactUpserter{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+
+	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), strp("15559876543@s.whatsapp.net")))
+
+	require.Len(t, comms.countsCalls, 1)
+	assert.Equal(t, 3, comms.countsCalls[0].minMessages,
+		"the HAVING clause applies the threshold, so there is no client-side filter to keep in step")
+	assert.Equal(t, "whatsapp", comms.countsCalls[0].source)
+	require.Len(t, ext.upserts, 1)
+}
+
+func TestDiscovery_BelowThresholdNoCandidate(t *testing.T) {
+	// The query returns nothing below the threshold; the matcher must not
+	// invent a candidate from an empty result.
+	comms := &fakeCommsPeerStore{}
+	ext := &fakeExternalContactUpserter{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+
+	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
+	assert.Empty(t, ext.upserts)
+}
+
+func TestDiscovery_MetadataCarriesCountsAndPhone(t *testing.T) {
+	row := peerCount("15559876543@s.whatsapp.net", 5, strp("+15559876543"), strp("Their Name"))
+	row.OutboundCount = 2
+	row.InboundCount = 3
+	comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{row}}
+	ext := &fakeExternalContactUpserter{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+
+	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
+	require.Len(t, ext.upserts, 1)
+	meta := ext.upserts[0].Metadata
+	assert.EqualValues(t, 5, meta["message_count"])
+	assert.EqualValues(t, 2, meta["outbound_count"])
+	assert.EqualValues(t, 3, meta["inbound_count"])
+	assert.Equal(t, "+15559876543", meta["phone_e164"],
+		"the resolved phone rides in metadata, which is what the import method builder reads")
+	assert.Equal(t, "Their Name", meta["push_name"])
+	assert.Equal(t, "15559876543@s.whatsapp.net", meta["peer_jid"])
+	assert.Equal(t, "2026-05-01T12:00:00Z", meta["last_message_at"])
+	assert.Equal(t, "whatsapp", ext.upserts[0].Source)
+	assert.Equal(t, "15559876543@s.whatsapp.net", ext.upserts[0].SourceID,
+		"the candidate is keyed by the same value the staging rows and the attach use")
+	assert.Nil(t, ext.upserts[0].FirstName, "WhatsApp gives a push name, not a split name")
+	assert.Nil(t, ext.upserts[0].LastName)
+}
+
+// TestDiscovery_AlwaysWritesADisplayName is the guarantee that makes
+// always-visible WhatsApp candidates safe: the imports queue's unresolved-hiding
+// predicates are Telegram-scoped, so a contentless WhatsApp row would reach the
+// user as a bare JID with nothing to act on.
+func TestDiscovery_AlwaysWritesADisplayName(t *testing.T) {
+	tests := []struct {
+		name string
+		row  repository.UnmatchedPeerCount
+		want string
+	}{
+		{"push name wins", peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), strp("Their Name")), "Their Name"},
+		{"phone next", peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), nil), "+15559876543"},
+		{"jid label last", peerCount("88800000002@lid", 3, nil, nil), "WhatsApp 88800000002"},
+		{"an empty push name is not a name", peerCount("88800000002@lid", 3, nil, strp("")), "WhatsApp 88800000002"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{tt.row}}
+			ext := &fakeExternalContactUpserter{}
+			m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+
+			require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
+			require.Len(t, ext.upserts, 1)
+			require.NotNil(t, ext.upserts[0].DisplayName, "a WhatsApp candidate is never contentless")
+			assert.Equal(t, tt.want, *ext.upserts[0].DisplayName)
+		})
+	}
+}
+
+// TestDiscovery_LaterPushNameUpgradesJIDLabel pins the ladder's monotonicity:
+// the upsert's COALESCE preserve means a non-nil incoming value always wins, so
+// a peer first labelled by JID is relabelled once a push name is seen.
+func TestDiscovery_LaterPushNameUpgradesJIDLabel(t *testing.T) {
+	comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{
+		peerCount("88800000002@lid", 3, nil, nil),
+	}}
+	ext := &fakeExternalContactUpserter{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+
+	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
+	comms.counts = []repository.UnmatchedPeerCount{peerCount("88800000002@lid", 4, nil, strp("Their Name"))}
+	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
+
+	require.Len(t, ext.upserts, 2)
+	assert.Equal(t, "WhatsApp 88800000002", *ext.upserts[0].DisplayName)
+	assert.Equal(t, "Their Name", *ext.upserts[1].DisplayName)
+}
+
+// TestDiscovery_EmptyPushNameDoesNotClobberStoredName is the reason the
+// nil-if-empty normalization exists: an empty string is a POPULATED value to
+// COALESCE(EXCLUDED.x, …) and would overwrite a stored name with nothing.
+func TestDiscovery_EmptyPushNameDoesNotClobberStoredName(t *testing.T) {
+	comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{
+		peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), strp("")),
+	}}
+	ext := &fakeExternalContactUpserter{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+
+	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
+	require.Len(t, ext.upserts, 1)
+	assert.NotContains(t, ext.upserts[0].Metadata, "push_name")
+	assert.Equal(t, "+15559876543", *ext.upserts[0].DisplayName)
+}
+
+func TestDiscovery_UpsertErrorIsNonFatal(t *testing.T) {
+	comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{
+		peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), nil),
+	}}
+	ext := &fakeExternalContactUpserter{upsertErrOne: errors.New("database down")}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+
+	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil),
+		"discovery is best-effort; it must not withhold an ack for a message already staged")
+}

--- a/backend/internal/whatsapp/message.go
+++ b/backend/internal/whatsapp/message.go
@@ -1,0 +1,394 @@
+package whatsapp
+
+import (
+	"context"
+	"regexp"
+
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/logger"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// Chat types. These are the only two values IngestedMessage.ChatType ever
+// carries: every other server is refused by classifyChat rather than typed.
+const (
+	ChatTypePrivate = "private"
+	ChatTypeGroup   = "group"
+)
+
+// Message types, derived from the envelope alone — no media byte is ever
+// downloaded, so the type is what the message carried, not what it contains.
+const (
+	MessageTypeText     = "text"
+	MessageTypePhoto    = "photo"
+	MessageTypeAudio    = "audio"
+	MessageTypeVideo    = "video"
+	MessageTypeDocument = "document"
+	MessageTypeSticker  = "sticker"
+	MessageTypeOther    = "other"
+)
+
+// Drop reasons, logged when an event is acknowledged without being stored.
+const (
+	dropReasonProtocol = "protocol"
+	dropReasonReaction = "reaction"
+	dropReasonPollVote = "poll_vote"
+)
+
+// phoneUserPattern is what a subscriber number looks like in a JID's user part.
+// A JID whose user is not a bare number is not a phone number, whatever server
+// it claims — so it falls through to the unresolved rung rather than being
+// normalized into a plausible-looking identifier.
+var phoneUserPattern = regexp.MustCompile(`^[0-9]{5,15}$`)
+
+// normalizeServer rewrites device-domain and legacy servers onto the canonical
+// user servers, so eligibility is decided on IDENTITY rather than on transport.
+//
+// hosted and hosted.lid are device domains for the same user identity — the
+// library mints them from the hosted domain constants and treats them as
+// first-class user servers — so a blind allowlist would drop real
+// conversations. c.us is the library's own legacy rewrite, already mirrored in
+// VerifyHistoryLIDMappings.
+//
+// It is applied to the chat JID AND to the peer JID before any comparison, so
+// peer_handle stays stable for one human across device domains.
+func normalizeServer(jid types.JID) types.JID {
+	switch jid.Server {
+	case types.HostedServer, types.LegacyUserServer:
+		jid.Server = types.DefaultUserServer
+	case types.HostedLIDServer:
+		jid.Server = types.HiddenUserServer
+	}
+	return jid
+}
+
+// ownIdentity is the emitting session's own JIDs. Both forms are carried
+// because a self-chat can be addressed either way and a phone-server own JID is
+// what makes the outbound-DM direction decidable.
+type ownIdentity struct {
+	PN  types.JID
+	LID types.JID
+}
+
+// ok reports whether at least one own JID is known. Without one the parser can
+// neither reject a self-chat nor stamp the account, so the handler withholds
+// the ack rather than dropping the message.
+func (o ownIdentity) ok() bool {
+	return !o.PN.IsEmpty() || !o.LID.IsEmpty()
+}
+
+// isSelf reports whether jid addresses the linked account itself, in either
+// form and on any device domain.
+func (o ownIdentity) isSelf(jid types.JID) bool {
+	target := normalizeServer(jid).ToNonAD()
+	if !o.PN.IsEmpty() && normalizeServer(o.PN).ToNonAD() == target {
+		return true
+	}
+	if !o.LID.IsEmpty() && normalizeServer(o.LID).ToNonAD() == target {
+		return true
+	}
+	return false
+}
+
+// accountJID is the value stamped onto comms_message.account_id.
+//
+// ToNonAD is load-bearing rather than decoration: the device store's own ID is
+// an AD JID and String() re-appends ":<device>" whenever the device number is
+// non-zero — and that number is reassigned on every re-link. Storing the AD
+// form would fragment account_id across exactly the re-pair this integration
+// has to survive.
+func (o ownIdentity) accountJID() *string {
+	source := o.PN
+	if source.IsEmpty() {
+		source = o.LID
+	}
+	if source.IsEmpty() {
+		return nil
+	}
+	out := normalizeServer(source).ToNonAD().String()
+	return &out
+}
+
+// classifyChat applies the person-to-person allowlist to an ALREADY-NORMALIZED
+// chat JID. ok=false means DROP — the event is acknowledged, because an
+// ineligible chat is handled, just to no effect.
+//
+// It deliberately does not branch on events.Message.Info.IsGroup: the library
+// sets that true for broadcast lists and the status broadcast as well as for
+// g.us, so it would admit exactly the chats this allowlist exists to refuse.
+func classifyChat(chat types.JID, own ownIdentity) (string, bool) {
+	switch chat.Server {
+	case types.GroupServer:
+		return ChatTypeGroup, true
+	case types.DefaultUserServer, types.HiddenUserServer:
+		if own.isSelf(chat) {
+			return "", false
+		}
+		return ChatTypePrivate, true
+	default:
+		// Broadcast, status broadcast, newsletter, messenger, bot, interop and
+		// anything the protocol grows later: fail closed.
+		return "", false
+	}
+}
+
+// classifiedContent is what the envelope says about a message, with no network
+// call and no media download.
+type classifiedContent struct {
+	MessageType   string
+	Body          *string
+	ReplyTargetID *string
+	Drop          bool
+	DropReason    string
+}
+
+// classifyMessage reads the UNWRAPPED message. whatsmeow unwraps ephemeral,
+// view-once, device-sent, document-with-caption and edited envelopes before
+// dispatch, so RawMessage would re-introduce every wrapper this reads through.
+//
+// Protocol messages, reactions and poll votes are dropped with an ack: an edit
+// would try to mutate a body the staging upsert holds immutable on conflict (a
+// silent no-op wearing the costume of an update), and reactions and poll votes
+// are not conversational turns. A poll CREATION is a real message and stages.
+func classifyMessage(msg *waE2E.Message) classifiedContent {
+	if msg == nil {
+		return classifiedContent{MessageType: MessageTypeOther}
+	}
+
+	switch {
+	case msg.GetProtocolMessage() != nil:
+		return classifiedContent{Drop: true, DropReason: dropReasonProtocol}
+	case msg.GetReactionMessage() != nil || msg.GetEncReactionMessage() != nil:
+		return classifiedContent{Drop: true, DropReason: dropReasonReaction}
+	case msg.GetPollUpdateMessage() != nil:
+		return classifiedContent{Drop: true, DropReason: dropReasonPollVote}
+	}
+
+	switch {
+	case msg.GetConversation() != "":
+		// A plain-text reply always arrives as an ExtendedTextMessage, so a
+		// bare conversation needs no context probe.
+		body := msg.GetConversation()
+		return classifiedContent{MessageType: MessageTypeText, Body: &body}
+
+	case msg.GetExtendedTextMessage() != nil:
+		ext := msg.GetExtendedTextMessage()
+		return classifiedContent{
+			MessageType:   MessageTypeText,
+			Body:          nilIfEmptyString(ext.GetText()),
+			ReplyTargetID: nilIfEmptyString(ext.GetContextInfo().GetStanzaID()),
+		}
+
+	case msg.GetImageMessage() != nil:
+		img := msg.GetImageMessage()
+		return classifiedContent{
+			MessageType:   MessageTypePhoto,
+			Body:          nilIfEmptyString(img.GetCaption()),
+			ReplyTargetID: nilIfEmptyString(img.GetContextInfo().GetStanzaID()),
+		}
+
+	case msg.GetVideoMessage() != nil:
+		vid := msg.GetVideoMessage()
+		return classifiedContent{
+			MessageType:   MessageTypeVideo,
+			Body:          nilIfEmptyString(vid.GetCaption()),
+			ReplyTargetID: nilIfEmptyString(vid.GetContextInfo().GetStanzaID()),
+		}
+
+	case msg.GetPtvMessage() != nil:
+		ptv := msg.GetPtvMessage()
+		return classifiedContent{
+			MessageType:   MessageTypeVideo,
+			Body:          nilIfEmptyString(ptv.GetCaption()),
+			ReplyTargetID: nilIfEmptyString(ptv.GetContextInfo().GetStanzaID()),
+		}
+
+	case msg.GetAudioMessage() != nil:
+		return classifiedContent{
+			MessageType:   MessageTypeAudio,
+			ReplyTargetID: nilIfEmptyString(msg.GetAudioMessage().GetContextInfo().GetStanzaID()),
+		}
+
+	case msg.GetDocumentMessage() != nil:
+		doc := msg.GetDocumentMessage()
+		return classifiedContent{
+			MessageType:   MessageTypeDocument,
+			Body:          nilIfEmptyString(doc.GetCaption()),
+			ReplyTargetID: nilIfEmptyString(doc.GetContextInfo().GetStanzaID()),
+		}
+
+	case msg.GetStickerMessage() != nil:
+		return classifiedContent{
+			MessageType:   MessageTypeSticker,
+			ReplyTargetID: nilIfEmptyString(msg.GetStickerMessage().GetContextInfo().GetStanzaID()),
+		}
+
+	case msg.GetPollCreationMessage() != nil:
+		return classifiedContent{MessageType: MessageTypeOther, Body: nilIfEmptyString(msg.GetPollCreationMessage().GetName())}
+	case msg.GetPollCreationMessageV2() != nil:
+		return classifiedContent{MessageType: MessageTypeOther, Body: nilIfEmptyString(msg.GetPollCreationMessageV2().GetName())}
+	case msg.GetPollCreationMessageV3() != nil:
+		return classifiedContent{MessageType: MessageTypeOther, Body: nilIfEmptyString(msg.GetPollCreationMessageV3().GetName())}
+
+	default:
+		return classifiedContent{MessageType: MessageTypeOther}
+	}
+}
+
+// peerAltResolver is the device store's LID<->PN mapping lookup, narrowed to
+// the one method the peer ladder uses. Satisfied by *store.Device.
+type peerAltResolver interface {
+	GetAltJID(ctx context.Context, jid types.JID) (types.JID, error)
+}
+
+// parseMessage projects a live event onto IngestedMessage.
+//
+// eligible=false means DROP with a true ack. It never returns an error: every
+// resolution failure degrades to a nil field rather than withholding a message
+// that is otherwise perfectly storable.
+//
+// ChatTitle and MemberCount are deliberately left nil — both would cost a
+// GetGroupInfo round trip per message, and the group's title and size live in
+// whatsapp_chat_config, written by the gate.
+func parseMessage(ctx context.Context, evt *events.Message, own ownIdentity, resolver peerAltResolver) (IngestedMessage, string, bool) {
+	chat := normalizeServer(evt.Info.Chat).ToNonAD()
+	chatType, ok := classifyChat(chat, own)
+	if !ok {
+		return IngestedMessage{}, "", false
+	}
+
+	content := classifyMessage(evt.Message)
+	if content.Drop {
+		logger.Debug().
+			Str("message_id", evt.Info.ID).
+			Str("reason", content.DropReason).
+			Msg("whatsapp: message dropped as a non-conversational turn")
+		return IngestedMessage{}, "", false
+	}
+
+	msg := IngestedMessage{
+		MessageID: evt.Info.ID,
+		ChatJID:   chat.String(),
+		ChatType:  chatType,
+		// External data, stored verbatim: the acceleration rule governs clocks
+		// we compute, not timestamps we receive.
+		SentAt:        evt.Info.Timestamp,
+		IsOutgoing:    evt.Info.IsFromMe,
+		Body:          content.Body,
+		MessageType:   content.MessageType,
+		ReplyTargetID: content.ReplyTargetID,
+		AccountJID:    own.accountJID(),
+	}
+
+	// The push name is the SENDER's, so on an outbound message it is the
+	// user's own display name. Filling it there would flow the user's name into
+	// the peer's display name, into source_metadata.push_name, and — via the
+	// COALESCE-preserve discovery upsert — stickily onto the peer's own import
+	// candidate. One outbound DM would relabel an unknown peer as the user.
+	if !evt.Info.IsFromMe {
+		msg.PushName = nilIfEmptyString(evt.Info.PushName)
+	}
+
+	peer, altJID, hasPeer := resolvePeer(evt, chat, chatType)
+	if !hasPeer {
+		// An outbound group message has no counterpart: it stages with a null
+		// contact and never aggregates.
+		return msg, "", true
+	}
+
+	peerStr := peer.String()
+	msg.PeerJID = &peerStr
+
+	if e164, resolved := resolvePeerPhone(ctx, peer, altJID, resolver); resolved {
+		msg.PeerPhoneE164 = &e164
+		return msg, "", true
+	}
+	return msg, peerStr, true
+}
+
+// resolvePeer attributes the message to its counterpart, on normalized JIDs.
+// hasPeer=false is the outbound-group case, which is permanently unmatched by
+// design.
+func resolvePeer(evt *events.Message, chat types.JID, chatType string) (peer types.JID, altJID types.JID, hasPeer bool) {
+	if chatType == ChatTypePrivate {
+		// whatsmeow sets Chat to the OTHER party for a DM in both directions.
+		if evt.Info.IsFromMe {
+			return chat, normalizeServer(evt.Info.RecipientAlt).ToNonAD(), true
+		}
+		return chat, normalizeServer(evt.Info.SenderAlt).ToNonAD(), true
+	}
+	if evt.Info.IsFromMe {
+		return types.EmptyJID, types.EmptyJID, false
+	}
+	return normalizeServer(evt.Info.Sender).ToNonAD(), normalizeServer(evt.Info.SenderAlt).ToNonAD(), true
+}
+
+// resolvePeerPhone walks the four-rung ladder. The order is load-bearing: each
+// rung is cheaper and more certain than the next, and rung 4 (no phone) is a
+// real outcome rather than a failure — a LID-only peer stages unmatched and is
+// reachable through the import queue.
+func resolvePeerPhone(ctx context.Context, peer, altJID types.JID, resolver peerAltResolver) (string, bool) {
+	// 1. The peer is already addressed by phone number.
+	if candidate, ok := phoneCandidate(peer); ok {
+		return candidate, true
+	}
+	// 2. The stanza carried the peer's alternative address.
+	if candidate, ok := phoneCandidate(altJID); ok {
+		return candidate, true
+	}
+	// 3. The device store may already know the mapping. The explicit bound
+	//    matters because the dispatcher hands in an unbounded context.
+	if resolver != nil && peer.Server == types.HiddenUserServer {
+		altCtx, cancel := context.WithTimeout(ctx, altJIDTimeout)
+		resolved, err := resolver.GetAltJID(altCtx, peer)
+		cancel()
+		if err != nil {
+			// The ordinary unmapped case is (EmptyJID, nil), so an error here
+			// is exceptional rather than routine.
+			logger.Debug().Err(err).Msg("whatsapp: LID to phone lookup failed")
+		} else if candidate, ok := phoneCandidate(normalizeServer(resolved).ToNonAD()); ok {
+			return candidate, true
+		}
+	}
+	// 4. No phone. The caller reports the peer as unresolved.
+	return "", false
+}
+
+// phoneCandidate accepts a JID only when it is addressed on the phone-number
+// server AND its user part really is a subscriber number, then normalizes it to
+// E.164. A JID that fails either test degrades to the next rung rather than
+// minting a plausible-looking identifier.
+func phoneCandidate(jid types.JID) (string, bool) {
+	if jid.IsEmpty() || jid.Server != types.DefaultUserServer {
+		return "", false
+	}
+	if !phoneUserPattern.MatchString(jid.User) {
+		return "", false
+	}
+	e164 := identity.Normalize("+"+jid.User, identity.IdentifierTypeWhatsApp)
+	if e164 == "" {
+		return "", false
+	}
+	return e164, true
+}
+
+// nilIfEmptyString is the whatsapp twin of telegram's nilIfEmpty, needed for
+// the same reason: an empty string is a POPULATED value to a
+// COALESCE(EXCLUDED.x, …) upsert and would clobber a stored name.
+func nilIfEmptyString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// nilIfEmptyPtr is nilIfEmptyString for a value that is already a pointer.
+func nilIfEmptyPtr(s *string) *string {
+	if s == nil || *s == "" {
+		return nil
+	}
+	return s
+}

--- a/backend/internal/whatsapp/message.go
+++ b/backend/internal/whatsapp/message.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"context"
 	"regexp"
+	"time"
 
 	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/logger"
@@ -253,7 +254,10 @@ type peerAltResolver interface {
 // ChatTitle and MemberCount are deliberately left nil — both would cost a
 // GetGroupInfo round trip per message, and the group's title and size live in
 // whatsapp_chat_config, written by the gate.
-func parseMessage(ctx context.Context, evt *events.Message, own ownIdentity, resolver peerAltResolver) (IngestedMessage, string, bool) {
+// altTimeout bounds the device-store lookup. It is a parameter rather than the
+// package constant read directly so tests can shrink it without a mutable
+// global that a parallel test could race.
+func parseMessage(ctx context.Context, evt *events.Message, own ownIdentity, resolver peerAltResolver, altTimeout time.Duration) (IngestedMessage, string, bool) {
 	chat := normalizeServer(evt.Info.Chat).ToNonAD()
 	chatType, ok := classifyChat(chat, own)
 	if !ok {
@@ -302,7 +306,7 @@ func parseMessage(ctx context.Context, evt *events.Message, own ownIdentity, res
 	peerStr := peer.String()
 	msg.PeerJID = &peerStr
 
-	if e164, resolved := resolvePeerPhone(ctx, peer, altJID, resolver); resolved {
+	if e164, resolved := resolvePeerPhone(ctx, peer, altJID, resolver, altTimeout); resolved {
 		msg.PeerPhoneE164 = &e164
 		return msg, "", true
 	}
@@ -330,7 +334,7 @@ func resolvePeer(evt *events.Message, chat types.JID, chatType string) (peer typ
 // rung is cheaper and more certain than the next, and rung 4 (no phone) is a
 // real outcome rather than a failure — a LID-only peer stages unmatched and is
 // reachable through the import queue.
-func resolvePeerPhone(ctx context.Context, peer, altJID types.JID, resolver peerAltResolver) (string, bool) {
+func resolvePeerPhone(ctx context.Context, peer, altJID types.JID, resolver peerAltResolver, altTimeout time.Duration) (string, bool) {
 	// 1. The peer is already addressed by phone number.
 	if candidate, ok := phoneCandidate(peer); ok {
 		return candidate, true
@@ -342,7 +346,7 @@ func resolvePeerPhone(ctx context.Context, peer, altJID types.JID, resolver peer
 	// 3. The device store may already know the mapping. The explicit bound
 	//    matters because the dispatcher hands in an unbounded context.
 	if resolver != nil && peer.Server == types.HiddenUserServer {
-		altCtx, cancel := context.WithTimeout(ctx, altJIDTimeout)
+		altCtx, cancel := context.WithTimeout(ctx, altTimeout)
 		resolved, err := resolver.GetAltJID(altCtx, peer)
 		cancel()
 		if err != nil {

--- a/backend/internal/whatsapp/message.go
+++ b/backend/internal/whatsapp/message.go
@@ -94,22 +94,39 @@ func (o ownIdentity) isSelf(jid types.JID) bool {
 	return false
 }
 
-// accountJID is the value stamped onto comms_message.account_id.
+// canonicalAccountJID picks the single canonical string form of one account's
+// identity: the phone-number JID when known, else the internal id, always
+// normalized and non-AD.
+//
+// It is SHARED by the two places that must agree on that form — the parser,
+// which stamps it onto every message, and the group-info seam, which reports it
+// so the gate can refuse to ask the wrong account about a group. If those two
+// derived it independently and disagreed about which form represents an
+// account, every group message would look like it came from a different account
+// and the gate would withhold its ack forever.
 //
 // ToNonAD is load-bearing rather than decoration: the device store's own ID is
 // an AD JID and String() re-appends ":<device>" whenever the device number is
 // non-zero — and that number is reassigned on every re-link. Storing the AD
 // form would fragment account_id across exactly the re-pair this integration
 // has to survive.
-func (o ownIdentity) accountJID() *string {
-	source := o.PN
+func canonicalAccountJID(pn, lid types.JID) string {
+	source := pn
 	if source.IsEmpty() {
-		source = o.LID
+		source = lid
 	}
 	if source.IsEmpty() {
+		return ""
+	}
+	return normalizeServer(source).ToNonAD().String()
+}
+
+// accountJID is the value stamped onto comms_message.account_id.
+func (o ownIdentity) accountJID() *string {
+	out := canonicalAccountJID(o.PN, o.LID)
+	if out == "" {
 		return nil
 	}
-	out := normalizeServer(source).ToNonAD().String()
 	return &out
 }
 

--- a/backend/internal/whatsapp/message_test.go
+++ b/backend/internal/whatsapp/message_test.go
@@ -1,0 +1,521 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+// --- fixtures ---------------------------------------------------------------
+
+var (
+	testOwnPN    = types.NewJID("15550000001", types.DefaultUserServer)
+	testOwnLID   = types.NewJID("99900000001", types.HiddenUserServer)
+	testPeerPN   = types.NewJID("15559876543", types.DefaultUserServer)
+	testPeerLID  = types.NewJID("88800000002", types.HiddenUserServer)
+	testGroupJID = types.NewJID("120363000000000001", types.GroupServer)
+)
+
+func testOwn() ownIdentity { return ownIdentity{PN: testOwnPN, LID: testOwnLID} }
+
+// fakeAltResolver stands in for the device store's LID mapping.
+type fakeAltResolver struct {
+	result types.JID
+	err    error
+	// entered is closed on the first call and block, when non-nil, holds the
+	// resolver inside it — which is how the time bound is proved without
+	// sleeping for it.
+	entered chan struct{}
+	block   chan struct{}
+	calls   int
+}
+
+func (f *fakeAltResolver) GetAltJID(ctx context.Context, _ types.JID) (types.JID, error) {
+	f.calls++
+	if f.entered != nil {
+		close(f.entered)
+		f.entered = nil
+	}
+	if f.block != nil {
+		select {
+		case <-f.block:
+		case <-ctx.Done():
+			return types.EmptyJID, ctx.Err()
+		}
+	}
+	return f.result, f.err
+}
+
+func textEvent(id string, info types.MessageSource, body string) *events.Message {
+	return &events.Message{
+		Info: types.MessageInfo{
+			ID:            id,
+			MessageSource: info,
+			Timestamp:     time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		},
+		Message:    &waE2E.Message{Conversation: proto.String(body)},
+		RawMessage: &waE2E.Message{Conversation: proto.String(body)},
+	}
+}
+
+// --- normalizeServer --------------------------------------------------------
+
+func TestNormalizeServer_HostedBecomesDefaultUser(t *testing.T) {
+	got := normalizeServer(types.NewJID("15551234567", types.HostedServer))
+	assert.Equal(t, types.DefaultUserServer, got.Server)
+	assert.Equal(t, "15551234567", got.User, "only the server is rewritten")
+}
+
+func TestNormalizeServer_HostedLIDBecomesLID(t *testing.T) {
+	got := normalizeServer(types.NewJID("777000111", types.HostedLIDServer))
+	assert.Equal(t, types.HiddenUserServer, got.Server)
+}
+
+func TestNormalizeServer_LegacyBecomesDefaultUser(t *testing.T) {
+	got := normalizeServer(types.NewJID("15551234567", types.LegacyUserServer))
+	assert.Equal(t, types.DefaultUserServer, got.Server)
+}
+
+func TestNormalizeServer_UnknownServerUntouched(t *testing.T) {
+	for _, server := range []string{
+		types.GroupServer, types.BroadcastServer, types.NewsletterServer,
+		types.MessengerServer, types.BotServer, types.InteropServer, "future.server",
+	} {
+		got := normalizeServer(types.NewJID("x", server))
+		assert.Equal(t, server, got.Server, "%s must be left alone for the allowlist to judge", server)
+	}
+}
+
+// --- classifyChat -----------------------------------------------------------
+
+func TestChatEligibility_SelfChatRejected(t *testing.T) {
+	_, ok := classifyChat(normalizeServer(testOwnPN).ToNonAD(), testOwn())
+	assert.False(t, ok, "a note-to-self is not a conversation with anybody")
+}
+
+func TestChatEligibility_SelfChatInLIDFormRejected(t *testing.T) {
+	_, ok := classifyChat(normalizeServer(testOwnLID).ToNonAD(), testOwn())
+	assert.False(t, ok, "the same account addressed by its internal id is still the same account")
+}
+
+func TestChatEligibility_SelfChatInHostedFormRejected(t *testing.T) {
+	hosted := types.NewJID(testOwnPN.User, types.HostedServer)
+	_, ok := classifyChat(normalizeServer(hosted).ToNonAD(), testOwn())
+	assert.False(t, ok, "a device domain does not make the account a different person")
+}
+
+func TestChatEligibility_StatusBroadcastRejected(t *testing.T) {
+	_, ok := classifyChat(types.StatusBroadcastJID, testOwn())
+	assert.False(t, ok)
+}
+
+func TestChatEligibility_NewsletterRejected(t *testing.T) {
+	_, ok := classifyChat(types.NewJID("123", types.NewsletterServer), testOwn())
+	assert.False(t, ok, "a channel is a broadcast, not a person-to-person conversation")
+}
+
+func TestChatEligibility_UnknownServerRejected(t *testing.T) {
+	for _, server := range []string{types.BroadcastServer, types.MessengerServer, types.BotServer, "future.server"} {
+		_, ok := classifyChat(types.NewJID("x", server), testOwn())
+		assert.False(t, ok, "%s must fail closed", server)
+	}
+}
+
+func TestChatEligibility_DirectAndGroupAccepted(t *testing.T) {
+	chatType, ok := classifyChat(testPeerPN, testOwn())
+	require.True(t, ok)
+	assert.Equal(t, ChatTypePrivate, chatType)
+
+	chatType, ok = classifyChat(testPeerLID, testOwn())
+	require.True(t, ok)
+	assert.Equal(t, ChatTypePrivate, chatType, "a LID-addressed peer is still a person")
+
+	chatType, ok = classifyChat(testGroupJID, testOwn())
+	require.True(t, ok)
+	assert.Equal(t, ChatTypeGroup, chatType)
+}
+
+func TestChatEligibility_HostedDirectChatAccepted(t *testing.T) {
+	hosted := types.NewJID("15559876543", types.HostedServer)
+	chatType, ok := classifyChat(normalizeServer(hosted).ToNonAD(), testOwn())
+	require.True(t, ok, "a hosted-device chat is a real conversation, not an unrecognised server")
+	assert.Equal(t, ChatTypePrivate, chatType)
+}
+
+// --- classifyMessage --------------------------------------------------------
+
+func TestClassifyMessage_TextConversation(t *testing.T) {
+	got := classifyMessage(&waE2E.Message{Conversation: proto.String("hello")})
+	assert.False(t, got.Drop)
+	assert.Equal(t, MessageTypeText, got.MessageType)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "hello", *got.Body)
+	assert.Nil(t, got.ReplyTargetID)
+}
+
+func TestClassifyMessage_ExtendedTextCarriesReplyTarget(t *testing.T) {
+	got := classifyMessage(&waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+		Text:        proto.String("re: that"),
+		ContextInfo: &waE2E.ContextInfo{StanzaID: proto.String("ORIGINAL-1")},
+	}})
+	assert.Equal(t, MessageTypeText, got.MessageType)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "re: that", *got.Body)
+	require.NotNil(t, got.ReplyTargetID)
+	assert.Equal(t, "ORIGINAL-1", *got.ReplyTargetID)
+}
+
+func TestClassifyMessage_MediaTypesFromEnvelope(t *testing.T) {
+	caption := proto.String("look")
+	tests := []struct {
+		name     string
+		msg      *waE2E.Message
+		wantType string
+		wantBody *string
+	}{
+		{"image", &waE2E.Message{ImageMessage: &waE2E.ImageMessage{Caption: caption}}, MessageTypePhoto, caption},
+		{"video", &waE2E.Message{VideoMessage: &waE2E.VideoMessage{Caption: caption}}, MessageTypeVideo, caption},
+		{"ptv", &waE2E.Message{PtvMessage: &waE2E.VideoMessage{Caption: caption}}, MessageTypeVideo, caption},
+		{"audio", &waE2E.Message{AudioMessage: &waE2E.AudioMessage{}}, MessageTypeAudio, nil},
+		{"document", &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{Caption: caption}}, MessageTypeDocument, caption},
+		{"sticker", &waE2E.Message{StickerMessage: &waE2E.StickerMessage{}}, MessageTypeSticker, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyMessage(tt.msg)
+			assert.False(t, got.Drop)
+			assert.Equal(t, tt.wantType, got.MessageType)
+			if tt.wantBody == nil {
+				assert.Nil(t, got.Body)
+			} else {
+				require.NotNil(t, got.Body)
+				assert.Equal(t, *tt.wantBody, *got.Body)
+			}
+		})
+	}
+}
+
+func TestClassifyMessage_ProtocolMessageDropped(t *testing.T) {
+	got := classifyMessage(&waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+		Type: waE2E.ProtocolMessage_REVOKE.Enum(),
+	}})
+	assert.True(t, got.Drop, "an edit or a revoke is not a new conversational turn")
+	assert.Equal(t, dropReasonProtocol, got.DropReason)
+}
+
+func TestClassifyMessage_ReactionDropped(t *testing.T) {
+	got := classifyMessage(&waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{Text: proto.String("👍")}})
+	assert.True(t, got.Drop)
+	assert.Equal(t, dropReasonReaction, got.DropReason)
+}
+
+func TestClassifyMessage_PollVoteDropped(t *testing.T) {
+	got := classifyMessage(&waE2E.Message{PollUpdateMessage: &waE2E.PollUpdateMessage{}})
+	assert.True(t, got.Drop)
+	assert.Equal(t, dropReasonPollVote, got.DropReason)
+}
+
+func TestClassifyMessage_PollCreationStagesAsOther(t *testing.T) {
+	got := classifyMessage(&waE2E.Message{PollCreationMessage: &waE2E.PollCreationMessage{
+		Name: proto.String("Lunch where?"),
+	}})
+	assert.False(t, got.Drop, "creating a poll IS a conversational turn")
+	assert.Equal(t, MessageTypeOther, got.MessageType)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "Lunch where?", *got.Body)
+}
+
+// TestClassifyMessage_ReadsUnwrappedMessageNotRaw is the guard for the field the
+// parser must read: whatsmeow unwraps ephemeral / view-once / device-sent /
+// edited envelopes into Message before dispatch, so reading RawMessage would
+// classify every wrapped message as "other" with no body.
+func TestClassifyMessage_ReadsUnwrappedMessageNotRaw(t *testing.T) {
+	inner := &waE2E.Message{Conversation: proto.String("secret")}
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			ID:            "wrapped-1",
+			MessageSource: types.MessageSource{Chat: testPeerPN},
+			Timestamp:     accelerated.GetCurrentTime(),
+		},
+		Message: inner,
+		// The wire form still carries the wrapper.
+		RawMessage: &waE2E.Message{EphemeralMessage: &waE2E.FutureProofMessage{Message: inner}},
+	}
+
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	require.True(t, eligible)
+	assert.Equal(t, MessageTypeText, msg.MessageType)
+	require.NotNil(t, msg.Body)
+	assert.Equal(t, "secret", *msg.Body)
+}
+
+// --- peer resolution --------------------------------------------------------
+
+func TestPeerResolution_PhoneServerJID(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+
+	require.True(t, eligible)
+	assert.Empty(t, unresolved)
+	require.NotNil(t, msg.PeerPhoneE164)
+	assert.Equal(t, "+15559876543", *msg.PeerPhoneE164)
+}
+
+func TestPeerResolution_SenderAltCarriesPhone(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{
+		Chat:      testGroupJID,
+		Sender:    testPeerLID,
+		SenderAlt: testPeerPN,
+	}, "hi")
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+
+	require.True(t, eligible)
+	assert.Empty(t, unresolved)
+	require.NotNil(t, msg.PeerPhoneE164)
+	assert.Equal(t, "+15559876543", *msg.PeerPhoneE164)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, testPeerLID.String(), *msg.PeerJID, "the handle stays the raw peer JID")
+}
+
+func TestPeerResolution_RecipientAltOnOutboundDM(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{
+		Chat:         testPeerLID,
+		IsFromMe:     true,
+		RecipientAlt: testPeerPN,
+	}, "hi")
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+
+	require.True(t, eligible)
+	require.NotNil(t, msg.PeerPhoneE164)
+	assert.Equal(t, "+15559876543", *msg.PeerPhoneE164,
+		"an outbound DM carries the peer's alternative address under RecipientAlt, not SenderAlt")
+}
+
+func TestPeerResolution_GetAltJIDFallback(t *testing.T) {
+	resolver := &fakeAltResolver{result: testPeerPN}
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerLID}, "hi")
+
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), resolver)
+	require.True(t, eligible)
+	assert.Empty(t, unresolved)
+	assert.Equal(t, 1, resolver.calls)
+	require.NotNil(t, msg.PeerPhoneE164)
+	assert.Equal(t, "+15559876543", *msg.PeerPhoneE164)
+}
+
+// TestPeerResolution_GetAltJIDIsTimeBounded proves the store lookup cannot hang
+// the library's handler goroutine: the dispatcher hands in an UNBOUNDED context,
+// so the bound has to be applied here.
+func TestPeerResolution_GetAltJIDIsTimeBounded(t *testing.T) {
+	resolver := &fakeAltResolver{block: make(chan struct{})}
+	t.Cleanup(func() { close(resolver.block) })
+
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerLID}, "hi")
+
+	done := make(chan struct{})
+	var unresolved string
+	go func() {
+		defer close(done)
+		_, unresolved, _ = parseMessage(context.Background(), evt, testOwn(), resolver)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(altJIDTimeout + 5*time.Second):
+		t.Fatal("the LID lookup was not bounded; it would block whatsmeow's handler goroutine")
+	}
+	assert.NotEmpty(t, unresolved, "a timed-out lookup degrades to unresolved, it does not fail the message")
+}
+
+func TestPeerResolution_UnresolvableLIDStagesUnmatched(t *testing.T) {
+	resolver := &fakeAltResolver{err: errors.New("store down")}
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerLID}, "hi")
+
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), resolver)
+	require.True(t, eligible, "an unresolvable peer is still a real message")
+	assert.Nil(t, msg.PeerPhoneE164)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, testPeerLID.String(), *msg.PeerJID)
+	assert.Equal(t, testPeerLID.String(), unresolved, "the peer is reported so the gap is countable")
+}
+
+func TestPeerResolution_NonPhoneUserRejected(t *testing.T) {
+	// A phone-server JID whose user part is not a subscriber number: normalizing
+	// it would mint a plausible-looking identifier out of nothing.
+	weird := types.NewJID("not-a-number", types.DefaultUserServer)
+	evt := textEvent("m1", types.MessageSource{Chat: weird}, "hi")
+
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	require.True(t, eligible)
+	assert.Nil(t, msg.PeerPhoneE164)
+	assert.Equal(t, weird.String(), unresolved)
+}
+
+func TestPeerResolution_HostedPeerNormalizedToDefaultServer(t *testing.T) {
+	hosted := types.NewJID("15559876543", types.HostedServer)
+	evt := textEvent("m1", types.MessageSource{Chat: hosted}, "hi")
+
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	require.True(t, eligible)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, testPeerPN.String(), *msg.PeerJID,
+		"one human must produce one peer_handle across device domains")
+	require.NotNil(t, msg.PeerPhoneE164)
+	assert.Equal(t, "+15559876543", *msg.PeerPhoneE164)
+}
+
+// --- parseMessage -----------------------------------------------------------
+
+func TestParseMessage_DirectInboundPeerIsChat(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+
+	require.True(t, eligible)
+	assert.Equal(t, ChatTypePrivate, msg.ChatType)
+	assert.False(t, msg.IsOutgoing)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, testPeerPN.String(), *msg.PeerJID)
+	assert.Equal(t, testPeerPN.String(), msg.ChatJID)
+}
+
+func TestParseMessage_DirectOutboundPeerIsChat(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN, IsFromMe: true}, "hi")
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+
+	require.True(t, eligible)
+	assert.True(t, msg.IsOutgoing)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, testPeerPN.String(), *msg.PeerJID,
+		"whatsmeow names the OTHER party in Chat for a DM in both directions")
+}
+
+func TestParseMessage_GroupInboundPeerIsSender(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{
+		Chat:   testGroupJID,
+		Sender: testPeerPN,
+	}, "hi")
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+
+	require.True(t, eligible)
+	assert.Equal(t, ChatTypeGroup, msg.ChatType)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, testPeerPN.String(), *msg.PeerJID)
+	assert.Equal(t, testGroupJID.String(), msg.ChatJID)
+}
+
+func TestParseMessage_GroupOutboundHasNilPeer(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{
+		Chat:     testGroupJID,
+		Sender:   testOwnPN,
+		IsFromMe: true,
+	}, "hi")
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+
+	require.True(t, eligible, "an outbound group message is still stored")
+	assert.Nil(t, msg.PeerJID, "there is no single counterpart in a group I sent to")
+	assert.Nil(t, msg.PeerPhoneE164)
+	assert.Empty(t, unresolved, "a nil peer is not an unresolved one")
+}
+
+// TestParseMessage_OutboundDMCarriesNoPushName is the guard for the user's own
+// name leaking onto a peer's record. PushName is the SENDER's, so on an outbound
+// message it is the user's — and it would flow into the peer's display name,
+// into source_metadata, and stickily onto the peer's own import candidate.
+func TestParseMessage_OutboundDMCarriesNoPushName(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN, IsFromMe: true}, "hi")
+	evt.Info.PushName = "My Own Name"
+
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	require.True(t, eligible)
+	assert.Nil(t, msg.PushName, "one outbound DM must not relabel an unknown peer as the user")
+}
+
+func TestParseMessage_InboundDMCarriesPushName(t *testing.T) {
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
+	evt.Info.PushName = "Their Name"
+
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	require.True(t, eligible)
+	require.NotNil(t, msg.PushName)
+	assert.Equal(t, "Their Name", *msg.PushName)
+}
+
+// TestParseMessage_AccountJIDComesFromTheEmittingSession pins both halves: the
+// account JID is derived from the identity handed in (the emitting session's),
+// not read from anywhere global, and it is stored in NON-AD form so the device
+// number a re-link reassigns cannot fragment account_id.
+func TestParseMessage_AccountJIDComesFromTheEmittingSession(t *testing.T) {
+	adOwn := testOwnPN
+	adOwn.Device = 7
+	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
+
+	msg, _, eligible := parseMessage(context.Background(), evt, ownIdentity{PN: adOwn}, nil)
+	require.True(t, eligible)
+	require.NotNil(t, msg.AccountJID)
+	assert.Equal(t, testOwnPN.ToNonAD().String(), *msg.AccountJID)
+	assert.NotContains(t, *msg.AccountJID, ":", "an AD-form account id fragments across every re-link")
+
+	// A different session yields a different account id — nothing global is read.
+	other := types.NewJID("15550000009", types.DefaultUserServer)
+	msg2, _, _ := parseMessage(context.Background(), evt, ownIdentity{PN: other}, nil)
+	require.NotNil(t, msg2.AccountJID)
+	assert.Equal(t, other.String(), *msg2.AccountJID)
+}
+
+// TestParseMessage_FillsEveryLiveKnowableField is the corrected inverse of the
+// handler's doc comment: everything except ChatTitle and MemberCount is filled
+// for a fully-populated event, and those two are nil BY DESIGN.
+func TestParseMessage_FillsEveryLiveKnowableField(t *testing.T) {
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			ID: "full-1",
+			MessageSource: types.MessageSource{
+				Chat:      testGroupJID,
+				Sender:    testPeerLID,
+				SenderAlt: testPeerPN,
+			},
+			Timestamp: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+			PushName:  "Their Name",
+		},
+		Message: &waE2E.Message{ImageMessage: &waE2E.ImageMessage{
+			Caption:     proto.String("a photo"),
+			ContextInfo: &waE2E.ContextInfo{StanzaID: proto.String("ORIG-9")},
+		}},
+	}
+
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	require.True(t, eligible)
+	assert.Empty(t, unresolved)
+
+	assert.Equal(t, "full-1", msg.MessageID)
+	assert.Equal(t, testGroupJID.String(), msg.ChatJID)
+	assert.Equal(t, ChatTypeGroup, msg.ChatType)
+	assert.False(t, msg.IsOutgoing)
+	assert.Equal(t, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), msg.SentAt)
+	assert.Equal(t, MessageTypePhoto, msg.MessageType)
+	require.NotNil(t, msg.Body)
+	assert.Equal(t, "a photo", *msg.Body)
+	require.NotNil(t, msg.ReplyTargetID)
+	assert.Equal(t, "ORIG-9", *msg.ReplyTargetID)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, testPeerLID.String(), *msg.PeerJID)
+	require.NotNil(t, msg.PeerPhoneE164)
+	assert.Equal(t, "+15559876543", *msg.PeerPhoneE164)
+	require.NotNil(t, msg.PushName)
+	assert.Equal(t, "Their Name", *msg.PushName)
+	require.NotNil(t, msg.AccountJID)
+	assert.Equal(t, testOwnPN.String(), *msg.AccountJID)
+
+	assert.Nil(t, msg.ChatTitle, "the live parser makes no group-metadata call, by design")
+	assert.Nil(t, msg.MemberCount, "the size lives in whatsapp_chat_config, written by the gate")
+}

--- a/backend/internal/whatsapp/message_test.go
+++ b/backend/internal/whatsapp/message_test.go
@@ -28,6 +28,11 @@ var (
 
 func testOwn() ownIdentity { return ownIdentity{PN: testOwnPN, LID: testOwnLID} }
 
+// testAltTimeout keeps the bounded-lookup tests off the production 3s bound —
+// the point of those tests is that a bound EXISTS, not how long it is, and
+// spending the real one in wall clock buys nothing.
+const testAltTimeout = 50 * time.Millisecond
+
 // fakeAltResolver stands in for the device store's LID mapping.
 type fakeAltResolver struct {
 	result types.JID
@@ -252,7 +257,7 @@ func TestClassifyMessage_ReadsUnwrappedMessageNotRaw(t *testing.T) {
 		RawMessage: &waE2E.Message{EphemeralMessage: &waE2E.FutureProofMessage{Message: inner}},
 	}
 
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 	require.True(t, eligible)
 	assert.Equal(t, MessageTypeText, msg.MessageType)
 	require.NotNil(t, msg.Body)
@@ -263,7 +268,7 @@ func TestClassifyMessage_ReadsUnwrappedMessageNotRaw(t *testing.T) {
 
 func TestPeerResolution_PhoneServerJID(t *testing.T) {
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
-	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 
 	require.True(t, eligible)
 	assert.Empty(t, unresolved)
@@ -277,7 +282,7 @@ func TestPeerResolution_SenderAltCarriesPhone(t *testing.T) {
 		Sender:    testPeerLID,
 		SenderAlt: testPeerPN,
 	}, "hi")
-	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 
 	require.True(t, eligible)
 	assert.Empty(t, unresolved)
@@ -293,7 +298,7 @@ func TestPeerResolution_RecipientAltOnOutboundDM(t *testing.T) {
 		IsFromMe:     true,
 		RecipientAlt: testPeerPN,
 	}, "hi")
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 
 	require.True(t, eligible)
 	require.NotNil(t, msg.PeerPhoneE164)
@@ -305,7 +310,7 @@ func TestPeerResolution_GetAltJIDFallback(t *testing.T) {
 	resolver := &fakeAltResolver{result: testPeerPN}
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerLID}, "hi")
 
-	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), resolver)
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), resolver, testAltTimeout)
 	require.True(t, eligible)
 	assert.Empty(t, unresolved)
 	assert.Equal(t, 1, resolver.calls)
@@ -326,12 +331,12 @@ func TestPeerResolution_GetAltJIDIsTimeBounded(t *testing.T) {
 	var unresolved string
 	go func() {
 		defer close(done)
-		_, unresolved, _ = parseMessage(context.Background(), evt, testOwn(), resolver)
+		_, unresolved, _ = parseMessage(context.Background(), evt, testOwn(), resolver, testAltTimeout)
 	}()
 
 	select {
 	case <-done:
-	case <-time.After(altJIDTimeout + 5*time.Second):
+	case <-time.After(testAltTimeout + 5*time.Second):
 		t.Fatal("the LID lookup was not bounded; it would block whatsmeow's handler goroutine")
 	}
 	assert.NotEmpty(t, unresolved, "a timed-out lookup degrades to unresolved, it does not fail the message")
@@ -341,7 +346,7 @@ func TestPeerResolution_UnresolvableLIDStagesUnmatched(t *testing.T) {
 	resolver := &fakeAltResolver{err: errors.New("store down")}
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerLID}, "hi")
 
-	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), resolver)
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), resolver, testAltTimeout)
 	require.True(t, eligible, "an unresolvable peer is still a real message")
 	assert.Nil(t, msg.PeerPhoneE164)
 	require.NotNil(t, msg.PeerJID)
@@ -355,7 +360,7 @@ func TestPeerResolution_NonPhoneUserRejected(t *testing.T) {
 	weird := types.NewJID("not-a-number", types.DefaultUserServer)
 	evt := textEvent("m1", types.MessageSource{Chat: weird}, "hi")
 
-	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 	require.True(t, eligible)
 	assert.Nil(t, msg.PeerPhoneE164)
 	assert.Equal(t, weird.String(), unresolved)
@@ -365,7 +370,7 @@ func TestPeerResolution_HostedPeerNormalizedToDefaultServer(t *testing.T) {
 	hosted := types.NewJID("15559876543", types.HostedServer)
 	evt := textEvent("m1", types.MessageSource{Chat: hosted}, "hi")
 
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 	require.True(t, eligible)
 	require.NotNil(t, msg.PeerJID)
 	assert.Equal(t, testPeerPN.String(), *msg.PeerJID,
@@ -378,7 +383,7 @@ func TestPeerResolution_HostedPeerNormalizedToDefaultServer(t *testing.T) {
 
 func TestParseMessage_DirectInboundPeerIsChat(t *testing.T) {
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 
 	require.True(t, eligible)
 	assert.Equal(t, ChatTypePrivate, msg.ChatType)
@@ -390,7 +395,7 @@ func TestParseMessage_DirectInboundPeerIsChat(t *testing.T) {
 
 func TestParseMessage_DirectOutboundPeerIsChat(t *testing.T) {
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN, IsFromMe: true}, "hi")
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 
 	require.True(t, eligible)
 	assert.True(t, msg.IsOutgoing)
@@ -404,7 +409,7 @@ func TestParseMessage_GroupInboundPeerIsSender(t *testing.T) {
 		Chat:   testGroupJID,
 		Sender: testPeerPN,
 	}, "hi")
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 
 	require.True(t, eligible)
 	assert.Equal(t, ChatTypeGroup, msg.ChatType)
@@ -419,7 +424,7 @@ func TestParseMessage_GroupOutboundHasNilPeer(t *testing.T) {
 		Sender:   testOwnPN,
 		IsFromMe: true,
 	}, "hi")
-	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 
 	require.True(t, eligible, "an outbound group message is still stored")
 	assert.Nil(t, msg.PeerJID, "there is no single counterpart in a group I sent to")
@@ -435,7 +440,7 @@ func TestParseMessage_OutboundDMCarriesNoPushName(t *testing.T) {
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN, IsFromMe: true}, "hi")
 	evt.Info.PushName = "My Own Name"
 
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 	require.True(t, eligible)
 	assert.Nil(t, msg.PushName, "one outbound DM must not relabel an unknown peer as the user")
 }
@@ -444,7 +449,7 @@ func TestParseMessage_InboundDMCarriesPushName(t *testing.T) {
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
 	evt.Info.PushName = "Their Name"
 
-	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 	require.True(t, eligible)
 	require.NotNil(t, msg.PushName)
 	assert.Equal(t, "Their Name", *msg.PushName)
@@ -459,7 +464,7 @@ func TestParseMessage_AccountJIDComesFromTheEmittingSession(t *testing.T) {
 	adOwn.Device = 7
 	evt := textEvent("m1", types.MessageSource{Chat: testPeerPN}, "hi")
 
-	msg, _, eligible := parseMessage(context.Background(), evt, ownIdentity{PN: adOwn}, nil)
+	msg, _, eligible := parseMessage(context.Background(), evt, ownIdentity{PN: adOwn}, nil, testAltTimeout)
 	require.True(t, eligible)
 	require.NotNil(t, msg.AccountJID)
 	assert.Equal(t, testOwnPN.ToNonAD().String(), *msg.AccountJID)
@@ -467,7 +472,7 @@ func TestParseMessage_AccountJIDComesFromTheEmittingSession(t *testing.T) {
 
 	// A different session yields a different account id — nothing global is read.
 	other := types.NewJID("15550000009", types.DefaultUserServer)
-	msg2, _, _ := parseMessage(context.Background(), evt, ownIdentity{PN: other}, nil)
+	msg2, _, _ := parseMessage(context.Background(), evt, ownIdentity{PN: other}, nil, testAltTimeout)
 	require.NotNil(t, msg2.AccountJID)
 	assert.Equal(t, other.String(), *msg2.AccountJID)
 }
@@ -493,7 +498,7 @@ func TestParseMessage_FillsEveryLiveKnowableField(t *testing.T) {
 		}},
 	}
 
-	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil)
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
 	require.True(t, eligible)
 	assert.Empty(t, unresolved)
 

--- a/backend/internal/whatsapp/types.go
+++ b/backend/internal/whatsapp/types.go
@@ -215,6 +215,8 @@ type Status struct {
 	// Backfill reports the history drain. PR3 records notifications; the
 	// counts stay zero until a chunk arrives.
 	Backfill BackfillStatus `json:"backfill"`
+	// Ingest reports what the live message path observed.
+	Ingest IngestStatus `json:"ingest"`
 }
 
 // clone deep-copies every pointer target.
@@ -225,6 +227,9 @@ type Status struct {
 // clones what it read — because either alone leaves a mutable path: publish-only
 // lets two concurrent readers share targets, read-only lets the loop keep
 // aliases into what it published.
+//
+// IngestStatus holds no pointers, so the exhaustiveness claim above stays true
+// without a line for it.
 func (s Status) clone() Status {
 	out := s
 	out.JID = cloneStringPtr(s.JID)
@@ -288,6 +293,17 @@ type BackfillStatus struct {
 	Stale bool `json:"stale,omitempty"`
 }
 
+// IngestStatus is what the live message path observed since this process
+// started. It is deliberately NOT persisted: it reports the current process's
+// view, so a restart resets it to zero.
+type IngestStatus struct {
+	// UnresolvedLIDPeers counts DISTINCT peers whose phone number could not be
+	// recovered from their LID. Their messages stage without a contact and can
+	// reach one only through the import queue, so the count is the visible size
+	// of that gap — not a message volume.
+	UnresolvedLIDPeers int `json:"unresolved_lid_peers"`
+}
+
 // Pairing is the in-flight pairing attempt. There is no session token: only one
 // pairing runs at a time and its state is read back through the status
 // endpoint.
@@ -338,6 +354,33 @@ type IngestedMessage struct {
 	PeerPhoneE164 *string // nil when unresolvable
 	PushName      *string
 	MemberCount   *int // groups only
+	// AccountJID is the EMITTING session's own JID, in non-AD form. It is
+	// carried per event rather than read from the published snapshot: during a
+	// re-pair a snapshot read would stamp a retired session's in-flight message
+	// with the new account's JID, and the non-AD form is what stops the device
+	// number a re-link reassigns from fragmenting account_id.
+	AccountJID *string
+}
+
+// ChatGroupInfo is a group's metadata, projected off whatsmeow's types.
+type ChatGroupInfo struct {
+	Title       string
+	MemberCount int
+}
+
+// GroupInfoFetcher is the seam the group gate uses to reach the live client for
+// the one metadata call this integration makes. It is defined on the manager so
+// the gate never holds a *whatsmeow.Client.
+type GroupInfoFetcher interface {
+	GroupInfo(ctx context.Context, chatJID string) (*ChatGroupInfo, error)
+}
+
+// GroupInfoBinder is implemented by an ingestor that needs to reach the live
+// client for group metadata. SetIngestor binds it, so an ingestor cannot be
+// installed without its source — there is no window in which one is installed
+// and the other is not.
+type GroupInfoBinder interface {
+	BindGroupInfoSource(src func() GroupInfoFetcher)
 }
 
 // MessageIngestor is the projected-message path: live messages now, and the

--- a/backend/internal/whatsapp/types.go
+++ b/backend/internal/whatsapp/types.go
@@ -297,10 +297,16 @@ type BackfillStatus struct {
 // started. It is deliberately NOT persisted: it reports the current process's
 // view, so a restart resets it to zero.
 type IngestStatus struct {
-	// UnresolvedLIDPeers counts DISTINCT peers whose phone number could not be
-	// recovered from their LID. Their messages stage without a contact and can
-	// reach one only through the import queue, so the count is the visible size
-	// of that gap — not a message volume.
+	// UnresolvedLIDPeers counts DISTINCT peers OBSERVED whose phone number
+	// could not be recovered from their LID. Such a peer cannot be matched to a
+	// contact automatically, so any message of theirs that IS stored is stored
+	// without one and can reach a contact only through the import queue.
+	//
+	// It counts peers observed, NOT peers whose messages were stored: a sender
+	// in a group the size gate declines to track is counted too. The number is
+	// therefore how much of the conversation graph the integration cannot
+	// attribute on its own — not a count of unattributed rows, and not a
+	// message volume. It saturates at maxUnresolvedLIDPeers.
 	UnresolvedLIDPeers int `json:"unresolved_lid_peers"`
 }
 
@@ -373,6 +379,17 @@ type ChatGroupInfo struct {
 // the gate never holds a *whatsmeow.Client.
 type GroupInfoFetcher interface {
 	GroupInfo(ctx context.Context, chatJID string) (*ChatGroupInfo, error)
+	// AccountJID reports which linked account this fetcher's client belongs to,
+	// in the same non-AD form IngestedMessage.AccountJID carries, or "" when it
+	// cannot be determined.
+	//
+	// It exists because the fetcher is resolved from the PUBLISHED session while
+	// a message is parsed against its EMITTING one. During an overlapping
+	// re-pair those differ, and asking the new account about a group only the
+	// old account was in answers "not in that group" — which the gate treats as
+	// a permanent decision and would therefore acknowledge and drop the message
+	// for good. Comparing the two identities turns that into a withheld ack.
+	AccountJID() string
 }
 
 // GroupInfoBinder is implemented by an ingestor that needs to reach the live

--- a/backend/tests/api/whatsapp_auth_api_test.go
+++ b/backend/tests/api/whatsapp_auth_api_test.go
@@ -498,6 +498,42 @@ func TestAPI_WhatsAppStatusReportsBackfillCounts(t *testing.T) {
 	assert.Equal(t, floor.Format(time.RFC3339), *backfill.ObservedFloorAt)
 }
 
+// TestAPI_WhatsAppStatusReportsUnresolvedLIDPeers is the wire contract for the
+// ingest observation: a peer the integration could not resolve to a phone number
+// is reachable only through the import queue, so the size of that gap has to be
+// visible.
+//
+// The count is driven to two DISTINCT values, which is what makes the test able
+// to fail: a dropped field, a field that is never mapped, and a field mapped to
+// a constant all fail here, where an assertion that "the key exists" or that "a
+// zero was serialized" would pass against every one of them. The end-to-end
+// drive — two unresolvable peers actually producing a count of two — is
+// TestStatus_ReportsUnresolvedLIDCount, in the package that owns the counter.
+func TestAPI_WhatsAppStatusReportsUnresolvedLIDPeers(t *testing.T) {
+	// spec: WHA-007.status-reports-unresolved-lid-peers
+	for _, want := range []int{0, 2} {
+		manager := &fakeWhatsAppManager{status: wapkg.Status{
+			Configured: true,
+			State:      wapkg.StateConnected,
+			Ingest:     wapkg.IngestStatus{UnresolvedLIDPeers: want},
+		}}
+		router := setupWhatsAppRouter(t, manager)
+
+		rec := doWhatsAppRequest(t, router, http.MethodGet, "/api/v1/whatsapp/auth/status", nil)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, want, decodeWhatsAppStatus(t, rec).Ingest.UnresolvedLIDPeers,
+			"the reported count must track the integration's own, not a constant")
+	}
+
+	// And the field is always present, including at zero: a client cannot tell
+	// "no unresolved peers" from "this build does not report it" if it vanishes.
+	router := setupWhatsAppRouter(t, &fakeWhatsAppManager{status: wapkg.Status{Configured: true, State: wapkg.StateConnected}})
+	rec := doWhatsAppRequest(t, router, http.MethodGet, "/api/v1/whatsapp/auth/status", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"unresolved_lid_peers":0`)
+}
+
 func TestAPI_WhatsAppStatusNamesTheMissingDependency(t *testing.T) {
 	// spec: WHA-007.status-reports-not-ready-reason
 	router := setupWhatsAppRouter(t, &fakeWhatsAppManager{status: wapkg.Status{

--- a/backend/tests/telegram_discovery_upsert_test.go
+++ b/backend/tests/telegram_discovery_upsert_test.go
@@ -62,7 +62,7 @@ func setupDiscoveryUpsertTest(t *testing.T) (
 	return repo, database, prefix, cleanup
 }
 
-func TestUpsertTelegramDiscoveryCandidate_InsertsNewRow(t *testing.T) {
+func TestUpsertDiscoveryCandidate_InsertsNewRow(t *testing.T) {
 	t.Parallel()
 	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -70,7 +70,8 @@ func TestUpsertTelegramDiscoveryCandidate_InsertsNewRow(t *testing.T) {
 	ctx := context.Background()
 	now := accelerated.GetCurrentTime()
 
-	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:      "telegram",
 		SourceID:    prefix + "insert",
 		DisplayName: strPtr("Dale Dobeck"),
 		FirstName:   strPtr("Dale"),
@@ -95,7 +96,82 @@ func TestUpsertTelegramDiscoveryCandidate_InsertsNewRow(t *testing.T) {
 	assert.Equal(t, repository.MatchStatusUnmatched, got.MatchStatus)
 }
 
-func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T) {
+// TestUpsertDiscoveryCandidate_TelegramSemanticsUnchanged is the regression
+// guard for source-parameterizing what used to be a Telegram-only query: the
+// four semantics a divergence would silently break, asserted on one row.
+func TestUpsertDiscoveryCandidate_TelegramSemanticsUnchanged(t *testing.T) {
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+	sourceID := prefix + "semantics"
+
+	seeded, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source: "telegram", SourceID: sourceID,
+		DisplayName: strPtr("Dale Dobeck"), FirstName: strPtr("Dale"), LastName: strPtr("Dobeck"),
+		Metadata: map[string]any{"username": "@daledobeck", "message_count": 5},
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+	require.Equal(t, repository.MatchStatusUnmatched, seeded.MatchStatus)
+
+	// A nil name preserves; a non-nil name overwrites; metadata merges with the
+	// incoming value winning per key; match_status is untouched.
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source: "telegram", SourceID: sourceID,
+		FirstName: nil, LastName: strPtr("Renamed"),
+		Metadata: map[string]any{"message_count": 9},
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.FirstName)
+	assert.Equal(t, "Dale", *got.FirstName, "a nil name never clears a captured one")
+	require.NotNil(t, got.LastName)
+	assert.Equal(t, "Renamed", *got.LastName, "a non-nil name does overwrite")
+	assert.Equal(t, "@daledobeck", got.Metadata["username"], "keys the new map omits are retained")
+	assert.EqualValues(t, 9, got.Metadata["message_count"], "and the incoming value wins per key")
+	assert.Equal(t, repository.MatchStatusUnmatched, got.MatchStatus, "match_status is never touched")
+}
+
+// TestUpsertDiscoveryCandidate_WhatsAppRowUsesSameSemantics proves the source
+// really is a parameter and not a decoration: the identical sequence on a
+// whatsapp row behaves identically.
+func TestUpsertDiscoveryCandidate_WhatsAppRowUsesSameSemantics(t *testing.T) {
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+	sourceID := prefix + "wa@lid"
+
+	_, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source: "whatsapp", SourceID: sourceID,
+		DisplayName: strPtr("WhatsApp 8880001"),
+		Metadata:    map[string]any{"peer_jid": sourceID, "message_count": 3},
+		SyncedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source: "whatsapp", SourceID: sourceID,
+		DisplayName: strPtr("Their Name"),
+		Metadata:    map[string]any{"message_count": 7, "phone_e164": "+15559876543"},
+		SyncedAt:    &now,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "whatsapp", got.Source)
+	require.NotNil(t, got.DisplayName)
+	assert.Equal(t, "Their Name", *got.DisplayName, "a later push name upgrades the JID label")
+	assert.Equal(t, sourceID, got.Metadata["peer_jid"], "earlier keys survive the merge")
+	assert.EqualValues(t, 7, got.Metadata["message_count"])
+	assert.Equal(t, "+15559876543", got.Metadata["phone_e164"])
+	assert.Equal(t, repository.MatchStatusUnmatched, got.MatchStatus)
+}
+
+func TestUpsertDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T) {
 	t.Parallel()
 	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -104,7 +180,8 @@ func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T
 	now := accelerated.GetCurrentTime()
 
 	// Seed with names populated.
-	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	_, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:    "telegram",
 		SourceID:  prefix + "preserve",
 		FirstName: strPtr("Dale"),
 		LastName:  strPtr("Dobeck"),
@@ -113,7 +190,8 @@ func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T
 	require.NoError(t, err)
 
 	// Re-upsert with nil names — should preserve existing.
-	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "preserve",
 		SyncedAt: &now,
 	})
@@ -124,7 +202,7 @@ func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T
 	assert.Equal(t, "Dobeck", *got.LastName)
 }
 
-func TestUpsertTelegramDiscoveryCandidate_OverwritesFirstNameWhenNewValueProvided(t *testing.T) {
+func TestUpsertDiscoveryCandidate_OverwritesFirstNameWhenNewValueProvided(t *testing.T) {
 	t.Parallel()
 	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -132,14 +210,16 @@ func TestUpsertTelegramDiscoveryCandidate_OverwritesFirstNameWhenNewValueProvide
 	ctx := context.Background()
 	now := accelerated.GetCurrentTime()
 
-	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	_, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:    "telegram",
 		SourceID:  prefix + "overwrite",
 		FirstName: strPtr("Dale"),
 		SyncedAt:  &now,
 	})
 	require.NoError(t, err)
 
-	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:    "telegram",
 		SourceID:  prefix + "overwrite",
 		FirstName: strPtr("Daniel"),
 		SyncedAt:  &now,
@@ -149,7 +229,7 @@ func TestUpsertTelegramDiscoveryCandidate_OverwritesFirstNameWhenNewValueProvide
 	assert.Equal(t, "Daniel", *got.FirstName)
 }
 
-func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t *testing.T) {
+func TestUpsertDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t *testing.T) {
 	t.Parallel()
 	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -158,7 +238,8 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t 
 	now := accelerated.GetCurrentTime()
 
 	// Seed with a username key.
-	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	_, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "merge-keep",
 		Metadata: map[string]any{"username": "@dale", "message_count": 5},
 		SyncedAt: &now,
@@ -166,7 +247,8 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t 
 	require.NoError(t, err)
 
 	// Re-upsert with only message_count — username must be retained.
-	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "merge-keep",
 		Metadata: map[string]any{"message_count": 10},
 		SyncedAt: &now,
@@ -176,7 +258,7 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t 
 	assert.EqualValues(t, 10, got.Metadata["message_count"], "incoming message_count should win for the duplicate key")
 }
 
-func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_IncomingWinsForDuplicate(t *testing.T) {
+func TestUpsertDiscoveryCandidate_MergesMetadata_IncomingWinsForDuplicate(t *testing.T) {
 	t.Parallel()
 	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -184,14 +266,16 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_IncomingWinsForDuplicat
 	ctx := context.Background()
 	now := accelerated.GetCurrentTime()
 
-	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	_, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "merge-new",
 		Metadata: map[string]any{"username": "@old"},
 		SyncedAt: &now,
 	})
 	require.NoError(t, err)
 
-	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "merge-new",
 		Metadata: map[string]any{"username": "@new"},
 		SyncedAt: &now,
@@ -200,7 +284,7 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_IncomingWinsForDuplicat
 	assert.Equal(t, "@new", got.Metadata["username"])
 }
 
-func TestUpsertTelegramDiscoveryCandidate_SyncedAtAlwaysUpdates(t *testing.T) {
+func TestUpsertDiscoveryCandidate_SyncedAtAlwaysUpdates(t *testing.T) {
 	t.Parallel()
 	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -208,14 +292,16 @@ func TestUpsertTelegramDiscoveryCandidate_SyncedAtAlwaysUpdates(t *testing.T) {
 	ctx := context.Background()
 
 	start := accelerated.GetCurrentTime()
-	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	_, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "syncedat",
 		SyncedAt: &start,
 	})
 	require.NoError(t, err)
 
 	later := start.Add(1 * time.Hour)
-	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	got, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "syncedat",
 		SyncedAt: &later,
 	})
@@ -224,10 +310,10 @@ func TestUpsertTelegramDiscoveryCandidate_SyncedAtAlwaysUpdates(t *testing.T) {
 	assert.WithinDuration(t, later, *got.SyncedAt, time.Second)
 }
 
-// TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert
+// TestUpsertDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert
 // proves the dedicated DO UPDATE SET only touches the 6 columns it manages —
 // anything seeded via the shared Upsert (emails, phones, etc.) is untouched.
-func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t *testing.T) {
+func TestUpsertDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t *testing.T) {
 	t.Parallel()
 	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -245,7 +331,8 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t 
 	require.NoError(t, err)
 
 	// Call the dedicated upsert with only names.
-	_, err = repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	_, err = repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:    "telegram",
 		SourceID:  prefix + "emails",
 		FirstName: strPtr("Dale"),
 		Metadata:  map[string]any{"username": "@dale"},
@@ -260,7 +347,7 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t 
 	assert.Equal(t, "a@x", got.Emails[0].Value, "existing email should survive the Telegram-specific upsert")
 }
 
-func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) {
+func TestUpsertDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) {
 	t.Parallel()
 	repo, database, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
@@ -275,7 +362,8 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) 
 	crmContact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
 	defer contactCleanup()
 
-	row, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	row, err := repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:   "telegram",
 		SourceID: prefix + "match",
 		SyncedAt: &now,
 	})
@@ -284,7 +372,8 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) 
 	_, err = repo.UpdateMatch(ctx, row.ID, &crmContact.ID, repository.MatchStatusMatched)
 	require.NoError(t, err)
 
-	_, err = repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+	_, err = repo.UpsertDiscoveryCandidate(ctx, repository.UpsertDiscoveryCandidateRequest{
+		Source:    "telegram",
 		SourceID:  prefix + "match",
 		FirstName: strPtr("Dale"),
 		SyncedAt:  &now,

--- a/backend/tests/whatsapp_ingest_test.go
+++ b/backend/tests/whatsapp_ingest_test.go
@@ -26,15 +26,21 @@ import (
 // stubGroupInfo is the group-metadata seam. Production reaches a live client;
 // no test may.
 type stubGroupInfo struct {
-	info  *whatsapp.ChatGroupInfo
-	err   error
-	calls int
+	info    *whatsapp.ChatGroupInfo
+	err     error
+	calls   int
+	account string
 }
 
 func (s *stubGroupInfo) GroupInfo(context.Context, string) (*whatsapp.ChatGroupInfo, error) {
 	s.calls++
 	return s.info, s.err
 }
+
+// AccountJID reports which linked account this fetcher's client belongs to. The
+// harness always answers with the account its projected messages carry, so the
+// gate's re-pair guard never fires on an unrelated test.
+func (s *stubGroupInfo) AccountJID() string { return s.account }
 
 // injectedFailure wraps the real repository so ONE call can be made to fail
 // without faking the rest of the write path.
@@ -123,6 +129,7 @@ func setupIngestTest(t *testing.T) *ingestEnv {
 		group:       &stubGroupInfo{info: &whatsapp.ChatGroupInfo{Title: "Book Club", MemberCount: 3}},
 		ns:          syntheticNS(t),
 	}
+	env.group.account = env.accountJID()
 	env.comms.SetPool(database.Pool)
 
 	fixtures := repository.NewTestJSONBFixturesRepository(database.Queries)
@@ -157,6 +164,9 @@ func (e *ingestEnv) lidJID(name string) string { return e.ns + name + "@lid" }
 
 func (e *ingestEnv) groupJID() string { return e.ns + "group@g.us" }
 
+// accountJID is the linked account every projected message in this test carries.
+func (e *ingestEnv) accountJID() string { return e.ns + "own@s.whatsapp.net" }
+
 // uniquePhone mints an E.164 no other test shares, so identity matching cannot
 // collide with another test's contact across the shared package DB.
 func (e *ingestEnv) uniquePhone(t *testing.T) string {
@@ -190,7 +200,7 @@ func strPtr2(s string) *string { return &s }
 
 // msg builds a projected message with inbound private-DM defaults.
 func (e *ingestEnv) msg(externalID, peerJID string, opts ...func(*whatsapp.IngestedMessage)) whatsapp.IngestedMessage {
-	account := e.ns + "own@s.whatsapp.net"
+	account := e.accountJID()
 	m := whatsapp.IngestedMessage{
 		MessageID:   externalID,
 		ChatJID:     peerJID,
@@ -404,7 +414,7 @@ func TestIngest_SourceMetadataCarriesReplyTarget(t *testing.T) {
 	assert.Equal(t, whatsapp.ChatTypePrivate, meta["chat_type"])
 	assert.Nil(t, row.Snippet, "the snippet stays nil: nothing on this route reads it")
 	require.NotNil(t, row.AccountID)
-	assert.Equal(t, env.ns+"own@s.whatsapp.net", *row.AccountID)
+	assert.Equal(t, env.accountJID(), *row.AccountID)
 }
 
 func TestIngest_RedeliveryIsIdempotent(t *testing.T) {
@@ -651,10 +661,46 @@ func TestGroupGate_PersistsAcrossRestart(t *testing.T) {
 	// FAIL if it were reached at all.
 	restarted := whatsapp.NewChatGate(env.waRepo, 10)
 	restarted.BindGroupInfoSource(func() whatsapp.GroupInfoFetcher {
-		return &stubGroupInfo{err: errors.New("must not be reached after a restart")}
+		return &stubGroupInfo{account: env.accountJID(), err: errors.New("must not be reached after a restart")}
 	})
 
-	tracked, err := restarted.ShouldTrack(env.ctx, env.groupJID(), whatsapp.ChatTypeGroup)
+	tracked, err := restarted.ShouldTrack(env.ctx, env.groupJID(), whatsapp.ChatTypeGroup, env.accountJID())
 	require.NoError(t, err, "the persisted count answers without a lookup")
 	assert.True(t, tracked)
+}
+
+// TestIngest_MissingMessageIDIsRefused is the symmetric twin of the staging
+// layer's missing-thread refusal. The live parser always supplies an id, but the
+// history drainer builds IngestedMessage by hand, and a row with no id is
+// staged and then permanently unreachable — dedup, the twin reconciliation and
+// the reply bridge all key on it.
+func TestIngest_MissingMessageIDIsRefused(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	msg := env.msg(env.extID(1), env.peerJID("noid"))
+	msg.MessageID = ""
+
+	err := env.ingestor.IngestMessage(env.ctx, msg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, whatsapp.ErrIngestMissingMessageID)
+	assert.Zero(t, env.liveUnmatched(t, env.peerJID("noid")), "and nothing is staged")
+}
+
+// TestIngest_GroupMessageFromAnotherAccountWithholdsAck is the re-pair guard at
+// the ingest boundary: the connected client belongs to a different account than
+// the one that observed the message, so its "not in that group" answer is not
+// this account's answer and must not be consumed.
+func TestIngest_GroupMessageFromAnotherAccountWithholdsAck(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	env.group.account = "15559999999@s.whatsapp.net"
+	env.group.info = nil
+	env.group.err = errors.New("status 403")
+
+	err := env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), env.peerJID("member"), withGroupChat(env.groupJID())))
+	require.Error(t, err, "acking a wrong-account answer would drop the message for good")
+	assert.ErrorIs(t, err, whatsapp.ErrChatGateUndecided)
+	assert.Zero(t, env.group.calls, "and the wrong client is never asked")
+	env.noStoredRow(t, env.extID(1))
 }

--- a/backend/tests/whatsapp_ingest_test.go
+++ b/backend/tests/whatsapp_ingest_test.go
@@ -1,0 +1,660 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/whatsapp"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- harness ----------------------------------------------------------------
+
+// stubGroupInfo is the group-metadata seam. Production reaches a live client;
+// no test may.
+type stubGroupInfo struct {
+	info  *whatsapp.ChatGroupInfo
+	err   error
+	calls int
+}
+
+func (s *stubGroupInfo) GroupInfo(context.Context, string) (*whatsapp.ChatGroupInfo, error) {
+	s.calls++
+	return s.info, s.err
+}
+
+// injectedFailure wraps the real repository so ONE call can be made to fail
+// without faking the rest of the write path.
+type injectedFailure struct {
+	*repository.CommsMessageRepository
+	probeErr     error
+	tombstoneErr error
+	upsertErr    error
+}
+
+func (f *injectedFailure) HasMatchedChatMessage(ctx context.Context, source, externalID string) (bool, error) {
+	if f.probeErr != nil {
+		return false, f.probeErr
+	}
+	return f.CommsMessageRepository.HasMatchedChatMessage(ctx, source, externalID)
+}
+
+func (f *injectedFailure) SoftDeleteUnmatchedTwin(ctx context.Context, source, externalID string) (int64, error) {
+	if f.tombstoneErr != nil {
+		return 0, f.tombstoneErr
+	}
+	return f.CommsMessageRepository.SoftDeleteUnmatchedTwin(ctx, source, externalID)
+}
+
+func (f *injectedFailure) UpsertChatMessage(ctx context.Context, params repository.UpsertChatMessageParams) (*repository.CommsMessage, error) {
+	if f.upsertErr != nil {
+		return nil, f.upsertErr
+	}
+	return f.CommsMessageRepository.UpsertChatMessage(ctx, params)
+}
+
+// commsChatStore mirrors the ingestor's consumer interface, which is
+// package-private to whatsapp. Go interfaces are structural, so naming it here
+// is only for the harness's own readability.
+type commsChatStore interface {
+	UpsertChatMessage(context.Context, repository.UpsertChatMessageParams) (*repository.CommsMessage, error)
+	SoftDeleteUnmatchedTwin(context.Context, string, string) (int64, error)
+	HasMatchedChatMessage(context.Context, string, string) (bool, error)
+}
+
+// ingestEnv is one test's view of the ingest path over the shared package DB.
+// Every identifier it mints is namespace-scoped, so assertions only ever see
+// this test's own rows.
+type ingestEnv struct {
+	ctx         context.Context
+	comms       *repository.CommsMessageRepository
+	contactRepo *repository.ContactRepository
+	methodRepo  *repository.ContactMethodRepository
+	externals   *repository.ExternalContactRepository
+	waRepo      *repository.WhatsAppRepository
+	identity    *service.IdentityService
+	group       *stubGroupInfo
+	matcher     *whatsapp.PeerMatcher
+	ingestor    *whatsapp.Ingestor
+	ns          string
+}
+
+func setupIngestTest(t *testing.T) *ingestEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	// Registered first so it runs LAST (t.Cleanup is LIFO) — the row sweeps
+	// below need the pool open.
+	t.Cleanup(database.Close)
+
+	env := &ingestEnv{
+		ctx:         ctx,
+		comms:       repository.NewCommsMessageRepository(database.Queries),
+		contactRepo: repository.NewContactRepository(database.Queries),
+		methodRepo:  repository.NewContactMethodRepository(database.Queries),
+		externals:   repository.NewExternalContactRepository(database.Queries),
+		waRepo:      repository.NewWhatsAppRepository(database.Queries),
+		identity:    service.NewIdentityService(repository.NewIdentityRepository(database.Queries)),
+		group:       &stubGroupInfo{info: &whatsapp.ChatGroupInfo{Title: "Book Club", MemberCount: 3}},
+		ns:          syntheticNS(t),
+	}
+	env.comms.SetPool(database.Pool)
+
+	fixtures := repository.NewTestJSONBFixturesRepository(database.Queries)
+	t.Cleanup(func() {
+		// An unmatched row has no contact for the usual by-contact sweep to
+		// reach, and 076's down migration refuses to revert while any
+		// NULL-contact row survives.
+		_ = env.comms.HardDeleteBySourceAndExternalIDPrefix(ctx,
+			repository.InteractionSourceWhatsApp, env.extIDPrefix()+"%")
+		_ = fixtures.DeleteExternalContactsBySourceIDPrefix(ctx, env.ns)
+	})
+
+	env.rebuild(env.comms)
+	return env
+}
+
+// rebuild reconstructs the ingest path over a (possibly wrapped) comms store.
+func (e *ingestEnv) rebuild(store commsChatStore) {
+	gate := whatsapp.NewChatGate(e.waRepo, 10)
+	gate.BindGroupInfoSource(func() whatsapp.GroupInfoFetcher { return e.group })
+	e.matcher = whatsapp.NewPeerMatcher(e.identity, e.comms, e.externals, nil, 2)
+	e.ingestor = whatsapp.NewIngestor(store, gate, e.matcher)
+}
+
+func (e *ingestEnv) extIDPrefix() string { return "wa-" + e.ns + "-" }
+
+func (e *ingestEnv) extID(n int) string { return fmt.Sprintf("%s%d", e.extIDPrefix(), n) }
+
+func (e *ingestEnv) peerJID(name string) string { return e.ns + name + "@s.whatsapp.net" }
+
+func (e *ingestEnv) lidJID(name string) string { return e.ns + name + "@lid" }
+
+func (e *ingestEnv) groupJID() string { return e.ns + "group@g.us" }
+
+// uniquePhone mints an E.164 no other test shares, so identity matching cannot
+// collide with another test's contact across the shared package DB.
+func (e *ingestEnv) uniquePhone(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("+1555%07d", uuid.New().ID()%10000000)
+}
+
+func (e *ingestEnv) newContact(t *testing.T, name string) *repository.Contact {
+	t.Helper()
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name + " " + e.ns})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.comms.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.methodRepo.DeleteContactMethodsByContact(e.ctx, contact.ID)
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+	})
+	return contact
+}
+
+func (e *ingestEnv) newContactWithPhone(t *testing.T, name, phone string) *repository.Contact {
+	t.Helper()
+	contact := e.newContact(t, name)
+	_, err := e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID, Type: "phone", Value: phone,
+	})
+	require.NoError(t, err)
+	return contact
+}
+
+func strPtr2(s string) *string { return &s }
+
+// msg builds a projected message with inbound private-DM defaults.
+func (e *ingestEnv) msg(externalID, peerJID string, opts ...func(*whatsapp.IngestedMessage)) whatsapp.IngestedMessage {
+	account := e.ns + "own@s.whatsapp.net"
+	m := whatsapp.IngestedMessage{
+		MessageID:   externalID,
+		ChatJID:     peerJID,
+		ChatType:    whatsapp.ChatTypePrivate,
+		SentAt:      accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond),
+		Body:        strPtr2("hello there"),
+		MessageType: whatsapp.MessageTypeText,
+		PeerJID:     &peerJID,
+		AccountJID:  &account,
+	}
+	for _, o := range opts {
+		o(&m)
+	}
+	return m
+}
+
+func withPhone(e164 string) func(*whatsapp.IngestedMessage) {
+	return func(m *whatsapp.IngestedMessage) { m.PeerPhoneE164 = &e164 }
+}
+func withPush(name string) func(*whatsapp.IngestedMessage) {
+	return func(m *whatsapp.IngestedMessage) { m.PushName = &name }
+}
+func withOutgoing() func(*whatsapp.IngestedMessage) {
+	return func(m *whatsapp.IngestedMessage) { m.IsOutgoing = true }
+}
+func withGroupChat(chatJID string) func(*whatsapp.IngestedMessage) {
+	return func(m *whatsapp.IngestedMessage) {
+		m.ChatType = whatsapp.ChatTypeGroup
+		m.ChatJID = chatJID
+	}
+}
+func withNilPeer() func(*whatsapp.IngestedMessage) {
+	return func(m *whatsapp.IngestedMessage) { m.PeerJID = nil; m.PeerPhoneE164 = nil }
+}
+func withReplyTo(id string) func(*whatsapp.IngestedMessage) {
+	return func(m *whatsapp.IngestedMessage) { m.ReplyTargetID = &id }
+}
+
+// hasMatched reports whether the message is staged against a contact.
+func (e *ingestEnv) hasMatched(t *testing.T, externalID string) bool {
+	t.Helper()
+	got, err := e.comms.HasMatchedChatMessage(e.ctx, repository.InteractionSourceWhatsApp, externalID)
+	require.NoError(t, err)
+	return got
+}
+
+// liveUnmatched counts a peer's LIVE unmatched staging rows. Every test's peer
+// handle is namespace-scoped, so this is a count over that test's rows alone.
+func (e *ingestEnv) liveUnmatched(t *testing.T, peerJID string) int64 {
+	t.Helper()
+	counts, err := e.comms.ListUnmatchedPeerCounts(e.ctx, repository.InteractionSourceWhatsApp, &peerJID, 1)
+	require.NoError(t, err)
+	if len(counts) == 0 {
+		return 0
+	}
+	return counts[0].TotalCount
+}
+
+// storedRow reads the staged row for one external id.
+func (e *ingestEnv) storedRow(t *testing.T, externalID string) *repository.CommsMessage {
+	t.Helper()
+	row, err := e.comms.GetLatestByExternalID(e.ctx, repository.InteractionSourceWhatsApp, externalID)
+	require.NoError(t, err)
+	return row
+}
+
+func (e *ingestEnv) noStoredRow(t *testing.T, externalID string) {
+	t.Helper()
+	_, err := e.comms.GetLatestByExternalID(e.ctx, repository.InteractionSourceWhatsApp, externalID)
+	assert.ErrorIs(t, err, db.ErrNotFound, "nothing may be staged")
+}
+
+// --- staging ----------------------------------------------------------------
+
+func TestIngest_DirectInboundMatchesKnownPhone(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	phone := env.uniquePhone(t)
+	contact := env.newContactWithPhone(t, "Known Peer", phone)
+	peer := env.peerJID("known")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer, withPhone(phone))))
+
+	row := env.storedRow(t, env.extID(1))
+	require.NotNil(t, row.MatchedContactID)
+	assert.Equal(t, contact.ID, *row.MatchedContactID,
+		"a phone the CRM already knows binds the message to its contact at staging time")
+	assert.Zero(t, env.liveUnmatched(t, peer))
+}
+
+func TestIngest_DirectInboundUnknownPeerStagesUnmatched(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.lidJID("unknown")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)))
+
+	row := env.storedRow(t, env.extID(1))
+	assert.Nil(t, row.MatchedContactID, "an unknown peer is staged, not dropped")
+	require.NotNil(t, row.PeerHandle)
+	assert.Equal(t, peer, *row.PeerHandle)
+	assert.EqualValues(t, 1, env.liveUnmatched(t, peer))
+}
+
+func TestIngest_DirectOutboundAttributedToPeer(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.peerJID("outbound")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer, withOutgoing())))
+
+	row := env.storedRow(t, env.extID(1))
+	assert.Equal(t, repository.InteractionDirectionOutbound, row.Direction)
+	require.NotNil(t, row.PeerHandle)
+	assert.Equal(t, peer, *row.PeerHandle, "an outbound DM is attributed to the recipient, not to me")
+}
+
+func TestIngest_GroupInboundAttributedToSender(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.peerJID("member")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), peer, withGroupChat(env.groupJID()))))
+
+	row := env.storedRow(t, env.extID(1))
+	require.NotNil(t, row.ThreadID)
+	assert.Equal(t, env.groupJID(), *row.ThreadID, "the chat scope is the group")
+	require.NotNil(t, row.PeerHandle)
+	assert.Equal(t, peer, *row.PeerHandle, "the counterpart is the sender, not the group")
+}
+
+func TestIngest_GroupOutboundStagedWithNullContact(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), env.peerJID("unused"), withGroupChat(env.groupJID()), withOutgoing(), withNilPeer())))
+
+	row := env.storedRow(t, env.extID(1))
+	assert.Nil(t, row.MatchedContactID, "there is no single counterpart to attribute it to")
+	assert.Nil(t, row.PeerHandle)
+}
+
+func TestIngest_GroupAboveThresholdStagesNothing(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	env.group.info = &whatsapp.ChatGroupInfo{Title: "Big Group", MemberCount: 42}
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), env.peerJID("member"), withGroupChat(env.groupJID()))),
+		"a resolved count above the threshold is a real decision, so the message is handled")
+
+	env.noStoredRow(t, env.extID(1))
+
+	cfg, err := env.waRepo.GetChatConfig(env.ctx, env.groupJID())
+	require.NoError(t, err)
+	require.NotNil(t, cfg.MemberCount)
+	assert.EqualValues(t, 42, *cfg.MemberCount, "the resolution persists, so no further lookup is needed")
+}
+
+// TestIngest_UnresolvedGroupCountWithholdsAck is the P0 regression guard: an
+// undecidable gate must return an ERROR — which withholds the ack — rather than
+// nil, and must stage nothing.
+func TestIngest_UnresolvedGroupCountWithholdsAck(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	env.group.info = nil
+	env.group.err = context.DeadlineExceeded
+
+	err := env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), env.peerJID("member"), withGroupChat(env.groupJID())))
+	require.Error(t, err, "acking here would drop the message irrecoverably")
+	assert.ErrorIs(t, err, whatsapp.ErrChatGateUndecided)
+	env.noStoredRow(t, env.extID(1))
+
+	_, cfgErr := env.waRepo.GetChatConfig(env.ctx, env.groupJID())
+	assert.ErrorIs(t, cfgErr, db.ErrNotFound, "a failed lookup records no false resolution")
+}
+
+func TestIngest_IgnoredGroupAcksWithoutStaging(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	_, err := env.waRepo.UpsertChatConfig(env.ctx, repository.WhatsAppChatConfig{
+		ChatJID: env.groupJID(), ChatType: whatsapp.ChatTypeGroup, Status: whatsapp.ChatStatusIgnored,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), env.peerJID("member"), withGroupChat(env.groupJID()))),
+		"an explicit ignore is a decision, so the message is handled")
+	env.noStoredRow(t, env.extID(1))
+	assert.Zero(t, env.group.calls, "an override needs no member count")
+}
+
+func TestIngest_SourceMetadataCarriesReplyTarget(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.peerJID("replier")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), peer, withReplyTo("ORIG-9"), withPush("Their Name"))))
+
+	row := env.storedRow(t, env.extID(1))
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(row.SourceMetadata, &meta))
+	assert.Equal(t, "ORIG-9", meta["reply_target_external_id"],
+		"this is the key the aggregation adapter already reads")
+	assert.Equal(t, "Their Name", meta["push_name"])
+	assert.Equal(t, whatsapp.MessageTypeText, meta["message_type"])
+	assert.Equal(t, whatsapp.ChatTypePrivate, meta["chat_type"])
+	assert.Nil(t, row.Snippet, "the snippet stays nil: nothing on this route reads it")
+	require.NotNil(t, row.AccountID)
+	assert.Equal(t, env.ns+"own@s.whatsapp.net", *row.AccountID)
+}
+
+func TestIngest_RedeliveryIsIdempotent(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.peerJID("redeliver")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)))
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)))
+
+	assert.EqualValues(t, 1, env.liveUnmatched(t, peer),
+		"a redelivery must not double-count a conversation turn")
+}
+
+// TestIngest_RedeliveryAfterPeerBecomesMatchedStagesOneRow is the matched-wins
+// rule forwards. The two upserts have DISJOINT conflict targets, so without the
+// tombstone the flip strands a permanent unmatched duplicate.
+func TestIngest_RedeliveryAfterPeerBecomesMatchedStagesOneRow(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	phone := env.uniquePhone(t)
+	contact := env.newContactWithPhone(t, "Flips To Matched", phone)
+	peer := env.lidJID("flip")
+
+	// Staged while the peer's phone was still unresolvable.
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)))
+	require.EqualValues(t, 1, env.liveUnmatched(t, peer))
+
+	// The same message redelivered once the phone resolved.
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer, withPhone(phone))))
+
+	assert.True(t, env.hasMatched(t, env.extID(1)), "the matched row is the survivor")
+	assert.Zero(t, env.liveUnmatched(t, peer), "the unmatched twin must be tombstoned, not left forever")
+
+	rows, err := env.comms.ListByContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1, "exactly one live row for one conversation turn")
+}
+
+// TestIngest_RedeliveryAfterMatchFailureDoesNotStageAnUnmatchedTwin is the same
+// rule in REVERSE: matching is best-effort, so a redelivery of an
+// already-matched message can take the unmatched path and mint the duplicate
+// pair with nothing to tombstone it.
+func TestIngest_RedeliveryAfterMatchFailureDoesNotStageAnUnmatchedTwin(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	phone := env.uniquePhone(t)
+	contact := env.newContactWithPhone(t, "Match Then Fail", phone)
+	peer := env.lidJID("reverse")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer, withPhone(phone))))
+
+	// Redelivered with no phone: MatchPeer yields nil, so the unmatched path
+	// would run — and the probe is what declines it.
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)))
+
+	assert.True(t, env.hasMatched(t, env.extID(1)))
+	assert.Zero(t, env.liveUnmatched(t, peer), "no duplicate pair may be minted")
+
+	rows, err := env.comms.ListByContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+
+	candidate, err := env.externals.GetBySource(env.ctx, repository.InteractionSourceWhatsApp, peer, nil)
+	require.NoError(t, err)
+	assert.Nil(t, candidate, "and discovery must not fire for a peer that already has a contact")
+}
+
+func TestIngest_TwinTombstoneFailureStillAcks(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	phone := env.uniquePhone(t)
+	env.newContactWithPhone(t, "Tombstone Fails", phone)
+	peer := env.peerJID("tombstonefail")
+
+	env.rebuild(&injectedFailure{CommsMessageRepository: env.comms, tombstoneErr: errors.New("database down")})
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer, withPhone(phone))),
+		"failing to tombstone a duplicate must not withhold an ack for a message that IS stored")
+	assert.True(t, env.hasMatched(t, env.extID(1)))
+}
+
+func TestIngest_MatchedProbeFailureStillStages(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.lidJID("probefail")
+
+	env.rebuild(&injectedFailure{CommsMessageRepository: env.comms, probeErr: errors.New("database down")})
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)),
+		"the worst case is a reconcilable duplicate, which is better than losing the message")
+	assert.EqualValues(t, 1, env.liveUnmatched(t, peer))
+}
+
+func TestIngest_StagingErrorPropagates(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	env.rebuild(&injectedFailure{CommsMessageRepository: env.comms, upsertErr: errors.New("database down")})
+
+	err := env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), env.peerJID("stagefail")))
+	require.Error(t, err, "a no-op that succeeds is the shape that loses data")
+	env.noStoredRow(t, env.extID(1))
+}
+
+func TestIngest_EmptyChatScopeIsRefused(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	msg := env.msg(env.extID(1), env.peerJID("nothread"))
+	msg.ChatJID = ""
+
+	err := env.ingestor.IngestMessage(env.ctx, msg)
+	require.Error(t, err, "a row with no chat scope is staged, attachable, and permanently unaggregatable")
+	assert.ErrorIs(t, err, repository.ErrChatMessageMissingThread)
+}
+
+// --- discovery + link -------------------------------------------------------
+
+func TestWhatsAppDiscovery_CandidateAppearsAtThreshold(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.lidJID("discover")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer, withPush("Their Name"))))
+	candidate, err := env.externals.GetBySource(env.ctx, repository.InteractionSourceWhatsApp, peer, nil)
+	require.NoError(t, err)
+	assert.Nil(t, candidate, "one message is below the threshold of two")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(2), peer, withPush("Their Name"))))
+	candidate, err = env.externals.GetBySource(env.ctx, repository.InteractionSourceWhatsApp, peer, nil)
+	require.NoError(t, err)
+	require.NotNil(t, candidate, "a frequent unknown peer surfaces as an import candidate")
+	require.NotNil(t, candidate.DisplayName)
+	assert.Equal(t, "Their Name", *candidate.DisplayName)
+	assert.Equal(t, peer, candidate.SourceID, "keyed by the raw peer JID, like the staging rows")
+	assert.EqualValues(t, 2, candidate.Metadata["message_count"])
+}
+
+// TestWhatsAppDiscovery_LIDOnlyPeerIsStillLabelled is what makes the
+// always-visible choice safe: the peers most at risk of being hidden — LID-only,
+// push-name-less — are exactly the ones the user cannot reach any other way, so
+// their candidate must never be contentless.
+func TestWhatsAppDiscovery_LIDOnlyPeerIsStillLabelled(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	peer := env.lidJID("nameless")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)))
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(2), peer)))
+
+	candidate, err := env.externals.GetBySource(env.ctx, repository.InteractionSourceWhatsApp, peer, nil)
+	require.NoError(t, err)
+	require.NotNil(t, candidate)
+	require.NotNil(t, candidate.DisplayName, "never contentless")
+	assert.Contains(t, *candidate.DisplayName, "WhatsApp ")
+}
+
+func TestWhatsAppOnPeerLinked_AttachesEveryUnmatchedRow(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	contact := env.newContact(t, "Linked Later")
+	peer := env.lidJID("linklater")
+
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer)))
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(2), peer)))
+
+	require.NoError(t, env.matcher.OnPeerLinked(env.ctx, peer, nil, contact.ID))
+
+	rows, err := env.comms.ListByContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2, "linking a peer retroactively binds their stored messages")
+	assert.Zero(t, env.liveUnmatched(t, peer))
+}
+
+// TestWhatsAppOnPeerLinked_ReconcilesDuplicateUnmatchedRow covers the case the
+// attach's own dedup statement exists for: a matched row for the same message
+// already exists, so the unmatched twin has to be tombstoned rather than
+// attached — attaching it would violate the dedup index.
+func TestWhatsAppOnPeerLinked_ReconcilesDuplicateUnmatchedRow(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	contact := env.newContact(t, "Dup Reconcile")
+	peer := env.lidJID("dupe")
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	base := repository.UpsertChatMessageParams{
+		Source: repository.InteractionSourceWhatsApp, ExternalID: env.extID(1), ThreadID: peer,
+		PeerHandle: &peer, Direction: repository.InteractionDirectionInbound, SentAt: sentAt,
+	}
+	// One message staged BOTH ways — the coexistence the two disjoint conflict
+	// targets make representable.
+	_, err := env.comms.UpsertChatMessage(env.ctx, base)
+	require.NoError(t, err)
+	matched := base
+	matched.MatchedContactID = &contact.ID
+	_, err = env.comms.UpsertChatMessage(env.ctx, matched)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, env.liveUnmatched(t, peer), "the unmatched twin is live")
+
+	require.NoError(t, env.matcher.OnPeerLinked(env.ctx, peer, nil, contact.ID))
+
+	rows, err := env.comms.ListByContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1, "the duplicate is reconciled, not attached")
+	assert.Zero(t, env.liveUnmatched(t, peer))
+}
+
+func TestWhatsAppOnPeerLinked_AttachesByPhoneWhenStagedUnderALID(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+	contact := env.newContact(t, "Phone Attach")
+	peer := env.lidJID("phoneattach")
+	phone := env.uniquePhone(t)
+
+	// Staged under the LID handle, but with the phone resolved on the row.
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx, env.msg(env.extID(1), peer, withPhone(phone))))
+
+	// Linking a candidate whose HANDLE is a different string still finds it,
+	// because the attach matches peer_handle OR peer_normalized. This is what
+	// the extra phone parameter exists for.
+	require.NoError(t, env.matcher.OnPeerLinked(env.ctx, env.lidJID("other"), &phone, contact.ID))
+
+	rows, err := env.comms.ListByContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+// --- the gate's durability --------------------------------------------------
+
+// TestGroupGate_PersistsAcrossRestart is why the gate is a TABLE rather than an
+// in-memory map: a resolved size survives a process restart, so a restarted
+// backend does not re-ask the server for every group on every message.
+func TestGroupGate_PersistsAcrossRestart(t *testing.T) {
+	t.Parallel()
+	env := setupIngestTest(t)
+
+	// First process: resolves and persists.
+	require.NoError(t, env.ingestor.IngestMessage(env.ctx,
+		env.msg(env.extID(1), env.peerJID("member"), withGroupChat(env.groupJID()))))
+	require.Equal(t, 1, env.group.calls)
+	require.True(t, env.hasMatched(t, env.extID(1)) || env.liveUnmatched(t, env.peerJID("member")) == 1,
+		"the message was stored")
+
+	// Second process: a brand-new gate over the same table, whose lookup would
+	// FAIL if it were reached at all.
+	restarted := whatsapp.NewChatGate(env.waRepo, 10)
+	restarted.BindGroupInfoSource(func() whatsapp.GroupInfoFetcher {
+		return &stubGroupInfo{err: errors.New("must not be reached after a restart")}
+	})
+
+	tracked, err := restarted.ShouldTrack(env.ctx, env.groupJID(), whatsapp.ChatTypeGroup)
+	require.NoError(t, err, "the persisted count answers without a lookup")
+	assert.True(t, tracked)
+}

--- a/frontend/src/lib/__tests__/source-display.test.ts
+++ b/frontend/src/lib/__tests__/source-display.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { getSourceDisplay } from '../source-display'
-import { Users, Calendar, Send, Cloud, HelpCircle } from 'lucide-react'
+import { Users, Calendar, Send, Cloud, MessageCircle, HelpCircle } from 'lucide-react'
 
 describe('getSourceDisplay', () => {
   it('returns friendly name and icon for gcontacts', () => {
@@ -25,6 +25,14 @@ describe('getSourceDisplay', () => {
     const result = getSourceDisplay('telegram')
     expect(result.label).toBe('Telegram')
     expect(result.icon).toBe(Send)
+  })
+
+  // WhatsApp import candidates carry this badge in the imports queue; without
+  // the map entry the badge would fall through to the raw source string.
+  it('returns friendly name and icon for whatsapp', () => {
+    const result = getSourceDisplay('whatsapp')
+    expect(result.label).toBe('WhatsApp')
+    expect(result.icon).toBe(MessageCircle)
   })
 
   it('returns raw source name for unknown sources', () => {

--- a/frontend/src/lib/source-display.ts
+++ b/frontend/src/lib/source-display.ts
@@ -11,6 +11,9 @@ const SOURCE_DISPLAY_MAP: Record<string, SourceDisplayInfo> = {
   gcal_attendee: { label: 'Google Calendar', icon: Calendar },
   icloud_contacts: { label: 'iCloud Contacts', icon: Cloud },
   telegram: { label: 'Telegram', icon: Send },
+  // lucide-react ships no WhatsApp glyph; MessageCircle is the generic
+  // chat mark already used for anarlog_humans.
+  whatsapp: { label: 'WhatsApp', icon: MessageCircle },
   // anarlog_humans candidates flow through the ordinary candidate queue;
   // anarlog_title name-candidate rows live behind the dedicated People-tab
   // name-candidates section and never carry this badge.

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -333,6 +333,10 @@
     "tags": ["@area:imports"]
   },
   {
+    "pattern": "^backend/internal/service/external_methods\\.go$",
+    "tags": ["@area:imports"]
+  },
+  {
     "pattern": "^backend/internal/api/handlers/calendar\\.go$",
     "tags": ["@area:meetings"]
   },

--- a/spec/whatsapp.yaml
+++ b/spec/whatsapp.yaml
@@ -168,7 +168,7 @@ behaviors:
       - key: status-always-carries-terminal-reason-persisted
         text: the status body always carries whether the permanent-disconnect reason was durably recorded, including when it was NOT — a client that cannot tell "absent" from "false" cannot tell a restart-safe decision from one that will be lost
       - key: status-reports-unresolved-lid-peers
-        text: the status carries how many peers the integration has seen but could not resolve to a phone number, since a message from such a peer cannot be matched to a contact automatically and can reach one only through the import queue
+        text: the status carries how many peers the integration has seen but could not resolve to a phone number — counted up to a cap, above which it reports "at least this many" — since a message from such a peer cannot be matched to a contact automatically and can reach one only through the import queue
     provenance: [WhatsAppHandler.GetStatus, RegisterWhatsAppRoutes]
     notes: Scoped to what the status reports without a linked account. The fields that need one, or a live pairing, are WHA-016.
 

--- a/spec/whatsapp.yaml
+++ b/spec/whatsapp.yaml
@@ -168,7 +168,7 @@ behaviors:
       - key: status-always-carries-terminal-reason-persisted
         text: the status body always carries whether the permanent-disconnect reason was durably recorded, including when it was NOT — a client that cannot tell "absent" from "false" cannot tell a restart-safe decision from one that will be lost
       - key: status-reports-unresolved-lid-peers
-        text: the status carries how many peers the integration could not resolve to a phone number, since their messages can reach a contact only through the import queue
+        text: the status carries how many peers the integration has seen but could not resolve to a phone number, since a message from such a peer cannot be matched to a contact automatically and can reach one only through the import queue
     provenance: [WhatsAppHandler.GetStatus, RegisterWhatsAppRoutes]
     notes: Scoped to what the status reports without a linked account. The fields that need one, or a live pairing, are WHA-016.
 
@@ -359,6 +359,11 @@ behaviors:
       Failing closed is a STORAGE rule, not an acknowledgement rule — the two are deliberately separate,
       because acknowledging a message that could not be assessed would discard it irrecoverably, while an
       unbounded retry of a permanently unanswerable question would degrade message handling indefinitely.
+      Two limits of the current implementation, recorded rather than hidden: the explicit track/ignore
+      choice is honoured wherever it is stored, but no surface can write one yet, so today the branch is
+      reachable only by seeding the stored state directly; and a size once established is never
+      re-resolved, so a group that later grows past the limit keeps being tracked. Both are settled by the
+      settings surface that owns the per-chat override.
 
   - id: WHA-024
     title: A frequent unknown peer becomes a labelled import candidate

--- a/spec/whatsapp.yaml
+++ b/spec/whatsapp.yaml
@@ -167,6 +167,8 @@ behaviors:
         text: with the feature disabled the WhatsApp endpoints do not exist (404), which is how the settings surface recognises an unconfigured integration
       - key: status-always-carries-terminal-reason-persisted
         text: the status body always carries whether the permanent-disconnect reason was durably recorded, including when it was NOT — a client that cannot tell "absent" from "false" cannot tell a restart-safe decision from one that will be lost
+      - key: status-reports-unresolved-lid-peers
+        text: the status carries how many peers the integration could not resolve to a phone number, since their messages can reach a contact only through the import queue
     provenance: [WhatsAppHandler.GetStatus, RegisterWhatsAppRoutes]
     notes: Scoped to what the status reports without a linked account. The fields that need one, or a live pairing, are WHA-016.
 
@@ -288,3 +290,140 @@ behaviors:
       - the error is evaluated even though the status row is not scheduler-enabled, since a manager-driven row is deliberately kept out of the polling scheduler's work queue
       - WhatsApp is not evaluated for sync staleness, because it has no periodic sync to fall behind on
     provenance: [managerDrivenSources, evaluateSyncStateBreaches]
+
+  # --- Message ingest ---
+
+  - id: WHA-020
+    title: Only person-to-person chats are ingested
+    type: business-logic
+    status: current
+    surface: none
+    given: an incoming WhatsApp message
+    when: the integration decides whether it belongs in the CRM
+    then:
+      - direct conversations and group conversations are ingested
+      - status updates, broadcast lists, channels and automated senders are not ingested, and a chat on a kind of address the integration does not recognise is refused rather than guessed at
+      - a note to self is not ingested, in whichever of the account's own forms it is addressed
+      - the same person reached through a different device domain is treated as the same person, not as an unrecognised address to discard
+      - a chat that is not ingested is treated as handled rather than as a failure, so it is not delivered again forever
+    provenance: [classifyChat, normalizeServer, parseMessage]
+    notes: The account's own identity is required before any of this can be decided; without it the message is left undelivered rather than guessed at, since an acknowledged message is never sent again.
+
+  - id: WHA-021
+    title: Each WhatsApp message is stored once, attributed to its counterpart
+    type: data
+    status: current
+    surface: none
+    given: a WhatsApp message the integration will ingest
+    when: it is stored
+    then:
+      - a direct message is attributed to the other party, whether the user sent it or received it
+      - a message in a group is attributed to whoever sent it, and one the user sent to a group is stored with no counterpart because it has none
+      - the same message delivered twice results in one stored message, not two, and its content is not rewritten by the second delivery
+      - a message that was first stored without a contact and later recognised as a known contact ends up as a single stored message bound to that contact
+      - the reverse case — a message already bound to a contact, redelivered while the contact could not be recognised — also ends up as a single stored message still bound to that contact
+      - the sender's display name is recorded only for messages the user received, never for messages the user sent, so the user's own name can never end up labelling somebody else
+      - each stored message records which linked account observed it, in a form that survives re-linking the same account
+    provenance: [Ingestor.IngestMessage, parseMessage, SoftDeleteUnmatchedTwin, HasMatchedChatMessage]
+
+  - id: WHA-022
+    title: A peer's phone number is recovered where WhatsApp exposes it, and its absence degrades rather than fails
+    type: business-logic
+    status: current
+    surface: none
+    given: a WhatsApp message from a peer
+    when: the integration tries to identify who the peer is
+    then:
+      - the peer's phone number is taken from the message when it carries one, and otherwise recovered from what the linked device already knows about that peer
+      - a peer whose phone number cannot be recovered is still stored, without a contact, rather than the message being dropped
+      - recovering the number is time-bounded, so a slow or unavailable lookup degrades to an unidentified peer instead of stalling incoming messages
+      - an address that is not a phone number is never treated as one
+    provenance: [resolvePeerPhone, phoneCandidate, PeerMatcher.MatchPeer]
+
+  - id: WHA-023
+    title: Group tracking is decided by a persisted size gate that fails closed, and an undecided group is retried rather than skipped
+    type: business-logic
+    status: current
+    surface: none
+    given: a message in a WhatsApp group
+    when: the integration decides whether to store it
+    then:
+      - a group at or below the configured size limit is tracked, and a larger one is not
+      - a group whose size cannot be established is not tracked, rather than being assumed small
+      - when the size could not be established because the answer could not be obtained right now, the message is also not treated as handled, so it is delivered again and the size can be established on the next attempt
+      - when the size could not be established because the answer will never come — the user is not in the group, or the group does not exist, or it reports no size at all — the message IS treated as handled, so one unanswerable group cannot be delivered forever
+      - a size once established survives a restart, so the same question is not asked again for every message
+      - a group the user has explicitly chosen to track or ignore honours that choice without establishing its size at all
+    provenance: [ChatGate.ShouldTrack, EffectiveTracked, whatsapp_chat_config]
+    notes: >-
+      Failing closed is a STORAGE rule, not an acknowledgement rule — the two are deliberately separate,
+      because acknowledging a message that could not be assessed would discard it irrecoverably, while an
+      unbounded retry of a permanently unanswerable question would degrade message handling indefinitely.
+
+  - id: WHA-024
+    title: A frequent unknown peer becomes a labelled import candidate
+    type: business-logic
+    status: current
+    surface: none
+    given: a WhatsApp peer with no matching contact
+    when: they have exchanged enough messages to cross the discovery threshold
+    then:
+      - the peer surfaces as an import candidate, keyed by the same identifier their stored messages carry
+      - the candidate always carries a label the user can act on — the peer's display name, else their phone number, else a recognisable placeholder — so a candidate is never presented as an unreadable identifier
+      - a display name learnt later replaces an earlier placeholder, and a blank one never erases a name already captured
+      - the candidate carries how many messages were exchanged and when the last one was, so the user can judge whether the peer is worth adding
+      - a peer already bound to a contact does not surface as a candidate
+    provenance: [PeerMatcher.UpdateDiscoveryCandidates, UpsertDiscoveryCandidate]
+
+  - id: WHA-025
+    title: Linking a peer retroactively attaches their stored messages
+    type: business-logic
+    status: current
+    surface: none
+    given: WhatsApp messages stored without a contact
+    when: the user imports or links that peer to a contact
+    then:
+      - every stored message for that peer is bound to the contact
+      - a peer stored before their phone number was known is still found, by either the identifier the messages carry or the recovered number
+      - a message already stored against the contact is reconciled rather than duplicated
+      - a failure to attach is reported rather than silently swallowed, because attaching is the visible effect of linking
+    provenance: [PeerMatcher.OnPeerLinked, AttachUnmatchedByPeer]
+
+  - id: WHA-026
+    title: An imported peer with a known phone number gains a WhatsApp contact method
+    type: business-logic
+    status: current
+    surface: none
+    given: a WhatsApp import candidate
+    when: it is imported or linked to a contact
+    then:
+      - a candidate whose phone number is known gains a WhatsApp contact method carrying that number
+      - a candidate whose phone number was never recovered gains no WhatsApp method, rather than one holding an internal identifier the user cannot use
+    provenance: [BuildMethodsFromExternal, EnrichmentService.SyncMethodsFromExternal]
+
+  - id: WHA-027
+    title: Media messages are recorded by type without downloading their content
+    type: data
+    status: current
+    surface: none
+    given: an incoming WhatsApp message carrying media
+    when: it is stored
+    then:
+      - the message is recorded with the kind of media it carried — photo, video, voice or audio, document, sticker — derived from the message itself, with no media content ever downloaded
+      - any caption is kept as the message's text, and a message with no text is stored without one rather than with an invented placeholder
+      - a reply records which message it replied to
+      - message edits, deletions, reactions and poll votes are not stored as conversation, because they are not turns in one; creating a poll is
+    provenance: [classifyMessage, buildSourceMetadata]
+
+  - id: WHA-028
+    title: Post-import back-fill is routed by the source that produced the candidate
+    type: business-logic
+    status: current
+    surface: none
+    given: import candidates from more than one messaging source
+    when: one of them is imported or linked
+    then:
+      - the back-fill that binds stored messages runs for the source that produced the candidate, and only that one
+      - a candidate from a source with no back-fill is imported normally, without error
+      - a back-fill failure does not fail the import, which has already succeeded
+    provenance: [ImportHandler.RegisterPostImportHook, triggerPostImportHook, telegram.PostImportHook, whatsapp.PostImportHook]


### PR DESCRIPTION
PR4 of the WhatsApp integration arc (spec `.ai/spec/whatsapp-integration.md`, #786). Builds on #787 (adapters), #788 (migration 076), #790 (actor-model client). The feature stays OFF: this fills `whatsappPrereqs.Ingestor`, and `Ready()` still refuses, now naming the drain worker PR6 registers.

## What this delivers

The live message-ingest path, end to end but inert until PR6:

- **Parser** (`message.go`): projects `*events.Message` onto `IngestedMessage` — JID normalization (incl. hosted/hosted.lid), person-to-person eligibility allowlist, envelope-only content classification (protocol messages/reactions/poll votes dropped with a true ack; poll creations staged as `other`), the four-rung peer-phone ladder, PushName only for inbound, `AccountJID` normalized non-AD from the emitting session.
- **Group gate** (`chatconfig.go` + `groupinfo.go`): persisted, fail-closed size gate whose **storage decision is strictly separated from its ack decision** — transient causes (timeouts, transport, DB errors, nil fetcher, cross-account lookups during re-pair overlap) withhold the ack so WhatsApp redelivers; permanent answers (not-in-group, group-gone, over-threshold, explicit ignore) ack. Explicit track/ignore short-circuits before any network lookup.
- **Ingest choke point** (`ingest.go`): stages into `comms_message(source='whatsapp')` with symmetric matched-row-wins reconciliation (probe before unmatched insert, tombstone after matched stage — both best-effort, never withholding an ack for a stored message). Panics on the path withhold the ack.
- **Peer matcher + discovery** (`matcher.go`): identity match via the existing service; first-match-gated reconciliation (identity `Cached` gate); always-labelled discovery candidates (push name → E.164 → "WhatsApp <user>") behind a source-keyed `PostImportHook` with narrow, tested adapters.
- **Status surface**: `Ingest.unresolved_lid_peers` (distinct peers observed whose number could not be recovered; capped, saturating, wording matched across DTO/internal/spec).
- Spec: WHA-020..028 minted; WHA-007 extended in place with a value-asserting citation.

## Review

Plan approved after a 3-round adversarial review (14 recorded decisions). Code reviewed in 2 rounds + coordinator-spot-checked polish; the review ran as the documented **Claude fallback** (Codex pool exhausted until Aug 8). Verdict file: `.ai/log/review/0b2c3b7c….codex.md` (RESULT=PASS). Round 1's blocking finding — the PostImportHook regression tests could not fail (nil-delegate short-circuit before the extraction) — was fixed with narrow linker interfaces + recording fakes and falsified with independent mutants by both the author and the reviewer.

Recorded deviations (8, all reviewer-judged sound), highlights: `sync.Map` → copy-on-write `atomic.Pointer` for the LID set (the merged no-mutex guard bans `sync.Map`; the guard's counted allowance moved 2→3); `ChatGate.ShouldTrack` gained an `accountJID` parameter (closes a re-pair decided-drop; the alternative changed the interface PR6 is contracted against); `whatsapp_dto.go` is not in tygo scope (the plan's blast radius was wrong).

## Ephemeral falsifications (defect injected → observed red → discarded; nothing committed)

All mutants lived in `/tmp` via `go test -overlay`, injections grep-confirmed, exit codes read directly (`cmd >/tmp/out 2>&1; echo $?`).

| # | Defect injected | Exit | Red test(s) |
|---|---|---|---|
| 1 | `IngestMessage` returns nil on a `ShouldTrack` error | 1 | `TestIngest_UnresolvedGroupCountWithholdsAck` |
| 2 | `EffectiveTracked` nil-count arm → true | 1 | `TestEffectiveTracked_AutoNilMemberCountFailsClosed` |
| 3 | `ErrGroupUnavailable` routed back into undecided | 1 | `TestGroupGate_NotInGroupIsDecidedNotUndecided`, `_GroupNotFoundIsDecidedNotUndecided` |
| 4 | `classifyChat` default arm → treat as private | 1 | `TestChatEligibility_NewsletterRejected`, `_UnknownServerRejected` |
| 5 | Swallow the `UpsertChatMessage` error | 1 | `TestIngest_StagingErrorPropagates` |
| 6 | Recovered panic sets `handled = true` | 1 | `TestHandleEvent_PanicWithholdsAck` |
| 7 | Telegram adapter strips `#` instead of `@` | 1 | `TestPostImportDispatch_TelegramBehaviorUnchanged` |
| 8 | WhatsApp adapter reads `metadata["phone"]` | 1 | `_WhatsAppDerivesJIDAndPhone` |
| 9 | Re-pair account guard removed | 1 | `TestGroupGate_DifferentAccountIsUndecided` |
| 10 | First-match gate removed from reconcile | 1 | `TestMatchPeer_ReconcileIsFirstMatchGated` |
| 11 | `MessageID` guard removed | 1 | `TestIngest_MissingMessageIDIsRefused` |
| 12 | Reconcile gated on candidate row instead of identity `Cached` | 1 | `_ReconcileIsFirstMatchGated` (2 rows), `_RepeatedMessagesFromAKnownPeerCostNothingExtra` |

Dependency delta: none — root `go.mod`/`go.sum` byte-identical to develop; backend module unchanged from PR3's set.