### PR TITLE
feat(whatsapp): wire aggregation pipeline (PR5)

### DIFF
--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -126,7 +126,7 @@ time-based + explicit reply bridging, same-direction coalescing) and depends
 only on interfaces — `SourceAdapter`, `MessageStore`, `InteractionFinder`,
 `InteractionPromoter`, `InteractionExtender`, `EventPublisher`.
 
-Three sources call the engine today: `telegram`, `messages`, and `gchat`.
+Four sources call the engine today: `telegram`, `messages`, `gchat`, and `whatsapp`.
 
 ### Where new chat-like sources stage content
 
@@ -158,7 +158,10 @@ two sources that predate `comms_message`. They are not the template.
    (`commsadapter.NewStore`), the `InteractionFinder`
    (`commsadapter.NewInteractionFinder`), and the bus wrappers. Declare the
    burst/reply-bridge windows as constants beside the source's own constructor,
-   not as wiring literals — the synthetic seed sizes its input to them.
+   not as wiring literals — the synthetic seed sizes its input to them. A source
+   whose windows are operator-tunable (telegram, whatsapp) instead passes config
+   values through and documents its defaults in `backend/internal/config`, so the
+   seed sizes to the documented default rather than to a wiring literal.
 3. **Source constant + CHECK** — add a `repository.InteractionSource*` constant
    and widen the `interaction_source_check` CHECK in a migration.
    `TestInteractionSourceCheck_AgreesWithDescriptorAndConstants` fails until

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -314,8 +314,8 @@ func run() int {
 		}
 	}
 
-	// Aggregation engines (messages + gchat) + reenqueuer registry.
-	agg := buildAggregationEngines(database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, telegramManager, gchatProvider, gchatSyncStates)
+	// Aggregation engines (messages + gchat + whatsapp) + reenqueuer registry.
+	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, telegramManager, gchatProvider, gchatSyncStates)
 
 	// Register the chat-aware messaging aggregate worker + sweeper (+ periodic).
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)

--- a/backend/cmd/crm-api/oauth_routes_boundary_test.go
+++ b/backend/cmd/crm-api/oauth_routes_boundary_test.go
@@ -122,7 +122,7 @@ func buildRouterForOAuthWiring(t *testing.T, cfg *config.Config) *gin.Engine {
 
 	// Telegram is intentionally SKIPPED (Start must not run); a nil
 	// telegramManager is exactly a telegram-disabled boot for aggregation.
-	agg := buildAggregationEngines(database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
+	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	handlersCore := buildCoreHandlers(database, core, contactService, graph, cfg, domain.NoteService, manualHandler, eventBus)

--- a/backend/cmd/crm-api/whatsapp_wiring_test.go
+++ b/backend/cmd/crm-api/whatsapp_wiring_test.go
@@ -1,0 +1,260 @@
+//go:build integration_testdb
+
+// Composition-root parity pin for the WhatsApp aggregation wiring.
+//
+// Every source-keyed fan-out site in the messaging pipeline is a map that is
+// SILENTLY LENIENT on a miss: an unregistered source yields (0, nil) or
+// (nil, nil) rather than an error, so a missing whatsapp entry is never a
+// compile error and never a runtime error — it is a silently dead source. The
+// golden-list test cannot see it (whatsapp registers no worker, periodic or
+// provider), and backend/tests/ cannot reach these wire functions (package
+// main). This test is the discriminating proof.
+//
+// EVERY assertion is an INVOCATION, never a presence check. A presence check
+// (`wiring.Engines["whatsapp"] != nil`) is behaviorally a keyset check: it
+// passes on the realistic copy-paste defect where the right KEY holds the wrong
+// VALUE — a gchat engine under the whatsapp key, or a reenqueuer constructed
+// with InteractionSourceGChat. Each assertion below therefore reaches its site
+// through a call whose observable effect differs under a mis-binding.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/testdb"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// whatsappWiringFixture is one run's rows. Chats C, D and E are DISJOINT so no
+// assertion consumes another's state: assertion 1 claims chat C, assertion 4
+// aggregates chat D, and assertions 2+3 use chat E, which nothing else claims
+// (MarkProcessedTx's underlying predicate is
+// `claimed_session_ref = @session_ref OR claimed_session_ref IS NULL`, so a row
+// the engine already claimed under its own session ref would return 0 for a
+// reason having nothing to do with the registry).
+type whatsappWiringFixture struct {
+	contactID uuid.UUID
+	chatC     string
+	chatD     string
+	chatE     string
+	firstC    string // external_id of the first (oldest) row in chat C
+	firstD    string
+	rowE      uuid.UUID
+	idPrefix  string
+	refPrefix string
+}
+
+// seedWhatsAppWiringFixture writes one contact and four unprocessed
+// comms_message(source='whatsapp') rows through the production upsert.
+//
+// Every external_id is per-run unique and a t.Cleanup hard-deletes the run's
+// rows, interactions AND events by prefix. That is load-bearing for the
+// ephemeral falsification protocol rather than hygiene: events.Bus.PublishTx
+// dedups on (source, source_id), so a leftover event row with
+// source_id = "whatsapp:<chatC>:<id>" from an earlier run would satisfy
+// assertion 1 no matter what the engine did — and the protocol runs this test
+// eleven times against the same database.
+func seedWhatsAppWiringFixture(t *testing.T, ctx context.Context, chain wireChain) whatsappWiringFixture {
+	t.Helper()
+
+	run := uuid.NewString()
+	fx := whatsappWiringFixture{
+		chatC:     "1204555" + run[:4] + "1@s.whatsapp.net",
+		chatD:     "1204555" + run[:4] + "2@s.whatsapp.net",
+		chatE:     "1204555" + run[:4] + "3@s.whatsapp.net",
+		idPrefix:  "wa-wiring-" + run + "-",
+		refPrefix: repository.InteractionSourceWhatsApp + ":1204555" + run[:4],
+	}
+
+	contact, err := chain.core.Contact.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "WhatsApp Wiring Fixture " + run[:8],
+	})
+	require.NoError(t, err)
+	fx.contactID = contact.ID
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_ = chain.messaging.CommsMessageRepo.HardDeleteBySourceAndExternalIDPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.idPrefix)
+		_ = chain.core.Interaction.HardDeleteInteractionsBySourceRefPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.refPrefix)
+		_ = chain.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.refPrefix)
+		_ = chain.core.Contact.HardDeleteContact(cleanupCtx, contact.ID)
+	})
+
+	now := accelerated.GetCurrentTime()
+	stage := func(chatJID, suffix string, sentAt time.Time) *repository.CommsMessage {
+		t.Helper()
+		body := "wiring fixture"
+		peer := chatJID
+		row, err := chain.messaging.CommsMessageRepo.UpsertChatMessage(ctx, repository.UpsertChatMessageParams{
+			Source:           repository.InteractionSourceWhatsApp,
+			ExternalID:       fx.idPrefix + suffix,
+			ThreadID:         chatJID,
+			Body:             &body,
+			PeerHandle:       &peer,
+			Direction:        repository.InteractionDirectionInbound,
+			SentAt:           sentAt,
+			MatchedContactID: &contact.ID,
+		})
+		require.NoError(t, err)
+		return row
+	}
+
+	// Chat C: two rows inside the burst window → one interaction (assertion 1).
+	fx.firstC = fx.idPrefix + "c1"
+	stage(fx.chatC, "c1", now.Add(-40*time.Minute))
+	stage(fx.chatC, "c2", now.Add(-30*time.Minute))
+	// Chat D: one row the reenqueuer's synchronous pass must find (assertion 4).
+	fx.firstD = fx.idPrefix + "d1"
+	stage(fx.chatD, "d1", now.Add(-20*time.Minute))
+	// Chat E: one row left UNCLAIMED for assertions 2 and 3.
+	fx.rowE = stage(fx.chatE, "e1", now.Add(-10*time.Minute)).ID
+
+	return fx
+}
+
+// TestWhatsAppWiring_ProductionRegistriesDispatchWhatsApp drives the real wire
+// functions and asserts that all seven remaining source-keyed sites dispatch
+// for 'whatsapp'. (Site 8, consumer.messageInteractionSources, landed with the
+// schema PR and is unexported; its regression guard is the pipeline test in
+// backend/tests, where a missing entry makes the recorder reject the source.)
+//
+// spec: WHA-040
+func TestWhatsAppWiring_ProductionRegistriesDispatchWhatsApp(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	cfg.Database.MigrationsPath = migrationsPathForTest()
+	cfg.Features.EnableWhatsAppSync = true
+
+	chain := buildWireChainForGolden(t, cfg)
+	fx := seedWhatsAppWiringFixture(t, ctx, chain)
+
+	// --- Sites 3 + 6, behaviorally -----------------------------------------
+	// The engine registered under the whatsapp key in the ChatAwareAggregator
+	// map must claim chat C's rows and publish the interaction event in ONE
+	// transaction, so the event row is durable, synchronous evidence — no
+	// running worker required.
+	//
+	// This discriminates BOTH mis-bindings: a gchat engine under the whatsapp
+	// key lists source='gchat' rows, finds none and publishes nothing; an
+	// engine built from the gchat source adapter publishes under source
+	// 'gchat' with a 'gchat:' ref, so the lookup misses.
+	engine := chain.wiring.Engines[repository.InteractionSourceWhatsApp]
+	require.NotNil(t, engine, "site 6: no ChatAwareAggregator registered for whatsapp")
+	require.NoError(t, engine.AggregateForContact(ctx, fx.contactID, fx.chatC))
+
+	wantRefC := repository.InteractionSourceWhatsApp + ":" + fx.chatC + ":" + fx.firstC
+	envC, err := chain.eventRepo.FindEventBySource(ctx, repository.InteractionSourceWhatsApp, wantRefC)
+	require.NoError(t, err, "sites 3+6: the whatsapp engine published no event for %s", wantRefC)
+	require.NotNil(t, envC)
+
+	// --- Site 1: the staging-processor registry ----------------------------
+	// An unregistered source returns 0 rows affected (and a logged warning),
+	// which is exactly what makes a missing entry silent in production.
+	//
+	// comms_message.interaction_id REFERENCES interaction(id), so an arbitrary
+	// UUID fails the FK at statement time even inside a rolled-back tx: create
+	// a real interaction first.
+	markRef := "wiring-session-" + uuid.NewString()
+	desc := "wiring fixture interaction"
+	sourceRef := fx.refPrefix + "3@s.whatsapp.net:" + fx.idPrefix + "e1"
+	interaction, err := chain.core.Interaction.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:   fx.contactID,
+		Source:      repository.InteractionSourceWhatsApp,
+		SourceRef:   &sourceRef,
+		OccurredAt:  accelerated.GetCurrentTime(),
+		Description: &desc,
+		Direction:   repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+
+	tx, err := chain.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	affected, err := chain.messaging.StagingRegistry.MarkProcessedTx(
+		ctx, tx, repository.InteractionSourceWhatsApp, []uuid.UUID{fx.rowE}, interaction.ID, markRef,
+	)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, affected, "site 1: no staging processor registered for whatsapp")
+
+	// --- Site 2: the venue-container-reader registry ------------------------
+	// An unregistered source returns (nil, nil) — the recorder then writes a
+	// NULL venue_id and nothing complains.
+	venueID, err := chain.messaging.VenueResolver.ResolveMessageVenueTx(
+		ctx, tx, repository.InteractionSourceWhatsApp, []uuid.UUID{fx.rowE},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, venueID, "site 2: no venue container reader registered for whatsapp")
+
+	require.NoError(t, tx.Rollback(ctx))
+
+	// --- Site 4: the aggregator-reenqueuer registry -------------------------
+	// The reenqueuer's SYNCHRONOUS second action parses the chat id by
+	// stripping "<source>:" from the envelope PeerRef, so an entry constructed
+	// with InteractionSourceGChat cannot parse a "whatsapp:" PeerRef, aggregates
+	// nothing and publishes nothing. (The River Insert it also performs is not
+	// asserted: reading river_job would need raw SQL.)
+	reenqueuer := chain.agg.ReenqueuerEntries[repository.InteractionSourceWhatsApp]
+	require.NotNil(t, reenqueuer, "site 4: no aggregator reenqueuer registered for whatsapp")
+	envD := envelopeWithPeerRef(t, repository.InteractionSourceWhatsApp+":"+fx.chatD)
+	require.NoError(t, reenqueuer.Reenqueue(ctx, envD, fx.contactID))
+
+	wantRefD := repository.InteractionSourceWhatsApp + ":" + fx.chatD + ":" + fx.firstD
+	envDOut, err := chain.eventRepo.FindEventBySource(ctx, repository.InteractionSourceWhatsApp, wantRefD)
+	require.NoError(t, err, "site 4: the whatsapp reenqueuer aggregated nothing for %s", wantRefD)
+	require.NotNil(t, envDOut)
+
+	// --- Site 5: the per-source chat-lister registry ------------------------
+	// An unregistered source returns (nil, nil); a lister bound to another
+	// source returns rows for that source, i.e. none of ours.
+	chats, err := chain.wiring.ChatListers.ListUnprocessedChats(ctx, repository.InteractionSourceWhatsApp, fx.contactID)
+	require.NoError(t, err)
+	assert.Contains(t, chats, fx.chatE, "site 5: chat lister did not enumerate the whatsapp chat")
+
+	// --- Site 7: the sweeper-lister map -------------------------------------
+	sweeper := chain.wiring.SweeperListers[repository.InteractionSourceWhatsApp]
+	require.NotNil(t, sweeper, "site 7: no sweeper lister registered for whatsapp")
+	contactIDs, err := sweeper.ListUnprocessedContactIDs(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, contactIDs, fx.contactID, "site 7: sweeper lister did not enumerate the contact")
+}
+
+// envelopeWithPeerRef builds the message.received envelope a comms aggregator
+// emits, carrying the PeerRef the reenqueuer parses its chat scope from.
+func envelopeWithPeerRef(t *testing.T, peerRef string) *events.Envelope {
+	t.Helper()
+	payload, err := json.Marshal(events.MessageReceivedPayload{
+		Version:   1,
+		PeerRef:   peerRef,
+		MessageAt: accelerated.GetCurrentTime(),
+	})
+	require.NoError(t, err)
+	return &events.Envelope{
+		ID:         uuid.New(),
+		Source:     repository.InteractionSourceWhatsApp,
+		SourceID:   uuid.NewString(),
+		Kind:       events.KindMessageReceived,
+		Payload:    payload,
+		ObservedAt: accelerated.GetCurrentTime(),
+	}
+}

--- a/backend/cmd/crm-api/whatsapp_wiring_test.go
+++ b/backend/cmd/crm-api/whatsapp_wiring_test.go
@@ -27,8 +27,10 @@ import (
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/testdb"
 
 	"github.com/google/uuid"
@@ -51,6 +53,8 @@ type whatsappWiringFixture struct {
 	firstC    string // external_id of the first (oldest) row in chat C
 	firstD    string
 	rowE      uuid.UUID
+	chatG     string // group JID, for the venue-kind discriminator
+	rowG      uuid.UUID
 	idPrefix  string
 	refPrefix string
 }
@@ -73,6 +77,7 @@ func seedWhatsAppWiringFixture(t *testing.T, ctx context.Context, chain wireChai
 		chatC:     "1204555" + run[:4] + "1@s.whatsapp.net",
 		chatD:     "1204555" + run[:4] + "2@s.whatsapp.net",
 		chatE:     "1204555" + run[:4] + "3@s.whatsapp.net",
+		chatG:     "1204555" + run[:4] + "4-1690000000@g.us",
 		idPrefix:  "wa-wiring-" + run + "-",
 		refPrefix: repository.InteractionSourceWhatsApp + ":1204555" + run[:4],
 	}
@@ -121,6 +126,9 @@ func seedWhatsAppWiringFixture(t *testing.T, ctx context.Context, chain wireChai
 	stage(fx.chatD, "d1", now.Add(-20*time.Minute))
 	// Chat E: one row left UNCLAIMED for assertions 2 and 3.
 	fx.rowE = stage(fx.chatE, "e1", now.Add(-10*time.Minute)).ID
+	// Chat G: a GROUP-threaded row, also unclaimed, so assertion 3 can prove the
+	// reader DISCRIMINATES dm from group_chat rather than merely resolving.
+	fx.rowG = stage(fx.chatG, "g1", now.Add(-5*time.Minute)).ID
 
 	return fx
 }
@@ -202,11 +210,31 @@ func TestWhatsAppWiring_ProductionRegistriesDispatchWhatsApp(t *testing.T) {
 	// --- Site 2: the venue-container-reader registry ------------------------
 	// An unregistered source returns (nil, nil) — the recorder then writes a
 	// NULL venue_id and nothing complains.
-	venueID, err := chain.messaging.VenueResolver.ResolveMessageVenueTx(
+	//
+	// Resolving BOTH a direct-chat row and a group row, and asserting the kinds
+	// DIFFER, is what makes this more than "a venue came back": the reader this
+	// PR adds is a copy of GChat's, whose kind is hard-coded to group_chat —
+	// right for Chat spaces, wrong for WhatsApp. A single-row assertion stays
+	// green under that defect.
+	dmVenueID, err := chain.messaging.VenueResolver.ResolveMessageVenueTx(
 		ctx, tx, repository.InteractionSourceWhatsApp, []uuid.UUID{fx.rowE},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, venueID, "site 2: no venue container reader registered for whatsapp")
+	require.NotNil(t, dmVenueID, "site 2: no venue container reader registered for whatsapp")
+
+	groupVenueID, err := chain.messaging.VenueResolver.ResolveMessageVenueTx(
+		ctx, tx, repository.InteractionSourceWhatsApp, []uuid.UUID{fx.rowG},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, groupVenueID)
+
+	venueRepoTx := repository.NewVenueRepository(db.New(tx))
+	dmVenue, err := venueRepoTx.GetVenue(ctx, *dmVenueID)
+	require.NoError(t, err)
+	groupVenue, err := venueRepoTx.GetVenue(ctx, *groupVenueID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.VenueKindDM, dmVenue.Kind, "site 2: a one-to-one chat JID must resolve to a dm venue")
+	assert.Equal(t, repository.VenueKindGroupChat, groupVenue.Kind, "site 2: an @g.us chat JID must resolve to a group_chat venue")
 
 	require.NoError(t, tx.Rollback(ctx))
 
@@ -258,5 +286,81 @@ func envelopeWithPeerRef(t *testing.T, peerRef string) *events.Envelope {
 		Kind:       events.KindMessageReceived,
 		Payload:    payload,
 		ObservedAt: accelerated.GetCurrentTime(),
+	}
+}
+
+// TestWhatsAppWiring_RematchHandlersFollowTheFeatureFlag pins D5.3, the ONE
+// piece of this PR's wiring that is not inert when WhatsApp is off.
+//
+// The engine and the seven registries are deliberately unconditional (rows
+// staged under an earlier enabled boot must still aggregate after a restart
+// with the flag off), and every query they run is source='whatsapp'-scoped, so
+// they cost nothing. The rematch handlers are different: registering the
+// 'phone' handler unconditionally would make a bare phone method
+// rematch-eligible on a deployment with BOTH Telegram and WhatsApp disabled,
+// minting a rematch job where none exists today.
+//
+// Nothing else observes this. The golden lists pin worker/periodic/provider
+// names, not rematch registrations, so hoisting the two Register calls out of
+// the `if` would be caught by no test without this one.
+func TestWhatsAppWiring_RematchHandlersFollowTheFeatureFlag(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	// A phone method is the discriminating input: 'whatsapp' has no other
+	// handler, but 'phone' is shared with Telegram, so an unconditional
+	// registration changes eligibility on a deployment that has neither.
+	phone := []service.Method{{Type: string(repository.ContactMethodPhone), Value: "+12045550101"}}
+	whatsapp := []service.Method{{Type: string(repository.ContactMethodWhatsApp), Value: "+12045550101"}}
+
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		want    int
+	}{
+		{name: "off", enabled: false, want: 0},
+		{name: "on", enabled: true, want: 1},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cloneURL, drop := testdb.NewEphemeralClone(t)
+			t.Cleanup(drop)
+
+			cfg := config.TestConfig()
+			cfg.Database.URL = cloneURL
+			cfg.Database.MigrationsPath = migrationsPathForTest()
+			cfg.Features.EnableWhatsAppSync = tc.enabled
+
+			chain := buildWireChainForGolden(t, cfg)
+
+			assert.Len(t, chain.graph.RematchService.EligibleMethods(phone), tc.want,
+				"a phone method must be rematch-eligible only while WhatsApp sync is enabled (Telegram is off in this chain)")
+			assert.Len(t, chain.graph.RematchService.EligibleMethods(whatsapp), tc.want,
+				"a whatsapp method must be rematch-eligible only while WhatsApp sync is enabled")
+
+			if !tc.enabled {
+				return
+			}
+
+			// With the handlers registered, DISPATCH one. This is the only
+			// assertion in the suite that exercises a registered rematch handler
+			// end-to-end, and it is what makes run()'s
+			// CommsMessageRepo.SetPool(database.Pool) observable:
+			// AttachUnmatchedByPeer owns its own transaction and returns
+			// "repository has no pool (call SetPool)" without it, so a chain that
+			// silently drifted from run()'s wiring fails here rather than in
+			// production. No rows match the number, so the handler attaches
+			// nothing and reports zero.
+			contact, err := chain.core.Contact.CreateContact(context.Background(), repository.CreateContactRequest{
+				FullName: "WhatsApp Flag Gate " + uuid.NewString()[:8],
+			})
+			require.NoError(t, err)
+			require.NoError(t,
+				chain.graph.RematchService.Run(context.Background(), uuid.New(), contact.ID, phone),
+				"the registered whatsapp phone handler must run against a pooled comms repository")
+		})
 	}
 }

--- a/backend/cmd/crm-api/whatsapp_wiring_test.go
+++ b/backend/cmd/crm-api/whatsapp_wiring_test.go
@@ -85,9 +85,11 @@ func seedWhatsAppWiringFixture(t *testing.T, ctx context.Context, chain wireChai
 
 	t.Cleanup(func() {
 		cleanupCtx := context.Background()
-		_ = chain.messaging.CommsMessageRepo.HardDeleteBySourceAndExternalIDPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.idPrefix)
-		_ = chain.core.Interaction.HardDeleteInteractionsBySourceRefPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.refPrefix)
-		_ = chain.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.refPrefix)
+		// These three take LIKE patterns, so the trailing % is what makes them
+		// prefix deletes rather than exact-match no-ops.
+		_ = chain.messaging.CommsMessageRepo.HardDeleteBySourceAndExternalIDPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.idPrefix+"%")
+		_ = chain.core.Interaction.HardDeleteInteractionsBySourceRefPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.refPrefix+"%")
+		_ = chain.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(cleanupCtx, repository.InteractionSourceWhatsApp, fx.refPrefix+"%")
 		_ = chain.core.Contact.HardDeleteContact(cleanupCtx, contact.ID)
 	})
 

--- a/backend/cmd/crm-api/wire_aggregation.go
+++ b/backend/cmd/crm-api/wire_aggregation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
@@ -11,25 +12,32 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	tgpkg "personal-crm/backend/internal/telegram"
+	wapkg "personal-crm/backend/internal/whatsapp"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
 )
 
-// aggregationStack holds the messages + gchat aggregation engines, consumed
-// by registerMessagingWorkers.
+// aggregationStack holds the messages + gchat + whatsapp aggregation engines,
+// consumed by registerMessagingWorkers. ReenqueuerEntries is the same map handed
+// to NewAggregatorReenqueuerRegistry — returned so the composition-root parity
+// test can invoke a per-source entry.
 type aggregationStack struct {
-	MessagesEngine *aggregation.Engine
-	GChatEngine    *aggregation.Engine
+	MessagesEngine    *aggregation.Engine
+	GChatEngine       *aggregation.Engine
+	WhatsAppEngine    *aggregation.Engine
+	ReenqueuerEntries map[string]consumer.AggregatorReenqueuer
 }
 
-// buildAggregationEngines constructs the messages + gchat aggregation engines
-// and their reenqueuers, registers the gchat rematch handlers (gated on a
-// constructed gchat provider), and populates the deferred aggregator-reenqueuer
+// buildAggregationEngines constructs the messages + gchat + whatsapp aggregation
+// engines and their reenqueuers, registers the gchat rematch handlers (gated on a
+// constructed gchat provider) and the whatsapp ones (gated on the WhatsApp
+// feature flag), and populates the deferred aggregator-reenqueuer
 // registry. Wired unconditionally — the engines are stateless and inert until
 // their source rows exist. telegramManager / gchatProvider / gchatSyncStates
 // are nil-safe params exactly as the old inline fallbacks.
 func buildAggregationEngines(
+	cfg *config.Config,
 	database *db.Database,
 	core coreRepos,
 	contactService *service.ContactService,
@@ -121,6 +129,42 @@ func buildAggregationEngines(
 		repository.InteractionSourceGChat,
 	)
 
+	// WhatsApp aggregation engine over comms_message. LIVE but INERT on the same
+	// terms as gchat: every query is source='whatsapp'-scoped and returns zero
+	// rows until ingest writes one. It is deliberately NOT gated on
+	// EnableWhatsAppSync — rows staged under an earlier ON boot must still
+	// aggregate after a restart with the flag off. Unlike gchat's, the
+	// burst/reply windows are operator-tunable env knobs.
+	whatsappEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
+	whatsappEngine := wapkg.NewAggregationEngine(
+		cfg.WhatsApp.BurstWindowHours,
+		cfg.WhatsApp.ReplyBridgeHours,
+		commsMessageRepo,
+		interactionRepo,
+		contactService,
+		contactService,
+		eventBus,
+		database.Pool,
+		whatsappEnqueuer,
+	)
+
+	// WhatsApp rematch handlers: registered ONLY when WhatsApp sync is enabled.
+	// Unlike the engine, these are not inert when off — registering the 'phone'
+	// handler unconditionally would make a bare phone method rematch-eligible on
+	// deployments with both Telegram and WhatsApp disabled, minting a rematch job
+	// where none exists today (RematchService.EligibleMethods).
+	if cfg.Features.EnableWhatsAppSync {
+		rematchService.Register(wapkg.NewWhatsAppMethodRematchHandler(commsMessageRepo, whatsappEngine))
+		rematchService.Register(wapkg.NewPhoneRematchHandler(commsMessageRepo, whatsappEngine))
+		logger.Info().Msg("WhatsApp rematch handlers registered (whatsapp + phone contact methods)")
+	}
+
+	whatsappReenqueuer := consumer.NewCommsAggregatorReenqueuer(
+		whatsappEngine,
+		riverClient,
+		repository.InteractionSourceWhatsApp,
+	)
+
 	// Wire the per-source aggregator reenqueuer registry. The
 	// InteractionRecorderWorker holds the deferred holder; this
 	// assignment makes the post-commit reenqueue path live for both
@@ -131,6 +175,7 @@ func buildAggregationEngines(
 	reenqueuerEntries := map[string]consumer.AggregatorReenqueuer{
 		repository.InteractionSourceMessages: messagesReenqueuer,
 		repository.InteractionSourceGChat:    gchatReenqueuer,
+		repository.InteractionSourceWhatsApp: whatsappReenqueuer,
 	}
 	if telegramManager != nil {
 		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NewTelegramAggregatorReenqueuer(telegramManager.AggregationEngine())
@@ -140,7 +185,9 @@ func buildAggregationEngines(
 	aggregatorReenqueuerHolder.set(consumer.NewAggregatorReenqueuerRegistry(reenqueuerEntries))
 
 	return aggregationStack{
-		MessagesEngine: messagesEngine,
-		GChatEngine:    gchatEngine,
+		MessagesEngine:    messagesEngine,
+		GChatEngine:       gchatEngine,
+		WhatsAppEngine:    whatsappEngine,
+		ReenqueuerEntries: reenqueuerEntries,
 	}
 }

--- a/backend/cmd/crm-api/wire_core.go
+++ b/backend/cmd/crm-api/wire_core.go
@@ -187,6 +187,11 @@ func buildMessagingFoundation(queries db.Querier, messagesMessageRepo *repositor
 			// zero-rows-affected rollback fires and the engine reprocesses
 			// forever. Inert until a chat provider writes gchat rows.
 			repository.InteractionSourceGChat: repository.NewCommsSessionStagingProcessor(commsMessageRepo),
+			// WhatsApp create-path: same source-agnostic session-scoped
+			// processor as gchat, over the same comms_message table. Without
+			// it the recorder's zero-rows-affected rollback fires and the
+			// engine reprocesses forever.
+			repository.InteractionSourceWhatsApp: repository.NewCommsSessionStagingProcessor(commsMessageRepo),
 		},
 	)
 
@@ -202,6 +207,10 @@ func buildMessagingFoundation(queries db.Querier, messagesMessageRepo *repositor
 			repository.InteractionSourceTelegram: repository.NewTelegramVenueContainerReader(),
 			repository.InteractionSourceMessages: repository.NewMessagesVenueContainerReader(),
 			repository.InteractionSourceGChat:    repository.NewGChatVenueContainerReader(),
+			// WhatsApp carries BOTH kinds, so its reader discriminates on the
+			// chat JID suffix rather than hard-coding one kind the way gchat's
+			// (always a space) does.
+			repository.InteractionSourceWhatsApp: repository.NewWhatsAppVenueContainerReader(),
 		},
 		calendarRepo,
 	)

--- a/backend/cmd/crm-api/wire_golden_test.go
+++ b/backend/cmd/crm-api/wire_golden_test.go
@@ -31,6 +31,7 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/testdb"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/stretchr/testify/require"
@@ -170,7 +171,8 @@ func TestWireGoldenLists(t *testing.T) {
 			cfg.Database.MigrationsPath = migrationsPathForTest()
 			tc.mutate(cfg)
 
-			reg, syncStk := buildWireChainForGolden(t, cfg)
+			chain := buildWireChainForGolden(t, cfg)
+			reg, syncStk := chain.reg, chain.sync
 
 			require.Equal(t, tc.wantWorkers, sortedCopy(reg.workerKinds), "worker kinds")
 			require.Equal(t, tc.wantPeriodic, sortedCopy(reg.periodicKinds), "periodic kinds")
@@ -187,11 +189,27 @@ func TestWireGoldenLists(t *testing.T) {
 	}
 }
 
+// wireChain is everything buildWireChainForGolden produces. The golden lists
+// read reg + sync; the WhatsApp composition-root parity test
+// (whatsapp_wiring_test.go) invokes the source-keyed registries in messaging,
+// agg and wiring, which is why they are returned rather than discarded.
+type wireChain struct {
+	reg       *riverRegistrar
+	sync      syncStack
+	database  *db.Database
+	core      coreRepos
+	messaging messagingFoundation
+	agg       aggregationStack
+	wiring    messagingWorkerWiring
+	river     *river.Client[pgx.Tx]
+	bus       *events.Bus
+	eventRepo *repository.EventRepository
+}
+
 // buildWireChainForGolden drives the wire chain in run()'s exact order, minus
 // buildTelegram (telegram-skip rule) and minus riverClient.Start / the HTTP
-// server. It returns the registrar (recording worker/periodic kinds) and the
-// external-sync stack (for provider enumeration).
-func buildWireChainForGolden(t *testing.T, cfg *config.Config) (*riverRegistrar, syncStack) {
+// server.
+func buildWireChainForGolden(t *testing.T, cfg *config.Config) wireChain {
 	t.Helper()
 	ctx := context.Background()
 
@@ -241,8 +259,8 @@ func buildWireChainForGolden(t *testing.T, cfg *config.Config) (*riverRegistrar,
 
 	// Telegram is intentionally SKIPPED (Start must not run); a nil
 	// telegramManager is exactly a telegram-disabled boot for aggregation.
-	agg := buildAggregationEngines(database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
-	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
+	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
+	wiring := registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	machost := buildMacHost(reg, database, core, ingest)
 	buildStaleness(reg, cfg, database, machost)
@@ -253,7 +271,18 @@ func buildWireChainForGolden(t *testing.T, cfg *config.Config) (*riverRegistrar,
 	// pinned by the golden lists.
 	registerJobSampleWorkers(reg, repository.NewJobSampleRepository(database.Queries), cfg)
 
-	return reg, syncStk
+	return wireChain{
+		reg:       reg,
+		sync:      syncStk,
+		database:  database,
+		core:      core,
+		messaging: messaging,
+		agg:       agg,
+		wiring:    wiring,
+		river:     riverClient,
+		bus:       eventBus,
+		eventRepo: eventRepo,
+	}
 }
 
 func sortedCopy(in []string) []string {

--- a/backend/cmd/crm-api/wire_golden_test.go
+++ b/backend/cmd/crm-api/wire_golden_test.go
@@ -198,6 +198,7 @@ type wireChain struct {
 	sync      syncStack
 	database  *db.Database
 	core      coreRepos
+	graph     graphCore
 	messaging messagingFoundation
 	agg       aggregationStack
 	wiring    messagingWorkerWiring
@@ -242,6 +243,11 @@ func buildWireChainForGolden(t *testing.T, cfg *config.Config) wireChain {
 	ingest := buildIngestRepos(database.Queries)
 	graph := buildGraphCore(database, eventBus)
 	messaging := buildMessagingFoundation(database.Queries, ingest.MessagesMessage, ingest.CalendarEvent)
+	// Part of run()'s order (main.go): AttachUnmatchedByPeer owns its own
+	// transaction and requires a pool, so the WhatsApp rematch handlers this
+	// chain registers would fail at runtime without it. Registers no worker,
+	// periodic or provider, so the golden lists are unaffected.
+	messaging.CommsMessageRepo.SetPool(database.Pool)
 	consumers := buildDomainConsumers(cfg, database, core, graph, eventBus, riverClient)
 	contactService := buildContactService(cfg, database, core, graph, consumers, eventBus, riverClient)
 	interactionRecorder := buildInteractionRecorder(contactService, messaging, ingest, consumers, eventBus)
@@ -276,6 +282,7 @@ func buildWireChainForGolden(t *testing.T, cfg *config.Config) wireChain {
 		sync:      syncStk,
 		database:  database,
 		core:      core,
+		graph:     graph,
 		messaging: messaging,
 		agg:       agg,
 		wiring:    wiring,

--- a/backend/cmd/crm-api/wire_scheduler.go
+++ b/backend/cmd/crm-api/wire_scheduler.go
@@ -17,6 +17,16 @@ import (
 	"github.com/riverqueue/river"
 )
 
+// messagingWorkerWiring is the set of source-keyed registries
+// registerMessagingWorkers hands to the workers. Returned (rather than only
+// closed over) so the composition-root parity test can invoke a per-source
+// entry; run() discards it.
+type messagingWorkerWiring struct {
+	ChatListers    *scheduler.PerSourceChatListerRegistry
+	Engines        map[string]scheduler.ChatAwareAggregator
+	SweeperListers map[string]scheduler.UnprocessedContactLister
+}
+
 // registerMessagingWorkers registers the chat-aware messaging aggregate
 // worker + the 5-min sweeper worker and its periodic job. The chat-lister
 // and sweeper-lister registries map source → repository lister; future
@@ -27,11 +37,12 @@ func registerMessagingWorkers(
 	messaging messagingFoundation,
 	agg aggregationStack,
 	riverClient *river.Client[pgx.Tx],
-) {
+) messagingWorkerWiring {
 	messagesMessageRepo := ingest.MessagesMessage
 	commsMessageRepo := messaging.CommsMessageRepo
 	messagesEngine := agg.MessagesEngine
 	gchatEngine := agg.GChatEngine
+	whatsappEngine := agg.WhatsAppEngine
 
 	// Register the messaging aggregate workers. The chat-lister
 	// registry maps source → repository's ListUnprocessedChatsByContact;
@@ -45,13 +56,19 @@ func registerMessagingWorkers(
 			repository.InteractionSourceGChat: func(ctx context.Context, contactID uuid.UUID) ([]string, error) {
 				return commsMessageRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceGChat, contactID)
 			},
+			// Same source-bound closure, pinned to 'whatsapp'.
+			repository.InteractionSourceWhatsApp: func(ctx context.Context, contactID uuid.UUID) ([]string, error) {
+				return commsMessageRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceWhatsApp, contactID)
+			},
 		},
 	)
+	chatAwareEngines := map[string]scheduler.ChatAwareAggregator{
+		repository.InteractionSourceMessages: messagesEngine,
+		repository.InteractionSourceGChat:    gchatEngine,
+		repository.InteractionSourceWhatsApp: whatsappEngine,
+	}
 	addWorker(reg, scheduler.NewMessagingAggregateForContactWorker(
-		map[string]scheduler.ChatAwareAggregator{
-			repository.InteractionSourceMessages: messagesEngine,
-			repository.InteractionSourceGChat:    gchatEngine,
-		},
+		chatAwareEngines,
 		chatListerRegistry,
 	))
 
@@ -64,6 +81,8 @@ func registerMessagingWorkers(
 		// Source-bound adapter: comms_message is multi-source, so wrap the
 		// repo with a 'gchat'-pinned lister.
 		repository.InteractionSourceGChat: newCommsSourceContactLister(commsMessageRepo, repository.InteractionSourceGChat),
+		// Same source-pinned adapter, for 'whatsapp'.
+		repository.InteractionSourceWhatsApp: newCommsSourceContactLister(commsMessageRepo, repository.InteractionSourceWhatsApp),
 	}
 	addWorker(reg, scheduler.NewMessagingAggregateSweeperWorker(sweeperListers, riverClient))
 	reg.addPeriodic(consumerjobs.MessagingAggregateSweeperArgs{}.Kind(), river.NewPeriodicJob(
@@ -73,6 +92,12 @@ func registerMessagingWorkers(
 		},
 		&river.PeriodicJobOpts{RunOnStart: true},
 	))
+
+	return messagingWorkerWiring{
+		ChatListers:    chatListerRegistry,
+		Engines:        chatAwareEngines,
+		SweeperListers: sweeperListers,
+	}
 }
 
 // stalenessStack holds the staleness service (consumed by the health

--- a/backend/internal/messaging/commsadapter/store.go
+++ b/backend/internal/messaging/commsadapter/store.go
@@ -14,10 +14,10 @@ import (
 )
 
 // ReplyTargetMetadataKey is the source_metadata key under which an explicit
-// reply's target external message id is stored. No provider writes this key yet
-// (explicit-reply bridging is deferred), so the projection's ReplyTargetID is
-// currently always nil — but wiring the field here means a later explicit-reply
-// provider need not touch the adapter.
+// reply's target external message id is stored. The WhatsApp ingest path writes
+// it, and the WhatsApp aggregation engine reads it through this projection, so
+// the key is live rather than reserved. A source that carries no explicit-reply
+// signal simply omits it and the projection's ReplyTargetID stays nil.
 const ReplyTargetMetadataKey = "reply_target_external_id"
 
 // StoreAdapter projects repository.CommsMessage rows into aggregation.Message,

--- a/backend/internal/repository/venue_resolver.go
+++ b/backend/internal/repository/venue_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 
 	"personal-crm/backend/internal/db"
 
@@ -218,6 +219,44 @@ func (r *GChatVenueContainerReader) ContainerForMessageTx(ctx context.Context, t
 	}
 	return VenueContainer{
 		Kind:        VenueKindGroupChat,
+		ContainerID: containerID,
+	}, nil
+}
+
+// whatsappGroupJIDSuffix is the server part of a WhatsApp group JID
+// (`<digits>-<digits>@g.us`). It is the ONLY discriminator the reader needs:
+// the ingest path's person-to-person allowlist refuses every chat server except
+// the group server and the two user servers (`s.whatsapp.net`, `lid`), so a
+// thread id that is not a group JID is necessarily a direct chat.
+const whatsappGroupJIDSuffix = "@g.us"
+
+// WhatsAppVenueContainerReader reads the WhatsApp chat container off a
+// comms_message staging row. Unlike GChat (whose spaces are always group
+// chats), WhatsApp carries both kinds, so the kind is derived from the chat
+// JID's server suffix.
+type WhatsAppVenueContainerReader struct{}
+
+// NewWhatsAppVenueContainerReader builds the reader.
+func NewWhatsAppVenueContainerReader() *WhatsAppVenueContainerReader {
+	return &WhatsAppVenueContainerReader{}
+}
+
+// ContainerForMessageTx implements VenueContainerReader for whatsapp.
+func (r *WhatsAppVenueContainerReader) ContainerForMessageTx(ctx context.Context, tx pgx.Tx, messageID uuid.UUID) (VenueContainer, error) {
+	row, err := db.New(tx).GetCommsMessageContainer(ctx, uuidToPgUUID(messageID))
+	if err != nil {
+		return VenueContainer{}, err
+	}
+	var containerID string
+	if row.ThreadID.Valid {
+		containerID = row.ThreadID.String
+	}
+	kind := VenueKindDM
+	if strings.HasSuffix(containerID, whatsappGroupJIDSuffix) {
+		kind = VenueKindGroupChat
+	}
+	return VenueContainer{
+		Kind:        kind,
 		ContainerID: containerID,
 	}, nil
 }

--- a/backend/internal/synthetic/factory/sources.go
+++ b/backend/internal/synthetic/factory/sources.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/identity"
 
 	"github.com/google/uuid"
 	calendarapi "google.golang.org/api/calendar/v3"
@@ -825,3 +826,74 @@ func encodeBody(s string) string {
 func trimAngle(s string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(s, "<"), ">")
 }
+
+// --- WhatsApp ---------------------------------------------------------------
+
+// WhatsAppMessageSpec bundles everything the WhatsApp replay adapter needs to
+// drive one message through the REAL Ingestor: the chat, the peer, and the
+// linked account. DIRECT CHATS ONLY — a group spec would write
+// whatsapp_chat_config rows, whose table has no namespace column and would need
+// its own tracked-id cleanup step.
+type WhatsAppMessageSpec struct {
+	ExternalID string // "<ns>wa-<seq>" → comms_message.external_id (the ns is what cleanup reclaims by)
+	ChatJID    string // "<digits>@s.whatsapp.net"; == PeerJID for a direct chat
+	PeerJID    string
+	PeerPhone  string // NORMALIZED E.164 ("+12045550107"), never the raw dashed form
+	AccountJID string // "<digits>@s.whatsapp.net" for the linked device
+	PushName   string
+	Body       string
+	SentAt     time.Time
+	Outbound   bool
+	Intent     MatchIntent
+}
+
+// WhatsAppMessage builds a direct-chat WhatsApp message from the target contact
+// (MatchSeeded) or from an unknown peer (MatchUnknown → the row IS written, with
+// no contact, which is legal for WhatsApp unlike Gmail/GChat). Inbound by
+// default; WithOutbound() flips the direction. Anchor-relative sent time.
+//
+// PeerPhone is normalized HERE because nothing downstream normalizes it: the
+// ingestor writes peer_normalized verbatim, and on the live path the value is
+// already E.164 only because the message parser ran identity.Normalize. A raw
+// dashed number would stage a peer_normalized production can never write,
+// silently falsifying both the rematch attach and the phone-prefix cleanup path.
+func (g *Generator) WhatsAppMessage(target ContactSpec, intent MatchIntent, opts ...MessageOption) WhatsAppMessageSpec {
+	mo := applyMessageOptions(opts)
+	ns := g.Prefix()
+	seq := g.bumpSourceSeq()
+	sentAt := g.at(-time.Hour - mo.age)
+
+	raw := target.Phone
+	if intent == MatchUnknown || raw == "" {
+		raw = g.unknownPhone()
+	}
+	peerPhone := identity.Normalize(raw, identity.IdentifierTypeWhatsApp)
+	// The normalized form is "+" followed by digits; a JID's user part is the
+	// digits alone.
+	peerJID := strings.TrimPrefix(peerPhone, "+") + "@" + whatsappUserServer
+
+	// The linked account is "me", not a contact, so it deliberately does NOT
+	// draw from the namespace's 555-01XX contact-phone block: that block is only
+	// 100 lines wide and every draw is a line a future contact cannot have. A
+	// fixed 555-0000 line in the same namespace area code is disjoint from every
+	// issuable contact phone and still namespace-scoped.
+	accountJID := fmt.Sprintf("1%d5550000@%s", g.PhoneAreaCode(), whatsappUserServer)
+
+	return WhatsAppMessageSpec{
+		ExternalID: fmt.Sprintf("%swa-%d", ns, seq),
+		ChatJID:    peerJID, // direct chat: the chat IS the peer
+		PeerJID:    peerJID,
+		PeerPhone:  peerPhone,
+		AccountJID: accountJID,
+		PushName:   target.FullName,
+		Body:       "synthetic whatsapp message",
+		SentAt:     sentAt,
+		Outbound:   mo.outbound,
+		Intent:     intent,
+	}
+}
+
+// whatsappUserServer is the phone-number user server every direct-chat JID this
+// factory mints is addressed on. Declared here rather than imported from the
+// whatsapp package so the factory carries no whatsmeow dependency.
+const whatsappUserServer = "s.whatsapp.net"

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -95,22 +95,26 @@ func (h *Harness) DrainGateB(ctx context.Context) error {
 	return fmt.Errorf("synthetic: Gate B did not clear within %s for namespace %q", teardownGateBBoundedWait, h.namespace)
 }
 
-// waitTeardownGateB bounded-waits until Gate B clears for BOTH aggregate sources
-// (messages + gchat). Returns false on timeout. The budget is REAL wall-clock
+// waitTeardownGateB bounded-waits until Gate B clears for EVERY aggregate source
+// (messages + gchat + whatsapp). Returns false on timeout. A source missing here
+// is invisible to teardown, so cleanup could start deleting under a live
+// aggregate job. Returns false on timeout. The budget is REAL wall-clock
 // (see defaultSettleTimeout) so it does not collapse under TIME_ACCELERATION.
 func (h *Harness) waitTeardownGateB(ctx context.Context) bool {
 	open, cancel := realTimeBudget(teardownGateBBoundedWait)
 	defer cancel()
 	for open() {
 		if h.gateBClear(ctx, repository.InteractionSourceMessages) &&
-			h.gateBClear(ctx, repository.InteractionSourceGChat) {
+			h.gateBClear(ctx, repository.InteractionSourceGChat) &&
+			h.gateBClear(ctx, repository.InteractionSourceWhatsApp) {
 			return true
 		}
 		time.Sleep(teardownPollInterval)
 	}
 	// Final check (covers the boundary).
 	return h.gateBClear(ctx, repository.InteractionSourceMessages) &&
-		h.gateBClear(ctx, repository.InteractionSourceGChat)
+		h.gateBClear(ctx, repository.InteractionSourceGChat) &&
+		h.gateBClear(ctx, repository.InteractionSourceWhatsApp)
 }
 
 // cleanup runs the D5a ID-tracked, FK-ordered teardown by tracked id (or

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -98,7 +98,7 @@ func (h *Harness) DrainGateB(ctx context.Context) error {
 // waitTeardownGateB bounded-waits until Gate B clears for EVERY aggregate source
 // (messages + gchat + whatsapp). Returns false on timeout. A source missing here
 // is invisible to teardown, so cleanup could start deleting under a live
-// aggregate job. Returns false on timeout. The budget is REAL wall-clock
+// aggregate job. The budget is REAL wall-clock
 // (see defaultSettleTimeout) so it does not collapse under TIME_ACCELERATION.
 func (h *Harness) waitTeardownGateB(ctx context.Context) bool {
 	open, cancel := realTimeBudget(teardownGateBBoundedWait)

--- a/backend/internal/synthetic/replay/harness_setup.go
+++ b/backend/internal/synthetic/replay/harness_setup.go
@@ -22,6 +22,7 @@ import (
 	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/synthetic/factory"
 	"personal-crm/backend/internal/telegram"
+	"personal-crm/backend/internal/whatsapp"
 
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
@@ -244,6 +245,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramRepo),
 		repository.InteractionSourceMessages: repository.NewMessagesStagingProcessor(messagesRepo),
 		repository.InteractionSourceGChat:    repository.NewCommsSessionStagingProcessor(commsRepo),
+		repository.InteractionSourceWhatsApp: repository.NewCommsSessionStagingProcessor(commsRepo),
 	})
 
 	// Venue resolver: populates interaction.venue_id so replay adapters can
@@ -256,6 +258,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 			repository.InteractionSourceTelegram: repository.NewTelegramVenueContainerReader(),
 			repository.InteractionSourceMessages: repository.NewMessagesVenueContainerReader(),
 			repository.InteractionSourceGChat:    repository.NewGChatVenueContainerReader(),
+			repository.InteractionSourceWhatsApp: repository.NewWhatsAppVenueContainerReader(),
 		},
 		calendarEventRepo,
 	)
@@ -300,11 +303,31 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		google.GChatBurstWindowHours, google.GChatReplyBridgeHours,
 		commsRepo, interactionRepo, contactService, contactService, bus, database.Pool, gchatEnqueuer,
 	)
+	// WhatsApp: the REAL ingest trio (repo → gate → matcher → ingestor),
+	// reproducing buildWhatsAppIngestor, plus its aggregation engine. The
+	// adapter drives the ingestor; the worker drives the engine.
+	whatsappRepo := repository.NewWhatsAppRepository(database.Queries)
+	whatsappIngestor := whatsapp.NewIngestor(
+		commsRepo,
+		whatsapp.NewChatGate(whatsappRepo, cfg.WhatsApp.GroupMaxMembers),
+		// enricher nil: EnrichmentService is not constructed in this package and
+		// PeerMatcher tolerates a nil one.
+		whatsapp.NewPeerMatcher(identityService, commsRepo, externalRepo, nil, cfg.WhatsApp.DiscoveryMinMessages),
+	)
+	whatsappEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(client)
+	whatsappEngine := whatsapp.NewAggregationEngine(
+		cfg.WhatsApp.BurstWindowHours, cfg.WhatsApp.ReplyBridgeHours,
+		commsRepo, interactionRepo, contactService, contactService, bus, database.Pool, whatsappEnqueuer,
+	)
+
 	chatListerRegistry := scheduler.NewPerSourceChatListerRegistry(
 		map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
 			repository.InteractionSourceMessages: messagesRepo.ListUnprocessedChatsByContact,
 			repository.InteractionSourceGChat: func(ctx context.Context, contactID uuid.UUID) ([]string, error) {
 				return commsRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceGChat, contactID)
+			},
+			repository.InteractionSourceWhatsApp: func(ctx context.Context, contactID uuid.UUID) ([]string, error) {
+				return commsRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceWhatsApp, contactID)
 			},
 		},
 	)
@@ -312,6 +335,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		map[string]scheduler.ChatAwareAggregator{
 			repository.InteractionSourceMessages: messagesEngine,
 			repository.InteractionSourceGChat:    gchatEngine,
+			repository.InteractionSourceWhatsApp: whatsappEngine,
 		},
 		chatListerRegistry,
 	))
@@ -376,6 +400,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		ingestService:   ingestService,
 		macHostID:       macHostID,
 		peerMatcher:     &telegramPeerMatcherDeps{matcher: peerMatcher, engine: tgAggEngine},
+		whatsapp:        &whatsappDeps{ingestor: whatsappIngestor},
 		groupMaxMembers: groupMaxMembers,
 		created:         newCreated(),
 	}

--- a/backend/internal/synthetic/replay/helpers.go
+++ b/backend/internal/synthetic/replay/helpers.go
@@ -38,6 +38,15 @@ func (h *Harness) gchatSettled(externalID string) gateA {
 	}
 }
 
+// whatsappSettled returns a Gate A predicate: the
+// comms_message(whatsapp, externalID) row is linked to an interaction.
+func (h *Harness) whatsappSettled(externalID string) gateA {
+	return func(ctx context.Context) (bool, error) {
+		n, err := h.support.CountLinkedCommsMessageByExternalID(ctx, "whatsapp", externalID)
+		return n > 0, err
+	}
+}
+
 // imessageSettled returns a Gate A predicate: the messages_message(guid) row is
 // linked to an interaction.
 func (h *Harness) imessageSettled(guid string) gateA {

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -289,6 +289,11 @@ type Harness struct {
 	// the telegram adapter.
 	peerMatcher *telegramPeerMatcherDeps
 
+	// whatsapp bundles the WhatsApp ingestor for the whatsapp adapter. The
+	// engine it feeds is registered in the ChatAwareAggregator map rather than
+	// held here, because the adapter drives aggregation through the WORKER.
+	whatsapp *whatsappDeps
+
 	// groupMaxMembers is the size threshold the MessageHandler is built with,
 	// sourced from the test config (TELEGRAM_GROUP_MAX_MEMBERS default) so the
 	// harness tracks the production default rather than hard-coding a copy.

--- a/backend/internal/synthetic/replay/whatsapp.go
+++ b/backend/internal/synthetic/replay/whatsapp.go
@@ -1,0 +1,107 @@
+package replay
+
+import (
+	"context"
+	"fmt"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/whatsapp"
+
+	"github.com/google/uuid"
+)
+
+// whatsappDeps bundles the WhatsApp ingest seam the adapter drives. It mirrors
+// telegramPeerMatcherDeps: per-source deps are Harness fields, since the package
+// has no adapter registry.
+type whatsappDeps struct {
+	ingestor *whatsapp.Ingestor
+}
+
+// WhatsAppResult is the settled outcome of a WhatsApp replay.
+type WhatsAppResult struct {
+	ContactID uuid.UUID
+	PeerJID   string
+	Matched   bool // false for MatchUnknown (the row IS written, just unattached)
+}
+
+// ReplayWhatsApp feeds a synthetic message through the REAL Ingestor — the same
+// seam the live handler and the history drainer use — so a seeded row is
+// byte-identical in shape to a production one.
+//
+// WhatsApp differs from Gmail/GChat on the unknown-sender path: an unrecognised
+// peer still WRITES a comms_message row (matched_contact_id IS NULL is legal for
+// this source), it just never aggregates. So MatchUnknown is a PENDING outcome
+// here, not a match-only one.
+//
+// contactID is the seeded contact this message targets (for MatchSeeded). The
+// caller must seed it with a phone or whatsapp method matching the peer's
+// number.
+func (h *Harness) ReplayWhatsApp(ctx context.Context, contactID uuid.UUID, spec factory.WhatsAppMessageSpec) (WhatsAppResult, error) {
+	if h.whatsapp == nil {
+		return WhatsAppResult{}, fmt.Errorf("whatsapp: harness has no whatsapp deps")
+	}
+
+	body := spec.Body
+	pushName := spec.PushName
+	peerJID := spec.PeerJID
+	peerPhone := spec.PeerPhone
+	accountJID := spec.AccountJID
+
+	msg := whatsapp.IngestedMessage{
+		MessageID:     spec.ExternalID,
+		ChatJID:       spec.ChatJID,
+		ChatType:      whatsapp.ChatTypePrivate,
+		IsOutgoing:    spec.Outbound,
+		SentAt:        spec.SentAt,
+		Body:          &body,
+		MessageType:   whatsapp.MessageTypeText,
+		PeerJID:       &peerJID,
+		PeerPhoneE164: &peerPhone,
+		PushName:      &pushName,
+		AccountJID:    &accountJID,
+	}
+
+	// The real seam. Synchronous: the staged row is durable when it returns.
+	if err := h.whatsapp.ingestor.IngestMessage(ctx, msg); err != nil {
+		return WhatsAppResult{}, fmt.Errorf("whatsapp ingest: %w", err)
+	}
+
+	// An unmatched peer that crosses the discovery threshold mints an
+	// external_contact candidate whose source_id is a bare JID — the ns-prefix
+	// cleanup step cannot reach it, so track it by id.
+	if external, err := h.externalRepo.GetBySource(ctx, repository.InteractionSourceWhatsApp, spec.PeerJID, nil); err == nil && external != nil {
+		h.track(func(c *created) { c.addExternalContact(external.ID) })
+	}
+
+	if spec.Intent == factory.MatchUnknown {
+		// Pending: the row exists but is unattached, so it never aggregates and
+		// there is no async work to wait for. Settle on the trivially-true gate
+		// so the harness's settle bookkeeping stays uniform across adapters.
+		if err := h.Settle(ctx, func(context.Context) (bool, error) { return true, nil }, ""); err != nil {
+			return WhatsAppResult{}, err
+		}
+		return WhatsAppResult{PeerJID: spec.PeerJID, Matched: false}, nil
+	}
+
+	// Drive aggregation for the matched contact through the WORKER path (the
+	// ingestor writes the row and publishes nothing; the engine derives the
+	// interaction on its own pass).
+	if _, err := h.client.Insert(ctx, consumerjobs.MessagingAggregateForContactArgs{
+		ContactID: contactID,
+		Source:    repository.InteractionSourceWhatsApp,
+	}, nil); err != nil {
+		return WhatsAppResult{}, fmt.Errorf("whatsapp enqueue aggregate: %w", err)
+	}
+
+	// Gate A: THIS replay's whatsapp row is linked to an interaction.
+	if err := h.Settle(ctx, h.whatsappSettled(spec.ExternalID), repository.InteractionSourceWhatsApp); err != nil {
+		return WhatsAppResult{}, err
+	}
+	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceWhatsApp); err != nil {
+		return WhatsAppResult{}, err
+	}
+	return WhatsAppResult{ContactID: contactID, PeerJID: spec.PeerJID, Matched: true}, nil
+}

--- a/backend/internal/whatsapp/aggregation.go
+++ b/backend/internal/whatsapp/aggregation.go
@@ -18,7 +18,7 @@ const whatsappLabel = "WhatsApp"
 // bytes the test pins are the bytes production writes. Unexported: every
 // cross-package consumer reaches the formats through NewAggregationEngine.
 func whatsappSourceAdapter() commsadapter.Adapter {
-	return commsadapter.NewAdapter(repository.InteractionSourceWhatsApp, whatsappLabel)
+	return commsadapter.NewAdapter(syncSource, whatsappLabel)
 }
 
 // NewAggregationEngine constructs the shared aggregator engine configured for

--- a/backend/internal/whatsapp/aggregation.go
+++ b/backend/internal/whatsapp/aggregation.go
@@ -1,0 +1,57 @@
+package whatsapp
+
+import (
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/messaging/commsadapter"
+	"personal-crm/backend/internal/repository"
+)
+
+// whatsappLabel is the human product name that appears in interaction
+// descriptions ("WhatsApp outreach (3 messages)"). Declared beside the
+// constructor because the (source, label) pair is the whole of WhatsApp's
+// adapter configuration; the source half is syncSource (manager.go).
+const whatsappLabel = "WhatsApp"
+
+// whatsappSourceAdapter returns the shared comms adapter configured for
+// WhatsApp. Both NewAggregationEngine and the wire-format test call it, so the
+// bytes the test pins are the bytes production writes. Unexported: every
+// cross-package consumer reaches the formats through NewAggregationEngine.
+func whatsappSourceAdapter() commsadapter.Adapter {
+	return commsadapter.NewAdapter(repository.InteractionSourceWhatsApp, whatsappLabel)
+}
+
+// NewAggregationEngine constructs the shared aggregator engine configured for
+// the WhatsApp source over the comms_message table. Returns the shared
+// *aggregation.Engine directly (NO facade): a WhatsApp chat id is the chat JID,
+// already a string, so the engine's native
+// AggregateForContact(ctx, contactID, chatID string) signature fits.
+//
+// The burst/reply windows are parameters rather than package constants because
+// WhatsApp's are operator-tunable (WHATSAPP_BURST_WINDOW_HOURS /
+// WHATSAPP_REPLY_BRIDGE_HOURS, defaults in config).
+//
+// nil bus / pool / enqueuer are safe (see commsadapter.NewEngine).
+func NewAggregationEngine(
+	burstWindowHours, replyBridgeHours int,
+	commsRepo *repository.CommsMessageRepository,
+	interactionRepo *repository.InteractionRepository,
+	promoter aggregation.InteractionPromoter,
+	extender aggregation.InteractionExtender,
+	eventBus *events.Bus,
+	pool aggregation.TxBeginner,
+	enqueuer aggregation.ConsumerJobEnqueuer,
+) *aggregation.Engine {
+	return commsadapter.NewEngine(
+		whatsappSourceAdapter(),
+		burstWindowHours,
+		replyBridgeHours,
+		commsRepo,
+		interactionRepo,
+		promoter,
+		extender,
+		eventBus,
+		pool,
+		enqueuer,
+	)
+}

--- a/backend/internal/whatsapp/aggregation_test.go
+++ b/backend/internal/whatsapp/aggregation_test.go
@@ -1,0 +1,61 @@
+package whatsapp
+
+import (
+	"strings"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWhatsAppSourceAdapter_WireFormat pins the exact bytes the WhatsApp
+// aggregation engine writes into interaction.source, interaction.source_ref,
+// the event PeerRef and interaction.description. In-package so it calls the
+// same unexported constructor NewAggregationEngine uses — the bytes pinned here
+// are the bytes production writes.
+//
+// spec: WHA-040.source-is-whatsapp
+// spec: WHA-040.source-ref-is-chat-scoped
+// spec: WHA-040.description-names-whatsapp
+func TestWhatsAppSourceAdapter_WireFormat(t *testing.T) {
+	t.Parallel()
+
+	adapter := whatsappSourceAdapter()
+
+	require.Equal(t, "whatsapp", adapter.SourceName())
+	require.Equal(t, repository.InteractionSourceWhatsApp, adapter.SourceName())
+
+	assert.Equal(t, "whatsapp:123-456@g.us:ABC", adapter.SourceRef("123-456@g.us", "ABC"))
+	assert.Equal(t, "whatsapp:12045550107@s.whatsapp.net:ABC", adapter.SourceRef("12045550107@s.whatsapp.net", "ABC"))
+
+	assert.Equal(t, "WhatsApp outreach (3 messages)", adapter.Description(repository.InteractionDirectionOutbound, 3))
+	assert.Equal(t, "WhatsApp response (2 messages)", adapter.Description(repository.InteractionDirectionInbound, 2))
+	assert.Equal(t, "WhatsApp exchange (5 messages)", adapter.Description("mutual", 5))
+}
+
+// TestWhatsAppSourceAdapter_PeerRefRoundTrip guards R5.1: the comms reenqueuer
+// recovers the chat id by stripping "<source>:" from the event PeerRef
+// (consumer.parseCommsPeerRef), a literal prefix strip with no escaping. A chat
+// JID containing a ':' would truncate. The ingest path normalizes to non-AD
+// form before staging, which strips the ':<device>' suffix, so every JID that
+// can reach the engine round-trips — this pins that for the two forms whose
+// user part is not a bare subscriber number (group and LID).
+func TestWhatsAppSourceAdapter_PeerRefRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	adapter := whatsappSourceAdapter()
+	const prefix = "whatsapp:"
+
+	for _, chatJID := range []string{
+		"12045550107@s.whatsapp.net",
+		"123456789-987654321@g.us",
+		"88776655443322@lid",
+	} {
+		peerRef := adapter.PeerRef(chatJID)
+		require.True(t, strings.HasPrefix(peerRef, prefix), "PeerRef %q must carry the source prefix", peerRef)
+		// Mirrors consumer/comms_aggregator_reenqueuer.go's parseCommsPeerRef.
+		assert.Equal(t, chatJID, peerRef[len(prefix):], "PeerRef must round-trip through the reenqueuer's strip rule")
+	}
+}

--- a/backend/internal/whatsapp/rematch.go
+++ b/backend/internal/whatsapp/rematch.go
@@ -1,0 +1,127 @@
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// commsAttacher is the slice of *repository.CommsMessageRepository the rematch
+// handlers write through. Narrow so unit tests need no pool.
+type commsAttacher interface {
+	AttachUnmatchedByPeer(ctx context.Context, source string, peerNormalized, peerHandle *string, contactID uuid.UUID) (int64, int64, error)
+}
+
+// contactAggregator is the slice of *aggregation.Engine the handlers drive
+// after a successful attach.
+type contactAggregator interface {
+	AggregateForContactBatch(ctx context.Context, contactID uuid.UUID) error
+}
+
+// phoneRematchBase holds the shared dependencies of the two WhatsApp rematch
+// handlers, which differ only in the contact-method type they bind to.
+//
+// Both attach by peer_normalized in ONE repository call rather than enumerating
+// peers: a RematchHandler receives the newly-added contact method's NORMALIZED
+// value, which for both 'phone' and 'whatsapp' methods is an E.164 string —
+// there is no peer JID to hand PeerMatcher.OnPeerLinked. Attaching by the number
+// also reaches the case where one human is staged under two handles (a PN-form
+// JID and a LID-form JID) that both resolved to the same phone.
+//
+// No identity row is minted for the peer here, deliberately: the WhatsApp
+// identifier type dual-maps to [whatsapp, phone], so the peer's next live
+// message matches through the newly-created contact method and runs the ingest
+// path's own reconciliation (including the import-candidate status).
+type phoneRematchBase struct {
+	commsRepo commsAttacher
+	engine    contactAggregator
+}
+
+// rematchByPhone attaches every unmatched WhatsApp row staged under this E.164
+// number to the contact, then derives the interactions in the same pass.
+//
+// An attach failure is RETURNED rather than swallowed: the rematch dispatcher's
+// River job is the retry, and a silently-swallowed attach leaves the messages
+// invisible with nothing reporting why.
+func (b *phoneRematchBase) rematchByPhone(ctx context.Context, contactID uuid.UUID, e164 string) (int, error) {
+	e164 = strings.TrimSpace(e164)
+	if e164 == "" {
+		return 0, nil
+	}
+
+	attached, deduped, err := b.commsRepo.AttachUnmatchedByPeer(
+		ctx,
+		repository.InteractionSourceWhatsApp,
+		&e164, // peer_normalized: the E.164 the ingest path staged
+		nil,   // peer_handle: a contact method carries no peer JID
+		contactID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("attach whatsapp staged messages: %w", err)
+	}
+	if attached == 0 {
+		return 0, nil
+	}
+
+	// The phone number is third-party PII and is deliberately absent; the
+	// contact id + counts attribute the attach without logging it.
+	logger.Info().
+		Str("contact_id", contactID.String()).
+		Int64("attached", attached).
+		Int64("deduped", deduped).
+		Msg("whatsapp rematch: attached staged messages")
+
+	if aggErr := b.engine.AggregateForContactBatch(ctx, contactID); aggErr != nil {
+		// The rows ARE attached, so the count is real even when aggregation
+		// fails; the next sweeper tick retries the aggregation.
+		return int(attached), fmt.Errorf("aggregate for contact: %w", aggErr)
+	}
+	return int(attached), nil
+}
+
+// WhatsAppMethodRematchHandler implements service.RematchHandler for the
+// "whatsapp" contact-method type.
+type WhatsAppMethodRematchHandler struct{ phoneRematchBase }
+
+// NewWhatsAppMethodRematchHandler constructs the whatsapp-method rematch handler.
+func NewWhatsAppMethodRematchHandler(commsRepo commsAttacher, engine contactAggregator) *WhatsAppMethodRematchHandler {
+	return &WhatsAppMethodRematchHandler{phoneRematchBase{commsRepo: commsRepo, engine: engine}}
+}
+
+// IdentifierType returns the contact_method type this handler binds to.
+func (h *WhatsAppMethodRematchHandler) IdentifierType() string {
+	return string(repository.ContactMethodWhatsApp)
+}
+
+// Rematch attaches the staged WhatsApp messages for the newly-added whatsapp
+// method and derives their interactions.
+func (h *WhatsAppMethodRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, valueNormalized string) (int, error) {
+	return h.rematchByPhone(ctx, contactID, valueNormalized)
+}
+
+// PhoneRematchHandler implements service.RematchHandler for the "phone"
+// contact-method type. It co-registers alongside Telegram's phone handler; each
+// reports its own count over its own source's rows.
+type PhoneRematchHandler struct{ phoneRematchBase }
+
+// NewPhoneRematchHandler constructs the phone rematch handler.
+func NewPhoneRematchHandler(commsRepo commsAttacher, engine contactAggregator) *PhoneRematchHandler {
+	return &PhoneRematchHandler{phoneRematchBase{commsRepo: commsRepo, engine: engine}}
+}
+
+// IdentifierType returns the contact_method type this handler binds to.
+func (h *PhoneRematchHandler) IdentifierType() string {
+	return string(repository.ContactMethodPhone)
+}
+
+// Rematch attaches the staged WhatsApp messages for the newly-added phone
+// number and derives their interactions. WhatsApp peers are identified by phone
+// number, so a plain phone method is a valid WhatsApp identity.
+func (h *PhoneRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, valueNormalized string) (int, error) {
+	return h.rematchByPhone(ctx, contactID, valueNormalized)
+}

--- a/backend/internal/whatsapp/rematch.go
+++ b/backend/internal/whatsapp/rematch.go
@@ -68,12 +68,11 @@ func (b *phoneRematchBase) rematchByPhone(ctx context.Context, contactID uuid.UU
 		return 0, nil
 	}
 
-	// The phone number is deliberately absent: an identifier is the part of a
-	// third party's data that is legible on sight, and the counts are what
-	// triage actually needs. The contact id attributes the attach, matching
-	// Telegram's rematch logging.
+	// Neither the phone number nor the contact id is logged. RematchService.Run
+	// — the loop that dispatches this handler — deliberately refuses to log the
+	// contact id, and a handler invoked from inside that loop should not
+	// reintroduce what its caller withholds. The counts are the triage signal.
 	logger.Info().
-		Str("contact_id", contactID.String()).
 		Int64("attached", attached).
 		Int64("deduped", deduped).
 		Msg("whatsapp rematch: attached staged messages")

--- a/backend/internal/whatsapp/rematch.go
+++ b/backend/internal/whatsapp/rematch.go
@@ -68,8 +68,10 @@ func (b *phoneRematchBase) rematchByPhone(ctx context.Context, contactID uuid.UU
 		return 0, nil
 	}
 
-	// The phone number is third-party PII and is deliberately absent; the
-	// contact id + counts attribute the attach without logging it.
+	// The phone number is deliberately absent: an identifier is the part of a
+	// third party's data that is legible on sight, and the counts are what
+	// triage actually needs. The contact id attributes the attach, matching
+	// Telegram's rematch logging.
 	logger.Info().
 		Str("contact_id", contactID.String()).
 		Int64("attached", attached).

--- a/backend/internal/whatsapp/rematch_test.go
+++ b/backend/internal/whatsapp/rematch_test.go
@@ -1,0 +1,148 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCommsAttacher records the exact arguments the handler passes, so the test
+// pins the attach SELECTOR (peer_normalized, not peer_handle) rather than only
+// the count.
+type fakeCommsAttacher struct {
+	calls         int
+	gotSource     string
+	gotNormalized *string
+	gotHandle     *string
+	gotContactID  uuid.UUID
+	attached      int64
+	deduped       int64
+	err           error
+}
+
+func (f *fakeCommsAttacher) AttachUnmatchedByPeer(_ context.Context, source string, peerNormalized, peerHandle *string, contactID uuid.UUID) (int64, int64, error) {
+	f.calls++
+	f.gotSource = source
+	f.gotNormalized = peerNormalized
+	f.gotHandle = peerHandle
+	f.gotContactID = contactID
+	return f.attached, f.deduped, f.err
+}
+
+type fakeContactAggregator struct {
+	calls        int
+	gotContactID uuid.UUID
+	err          error
+}
+
+func (f *fakeContactAggregator) AggregateForContactBatch(_ context.Context, contactID uuid.UUID) error {
+	f.calls++
+	f.gotContactID = contactID
+	return f.err
+}
+
+// Both handlers must satisfy the service-layer contract.
+var (
+	_ service.RematchHandler = (*WhatsAppMethodRematchHandler)(nil)
+	_ service.RematchHandler = (*PhoneRematchHandler)(nil)
+)
+
+// spec: WHA-042.attach-by-recovered-number
+// spec: WHA-042.interactions-appear-without-waiting-for-a-sweep
+func TestWhatsAppRematch_AttachesByNormalizedPhoneOnly(t *testing.T) {
+	t.Parallel()
+
+	attacher := &fakeCommsAttacher{attached: 3, deduped: 1}
+	engine := &fakeContactAggregator{}
+	contactID := uuid.New()
+
+	n, err := NewWhatsAppMethodRematchHandler(attacher, engine).Rematch(context.Background(), contactID, "+12045550107")
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, 1, attacher.calls)
+	assert.Equal(t, "whatsapp", attacher.gotSource)
+	require.NotNil(t, attacher.gotNormalized)
+	assert.Equal(t, "+12045550107", *attacher.gotNormalized)
+	assert.Nil(t, attacher.gotHandle, "a contact method carries no peer JID, so peer_handle must stay nil")
+	assert.Equal(t, contactID, attacher.gotContactID)
+	// Attaching without aggregating would leave the rows invisible until the
+	// next 5-minute sweep.
+	assert.Equal(t, 1, engine.calls)
+	assert.Equal(t, contactID, engine.gotContactID)
+}
+
+func TestWhatsAppRematch_EmptyValueIsANoop(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"", "   "} {
+		attacher := &fakeCommsAttacher{attached: 5}
+		engine := &fakeContactAggregator{}
+
+		n, err := NewPhoneRematchHandler(attacher, engine).Rematch(context.Background(), uuid.New(), value)
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+		assert.Zero(t, attacher.calls, "an empty method value must not run a full-source attach")
+		assert.Zero(t, engine.calls)
+	}
+}
+
+// spec: WHA-042.no-attachment-means-no-aggregation
+func TestWhatsAppRematch_ZeroAttachedSkipsAggregation(t *testing.T) {
+	t.Parallel()
+
+	attacher := &fakeCommsAttacher{attached: 0}
+	engine := &fakeContactAggregator{}
+
+	n, err := NewPhoneRematchHandler(attacher, engine).Rematch(context.Background(), uuid.New(), "+12045550107")
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, 1, attacher.calls)
+	assert.Zero(t, engine.calls)
+}
+
+// spec: WHA-042.attach-failure-is-reported
+func TestWhatsAppRematch_AttachErrorIsReturned(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	attacher := &fakeCommsAttacher{attached: 4, err: sentinel}
+	engine := &fakeContactAggregator{}
+
+	n, err := NewWhatsAppMethodRematchHandler(attacher, engine).Rematch(context.Background(), uuid.New(), "+12045550107")
+
+	require.Error(t, err, "a failure to attach must be reported, not swallowed")
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 0, n)
+	assert.Zero(t, engine.calls)
+}
+
+func TestWhatsAppRematch_AggregationErrorReturnsTheAttachedCount(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("aggregate exploded")
+	attacher := &fakeCommsAttacher{attached: 7}
+	engine := &fakeContactAggregator{err: sentinel}
+
+	n, err := NewWhatsAppMethodRematchHandler(attacher, engine).Rematch(context.Background(), uuid.New(), "+12045550107")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+	// The rows ARE attached; the count is real even when aggregation fails.
+	assert.Equal(t, 7, n)
+}
+
+func TestWhatsAppRematch_IdentifierTypes(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "whatsapp", NewWhatsAppMethodRematchHandler(nil, nil).IdentifierType())
+	assert.Equal(t, "phone", NewPhoneRematchHandler(nil, nil).IdentifierType())
+}

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -776,7 +776,12 @@ func whatsappVenueKindFor(t *testing.T, ctx context.Context, database *db.Databa
 //
 // spec: WHA-043.direct-chat-is-a-dm
 func TestWhatsAppVenue_DirectJIDIsDM(t *testing.T) {
-	testsupport.RequireLongTests(t)
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
 	database, ctx := newSyntheticDB(t)
 	t.Parallel()
 
@@ -791,7 +796,12 @@ func TestWhatsAppVenue_DirectJIDIsDM(t *testing.T) {
 //
 // spec: WHA-043.group-chat-is-a-group-chat
 func TestWhatsAppVenue_GroupJIDIsGroupChat(t *testing.T) {
-	testsupport.RequireLongTests(t)
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
 	database, ctx := newSyntheticDB(t)
 	t.Parallel()
 

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -721,3 +721,80 @@ func interactionVenueColumnExists(ctx context.Context, t *testing.T, database *d
 	require.NoError(t, err)
 	return exists
 }
+
+// whatsappVenueKindFor stages one comms_message(source='whatsapp') row with the
+// given chat JID as its thread id, resolves it through the SAME registry the
+// recorder uses, and returns the venue's kind. It proves the reader where every
+// other VenueContainerReader is proved — against a staged row, through
+// ResolveMessageVenueTx — because no test anywhere exercises
+// ContainerForMessageTx directly.
+func whatsappVenueKindFor(t *testing.T, ctx context.Context, database *db.Database, chatJID, externalID string) string {
+	t.Helper()
+
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+	body := "whatsapp venue body"
+	peer := chatJID
+	row, err := commsRepo.UpsertChatMessage(ctx, repository.UpsertChatMessageParams{
+		Source:     repository.InteractionSourceWhatsApp,
+		ExternalID: externalID,
+		ThreadID:   chatJID,
+		Body:       &body,
+		PeerHandle: &peer,
+		Direction:  repository.InteractionDirectionInbound,
+		SentAt:     accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = commsRepo.HardDeleteBySourceAndExternalIDPrefix(context.Background(), repository.InteractionSourceWhatsApp, externalID)
+	})
+
+	venueRepo := repository.NewVenueRepository(database.Queries)
+	resolver := repository.NewVenueResolverRegistry(
+		venueRepo,
+		map[string]repository.VenueContainerReader{
+			repository.InteractionSourceWhatsApp: repository.NewWhatsAppVenueContainerReader(),
+		},
+		nil,
+	)
+
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	venueID, err := resolver.ResolveMessageVenueTx(ctx, tx, repository.InteractionSourceWhatsApp, []uuid.UUID{row.ID})
+	require.NoError(t, err)
+	require.NotNil(t, venueID, "the whatsapp reader must resolve a venue for a staged row")
+
+	venue, err := repository.NewVenueRepository(db.New(tx)).GetVenue(ctx, *venueID)
+	require.NoError(t, err)
+	require.Equal(t, chatJID, venue.SourceContainerID)
+	return venue.Kind
+}
+
+// TestWhatsAppVenue_DirectJIDIsDM: a one-to-one chat JID yields a dm venue.
+//
+// spec: WHA-043.direct-chat-is-a-dm
+func TestWhatsAppVenue_DirectJIDIsDM(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+	t.Parallel()
+
+	suffix := uuid.NewString()[:8]
+	kind := whatsappVenueKindFor(t, ctx, database, "1204555"+suffix+"@s.whatsapp.net", "wa-venue-dm-"+suffix)
+	assert.Equal(t, repository.VenueKindDM, kind)
+}
+
+// TestWhatsAppVenue_GroupJIDIsGroupChat: a group chat JID yields a group_chat
+// venue. This is the case GChat's reader gets wrong as a template — it
+// hard-codes group_chat, which is right for spaces and wrong for WhatsApp.
+//
+// spec: WHA-043.group-chat-is-a-group-chat
+func TestWhatsAppVenue_GroupJIDIsGroupChat(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+	t.Parallel()
+
+	suffix := uuid.NewString()[:8]
+	kind := whatsappVenueKindFor(t, ctx, database, "1204555"+suffix+"-1690000000@g.us", "wa-venue-group-"+suffix)
+	assert.Equal(t, repository.VenueKindGroupChat, kind)
+}

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -745,7 +745,8 @@ func whatsappVenueKindFor(t *testing.T, ctx context.Context, database *db.Databa
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = commsRepo.HardDeleteBySourceAndExternalIDPrefix(context.Background(), repository.InteractionSourceWhatsApp, externalID)
+		// LIKE pattern: the trailing % is what makes this a prefix delete.
+		_ = commsRepo.HardDeleteBySourceAndExternalIDPrefix(context.Background(), repository.InteractionSourceWhatsApp, externalID+"%")
 	})
 
 	venueRepo := repository.NewVenueRepository(database.Queries)

--- a/backend/tests/synthetic_replay_integration_test.go
+++ b/backend/tests/synthetic_replay_integration_test.go
@@ -99,6 +99,18 @@ func TestSyntheticReplay_SeededSenderSettled(t *testing.T) {
 		requireInteractionSource(t, ctx, h, contact.ID, "gchat")
 	})
 
+	t.Run("whatsapp", func(t *testing.T) {
+		h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+		gen := h.Generator()
+		spec := gen.Contact(factory.WithPhone())
+		contact, err := h.SeedContact(ctx, spec)
+		require.NoError(t, err)
+		res, err := h.ReplayWhatsApp(ctx, contact.ID, gen.WhatsAppMessage(spec, factory.MatchSeeded))
+		require.NoError(t, err)
+		require.True(t, res.Matched)
+		requireInteractionSource(t, ctx, h, contact.ID, "whatsapp")
+	})
+
 	t.Run("imessage", func(t *testing.T) {
 		h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
 		gen := h.Generator()
@@ -322,6 +334,32 @@ func TestSyntheticReplay_UnknownSenderPending(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, res.Matched)
 	})
+
+	// WhatsApp belongs HERE, not in the match-only test: gmail/gchat write no
+	// row for an unknown sender, while matched_contact_id IS NULL is legal for
+	// whatsapp and the row IS written — it simply never aggregates.
+	t.Run("whatsapp_stranded", func(t *testing.T) {
+		h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+		gen := h.Generator()
+		target := gen.Contact(factory.WithPhone())
+		contact, err := h.SeedContact(ctx, target)
+		require.NoError(t, err)
+
+		spec := gen.WhatsAppMessage(gen.Contact(factory.WithPhone()), factory.MatchUnknown)
+		res, err := h.ReplayWhatsApp(ctx, uuid.Nil, spec)
+		require.NoError(t, err)
+		require.False(t, res.Matched)
+
+		exists, err := h.CommsRowExists(ctx, "whatsapp", spec.ExternalID)
+		require.NoError(t, err)
+		require.True(t, exists, "an unknown WhatsApp peer's message IS stored, just unattached")
+
+		rows, err := h.InteractionRepo().ListContactInteractions(ctx, contact.ID, 100, 0)
+		require.NoError(t, err)
+		for _, r := range rows {
+			require.NotEqual(t, "whatsapp", r.Source, "an unattached whatsapp row must not produce an interaction")
+		}
+	})
 }
 
 func TestSyntheticReplay_UnknownSenderMatchOnly(t *testing.T) {
@@ -375,6 +413,21 @@ func TestSyntheticReplay_IdempotentReReplay(t *testing.T) {
 	rows, err := h.CommsRepo().ListByContact(ctx, contact.ID)
 	require.NoError(t, err)
 	require.Len(t, rows, 1, "re-replay of the same payload must not add a duplicate comms_message row")
+
+	// WhatsApp shares the same comms_message store and the same (source,
+	// external_id) dedup, driven through its own ingest seam.
+	waSpec := gen.Contact(factory.WithPhone())
+	waContact, err := h.SeedContact(ctx, waSpec)
+	require.NoError(t, err)
+	waMsg := gen.WhatsAppMessage(waSpec, factory.MatchSeeded)
+	_, err = h.ReplayWhatsApp(ctx, waContact.ID, waMsg)
+	require.NoError(t, err)
+	_, err = h.ReplayWhatsApp(ctx, waContact.ID, waMsg)
+	require.NoError(t, err)
+
+	waRows, err := h.CommsRepo().ListByContact(ctx, waContact.ID)
+	require.NoError(t, err)
+	require.Len(t, waRows, 1, "re-replay of the same whatsapp payload must not add a duplicate row")
 }
 
 // requireInteractionSource asserts the contact has at least one interaction with

--- a/backend/tests/whatsapp_aggregation_test.go
+++ b/backend/tests/whatsapp_aggregation_test.go
@@ -289,7 +289,10 @@ func TestWhatsAppAggregation_ReplyBridgePromotesToMutual(t *testing.T) {
 
 	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-br-out1-"+suffix, repository.InteractionDirectionOutbound, base)
 	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-br-out2-"+suffix, repository.InteractionDirectionOutbound, base.Add(5*time.Minute))
-	// Inbound one hour later — inside the 48h bridge, outside the 2h burst.
+	// Inbound 55 minutes after the last outbound. The DIRECTION CHANGE is what
+	// starts a new burst (groupIntoBursts splits on direction regardless of
+	// gap); the gap being inside the 48h reply-bridge window is what merges the
+	// two back into one mutual interaction.
 	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-br-in1-"+suffix, repository.InteractionDirectionInbound, base.Add(time.Hour))
 
 	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, chatJID))

--- a/backend/tests/whatsapp_aggregation_test.go
+++ b/backend/tests/whatsapp_aggregation_test.go
@@ -1,0 +1,374 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	wapkg "personal-crm/backend/internal/whatsapp"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// whatsappTestEnv bundles everything a WhatsApp engine integration test needs.
+type whatsappTestEnv struct {
+	ctx             context.Context
+	database        *db.Database
+	commsRepo       *repository.CommsMessageRepository
+	interactionRepo *repository.InteractionRepository
+	contactRepo     *repository.ContactRepository
+	engine          *aggregation.Engine
+}
+
+// setupWhatsAppEngineTest wires the FULL create-path harness, mirroring
+// setupGChatEngineTest: a live river client running the InteractionRecorder
+// worker, a StagingProcessorRegistry carrying the whatsapp session-scoped
+// processor, and a WhatsApp aggregation engine built with database.Pool as
+// TxBeginner so the create path takes the ClaimRowsTx + PublishTx branch.
+//
+// It is the regression guard for TWO seams a missing entry would silence: the
+// whatsapp StagingProcessor (without it the recorder's zero-rows-affected
+// rollback fires and the engine reprocesses forever) and
+// consumer.messageInteractionSources (without the whatsapp entry the recorder
+// rejects the source outright and no interaction is ever written).
+func setupWhatsAppEngineTest(t *testing.T) *whatsappTestEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	database, _ := newIsolatedRiverTestDB(t, ctx)
+
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+
+	bus, contactService := setupWhatsAppEventBus(t, ctx, database, commsRepo)
+
+	engine := wapkg.NewAggregationEngine(
+		2, 48, // the WhatsApp defaults (DefaultWhatsAppBurstWindowHours / ReplyBridgeHours)
+		commsRepo, interactionRepo,
+		contactService, contactService,
+		bus,
+		database.Pool, // TxBeginner: create path takes ClaimRowsTx + PublishTx
+		consumer.NewRiverInteractionRecorderEnqueuer(nil),
+	)
+
+	return &whatsappTestEnv{
+		ctx:             ctx,
+		database:        database,
+		commsRepo:       commsRepo,
+		interactionRepo: interactionRepo,
+		contactRepo:     contactRepo,
+		engine:          engine,
+	}
+}
+
+// setupWhatsAppEventBus mirrors setupGChatEventBus but registers the WHATSAPP
+// session-scoped StagingProcessor.
+func setupWhatsAppEventBus(
+	t *testing.T,
+	ctx context.Context,
+	database *db.Database,
+	commsRepo *repository.CommsMessageRepository,
+) (*events.Bus, *service.ContactService) {
+	t.Helper()
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+
+	workers := river.NewWorkers()
+	shim := &deferredRecorderWorker{}
+	river.AddWorker(workers, shim)
+	river.AddWorker(workers, &cadenceUpdaterNoopWorker{})
+	river.AddWorker(workers, &followUpManagerNoopWorker{})
+	river.AddWorker(workers, &emailInteractionNoopWorker{})
+
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 2},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+
+	bus := events.NewBus(database.Pool, client, eventRepo)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(
+		claimRepo, contactRepo, database.Queries,
+		consumer.CadenceModeCutover,
+		false,
+	)
+	assertSvc, cache := buildKnowledgeDeps(t, database, bus)
+	contactService := service.NewContactService(
+		database, contactRepo,
+		repository.NewContactMethodRepository(database.Queries),
+		repository.NewInteractionRepository(database.Queries),
+		repository.NewContactTaskRepository(database.Queries),
+		nil, nil,
+		cadenceUpdater, assertSvc, cache, nil,
+	)
+	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
+		repository.InteractionSourceWhatsApp: repository.NewCommsSessionStagingProcessor(commsRepo),
+	})
+	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil, repository.NewCalendarEventRepository(database.Queries))
+	shim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
+
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	return bus, contactService
+}
+
+// newWhatsAppContact creates a contact and registers cleanup for its rows.
+func (e *whatsappTestEnv) newWhatsAppContact(t *testing.T, name string) *repository.Contact {
+	t.Helper()
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+	})
+	return contact
+}
+
+// seedWhatsAppRow stages one comms_message(source='whatsapp') row. contactID
+// may be uuid.Nil, which stages the row UNMATCHED (legal for whatsapp, unlike
+// gmail/gchat).
+func (e *whatsappTestEnv) seedWhatsAppRow(t *testing.T, contactID *uuid.UUID, chatJID, externalID, direction string, sentAt time.Time) *repository.CommsMessage {
+	t.Helper()
+	body := "whatsapp body"
+	peer := chatJID
+	row, err := e.commsRepo.UpsertChatMessage(e.ctx, repository.UpsertChatMessageParams{
+		Source:           repository.InteractionSourceWhatsApp,
+		ExternalID:       externalID,
+		ThreadID:         chatJID,
+		Body:             &body,
+		PeerHandle:       &peer,
+		Direction:        direction,
+		SentAt:           sentAt,
+		MatchedContactID: contactID,
+	})
+	require.NoError(t, err)
+	return row
+}
+
+// waitForWhatsAppRowsProcessed polls each row until all carry processed_at +
+// the expected interaction_id. Routes through the repository (no raw SQL).
+func waitForWhatsAppRowsProcessed(t *testing.T, e *whatsappTestEnv, ids []uuid.UUID, interactionID uuid.UUID) {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(defaultInteractionWaitTimeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		all := true
+		for _, id := range ids {
+			row, err := e.commsRepo.GetByID(e.ctx, id)
+			require.NoError(t, err)
+			if row.ProcessedAt == nil || row.InteractionID == nil || *row.InteractionID != interactionID {
+				all = false
+				break
+			}
+		}
+		if all {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d whatsapp rows to be processed + linked to interaction %s", len(ids), interactionID)
+}
+
+// TestWhatsAppPipeline_StagedRowBecomesInteraction is the pipeline half of the
+// aggregation proof: two staged inbound rows in one chat become ONE interaction
+// with the WhatsApp wire format, both rows are marked processed, and the
+// contact's last_contacted moves.
+//
+// spec: WHA-040.interaction-per-burst
+// spec: WHA-040.source-is-whatsapp
+// spec: WHA-040.source-ref-is-chat-scoped
+// spec: WHA-040.description-names-whatsapp
+// spec: WHA-040.rows-marked-processed
+// spec: WHA-040.last-contacted-moves
+func TestWhatsAppPipeline_StagedRowBecomesInteraction(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Pipeline "+suffix)
+	require.Nil(t, contact.LastContacted, "a freshly created contact has never been contacted")
+
+	chatJID := "1204555" + suffix + "@s.whatsapp.net"
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	r1 := e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-pipe1-"+suffix, repository.InteractionDirectionInbound, base)
+	r2 := e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-pipe2-"+suffix, repository.InteractionDirectionInbound, base.Add(20*time.Minute))
+
+	require.NoError(t, e.engine.AggregateAll(e.ctx))
+
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, repository.InteractionSourceWhatsApp, interactions[0].Source)
+	assert.Equal(t, repository.InteractionDirectionInbound, interactions[0].Direction)
+	require.NotNil(t, interactions[0].SourceRef)
+	assert.Equal(t, "whatsapp:"+chatJID+":wa-pipe1-"+suffix, *interactions[0].SourceRef)
+	require.NotNil(t, interactions[0].Description)
+	assert.Equal(t, "WhatsApp response (2 messages)", *interactions[0].Description)
+
+	waitForWhatsAppRowsProcessed(t, e, []uuid.UUID{r1.ID, r2.ID}, interactions[0].ID)
+
+	moved, err := e.contactRepo.GetContact(e.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, moved.LastContacted, "an inbound WhatsApp interaction must move last_contacted")
+}
+
+// TestWhatsAppAggregation_BurstExtends: a third same-direction message inside
+// the 2h burst window extends the existing interaction instead of creating a
+// second one.
+//
+// spec: WHA-040.interaction-per-burst
+func TestWhatsAppAggregation_BurstExtends(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Burst "+suffix)
+	chatJID := "1204555" + suffix + "@s.whatsapp.net"
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-burst1-"+suffix, repository.InteractionDirectionOutbound, base)
+	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-burst2-"+suffix, repository.InteractionDirectionOutbound, base.Add(20*time.Minute))
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, chatJID))
+	first := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	require.NotNil(t, first[0].Description)
+	require.Equal(t, "WhatsApp outreach (2 messages)", *first[0].Description)
+
+	// A third outbound inside the burst window extends the SAME interaction:
+	// the count stays at one and the new row links to the interaction that
+	// already existed. (The extender rewrites the description from the NEW
+	// session, so the text is not the evidence — the linkage is.)
+	r3 := e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-burst3-"+suffix, repository.InteractionDirectionOutbound, base.Add(40*time.Minute))
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, chatJID))
+
+	waitForWhatsAppRowsProcessed(t, e, []uuid.UUID{r3.ID}, first[0].ID)
+	rows, err := e.interactionRepo.ListContactInteractions(e.ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the burst must extend the existing interaction, not create a second one")
+	assert.Equal(t, first[0].ID, rows[0].ID)
+}
+
+// TestWhatsAppAggregation_ReplyBridgePromotesToMutual: an inbound message
+// inside the 48h reply bridge promotes the outbound interaction to mutual
+// rather than creating a second one.
+func TestWhatsAppAggregation_ReplyBridgePromotesToMutual(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Bridge "+suffix)
+	chatJID := "1204555" + suffix + "@s.whatsapp.net"
+	base := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
+
+	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-br-out1-"+suffix, repository.InteractionDirectionOutbound, base)
+	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-br-out2-"+suffix, repository.InteractionDirectionOutbound, base.Add(5*time.Minute))
+	// Inbound one hour later — inside the 48h bridge, outside the 2h burst.
+	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-br-in1-"+suffix, repository.InteractionDirectionInbound, base.Add(time.Hour))
+
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, chatJID))
+
+	rows := waitForInteractionDirection(t, e.ctx, e.interactionRepo, contact.ID, repository.InteractionDirectionMutual, defaultInteractionWaitTimeout)
+	require.Len(t, rows, 1, "the reply bridge must promote the outbound interaction, not add a second one")
+	assert.Equal(t, repository.InteractionDirectionMutual, rows[0].Direction)
+}
+
+// TestWhatsAppAggregation_SameDirectionCoalesces: two same-direction bursts in
+// the same chat, the second inside the first's burst window, coalesce into one
+// interaction rather than two.
+func TestWhatsAppAggregation_SameDirectionCoalesces(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Coalesce "+suffix)
+	chatJID := "1204555" + suffix + "@s.whatsapp.net"
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-co1-"+suffix, repository.InteractionDirectionInbound, base)
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, chatJID))
+	first := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+
+	// A second INBOUND message inside the burst window. The engine checks the
+	// reply bridge first (no outbound to promote), then coalesces onto the
+	// existing same-direction interaction rather than creating a second one.
+	r2 := e.seedWhatsAppRow(t, &contact.ID, chatJID, "wa-co2-"+suffix, repository.InteractionDirectionInbound, base.Add(30*time.Minute))
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, chatJID))
+
+	waitForWhatsAppRowsProcessed(t, e, []uuid.UUID{r2.ID}, first[0].ID)
+	rows, err := e.interactionRepo.ListContactInteractions(e.ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "a same-direction follow-up inside the burst window must coalesce")
+	assert.Equal(t, first[0].ID, rows[0].ID)
+}
+
+// TestWhatsAppAggregation_UnmatchedRowIsNeverAggregated is I2's regression
+// guard. A staged row with matched_contact_id IS NULL is legal for WhatsApp (a
+// peer whose phone was never recovered), and it must never reach the claim path
+// or produce an interaction.
+//
+// spec: WHA-041.unmatched-row-never-aggregated
+// spec: WHA-041.attach-makes-it-eligible
+func TestWhatsAppAggregation_UnmatchedRowIsNeverAggregated(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Unmatched "+suffix)
+	chatJID := "1204555" + suffix + "@s.whatsapp.net"
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	// Staged WITHOUT a contact.
+	row := e.seedWhatsAppRow(t, nil, chatJID, "wa-unmatched-"+suffix, repository.InteractionDirectionInbound, base)
+	require.Nil(t, row.MatchedContactID)
+
+	require.NoError(t, e.engine.AggregateAll(e.ctx))
+
+	rows, err := e.interactionRepo.ListContactInteractions(e.ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "an unattached whatsapp row must never become an interaction")
+
+	after, err := e.commsRepo.GetByID(e.ctx, row.ID)
+	require.NoError(t, err)
+	assert.Nil(t, after.ProcessedAt, "an unattached row must stay unprocessed")
+	assert.Nil(t, after.InteractionID)
+
+	// Attaching it makes it eligible: the same engine pass now derives one.
+	e.commsRepo.SetPool(e.database.Pool)
+	peer := chatJID
+	attached, _, err := e.commsRepo.AttachUnmatchedByPeer(e.ctx, repository.InteractionSourceWhatsApp, nil, &peer, contact.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, attached)
+
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, chatJID))
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	assert.Equal(t, repository.InteractionSourceWhatsApp, interactions[0].Source)
+}

--- a/backend/tests/whatsapp_rematch_test.go
+++ b/backend/tests/whatsapp_rematch_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -97,11 +98,35 @@ func TestWhatsAppRematch_OnWhatsAppMethodAdded(t *testing.T) {
 	assert.Equal(t, repository.InteractionSourceWhatsApp, interactions[0].Source)
 }
 
+// countingRematchHandler wraps a real RematchHandler and records how many times
+// Run dispatched to it. It exists because RematchService.Run returns only an
+// error: without observing the wrapped handler directly, a Run that stopped
+// after the first productive handler — or a registration that silently dropped
+// one — would look identical to a healthy fan-out.
+type countingRematchHandler struct {
+	inner  service.RematchHandler
+	calls  int
+	counts []int
+	errs   []error
+}
+
+func (c *countingRematchHandler) IdentifierType() string { return c.inner.IdentifierType() }
+
+func (c *countingRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, value string) (int, error) {
+	c.calls++
+	n, err := c.inner.Rematch(ctx, contactID, value)
+	c.counts = append(c.counts, n)
+	c.errs = append(c.errs, err)
+	return n, err
+}
+
 // TestWhatsAppRematch_TelegramPhoneHandlerUnaffected is R5.4's guard. Adding a
 // WhatsApp handler for the 'phone' type means TWO handlers now run for a phone
 // method; RematchService fans out to every one and FAILS FAST on the first
 // error, so a WhatsApp attach failure would stop Telegram's handler running in
-// the same pass. This asserts both run and neither errors.
+// the same pass. Both handlers are therefore wrapped and each is asserted to
+// have been dispatched exactly once and to have reported its own count without
+// erroring — the fan-out itself is the claim, not just the absence of an error.
 func TestWhatsAppRematch_TelegramPhoneHandlerUnaffected(t *testing.T) {
 	t.Parallel()
 	e := setupWhatsAppEngineTest(t)
@@ -122,16 +147,27 @@ func TestWhatsAppRematch_TelegramPhoneHandlerUnaffected(t *testing.T) {
 		2, 48, telegramRepo, e.interactionRepo, nil, nil, nil, e.database.Pool, nil,
 	)
 
+	telegramHandler := &countingRematchHandler{inner: tgpkg.NewPhoneRematchHandler(telegramRepo, telegramMatcher, telegramEngine)}
+	whatsappHandler := &countingRematchHandler{inner: wapkg.NewPhoneRematchHandler(e.commsRepo, e.engine)}
+
 	svc := service.NewRematchService()
 	// Registration order mirrors the composition root: telegram (main.go builds
 	// it first) then whatsapp.
-	svc.Register(tgpkg.NewPhoneRematchHandler(telegramRepo, telegramMatcher, telegramEngine))
-	svc.Register(wapkg.NewPhoneRematchHandler(e.commsRepo, e.engine))
+	svc.Register(telegramHandler)
+	svc.Register(whatsappHandler)
 
 	require.Len(t, svc.EligibleMethods([]service.Method{{Type: "phone", Value: e164}}), 1)
 
 	err := svc.Run(e.ctx, uuid.New(), contact.ID, []service.Method{{Type: "phone", Value: e164}})
 	require.NoError(t, err, "neither phone handler may error when both are registered")
+
+	// BOTH handlers ran, each reporting its own count over its own source's rows.
+	require.Equal(t, 1, telegramHandler.calls, "the telegram phone handler must still be dispatched")
+	require.Equal(t, 1, whatsappHandler.calls, "the whatsapp phone handler must be dispatched")
+	assert.Equal(t, []int{0}, telegramHandler.counts, "telegram owns no rows for this peer, so it reports zero")
+	assert.Equal(t, []error{nil}, telegramHandler.errs, "telegram's handler must not error when whatsapp co-registers")
+	assert.Equal(t, []int{2}, whatsappHandler.counts, "whatsapp attaches both of its staged rows")
+	assert.Equal(t, []error{nil}, whatsappHandler.errs)
 
 	// The WhatsApp handler did its own work: the staged rows became an interaction.
 	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)

--- a/backend/tests/whatsapp_rematch_test.go
+++ b/backend/tests/whatsapp_rematch_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	tgpkg "personal-crm/backend/internal/telegram"
+	wapkg "personal-crm/backend/internal/whatsapp"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedUnmatchedWhatsAppPeer stages two unmatched rows for a peer whose recovered
+// phone number is e164, mirroring what the ingest path writes for a peer with no
+// contact yet.
+func (e *whatsappTestEnv) seedUnmatchedWhatsAppPeer(t *testing.T, chatJID, e164, prefix string) {
+	t.Helper()
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+	for i, at := range []time.Time{base, base.Add(20 * time.Minute)} {
+		body := "whatsapp body"
+		peer := chatJID
+		normalized := e164
+		_, err := e.commsRepo.UpsertChatMessage(e.ctx, repository.UpsertChatMessageParams{
+			Source:         repository.InteractionSourceWhatsApp,
+			ExternalID:     prefix + string(rune('a'+i)),
+			ThreadID:       chatJID,
+			Body:           &body,
+			PeerHandle:     &peer,
+			PeerNormalized: &normalized,
+			Direction:      repository.InteractionDirectionInbound,
+			SentAt:         at,
+		})
+		require.NoError(t, err)
+	}
+}
+
+// whatsappPeerFixture is the (chat JID, normalized phone) pair a synthetic
+// contact's phone number produces on the ingest path.
+func whatsappPeerFixture(t *testing.T, rawPhone string) (chatJID, e164 string) {
+	t.Helper()
+	e164 = identity.Normalize(rawPhone, identity.IdentifierTypeWhatsApp)
+	require.NotEmpty(t, e164)
+	require.Equal(t, "+", e164[:1], "the normalized WhatsApp identifier is E.164")
+	return e164[1:] + "@s.whatsapp.net", e164
+}
+
+// spec: WHA-042.attach-by-recovered-number
+// spec: WHA-042.interactions-appear-without-waiting-for-a-sweep
+func TestWhatsAppRematch_OnPhoneMethodAdded(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	e.commsRepo.SetPool(e.database.Pool)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Rematch Phone "+suffix)
+	chatJID, e164 := whatsappPeerFixture(t, "+1-204-555-0142")
+	e.seedUnmatchedWhatsAppPeer(t, chatJID, e164, "wa-rm-phone-"+suffix+"-")
+
+	handler := wapkg.NewPhoneRematchHandler(e.commsRepo, e.engine)
+	require.Equal(t, "phone", handler.IdentifierType())
+
+	n, err := handler.Rematch(e.ctx, contact.ID, e164)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "both staged rows for that number must attach")
+
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	assert.Equal(t, repository.InteractionSourceWhatsApp, interactions[0].Source)
+}
+
+// spec: WHA-042.attach-by-recovered-number
+func TestWhatsAppRematch_OnWhatsAppMethodAdded(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	e.commsRepo.SetPool(e.database.Pool)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Rematch Method "+suffix)
+	chatJID, e164 := whatsappPeerFixture(t, "+1-204-555-0143")
+	e.seedUnmatchedWhatsAppPeer(t, chatJID, e164, "wa-rm-wa-"+suffix+"-")
+
+	handler := wapkg.NewWhatsAppMethodRematchHandler(e.commsRepo, e.engine)
+	require.Equal(t, "whatsapp", handler.IdentifierType())
+
+	n, err := handler.Rematch(e.ctx, contact.ID, e164)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	assert.Equal(t, repository.InteractionSourceWhatsApp, interactions[0].Source)
+}
+
+// TestWhatsAppRematch_TelegramPhoneHandlerUnaffected is R5.4's guard. Adding a
+// WhatsApp handler for the 'phone' type means TWO handlers now run for a phone
+// method; RematchService fans out to every one and FAILS FAST on the first
+// error, so a WhatsApp attach failure would stop Telegram's handler running in
+// the same pass. This asserts both run and neither errors.
+func TestWhatsAppRematch_TelegramPhoneHandlerUnaffected(t *testing.T) {
+	t.Parallel()
+	e := setupWhatsAppEngineTest(t)
+	e.commsRepo.SetPool(e.database.Pool)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contact := e.newWhatsAppContact(t, "WhatsApp Rematch Coexist "+suffix)
+	chatJID, e164 := whatsappPeerFixture(t, "+1-204-555-0144")
+	e.seedUnmatchedWhatsAppPeer(t, chatJID, e164, "wa-rm-coexist-"+suffix+"-")
+
+	telegramRepo := repository.NewTelegramMessageRepository(e.database.Queries)
+	identitySvc := service.NewIdentityService(repository.NewIdentityRepository(e.database.Queries))
+	telegramMatcher := tgpkg.NewPeerMatcher(
+		identitySvc, telegramRepo, repository.NewExternalContactRepository(e.database.Queries), nil, 3,
+	)
+	telegramEngine := tgpkg.NewAggregationEngine(
+		2, 48, telegramRepo, e.interactionRepo, nil, nil, nil, e.database.Pool, nil,
+	)
+
+	svc := service.NewRematchService()
+	// Registration order mirrors the composition root: telegram (main.go builds
+	// it first) then whatsapp.
+	svc.Register(tgpkg.NewPhoneRematchHandler(telegramRepo, telegramMatcher, telegramEngine))
+	svc.Register(wapkg.NewPhoneRematchHandler(e.commsRepo, e.engine))
+
+	require.Len(t, svc.EligibleMethods([]service.Method{{Type: "phone", Value: e164}}), 1)
+
+	err := svc.Run(e.ctx, uuid.New(), contact.ID, []service.Method{{Type: "phone", Value: e164}})
+	require.NoError(t, err, "neither phone handler may error when both are registered")
+
+	// The WhatsApp handler did its own work: the staged rows became an interaction.
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	assert.Equal(t, repository.InteractionSourceWhatsApp, interactions[0].Source)
+}

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -381,6 +381,10 @@
     "tags": ["@area:settings"]
   },
   {
+    "pattern": "^backend/internal/repository/venue_resolver\\.go$",
+    "tags": ["@area:contacts"]
+  },
+  {
     "pattern": "^backend/internal/repository/contact\\.go$",
     "tags": ["@area:contacts", "@area:contact-navigation", "@area:contact-merge", "@area:overdue"]
   },

--- a/spec/whatsapp.yaml
+++ b/spec/whatsapp.yaml
@@ -432,3 +432,80 @@ behaviors:
       - a candidate from a source with no back-fill is imported normally, without error
       - a back-fill failure does not fail the import, which has already succeeded
     provenance: [ImportHandler.RegisterPostImportHook, triggerPostImportHook, telegram.PostImportHook, whatsapp.PostImportHook]
+
+  # --- Aggregation ---
+
+  - id: WHA-040
+    title: Stored WhatsApp messages become interactions through the shared aggregation pipeline
+    type: business-logic
+    status: current
+    surface: none
+    given: WhatsApp messages stored against a contact
+    when: aggregation runs for that contact
+    then:
+      - key: interaction-per-burst
+        text: consecutive messages in one chat collapse into a single interaction per burst rather than one interaction per message, and a later message inside the same burst extends that interaction instead of adding another
+      - key: source-is-whatsapp
+        text: the interaction is attributed to WhatsApp, so it is distinguishable from the other messaging sources on the same shared store
+      - key: source-ref-is-chat-scoped
+        text: the interaction's reference identifies the chat and the burst's first message, so re-running aggregation recognises the same burst rather than duplicating it
+      - key: description-names-whatsapp
+        text: the description names WhatsApp and whether the burst was outreach, a response, or an exchange, together with how many messages it covered
+      - key: rows-marked-processed
+        text: every message the interaction covers is marked processed and linked to it, so no message is aggregated twice
+      - key: last-contacted-moves
+        text: an inbound or mutual WhatsApp interaction moves the contact's last-contacted, so WhatsApp counts toward cadence like any other conversation
+    provenance: [whatsapp.NewAggregationEngine, commsadapter.NewEngine, CommsSessionStagingProcessor, TestWhatsAppPipeline_StagedRowBecomesInteraction, TestWhatsAppWiring_ProductionRegistriesDispatchWhatsApp]
+    notes: The engine, the burst/session/bridge machinery and the interaction recorder are the shared ones every comms-backed source uses; WhatsApp supplies only its source name, product label, and its two operator-tunable windows.
+
+  - id: WHA-041
+    title: WhatsApp messages with no contact never become interactions
+    type: business-logic
+    status: current
+    surface: none
+    given: a WhatsApp message stored without a contact, which is a normal outcome for an unrecognised peer
+    when: aggregation runs
+    then:
+      - key: unmatched-row-never-aggregated
+        text: the message is never aggregated and stays unprocessed, so an unrecognised peer can never produce an interaction attributed to the wrong person or to nobody
+      - key: attach-makes-it-eligible
+        text: once the message is attached to a contact it becomes eligible on the next aggregation pass, with no further intervention
+    provenance: [ListUnprocessedCommsContactIDsForSource, ClaimCommsMessages, TestWhatsAppAggregation_UnmatchedRowIsNeverAggregated]
+
+  - id: WHA-042
+    title: Adding a phone or WhatsApp contact method attaches that number's stored WhatsApp messages
+    type: business-logic
+    status: current
+    surface: none
+    given: WhatsApp messages stored for a peer whose phone number is known but who has no contact
+    when: a contact gains a phone or WhatsApp contact method carrying that number
+    then:
+      - key: attach-by-recovered-number
+        text: every stored WhatsApp message for that number is attached to the contact, including messages the same person sent under more than one WhatsApp identifier that both resolved to it
+      - key: interactions-appear-without-waiting-for-a-sweep
+        text: the attached messages are aggregated in the same pass, so the interactions appear immediately rather than after the next periodic sweep
+      - key: attach-failure-is-reported
+        text: a failure to attach is reported rather than swallowed, so the retry can run and the user is not left with messages that silently never arrived
+      - key: no-attachment-means-no-aggregation
+        text: when nothing was attached, no aggregation is driven, so adding an unrelated number costs nothing
+    provenance: [whatsapp.NewWhatsAppMethodRematchHandler, whatsapp.NewPhoneRematchHandler, AttachUnmatchedByPeer, TestWhatsAppRematch_AttachesByNormalizedPhoneOnly, TestWhatsAppRematch_OnPhoneMethodAdded]
+    notes: >-
+      These handlers are registered only while the WhatsApp integration is enabled, so a deployment with WhatsApp
+      off does not make a bare phone number rematch-eligible where it was not before. A peer whose phone number was
+      never recovered is not reachable this way — that population is reached through the import path, which carries
+      the peer's WhatsApp identifier (WHA-025).
+
+  - id: WHA-043
+    title: A WhatsApp interaction's venue reflects whether the conversation was one-to-one or a group
+    type: business-logic
+    status: current
+    surface: none
+    given: a WhatsApp interaction being recorded
+    when: its venue is resolved
+    then:
+      - key: direct-chat-is-a-dm
+        text: an interaction from a one-to-one chat is placed in a direct-message venue
+      - key: group-chat-is-a-group-chat
+        text: an interaction from a group chat is placed in a group-chat venue
+    provenance: [WhatsAppVenueContainerReader, VenueResolverRegistry, TestWhatsAppVenue_DirectJIDIsDM, TestWhatsAppVenue_GroupJIDIsGroupChat]
+    notes: Unlike Google Chat, whose spaces are always group containers, WhatsApp carries both kinds, so the kind is derived per chat rather than fixed for the source.


### PR DESCRIPTION
PR5 of the WhatsApp integration arc (spec: `.ai/spec/whatsapp-integration.md`, merged as #786). Wires `comms_message(source='whatsapp')` rows — staged by PR4's ingest path — into the shared aggregation pipeline. The feature remains OFF until PR6 (`ENABLE_WHATSAPP_SYNC` readiness gate); everything here is inert with the flag unset except source-scoped registry entries.

## What this adds

- **`whatsapp.NewAggregationEngine`** — thin construction over `commsadapter.NewEngine` with an unexported `whatsappSourceAdapter` (mirrors `gchatSourceAdapter`); burst/reply windows from `cfg.WhatsApp`.
- **`WhatsAppVenueContainerReader`** — derives `dm` vs `group_chat` from the chat JID suffix (`@g.us` → group), unlike GChat's fixed-kind reader.
- **Two rematch handlers** (`phone`, `whatsapp` method types) attaching unmatched rows by normalized E.164 through the existing `AttachUnmatchedByPeer` — the only flag-gated wiring in the PR (`cfg.Features.EnableWhatsAppSync`).
- **Seven source-keyed wiring sites** in `cmd/crm-api` (staging processor, venue reader, engine, reenqueuer, chat lister, ChatAwareAggregator map, sweeper lister) plus their counterparts in the synthetic replay harness, and a Gate-B teardown fix (`waitTeardownGateB` now includes whatsapp).
- **Synthetic coverage** — WhatsApp factory spec (PeerPhone normalized via `identity.Normalize(..., IdentifierTypeWhatsApp)`, JID user part derived from it) + replay adapter driving the real `Ingestor` seam.
- **Spec** — WHA-040..043 minted (`surface: none`); `spec-lint` + `spec-coverage` clean, zero new orphans.

No migration, no new sqlc query, no new repository method, no frontend change.

## Verification

The composition-root parity test (`TestWhatsAppWiring_ProductionRegistriesDispatchWhatsApp`, `package main`) is invocation-only across all seven wiring sites — every assertion drives production code and observes a durable effect (published event row, enqueued job source, resolved venue kind), never presence-in-map. Two sibling tests pin the flag gate (`EligibleMethods` empty/non-empty across off/on) and the rematch fan-out (counting decorator asserts both phone handlers dispatched exactly once with their own counts).

### Ephemeral falsification (per `.ai/rules/core.md`)

14 mutants, all kept outside the repository (`/tmp` + `go test -overlay`), each injection diff/grep-confirmed as landed before its run, exit codes read directly (`cmd >/tmp/out 2>&1; echo $?`), nothing committed. Command per run: `go test -overlay <mutant>.json -tags integration_testdb ./cmd/crm-api -run TestWhatsAppWiring_... >/tmp/out 2>&1; echo $?` (or `./tests -run <test>` for the tests-package lanes). Each run starts from a per-run `testdb.NewEphemeralClone`.

| # | Defect injected | Exit | Failing assertion |
|---|---|---|---|
| — | baseline (no mutant) | 0 | — |
| 1 | delete whatsapp staging-processor entry | 1 | site 1: no staging processor registered |
| 2 | delete whatsapp venue-reader entry | 1 | site 2: no venue container reader registered |
| 3 | `aggregationStack{WhatsAppEngine: nil}` | 1 | site 6: no ChatAwareAggregator registered |
| 4 | delete whatsapp reenqueuer entry | 1 | site 4: no aggregator reenqueuer registered |
| 5 | delete whatsapp chat-lister closure | 1 | site 5: chat lister did not enumerate the whatsapp chat |
| 6 | delete whatsapp ChatAwareAggregator map entry | 1 | site 6: no ChatAwareAggregator registered |
| 7 | delete whatsapp sweeper-lister | 1 | site 7: sweeper lister did not enumerate the contact |
| a | mis-binding: `Engines["whatsapp"] = gchatEngine` | 1 | sites 3+6: whatsapp engine published no event |
| b | mis-binding: reenqueuer built with gchat source | 1 | site 4: whatsapp reenqueuer aggregated nothing |
| c | mis-binding: adapter → `NewAdapter("gchat", "GChat")` | 1 | sites 3+6: whatsapp engine published no event |
| mD | venue reader hard-codes `VenueKindGroupChat` | 1 | dm-venue assertion, red in BOTH lanes (`cmd/crm-api` + `tests`) |
| mE | rematch `Register` calls hoisted out of the flag `if` | 1 | flag-off: `EligibleMethods` should have 0 items, has 1 |
| mF | `RematchService.Run` dispatches only the last handler | 1 | telegram phone handler must still be dispatched |
| mG | delete `CommsMessageRepo.SetPool` from the golden chain | 1 | repository has no pool (call SetPool), via `rematchByPhone` |

Honesty note: raw-deletion forms of mutants 4, 6 and (a) are compile errors (unused local) — proving nothing about the test — so each was re-run with `_ = <var>` added; the exit codes above are from those runs. The round-2 reviewer independently re-ran mD (both lanes), mE, mF, mG and reproduced all four reds.

## Recorded deviations from the plan

1. `oauth_routes_boundary_test.go` call site given `cfg` — outside the plan's blast radius, found by symbol sweep; mechanically forced by the signature change.
2. `buildWireChainForGolden` returns a `wireChain` struct rather than a 10-value tuple; golden assertions byte-identical.
3. T6 takes a per-run `testdb.NewEphemeralClone` — strictly stronger than the plan's fixture-hygiene requirement.
4. T2 burst/coalesce tests assert linkage (count stays 1, `interaction_id` equality) rather than a cumulative "(3 messages)" description — the engine's `ExtendInteraction` builds the description from the new session only, so the planned assertion would have asserted a bug.
5. WHA-041 is `type: business-logic`, not `invariant` — spec-lint forbids given/when/then on invariants and the behavior is naturally GWT.
6. Factory `AccountJID` is a fixed 555-0000 line in the namespace area code — the linked account is "me", not a contact, and the 555-01XX contact block is only 100 lines wide.
7. T7 replicates the reenqueuer's PeerRef strip rule inline (`parseCommsPeerRef` is unexported), with a comment naming the source of truth.
8. `HardDelete*Prefix` helpers take LIKE patterns, so cleanup prefixes carry `%`; a rematch log comment was reworded to match what the line logs.
9. T1 cleanup relies on the per-test ephemeral clone instead of the plan's three `HardDelete*Prefix` calls — strictly stronger (cross-run event dedup structurally impossible).
10. T6's retained per-run-unique `external_id`s and `t.Cleanup` purge are defence-in-depth, not load-bearing, under per-run clones — kept deliberately, stated accurately.

## Review

Adversarial review ran as the Claude fallback (codex pool exhausted until 2026-08-08), 2 rounds: r1 FAIL (P1: both venue-kind tests were `LONG_TESTS`-gated and outside the nightly slow regex — ran in no automated lane; fixed by moving to the fast-lane guard + adding a two-sided kind discriminator to the wiring test) → r2 delta PASS (0 findings; reviewer re-ran the new mutants itself). Verdict: `.ai/log/review/5a0d7eab….codex.md`.
