### PR TITLE
fix(whatsapp): drop null-JID system envelopes at ingest

### DIFF
--- a/backend/internal/whatsapp/message.go
+++ b/backend/internal/whatsapp/message.go
@@ -50,19 +50,20 @@ const (
 // normalized into a plausible-looking identifier.
 var phoneUserPattern = regexp.MustCompile(`^[0-9]{5,15}$`)
 
-// nullUserJID is the user part WhatsApp addresses protocol and system
-// records to — not a subscriber, and not anybody the CRM could ever have a
-// conversation with. An envelope that names it (as the chat itself, or as a
-// sender inside a group) describes no person, and must never be allowed to
-// mint a discovery candidate or be attributed to a real contact.
+// isNonPersonUserJID reports whether jid's user part could never belong to a
+// subscriber: the protocol's null user (types.PSAJID, matched on its User
+// field rather than a locally re-derived copy — the library's own PSA-sender
+// checks compare the same way), or an empty user part (types.ServerJID, one
+// of the library's own "contacted often" JIDs). Neither is a subscriber, and
+// neither is anybody the CRM could ever have a conversation with. An
+// envelope that names either — as the chat itself, or as a sender inside a
+// group — describes no person, and must never be allowed to mint a
+// discovery candidate or be attributed to a real contact.
 //
-// The match is on the exact user part, never a prefix: a real subscriber
-// number can legitimately begin with a zero.
-const nullUserJID = "0"
-
-// isNullUserJID reports whether jid is the protocol's null user.
-func isNullUserJID(jid types.JID) bool {
-	return jid.User == nullUserJID
+// The null-user match is on the exact user part, never a prefix: a real
+// subscriber number can legitimately begin with a zero.
+func isNonPersonUserJID(jid types.JID) bool {
+	return jid.User == "" || jid.User == types.PSAJID.User
 }
 
 // normalizeServer rewrites device-domain and legacy servers onto the canonical
@@ -165,7 +166,7 @@ func classifyChat(chat types.JID, own ownIdentity) (string, bool) {
 		if own.isSelf(chat) {
 			return "", false
 		}
-		if isNullUserJID(chat) {
+		if isNonPersonUserJID(chat) {
 			return "", false
 		}
 		return ChatTypePrivate, true
@@ -373,7 +374,7 @@ func resolvePeer(evt *events.Message, chat types.JID, chatType string) (peer typ
 		return types.EmptyJID, types.EmptyJID, false
 	}
 	sender := normalizeServer(evt.Info.Sender).ToNonAD()
-	if isNullUserJID(sender) {
+	if isNonPersonUserJID(sender) {
 		// A system envelope inside a tracked group still stages — the group
 		// itself is real — but it has no human counterpart, so it must not
 		// carry a peer handle that could mint a discovery candidate.

--- a/backend/internal/whatsapp/message.go
+++ b/backend/internal/whatsapp/message.go
@@ -50,6 +50,21 @@ const (
 // normalized into a plausible-looking identifier.
 var phoneUserPattern = regexp.MustCompile(`^[0-9]{5,15}$`)
 
+// nullUserJID is the user part WhatsApp addresses protocol and system
+// records to — not a subscriber, and not anybody the CRM could ever have a
+// conversation with. An envelope that names it (as the chat itself, or as a
+// sender inside a group) describes no person, and must never be allowed to
+// mint a discovery candidate or be attributed to a real contact.
+//
+// The match is on the exact user part, never a prefix: a real subscriber
+// number can legitimately begin with a zero.
+const nullUserJID = "0"
+
+// isNullUserJID reports whether jid is the protocol's null user.
+func isNullUserJID(jid types.JID) bool {
+	return jid.User == nullUserJID
+}
+
 // normalizeServer rewrites device-domain and legacy servers onto the canonical
 // user servers, so eligibility is decided on IDENTITY rather than on transport.
 //
@@ -148,6 +163,9 @@ func classifyChat(chat types.JID, own ownIdentity) (string, bool) {
 		return ChatTypeGroup, true
 	case types.DefaultUserServer, types.HiddenUserServer:
 		if own.isSelf(chat) {
+			return "", false
+		}
+		if isNullUserJID(chat) {
 			return "", false
 		}
 		return ChatTypePrivate, true
@@ -354,7 +372,14 @@ func resolvePeer(evt *events.Message, chat types.JID, chatType string) (peer typ
 	if evt.Info.IsFromMe {
 		return types.EmptyJID, types.EmptyJID, false
 	}
-	return normalizeServer(evt.Info.Sender).ToNonAD(), normalizeServer(evt.Info.SenderAlt).ToNonAD(), true
+	sender := normalizeServer(evt.Info.Sender).ToNonAD()
+	if isNullUserJID(sender) {
+		// A system envelope inside a tracked group still stages — the group
+		// itself is real — but it has no human counterpart, so it must not
+		// carry a peer handle that could mint a discovery candidate.
+		return types.EmptyJID, types.EmptyJID, false
+	}
+	return sender, normalizeServer(evt.Info.SenderAlt).ToNonAD(), true
 }
 
 // resolvePeerPhone walks the four-rung ladder. The order is load-bearing: each

--- a/backend/internal/whatsapp/message_test.go
+++ b/backend/internal/whatsapp/message_test.go
@@ -157,6 +157,20 @@ func TestChatEligibility_HostedDirectChatAccepted(t *testing.T) {
 	assert.Equal(t, ChatTypePrivate, chatType)
 }
 
+// spec: WHA-020.null-user-envelope-refused
+func TestChatEligibility_NullUserJIDRejected(t *testing.T) {
+	nullUser := types.NewJID("0", types.DefaultUserServer)
+	_, ok := classifyChat(nullUser, testOwn())
+	assert.False(t, ok, "WhatsApp addresses protocol/system records to the null user; that describes no person")
+}
+
+// spec: WHA-020.null-user-envelope-refused
+func TestChatEligibility_NullUserJIDInHiddenServerRejected(t *testing.T) {
+	nullUser := types.NewJID("0", types.HiddenUserServer)
+	_, ok := classifyChat(nullUser, testOwn())
+	assert.False(t, ok, "the null user is refused on either user server")
+}
+
 // --- classifyMessage --------------------------------------------------------
 
 func TestClassifyMessage_TextConversation(t *testing.T) {
@@ -366,6 +380,20 @@ func TestPeerResolution_NonPhoneUserRejected(t *testing.T) {
 	assert.Equal(t, weird.String(), unresolved)
 }
 
+// TestPeerResolution_NumberStartingWithZeroAccepted is the falsification test
+// for the null-user guard: it must be an exact match on the user part "0",
+// never a prefix test, because a real subscriber number can begin with a
+// zero.
+func TestPeerResolution_NumberStartingWithZeroAccepted(t *testing.T) {
+	leadingZero := types.NewJID("0100000099", types.DefaultUserServer)
+	evt := textEvent("m1", types.MessageSource{Chat: leadingZero}, "hi")
+
+	msg, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
+	require.True(t, eligible)
+	require.NotNil(t, msg.PeerJID)
+	assert.Equal(t, leadingZero.String(), *msg.PeerJID)
+}
+
 func TestPeerResolution_HostedPeerNormalizedToDefaultServer(t *testing.T) {
 	hosted := types.NewJID("15559876543", types.HostedServer)
 	evt := textEvent("m1", types.MessageSource{Chat: hosted}, "hi")
@@ -428,6 +456,25 @@ func TestParseMessage_GroupOutboundHasNilPeer(t *testing.T) {
 
 	require.True(t, eligible, "an outbound group message is still stored")
 	assert.Nil(t, msg.PeerJID, "there is no single counterpart in a group I sent to")
+	assert.Nil(t, msg.PeerPhoneE164)
+	assert.Empty(t, unresolved, "a nil peer is not an unresolved one")
+}
+
+// spec: WHA-020.null-user-envelope-refused
+// TestParseMessage_GroupNullUserSenderHasNilPeer proves the null-user guard in
+// the group branch: the message still stages (it happened in a tracked
+// group), but it carries no peer handle, so it can never mint a discovery
+// candidate or attribute system noise to a real contact.
+func TestParseMessage_GroupNullUserSenderHasNilPeer(t *testing.T) {
+	nullUser := types.NewJID("0", types.DefaultUserServer)
+	evt := textEvent("m1", types.MessageSource{
+		Chat:   testGroupJID,
+		Sender: nullUser,
+	}, "hi")
+	msg, unresolved, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
+
+	require.True(t, eligible, "the group message still stages")
+	assert.Nil(t, msg.PeerJID, "a null-user sender describes no person")
 	assert.Nil(t, msg.PeerPhoneE164)
 	assert.Empty(t, unresolved, "a nil peer is not an unresolved one")
 }

--- a/backend/internal/whatsapp/message_test.go
+++ b/backend/internal/whatsapp/message_test.go
@@ -171,6 +171,18 @@ func TestChatEligibility_NullUserJIDInHiddenServerRejected(t *testing.T) {
 	assert.False(t, ok, "the null user is refused on either user server")
 }
 
+// spec: WHA-020.null-user-envelope-refused
+// TestChatEligibility_EmptyUserJIDRejected pins the sibling non-person shape:
+// types.ServerJID has an empty user part, is not the account itself and is
+// not the protocol's null user, so it would otherwise classify as an
+// ordinary private chat and mint peer_handle "s.whatsapp.net" — the same
+// defect as the null-user case under a different label.
+func TestChatEligibility_EmptyUserJIDRejected(t *testing.T) {
+	emptyUser := types.NewJID("", types.DefaultUserServer)
+	_, ok := classifyChat(emptyUser, testOwn())
+	assert.False(t, ok, "an empty user part can never belong to a subscriber")
+}
+
 // --- classifyMessage --------------------------------------------------------
 
 func TestClassifyMessage_TextConversation(t *testing.T) {
@@ -458,6 +470,21 @@ func TestParseMessage_GroupOutboundHasNilPeer(t *testing.T) {
 	assert.Nil(t, msg.PeerJID, "there is no single counterpart in a group I sent to")
 	assert.Nil(t, msg.PeerPhoneE164)
 	assert.Empty(t, unresolved, "a nil peer is not an unresolved one")
+}
+
+// spec: WHA-020.null-user-envelope-refused
+// TestParseMessage_PrivateNullUserChatRejected proves the null-user guard
+// through parseMessage rather than through a direct classifyChat call: the
+// production shape was a PRIVATE chat whose chat JID was the null user,
+// arriving through history ingest, and a refactor that bypassed the
+// classifyChat call inside parseMessage would leave a classifyChat-only test
+// green while that exact bug returned.
+func TestParseMessage_PrivateNullUserChatRejected(t *testing.T) {
+	nullUser := types.NewJID("0", types.DefaultUserServer)
+	evt := textEvent("m1", types.MessageSource{Chat: nullUser}, "hi")
+
+	_, _, eligible := parseMessage(context.Background(), evt, testOwn(), nil, testAltTimeout)
+	assert.False(t, eligible, "a private chat addressed to the null user describes no person")
 }
 
 // spec: WHA-020.null-user-envelope-refused

--- a/spec/whatsapp.yaml
+++ b/spec/whatsapp.yaml
@@ -444,7 +444,9 @@ behaviors:
       - a note to self is not ingested, in whichever of the account's own forms it is addressed
       - the same person reached through a different device domain is treated as the same person, not as an unrecognised address to discard
       - a chat that is not ingested is treated as handled rather than as a failure, so it is not delivered again forever
-    provenance: [classifyChat, normalizeServer, parseMessage]
+      - key: null-user-envelope-refused
+        text: an envelope addressed to the protocol's null user describes no person and is refused, whether the null user is the chat itself or a sender inside a group
+    provenance: [classifyChat, normalizeServer, parseMessage, resolvePeer]
     notes: The account's own identity is required before any of this can be decided; without it the message is left undelivered rather than guessed at, since an acknowledged message is never sent again.
 
   - id: WHA-021

--- a/spec/whatsapp.yaml
+++ b/spec/whatsapp.yaml
@@ -445,7 +445,7 @@ behaviors:
       - the same person reached through a different device domain is treated as the same person, not as an unrecognised address to discard
       - a chat that is not ingested is treated as handled rather than as a failure, so it is not delivered again forever
       - key: null-user-envelope-refused
-        text: an envelope addressed to the protocol's null user describes no person and is refused, whether the null user is the chat itself or a sender inside a group
+        text: an envelope addressed to a user part that could never belong to a subscriber — the protocol's null user, or an empty user part — describes no person and is refused, whether that user part is the chat itself or a sender inside a group
     provenance: [classifyChat, normalizeServer, parseMessage, resolvePeer]
     notes: The account's own identity is required before any of this can be decided; without it the message is left undelivered rather than guessed at, since an acknowledged message is never sent again.
 


### PR DESCRIPTION
Closes #802. Production cleanup of the already-stored records is tracked separately in #805.

WhatsApp addresses protocol and system records — key-change notices, setting changes and similar — to the null user `0`. Those envelopes were reaching `comms_message` as ordinary inbound private messages: no body, no snippet, `message_type: "other"` from the classifier's `default:` arm, and a `peer_handle` of `0@s.whatsapp.net` that made the "conversation" appear to be with somebody. Because the handle was non-null, `ListUnmatchedCommsPeerCounts` counted them like any real peer, they cleared the discovery threshold, and discovery minted an import candidate for a person who does not exist. Having no push name and no resolvable phone (the JID's user part is the literal character `0`), it rendered through `discoveryDisplayName`'s last rung as `WhatsApp 0` and sat in the imports queue looking like a genuine unidentified correspondent. Linking it would have attributed system noise to a real contact and derived interactions from bodyless records.

## The fix

Both ingest routes — the live handler and the history drainer — funnel through `parseMessage`, so one guard covers both and no second check is needed downstream.

`isNonPersonUserJID` refuses a user part that could never belong to a subscriber. Two shapes qualify, and whatsmeow names both: the protocol's null user (`types.PSAJID`, matched on its `User` field rather than a locally re-derived copy — the library's own PSA-sender checks compare the same way) and an empty user part (`types.ServerJID`, which `JID.String()` renders as the bare server `s.whatsapp.net`, so it would have minted a peer handle of exactly that).

- `classifyChat` refuses such a chat, on both the phone-number and hidden-user servers. It is dropped with an ack, exactly as a self-chat or a broadcast address already is, so nothing is stored.
- `resolvePeer` strips such a sender inside a group. The message still stages — the group itself is real — but it carries no peer handle, so it can never mint a discovery candidate or be attributed to a contact. Dropping the whole message here would be wider than the bug.

The null-user match is on the exact user part, never a prefix: a real subscriber number can legitimately begin with a zero. `TestPeerResolution_NumberStartingWithZeroAccepted` is the falsification test for that, and it is red under a prefix-match implementation.

The private branch of `resolvePeer` deliberately carries no guard — `classifyChat` has already refused that chat before it runs.

The empty-user half arrived as a review finding rather than from the original report. It is byte-for-byte the same defect as the observed one under a different label: not the account itself and not `"0"`, so it classified as an ordinary private chat. Only the null-user shape was seen in production; the sibling was reachable and is now closed.

## Ephemeral second-order verification

Per `.ai/rules/core.md`, the mutants were run and discarded rather than committed.

TDD red, before the guards existed:

```
cd backend && go test ./internal/whatsapp/... -run 'TestChatEligibility_NullUserJID|TestPeerResolution_NumberStartingWithZeroAccepted|TestParseMessage_GroupNullUserSenderHasNilPeer' -v

--- FAIL: TestChatEligibility_NullUserJIDRejected (0.00s)
    Error: Should be false
--- FAIL: TestChatEligibility_NullUserJIDInHiddenServerRejected (0.00s)
    Error: Should be false
--- PASS: TestPeerResolution_NumberStartingWithZeroAccepted (0.00s)
--- FAIL: TestParseMessage_GroupNullUserSenderHasNilPeer (0.00s)
    Error: Expected nil, but got: (*string)(0x1400004b450)
    Error: Should be empty, but was 0@s.whatsapp.net
FAIL
```

The falsification test passing here is the correct outcome: a number beginning with zero was already legal, and the test exists to prove the new guard does not make it illegal.

Red for the empty-user half, against the first commit's code:

```
=== RUN   TestChatEligibility_EmptyUserJIDRejected
    message_test.go:183: Should be false — "an empty user part can never belong to a subscriber"
--- FAIL: TestChatEligibility_EmptyUserJIDRejected (0.00s)
```

That red is the proof the sibling hole was real rather than theoretical.

An independent pass then reverted each guard in turn to confirm the tests are not vacuous. Each mutant was grepped to confirm the edit landed, run with the exit code checked directly, and reverted:

| Mutant | Exit | Turned red |
| --- | --- | --- |
| `classifyChat` guard removed | 1 | `TestChatEligibility_NullUserJIDRejected`, `TestChatEligibility_NullUserJIDInHiddenServerRejected` |
| `resolvePeer` guard removed | 1 | `TestParseMessage_GroupNullUserSenderHasNilPeer` |
| null-user comparison weakened to `strings.HasPrefix` | 1 | `TestPeerResolution_NumberStartingWithZeroAccepted` |

In each case the tests belonging to the *other* guard stayed green, which is what makes the tests independent rather than a single assertion wearing several names.

Boundary probes written, run and deleted: a null user arriving on the device domains `normalizeServer` rewrites (`0@hosted`, `0@c.us`, `0@hosted.lid`) is refused on every one, while a real number on `hosted` is still accepted — `normalizeServer` rewrites only `.Server` and never `.User`, and both call sites normalize before the guard runs. That also covers `types.LegacyPSAJID`, which is the null user on the legacy server. An outbound private chat to the null user is refused too, since `classifyChat` does not branch on direction.

`TestParseMessage_PrivateNullUserChatRejected` pins the production shape at the `parseMessage` level rather than through a direct `classifyChat` call. It was green the moment it was written — it fixes nothing, and exists so that a refactor bypassing the `classifyChat` call inside `parseMessage` cannot leave a `classifyChat`-only test green while the original bug returns.

## Spec

`WHA-020` ("Only person-to-person chats are ingested") extended in place, keeping the key `null-user-envelope-refused` and broadening its text to cover both non-person user parts. The refusal set grew and nothing was reversed, which is the extend-in-place case in `spec/README.md`; keys are permanent handles, so the key does not move when the wording widens. Five tests cite it. `resolvePeer` added to the behavior's provenance.

## Not in scope

The rows already stored in production are untouched by this change — it prevents new ones. Deleting them and retiring their import candidate is tracked in #805.
