### PR TITLE
chore: pin the Go toolchain and golangci-lint across environments

### DIFF
--- a/.github/workflows/backend-slow-tests.yml
+++ b/.github/workflows/backend-slow-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.5'
           cache-dependency-path: backend/go.sum
 
       # The integration target runs via make, which defaults GOCACHE to a

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.5'
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.5'
           cache: false
 
       # Rolling Go module download cache. Per-job primary key (trailing token)
@@ -57,10 +57,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-quality
+          key: go-mod-${{ runner.os }}-go1.25.5-${{ hashFiles('backend/go.sum') }}-quality
           restore-keys: |
-            go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-
-            go-mod-${{ runner.os }}-go1.23-
+            go-mod-${{ runner.os }}-go1.25.5-${{ hashFiles('backend/go.sum') }}-
+            go-mod-${{ runner.os }}-go1.25.5-
 
       # Rolling Go build cache. SHA-keyed so every run misses its exact key and
       # saves a fresh entry; restore-keys brings the most recent prior build
@@ -71,9 +71,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
-          key: go-build-quality-${{ runner.os }}-go1.23-${{ github.sha }}
+          key: go-build-quality-${{ runner.os }}-go1.25.5-${{ github.sha }}
           restore-keys: |
-            go-build-quality-${{ runner.os }}-go1.23-
+            go-build-quality-${{ runner.os }}-go1.25.5-
 
       # The Makefile defaults GOCACHE to a workspace-local dir via `?=`, which
       # would bypass the restored ~/.cache/go-build for every make-driven Go
@@ -92,7 +92,14 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # Pinned, not `latest`: with `latest` this job silently re-versions
+          # itself, so the same commit can lint clean today and fail tomorrow,
+          # and a local binary drifts from it with no signal. A stale local
+          # linter then reports failures CI never sees — SA5011 false positives
+          # that a newer staticcheck no longer emits — which read exactly like
+          # real regressions on develop.
+          # Keep in lockstep with GOLANGCI_LINT_VERSION in scripts/setup-dev.sh.
+          version: v2.12.2
           working-directory: backend
           # No --timeout flag: inherit the single source in .golangci.yml (10m).
 
@@ -154,7 +161,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.5'
           cache: false
       - name: Run spec linter
         run: make spec-lint
@@ -198,7 +205,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.5'
           cache: false
       - name: Check generated API types are in sync
         run: make api-types-check
@@ -221,7 +228,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.5'
           cache: false
 
       # Rolling Go module download cache. Per-job primary key (trailing token)
@@ -234,10 +241,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-tests
+          key: go-mod-${{ runner.os }}-go1.25.5-${{ hashFiles('backend/go.sum') }}-tests
           restore-keys: |
-            go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-
-            go-mod-${{ runner.os }}-go1.23-
+            go-mod-${{ runner.os }}-go1.25.5-${{ hashFiles('backend/go.sum') }}-
+            go-mod-${{ runner.os }}-go1.25.5-
 
       # Rolling Go build cache. SHA-keyed so every run misses its exact key and
       # saves a fresh entry; restore-keys brings the most recent prior build
@@ -248,9 +255,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
-          key: go-build-tests-${{ runner.os }}-go1.23-${{ github.sha }}
+          key: go-build-tests-${{ runner.os }}-go1.25.5-${{ github.sha }}
           restore-keys: |
-            go-build-tests-${{ runner.os }}-go1.23-
+            go-build-tests-${{ runner.os }}-go1.25.5-
 
       # See backend-quality: pin GOCACHE so make-invoked builds (the
       # integration step calls `make test-integration-fast`) reuse the
@@ -528,7 +535,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.5'
           cache: false
 
       # Rolling Go module download cache. Per-job primary key (trailing token)
@@ -544,10 +551,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-e2e-${{ matrix.shard }}
+          key: go-mod-${{ runner.os }}-go1.25.5-${{ hashFiles('backend/go.sum') }}-e2e-${{ matrix.shard }}
           restore-keys: |
-            go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-
-            go-mod-${{ runner.os }}-go1.23-
+            go-mod-${{ runner.os }}-go1.25.5-${{ hashFiles('backend/go.sum') }}-
+            go-mod-${{ runner.os }}-go1.25.5-
 
       # Rolling Go build cache. SHA-keyed so every run misses its exact key and
       # saves a fresh entry; restore-keys brings the most recent prior build
@@ -562,9 +569,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
-          key: go-build-e2e-${{ runner.os }}-go1.23-${{ github.sha }}-${{ matrix.shard }}
+          key: go-build-e2e-${{ runner.os }}-go1.25.5-${{ github.sha }}-${{ matrix.shard }}
           restore-keys: |
-            go-build-e2e-${{ runner.os }}-go1.23-
+            go-build-e2e-${{ runner.os }}-go1.25.5-
 
       # The Playwright webServer launches the backend via `go run`; pin GOCACHE
       # to the ~/.cache/go-build restored by the explicit actions/cache step

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Read and follow: `.ai/rules/core.md`
 Personal CRM: single-user, local-first CRM for privacy-focused personal use.
 Target deployment: Raspberry Pi backend, access via Tailscale.
 
-**Stack:** Go 1.24 + Gin + PostgreSQL 16 + sqlc | Next.js 15 + React 19 + TailwindCSS 4 | bun (never npm)
+**Stack:** Go 1.25 + Gin + PostgreSQL 16 + sqlc | Next.js 15 + React 19 + TailwindCSS 4 | bun (never npm)
 
 Run `make help` from project root for the full command reference.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A single-user, local-first customer relationship management system with AI-power
 ## Prerequisites
 
 - Docker and Docker Compose
-- Go 1.24+
+- Go 1.25+
 - Bun 1.0+ (for frontend)
 - Make
 
@@ -167,10 +167,10 @@ Deploy PersonalCRM as a systemd service on Raspberry Pi for automatic startup on
    curl -sSL https://get.docker.com | sh
    sudo usermod -aG docker $USER
    ```
-3. **Go 1.24+**:
+3. **Go 1.25+**:
    ```bash
-   wget https://go.dev/dl/go1.24.0.linux-arm64.tar.gz
-   sudo tar -C /usr/local -xzf go1.24.0.linux-arm64.tar.gz
+   wget https://go.dev/dl/go1.25.5.linux-arm64.tar.gz
+   sudo tar -C /usr/local -xzf go1.25.5.linux-arm64.tar.gz
    export PATH=$PATH:/usr/local/go/bin
    ```
 4. **Bun**:

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,6 +2,17 @@ module personal-crm/backend
 
 go 1.25.0
 
+// The SINGLE source of the compiler every environment builds with. Without it,
+// `go 1.25.0` is only a floor: GOTOOLCHAIN=auto uses any locally-installed
+// toolchain that satisfies it, so a developer on a newer patch compiled with
+// that one while CI and the release images downloaded exactly 1.25.0 — the
+// binary shipped to prod was built by a different compiler than the one the
+// change was written and tested against. Pinning binds all three.
+//
+// Bumping this is a deliberate act: it changes the compiler for local, CI and
+// the published images together, which is the point.
+toolchain go1.25.5
+
 require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-playground/validator/v10 v10.27.0

--- a/docs/FIRST_TIME_PI_DEPLOYMENT.md
+++ b/docs/FIRST_TIME_PI_DEPLOYMENT.md
@@ -49,7 +49,7 @@ retired.
 - **Network connection** (Ethernet or WiFi)
 
 ### Your Mac
-- Git, Go 1.24+, Bun (for building)
+- Git, Go 1.25+, Bun (for building)
 - SSH configured for passwordless login to Pi
 - Pi accessible via Tailscale (recommended) or local network
 

--- a/docs/LOCAL_MACOS_DEPLOYMENT.md
+++ b/docs/LOCAL_MACOS_DEPLOYMENT.md
@@ -58,14 +58,14 @@ brew install --cask docker
 # Start Docker Desktop from Applications
 ```
 
-#### Go 1.24+
+#### Go 1.25+
 ```bash
 # Using Homebrew:
 brew install go@1.24
 
 # Verify:
 go version
-# Should output: go version go1.24.x darwin/amd64 (or darwin/arm64)
+# Should output: go version go1.25.x darwin/amd64 (or darwin/arm64)
 ```
 
 #### Bun

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -72,27 +72,38 @@ echo_step "Installing Go tools..."
 GOPATH="${GOPATH:-$HOME/go}"
 mkdir -p "$GOPATH/bin"
 
-# golangci-lint v2 (installed via curl, not go install, for version compatibility)
-if command -v golangci-lint &> /dev/null || [ -f "$GOPATH/bin/golangci-lint" ]; then
-    LINT_VERSION=$("$GOPATH/bin/golangci-lint" --version 2>/dev/null | head -1 || golangci-lint --version 2>/dev/null | head -1)
-    if [[ "$LINT_VERSION" == *"version 2"* ]]; then
-        echo_ok "golangci-lint v2 already installed"
-    else
-        echo_warn "golangci-lint v1 found, upgrading to v2..."
-        if curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$GOPATH/bin" latest; then
-            echo_ok "golangci-lint v2 installed"
-        else
-            echo_err "Failed to install golangci-lint"
-            MANUAL_STEPS+=("Install golangci-lint: https://golangci-lint.run/welcome/install/")
-        fi
-    fi
+# golangci-lint, installed via curl rather than `go install`: a go-installed
+# build reports its version as "(unknown, modified: ?)" and can bundle a
+# different staticcheck than the release, so it disagrees with CI while looking
+# like the same tool.
+#
+# PINNED, and matched EXACTLY rather than "any v2". The previous any-v2 check is
+# what let a 2.7.2 binary sit here untouched while CI (`version: latest`) moved
+# to 2.12.2: `make lint` then reported SA5011 failures that CI never saw and
+# that reproduced on a clean develop, which reads exactly like a real regression.
+# Keep in lockstep with the golangci-lint-action version in .github/workflows/ci.yml.
+GOLANGCI_LINT_VERSION="v2.12.2"
+
+lint_version_line() {
+    "$GOPATH/bin/golangci-lint" version 2>/dev/null | head -1 \
+        || command -v golangci-lint &> /dev/null && golangci-lint version 2>/dev/null | head -1 \
+        || true
+}
+
+CURRENT_LINT="$(lint_version_line)"
+if [[ "$CURRENT_LINT" == *"version ${GOLANGCI_LINT_VERSION#v} "* ]]; then
+    echo_ok "golangci-lint ${GOLANGCI_LINT_VERSION} already installed"
 else
-    echo "   Installing golangci-lint v2..."
-    if curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$GOPATH/bin" latest; then
-        echo_ok "golangci-lint v2 installed"
+    if [ -n "$CURRENT_LINT" ]; then
+        echo_warn "golangci-lint does not match the pin (${GOLANGCI_LINT_VERSION}), reinstalling..."
+    else
+        echo "   Installing golangci-lint ${GOLANGCI_LINT_VERSION}..."
+    fi
+    if curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$GOPATH/bin" "$GOLANGCI_LINT_VERSION"; then
+        echo_ok "golangci-lint ${GOLANGCI_LINT_VERSION} installed"
     else
         echo_err "Failed to install golangci-lint"
-        MANUAL_STEPS+=("Install golangci-lint: https://golangci-lint.run/welcome/install/")
+        MANUAL_STEPS+=("Install golangci-lint ${GOLANGCI_LINT_VERSION}: https://golangci-lint.run/welcome/install/")
     fi
 fi
 


### PR DESCRIPTION
## Problem

The Go version was three different numbers depending on where you looked:

| source | claimed |
|---|---|
| `backend/go.mod` | `go 1.25.0` |
| all 7 `setup-go` steps | `'1.23'` |
| `AGENTS.md` stack line | Go 1.24 |
| prod (`/health`) | `go1.25.0` |

The `'1.23'` pins were **inert**. `GOTOOLCHAIN` defaults to `auto`, so `go build` read the go.mod floor and downloaded 1.25.0 regardless — which is why prod reported `go1.25.0` while every workflow claimed 1.23.

The deeper issue: **a floor is not a pin**. Any locally-installed toolchain satisfying `go 1.25.0` was used as-is, so a developer on 1.25.5 compiled and tested with 1.25.5 while the release images were built by 1.25.0. The binary shipped to prod came from a different compiler than the change was written against.

`golangci-lint` had the mirror-image problem: CI ran `version: latest`, so the same commit could lint clean one day and fail the next, and `setup-dev.sh` treated **any** v2 as satisfied. A 2.7.2 binary therefore sat on a dev machine untouched while CI moved to 2.12.2, and `make lint` reported `SA5011` failures CI never saw — false positives on branches guarded by `t.Fatalf`, which newer staticcheck knows is terminal. Because they reproduced on a clean `develop`, they read exactly like a real regression.

## Change

- `toolchain go1.25.5` in `go.mod` — the single source binding local, CI and the published images to one compiler. It reaches prod because the image is distroless (`infra/images/backend.Dockerfile` only `COPY`s prebuilt binaries), so prod's Go comes solely from the cross-compile in `build-images.yml`.
- The 7 `go-version: '1.23'` entries now say `'1.25.5'`, so the config stops describing a build that never happened.
- `golangci-lint` pinned to `v2.12.2` on **both** sides — `ci.yml` instead of `latest`, and `setup-dev.sh` matching the exact version rather than the major, with each comment naming the other as its counterpart.
- Workflow cache keys carried the same stale `go1.23` label; a key naming the wrong toolchain lets caches built by different compilers collide, so they move with the pin.
- Stale doc references swept per the repo's own gotcha (`README.md`, `docs/FIRST_TIME_PI_DEPLOYMENT.md`, `docs/LOCAL_MACOS_DEPLOYMENT.md`, `AGENTS.md`) — fix all instances, not one.

## Verification the pin is load-bearing

Asserting that a local build produced 1.25.5 would have proved nothing: this machine's Go **already is** 1.25.5, so the assertion passes whether or not the directive does anything — a no-op probe reported as success.

So the pin was temporarily set to `go1.25.6` instead:

```
probe pin: toolchain go1.25.6
go: downloading go1.25.6 (darwin/arm64)
binary stamped: go1.25.6
```

Go downloaded and switched compilers despite 1.25.5 being installed, which is exactly the mechanism CI and the image build will follow. `go.mod` restored; nothing from the probe is committed.

Also confirmed all three edited workflows still parse, and `make lint` (0 issues) and `make test-unit` pass under the pin.

## Notes

- **This changes prod's compiler** from 1.25.0 to 1.25.5 on the next promote. Patch-level within the same minor, but it is a real change to the shipped artifact.
- 1.25.x has since reached **1.25.12** — 1.25.5 is a deliberate convergence point (it matches the current dev machine), not the newest. Bumping is now a one-line change that moves every environment together, which is the point.
- `golangci-lint` is dev/CI only and never runs on staging or prod, so it has nothing to converge there; the Go toolchain is the part that reaches the deployed artifact.