### PR TITLE
feat(imports): add WhatsApp source filter, rename All Sources to All

### DIFF
--- a/frontend/src/app/imports/__tests__/page.test.tsx
+++ b/frontend/src/app/imports/__tests__/page.test.tsx
@@ -544,16 +544,17 @@ describe('ImportsPage - Source Filter', () => {
     render(<ImportsPage />, { wrapper: createWrapper() })
 
     expect(screen.getByText('Filter:')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'All Sources' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Google Contacts' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Telegram' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'WhatsApp' })).toBeInTheDocument()
   })
 
-  it('All Sources filter is selected by default', () => {
+  it('All filter is selected by default', () => {
     render(<ImportsPage />, { wrapper: createWrapper() })
 
-    const allSourcesButton = screen.getByRole('button', { name: 'All Sources' })
+    const allSourcesButton = screen.getByRole('button', { name: 'All' })
     expect(allSourcesButton).toHaveClass('bg-blue-600')
 
     const googleContactsButton = screen.getByRole('button', { name: 'Google Contacts' })
@@ -598,7 +599,18 @@ describe('ImportsPage - Source Filter', () => {
     expect(useSuggestions).toHaveBeenCalledWith(expect.objectContaining({ source: 'telegram' }))
   })
 
-  it('clicking All Sources removes source filter', async () => {
+  it('clicking WhatsApp filter updates selection', async () => {
+    const user = userEvent.setup()
+    render(<ImportsPage />, { wrapper: createWrapper() })
+
+    const whatsAppButton = screen.getByRole('button', { name: 'WhatsApp' })
+    await user.click(whatsAppButton)
+
+    // useSuggestions should be called with the source filter
+    expect(useSuggestions).toHaveBeenCalledWith(expect.objectContaining({ source: 'whatsapp' }))
+  })
+
+  it('clicking All removes source filter', async () => {
     const user = userEvent.setup()
     render(<ImportsPage />, { wrapper: createWrapper() })
 
@@ -606,8 +618,8 @@ describe('ImportsPage - Source Filter', () => {
     const calendarButton = screen.getByRole('button', { name: 'Calendar' })
     await user.click(calendarButton)
 
-    // Then click All Sources
-    const allSourcesButton = screen.getByRole('button', { name: 'All Sources' })
+    // Then click All
+    const allSourcesButton = screen.getByRole('button', { name: 'All' })
     await user.click(allSourcesButton)
 
     // useSuggestions should be called without source filter (undefined)

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -57,11 +57,12 @@ import type {
 // Constants
 const DEFAULT_PAGE_SIZE = 20
 const SOURCE_FILTERS = [
-  { value: '', label: 'All Sources' },
+  { value: '', label: 'All' },
   { value: 'gcontacts', label: 'Google Contacts' },
   { value: 'gcal_attendee', label: 'Calendar' },
   { value: 'icloud_contacts', label: 'iCloud Contacts' },
   { value: 'telegram', label: 'Telegram' },
+  { value: 'whatsapp', label: 'WhatsApp' },
   { value: 'anarlog_humans', label: 'Anarlog' },
 ] as const
 

--- a/frontend/tests/e2e/imports-page.spec.ts
+++ b/frontend/tests/e2e/imports-page.spec.ts
@@ -85,15 +85,17 @@ test.describe('Imports Page @area:imports', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // The source filter pills exist.
-    const allSources = page.getByRole('button', { name: 'All Sources', exact: true })
+    const allFilter = page.getByRole('button', { name: 'All', exact: true })
     const googleContacts = page.getByRole('button', { name: 'Google Contacts', exact: true })
     const calendar = page.getByRole('button', { name: 'Calendar', exact: true })
-    await expect(allSources).toBeVisible()
+    const whatsApp = page.getByRole('button', { name: 'WhatsApp', exact: true })
+    await expect(allFilter).toBeVisible()
     await expect(googleContacts).toBeVisible()
     await expect(calendar).toBeVisible()
+    await expect(whatsApp).toBeVisible()
 
-    // All Sources is the default selection.
-    await expect(allSources).toHaveAttribute('aria-pressed', 'true')
+    // All is the default selection.
+    await expect(allFilter).toHaveAttribute('aria-pressed', 'true')
 
     // Selecting a source flips the pressed state AND refetches the
     // suggestions feed scoped to that source (network-param proof).
@@ -106,7 +108,7 @@ test.describe('Imports Page @area:imports', () => {
     await googleContacts.click()
     await gcontactsResponse
     await expect(googleContacts).toHaveAttribute('aria-pressed', 'true')
-    await expect(allSources).toHaveAttribute('aria-pressed', 'false')
+    await expect(allFilter).toHaveAttribute('aria-pressed', 'false')
 
     const gcalResponse = page.waitForResponse(
       res =>


### PR DESCRIPTION
## What

Adds a WhatsApp pill to the imports page source filter (`SOURCE_FILTERS`), placed next to Telegram, and renames the default pill from "All Sources" to "All" to free horizontal space in the pill row.

## Why

The WhatsApp integration (#787–#795) lands discovery candidates with `source: 'whatsapp'`, but the filter list predated the arc, so those candidates were only visible under the unfiltered view. The backend `GET /imports/suggestions` endpoint takes `source` as a free-form string, so no backend change is needed.

## Tests

- Unit (`page.test.tsx`): WhatsApp pill presence added to the filter-buttons test; new `clicking WhatsApp filter updates selection` test asserting `useSuggestions` is called with `source: 'whatsapp'`; "All Sources" label assertions updated to "All".
- E2E (`imports-page.spec.ts`): WhatsApp pill visibility added to the source-filter test; label assertions updated.

Requested as a quick change (no heavy review process) — user-directed follow-up to the WhatsApp arc.
