### PR TITLE
fix(matching): ambiguity is per contact, not per method row

### DIFF
--- a/backend/internal/service/identity.go
+++ b/backend/internal/service/identity.go
@@ -398,18 +398,48 @@ func (s *IdentityService) findContactByMethodTx(ctx context.Context, tx pgx.Tx, 
 		return nil, repository.MatchTypeUnmatched, err
 	}
 
+	contactID, matchType := resolveContactFromMethods(identifier, matches)
+	return contactID, matchType, nil
+}
+
+// resolveContactFromMethods collapses contact-method matches down to a single
+// contact.
+//
+// Ambiguity is a property of CONTACTS, not of rows. An identifier type may map
+// to SEVERAL contact-method types — whatsapp resolves against
+// [whatsapp, phone] so a peer can match a contact who only ever had a phone
+// number on file — so one contact legitimately returns one row per method it
+// holds the value under. Counting rows calls that a conflict and refuses to
+// match a contact that is not in doubt.
+//
+// That misfire is self-inflicting rather than rare: reconciliation mints the
+// whatsapp method for a contact the moment its first message matches on the
+// phone method, so under a row count every peer matches exactly once and is
+// permanently unmatched from its second message onward.
+//
+// Two or more DISTINCT contacts sharing the identifier is the real ambiguity,
+// and it still refuses to guess.
+func resolveContactFromMethods(identifier string, matches []repository.ContactMethodMatch) (*uuid.UUID, repository.MatchType) {
 	if len(matches) == 0 {
-		return nil, repository.MatchTypeUnmatched, nil
+		return nil, repository.MatchTypeUnmatched
 	}
-	if len(matches) == 1 {
-		return &matches[0].ContactID, repository.MatchTypeExact, nil
+
+	distinct := make(map[uuid.UUID]struct{}, len(matches))
+	for _, m := range matches {
+		distinct[m.ContactID] = struct{}{}
 	}
-	// Multiple matches — ambiguous, leave for user to resolve.
-	logger.Warn().
-		Str("identifier", identifier).
-		Int("match_count", len(matches)).
-		Msg("ambiguous identity match - multiple contacts found")
-	return nil, repository.MatchTypeUnmatched, nil
+	if len(distinct) > 1 {
+		logger.Warn().
+			Str("identifier", identifier).
+			Int("match_count", len(matches)).
+			Int("contact_count", len(distinct)).
+			Msg("ambiguous identity match - multiple contacts found")
+		return nil, repository.MatchTypeUnmatched
+	}
+
+	// Return the first row's contact rather than a map key: every row agrees on
+	// the contact here, and map iteration order is randomized.
+	return &matches[0].ContactID, repository.MatchTypeExact
 }
 
 // findContactByMethod searches contact_method table for a match
@@ -436,22 +466,7 @@ func (s *IdentityService) findContactByMethod(ctx context.Context, identifier st
 		return nil, repository.MatchTypeUnmatched
 	}
 
-	// Handle match results
-	if len(matches) == 0 {
-		return nil, repository.MatchTypeUnmatched
-	}
-
-	if len(matches) == 1 {
-		// Unique match found
-		return &matches[0].ContactID, repository.MatchTypeExact
-	}
-
-	// Multiple matches - ambiguous, let user resolve
-	logger.Warn().
-		Str("identifier", identifier).
-		Int("match_count", len(matches)).
-		Msg("ambiguous identity match - multiple contacts found")
-	return nil, repository.MatchTypeUnmatched
+	return resolveContactFromMethods(identifier, matches)
 }
 
 // LinkIdentity manually links an identity to a contact

--- a/backend/internal/service/identity_ambiguity_test.go
+++ b/backend/internal/service/identity_ambiguity_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveContactFromMethods_AmbiguityIsPerContactNotPerRow pins the
+// distinction the matcher rests on: an identifier type may map to SEVERAL
+// contact-method types, so one contact returns one row per method it holds the
+// value under. Counting rows refuses to match a contact that is not in doubt —
+// and because reconciliation mints the second method on a peer's FIRST
+// successful match, a row count makes every peer match exactly once and strand
+// from its second message onward.
+func TestResolveContactFromMethods_AmbiguityIsPerContactNotPerRow(t *testing.T) {
+	t.Parallel()
+
+	alice := uuid.New()
+	bob := uuid.New()
+	row := func(contactID uuid.UUID, methodType string) repository.ContactMethodMatch {
+		return repository.ContactMethodMatch{ID: uuid.New(), ContactID: contactID, Type: methodType}
+	}
+
+	t.Run("no rows is unmatched", func(t *testing.T) {
+		t.Parallel()
+		id, mt := resolveContactFromMethods("+15550000000", nil)
+		assert.Nil(t, id)
+		assert.Equal(t, repository.MatchTypeUnmatched, mt)
+	})
+
+	t.Run("one row matches exactly", func(t *testing.T) {
+		t.Parallel()
+		id, mt := resolveContactFromMethods("+15550000001", []repository.ContactMethodMatch{
+			row(alice, "phone"),
+		})
+		require.NotNil(t, id)
+		assert.Equal(t, alice, *id)
+		assert.Equal(t, repository.MatchTypeExact, mt)
+	})
+
+	t.Run("several rows on ONE contact still match exactly", func(t *testing.T) {
+		t.Parallel()
+		// The shape reconciliation creates: the same number held as both a
+		// whatsapp and a phone method by a single contact.
+		id, mt := resolveContactFromMethods("+15550000002", []repository.ContactMethodMatch{
+			row(alice, "whatsapp"),
+			row(alice, "phone"),
+		})
+		require.NotNil(t, id)
+		assert.Equal(t, alice, *id)
+		assert.Equal(t, repository.MatchTypeExact, mt,
+			"two methods on one contact is not a conflict about WHO the peer is")
+	})
+
+	t.Run("rows across DISTINCT contacts stay unmatched", func(t *testing.T) {
+		t.Parallel()
+		id, mt := resolveContactFromMethods("+15550000003", []repository.ContactMethodMatch{
+			row(alice, "phone"),
+			row(bob, "whatsapp"),
+		})
+		assert.Nil(t, id, "two contacts claiming one identifier is the real ambiguity")
+		assert.Equal(t, repository.MatchTypeUnmatched, mt)
+	})
+
+	t.Run("many rows across distinct contacts stay unmatched", func(t *testing.T) {
+		t.Parallel()
+		id, mt := resolveContactFromMethods("+15550000004", []repository.ContactMethodMatch{
+			row(alice, "phone"),
+			row(alice, "whatsapp"),
+			row(bob, "phone"),
+		})
+		assert.Nil(t, id)
+		assert.Equal(t, repository.MatchTypeUnmatched, mt)
+	})
+}

--- a/backend/tests/identity_integration_test.go
+++ b/backend/tests/identity_integration_test.go
@@ -547,6 +547,88 @@ func TestIdentityService_Integration(t *testing.T) {
 		assert.Nil(t, unlinked.ContactID)
 		assert.Equal(t, repository.MatchTypeUnmatched, unlinked.MatchType)
 	})
+
+	// A WhatsApp identifier resolves against BOTH whatsapp and phone contact
+	// methods, so a contact holding one number under both returns two rows for
+	// one contact. These two sub-tests pin the halves apart: same contact still
+	// matches, different contacts still refuse.
+	//
+	// The first is the production failure mode rather than a hypothetical —
+	// reconciliation mints the whatsapp method for a contact whose phone method
+	// just matched, so this is the state EVERY matched peer lands in.
+	phoneNS := func() string {
+		return fmt.Sprintf("+1555%07d", uuid.New().ID()%10_000_000)
+	}
+
+	t.Run("MatchOrCreate_WhatsApp_OneContactUnderBothMethodTypes", func(t *testing.T) {
+		number := phoneNS()
+
+		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: "WhatsApp Dual Method Test",
+		})
+		require.NoError(t, err)
+		defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
+		defer func() { _ = methodRepo.DeleteContactMethodsByContact(ctx, contact.ID) }()
+
+		for _, mt := range []repository.ContactMethodType{
+			repository.ContactMethodPhone,
+			repository.ContactMethodWhatsApp,
+		} {
+			_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+				ContactID: contact.ID,
+				Type:      string(mt),
+				Value:     number,
+			})
+			require.NoError(t, err, "one contact may hold the same number under both types")
+		}
+
+		result, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: number,
+			Type:          identity.IdentifierTypeWhatsApp,
+			Source:        "test_wa_dual_" + ns,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		defer func() { _ = identityRepo.Delete(ctx, result.Identity.ID) }()
+
+		require.NotNil(t, result.ContactID,
+			"two methods on ONE contact is not ambiguity about who the peer is")
+		assert.Equal(t, contact.ID, *result.ContactID)
+		assert.Equal(t, repository.MatchTypeExact, result.MatchType)
+	})
+
+	t.Run("MatchOrCreate_WhatsApp_TwoContactsShareTheNumberStaysUnmatched", func(t *testing.T) {
+		number := phoneNS()
+
+		for i, name := range []string{"WhatsApp Shared A", "WhatsApp Shared B"} {
+			c, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+				FullName: fmt.Sprintf("%s %s-%d", name, ns, i),
+			})
+			require.NoError(t, err)
+			defer func() { _ = contactRepo.HardDeleteContact(ctx, c.ID) }()
+			defer func() { _ = methodRepo.DeleteContactMethodsByContact(ctx, c.ID) }()
+
+			_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+				ContactID: c.ID,
+				Type:      string(repository.ContactMethodPhone),
+				Value:     number,
+			})
+			require.NoError(t, err)
+		}
+
+		result, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: number,
+			Type:          identity.IdentifierTypeWhatsApp,
+			Source:        "test_wa_shared_" + ns,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		defer func() { _ = identityRepo.Delete(ctx, result.Identity.ID) }()
+
+		assert.Nil(t, result.ContactID,
+			"two DISTINCT contacts claiming one number is the real ambiguity; guessing would mis-attribute")
+		assert.Equal(t, repository.MatchTypeUnmatched, result.MatchType)
+	})
 }
 
 // TestIdentityService_NormalizationPolicy_Integration exercises the

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -58,6 +58,21 @@ behaviors:
     provenance: [usernameMatchGap, NormalizeHandleForNameMatch, applyExactHandleBonus]
     notes: Ambiguous common handles must not guess; the collision-gap rule is reused by anarlog title-token matching.
 
+  - id: IMP-041
+    title: An identifier matching one contact under several method types is not ambiguous
+    type: business-logic
+    status: current
+    surface: none
+    given: an external identifier whose type resolves against more than one kind of contact method (a WhatsApp peer is looked up against both whatsapp and phone methods)
+    when: the matching engine decides which contact it belongs to
+    then:
+      - key: several-methods-on-one-contact-still-match
+        text: a contact holding the identifier under several of those method types is matched, because the duplication is about how many ways one person is reachable rather than about which person the identifier belongs to
+      - key: distinct-contacts-refuse-to-guess
+        text: the identifier is left unmatched only when two or more DISTINCT contacts claim it, since guessing between real people would mis-attribute every message from that peer
+    provenance: [resolveContactFromMethods, findContactByMethod, findContactByMethodTx, MapIdentifierTypeToContactMethodTypes, TestResolveContactFromMethods_AmbiguityIsPerContactNotPerRow, TestIdentityService_Integration]
+    notes: Counting matched method ROWS instead of distinct contacts refuses a contact that is not in doubt, and reconciliation mints a second method on a peer's first successful match, so a row count strands every peer from its second message onward.
+
   - id: IMP-005
     title: The import queue only ever suggests
     type: invariant


### PR DESCRIPTION
Fixes #798.

## Problem

`findContactByMethod` and its tx twin treated **any** extra `contact_method` row as an ambiguous match. The ambiguity that matters is about which **contact** an identifier belongs to — and an identifier type may resolve against several method types. WhatsApp deliberately looks up `[whatsapp, phone]` so a peer can match a contact who only ever had a phone number on file, so one contact holding the value under both types returns two rows. The row count then refused to match a contact that was never in doubt.

## It is self-inflicting

`reconcileOnMatch` mints the `whatsapp` method for a contact the moment its first message matches on the `phone` method. Under a row count, that means every peer matches **exactly once** and is permanently unmatched from its second message onward.

Prod evidence: 33 of 38 ingested WhatsApp messages stranded with `matched_contact_id IS NULL`, across both the backfill and live ingest paths, with no interactions and untouched `last_contacted`. 34 `ambiguous identity match` warnings, every one resolving to exactly one contact. No identifier in the database is held by more than one contact — so the check had never once fired on a real ambiguity. Timestamps confirm the mechanism: for every peer that matched, the `phone` method predates the backfill by weeks while the `whatsapp` method was created ~1.5 ms before the message row that matched it.

## Change

Both call sites route through `resolveContactFromMethods`, which collapses matches by `contact_id`:

- several rows on **one** contact → exact match
- two or more **distinct** contacts → still refuses to guess, and the warning now carries `contact_count` alongside `match_count` so a future occurrence explains itself

`reconcileOnMatch` is deliberately unchanged: a `whatsapp` method asserts something a `phone` method does not — that the person is reachable on WhatsApp — and dropping it to dodge this bug would trade real information for a workaround.

## Tests

There was **no ambiguity coverage anywhere** in the suite before this, which is why it shipped.

- Unit (`identity_ambiguity_test.go`): the branch table — zero rows, one row, several rows on one contact, rows across distinct contacts, and the mixed case.
- Integration (`identity_integration_test.go`): drives the real DB through `MatchOrCreate` with a contact holding one number under both method types, plus the two-distinct-contacts case that must stay unmatched.

## Ephemeral second-order verification

Injected the old row-count logic as a mutant outside the repo and ran through `go test -overlay`:

- Unit: exit **1** — `several rows on ONE contact still match exactly` FAILED
- Integration: exit **1** — `MatchOrCreate_WhatsApp_OneContactUnderBothMethodTypes` FAILED
- The distinct-contact cases **passed** under the mutant, confirming they guard preserved behaviour rather than catching this defect

Mutant discarded; nothing committed.

## Spec

Mints `IMP-041` in `imports-matching.yaml` (`surface: none`). `make spec-lint` and `make spec-coverage` exit 0, zero orphans.

## Verification

`make lint` 0 issues · `make test-unit` exit 0 · integration exit 0 across `tests`, `tests/api`, `tests/river`, `tests/scheduler`, `tests/unit`, `internal/service`.

## Not in this PR

The ~36 already-stranded rows are untouched — this only fixes matching going forward. They carry the identifier and their contacts exist, so re-binding them is recoverable housekeeping, tracked separately on #798.