### PR TITLE
fix(whatsapp): aggregate interactions when a peer link is created

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -261,6 +261,16 @@ func run() int {
 		defer telegramManager.Stop()
 	}
 
+	// WhatsApp aggregation engine over comms_message, built HERE — before the
+	// gated WhatsApp block below — and unconditionally, not behind
+	// cfg.Features.EnableWhatsAppSync: PeerMatcher.OnPeerLinked needs this exact
+	// instance to derive interactions right after a link, and rows staged under
+	// an earlier ON boot must still aggregate after a restart with the flag off
+	// (see buildWhatsAppAggregationEngine). Threading one instance into both
+	// buildWhatsAppIngestor and buildAggregationEngines keeps a single engine
+	// alive rather than two.
+	whatsappEngine := buildWhatsAppAggregationEngine(cfg, database, core.Interaction, messaging.CommsMessageRepo, contactService, eventBus, riverClient)
+
 	// WhatsApp integration. Config validation already refuses a WhatsApp-on /
 	// external-sync-off configuration, so no second gate is needed here. A zero
 	// whatsappStack reproduces the nil manager/handler when disabled.
@@ -276,7 +286,7 @@ func run() int {
 		if externalContactRepo == nil {
 			logger.Error().Msg("whatsapp: external contact repository is absent; ingest stays unwired")
 		} else {
-			waIngestor = buildWhatsAppIngestor(cfg, database, messaging.CommsMessageRepo, ingest.IdentityService, externalContactRepo, domain.EnrichmentService)
+			waIngestor = buildWhatsAppIngestor(cfg, database, messaging.CommsMessageRepo, ingest.IdentityService, externalContactRepo, domain.EnrichmentService, whatsappEngine)
 		}
 		// wireWhatsApp builds the stack, registers the history drain worker,
 		// and activates the manager — including SetHistoryDrainReady, the line
@@ -307,7 +317,8 @@ func run() int {
 	}
 
 	// Aggregation engines (messages + gchat + whatsapp) + reenqueuer registry.
-	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, telegramManager, gchatProvider, gchatSyncStates)
+	// whatsappEngine is the SAME instance built above, before the WhatsApp block.
+	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, telegramManager, gchatProvider, gchatSyncStates, whatsappEngine)
 
 	// Register the chat-aware messaging aggregate worker + sweeper (+ periodic).
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)

--- a/backend/cmd/crm-api/oauth_routes_boundary_test.go
+++ b/backend/cmd/crm-api/oauth_routes_boundary_test.go
@@ -119,7 +119,8 @@ func buildRouterForOAuthWiring(t *testing.T, cfg *config.Config) *gin.Engine {
 
 	// Telegram is intentionally SKIPPED (Start must not run); a nil
 	// telegramManager is exactly a telegram-disabled boot for aggregation.
-	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
+	whatsappEngine := buildWhatsAppAggregationEngine(cfg, database, core.Interaction, messaging.CommsMessageRepo, contactService, eventBus, riverClient)
+	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates, whatsappEngine)
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	handlersCore := buildCoreHandlers(database, core, contactService, graph, cfg, domain.NoteService, manualHandler, eventBus)

--- a/backend/cmd/crm-api/wire_aggregation.go
+++ b/backend/cmd/crm-api/wire_aggregation.go
@@ -29,13 +29,56 @@ type aggregationStack struct {
 	ReenqueuerEntries map[string]consumer.AggregatorReenqueuer
 }
 
-// buildAggregationEngines constructs the messages + gchat + whatsapp aggregation
-// engines and their reenqueuers, registers the gchat rematch handlers (gated on a
+// buildWhatsAppAggregationEngine constructs the WhatsApp aggregation engine
+// over comms_message.
+//
+// Extracted into its own builder — rather than inlined in
+// buildAggregationEngines, where it used to live — because
+// PeerMatcher.OnPeerLinked (backend/internal/whatsapp/matcher.go) needs this
+// SAME engine instance at construction time, and the matcher is wired earlier
+// in main.go than buildAggregationEngines runs. Calling this builder first and
+// threading its result into both call sites keeps exactly one engine instance
+// alive rather than two.
+//
+// LIVE but INERT: every query is source='whatsapp'-scoped and returns zero
+// rows until ingest writes one. It is deliberately NOT gated on
+// EnableWhatsAppSync — rows staged under an earlier ON boot must still
+// aggregate after a restart with the flag off, and the matcher's post-link
+// aggregation must work the same way regardless of the flag's current value.
+func buildWhatsAppAggregationEngine(
+	cfg *config.Config,
+	database *db.Database,
+	interactionRepo *repository.InteractionRepository,
+	commsMessageRepo *repository.CommsMessageRepository,
+	contactService *service.ContactService,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+) *aggregation.Engine {
+	whatsappEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
+	return wapkg.NewAggregationEngine(
+		cfg.WhatsApp.BurstWindowHours,
+		cfg.WhatsApp.ReplyBridgeHours,
+		commsMessageRepo,
+		interactionRepo,
+		contactService,
+		contactService,
+		eventBus,
+		database.Pool,
+		whatsappEnqueuer,
+	)
+}
+
+// buildAggregationEngines constructs the messages + gchat aggregation engines
+// and their reenqueuers, registers the gchat rematch handlers (gated on a
 // constructed gchat provider) and the whatsapp ones (gated on the WhatsApp
 // feature flag), and populates the deferred aggregator-reenqueuer
 // registry. Wired unconditionally — the engines are stateless and inert until
 // their source rows exist. telegramManager / gchatProvider / gchatSyncStates
 // are nil-safe params exactly as the old inline fallbacks.
+//
+// whatsappEngine is built by buildWhatsAppAggregationEngine and passed in
+// rather than built here, so the composition root holds exactly one WhatsApp
+// engine instance — the same one PeerMatcher.OnPeerLinked drives.
 func buildAggregationEngines(
 	cfg *config.Config,
 	database *db.Database,
@@ -50,6 +93,7 @@ func buildAggregationEngines(
 	telegramManager *tgpkg.TelegramManager,
 	gchatProvider *google.GChatSyncProvider,
 	gchatSyncStates google.GChatSyncStateLister,
+	whatsappEngine *aggregation.Engine,
 ) aggregationStack {
 	interactionRepo := core.Interaction
 	rematchService := graph.RematchService
@@ -127,25 +171,6 @@ func buildAggregationEngines(
 		gchatEngine,
 		riverClient,
 		repository.InteractionSourceGChat,
-	)
-
-	// WhatsApp aggregation engine over comms_message. LIVE but INERT on the same
-	// terms as gchat: every query is source='whatsapp'-scoped and returns zero
-	// rows until ingest writes one. It is deliberately NOT gated on
-	// EnableWhatsAppSync — rows staged under an earlier ON boot must still
-	// aggregate after a restart with the flag off. Unlike gchat's, the
-	// burst/reply windows are operator-tunable env knobs.
-	whatsappEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
-	whatsappEngine := wapkg.NewAggregationEngine(
-		cfg.WhatsApp.BurstWindowHours,
-		cfg.WhatsApp.ReplyBridgeHours,
-		commsMessageRepo,
-		interactionRepo,
-		contactService,
-		contactService,
-		eventBus,
-		database.Pool,
-		whatsappEnqueuer,
 	)
 
 	// WhatsApp rematch handlers: registered ONLY when WhatsApp sync is enabled.

--- a/backend/cmd/crm-api/wire_golden_test.go
+++ b/backend/cmd/crm-api/wire_golden_test.go
@@ -294,7 +294,8 @@ func buildWireChainForGolden(t *testing.T, cfg *config.Config) wireChain {
 
 	// Telegram is intentionally SKIPPED (Start must not run); a nil
 	// telegramManager is exactly a telegram-disabled boot for aggregation.
-	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
+	whatsappEngine := buildWhatsAppAggregationEngine(cfg, database, core.Interaction, messaging.CommsMessageRepo, contactService, eventBus, riverClient)
+	agg := buildAggregationEngines(cfg, database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates, whatsappEngine)
 	wiring := registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	machost := buildMacHost(reg, database, core, ingest)

--- a/backend/cmd/crm-api/wire_whatsapp.go
+++ b/backend/cmd/crm-api/wire_whatsapp.go
@@ -9,6 +9,7 @@ import (
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/messaging/aggregation"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	wapkg "personal-crm/backend/internal/whatsapp"
@@ -189,6 +190,11 @@ func wireWhatsApp(
 // The WhatsAppRepository built here is a stateless wrapper over the shared
 // db.Querier, so the second instance newWhatsAppStack constructs for the
 // manager is the same thing; there is no state to share.
+//
+// engine is the SAME aggregation engine instance buildAggregationEngines wires
+// in — built earlier, by buildWhatsAppAggregationEngine, so the matcher's
+// post-link aggregation and the periodic sweep share one engine rather than
+// two. It is never nil in production: the caller builds it unconditionally.
 func buildWhatsAppIngestor(
 	cfg *config.Config,
 	database *db.Database,
@@ -196,6 +202,7 @@ func buildWhatsAppIngestor(
 	identityService *service.IdentityService,
 	externalContactRepo *repository.ExternalContactRepository,
 	enricher *service.EnrichmentService,
+	engine *aggregation.Engine,
 ) *wapkg.Ingestor {
 	whatsappRepo := repository.NewWhatsAppRepository(database.Queries)
 	gate := wapkg.NewChatGate(whatsappRepo, cfg.WhatsApp.GroupMaxMembers)
@@ -204,6 +211,7 @@ func buildWhatsAppIngestor(
 		commsMessageRepo,
 		externalContactRepo,
 		enricher,
+		engine,
 		cfg.WhatsApp.DiscoveryMinMessages,
 	)
 	return wapkg.NewIngestor(commsMessageRepo, gate, matcher)

--- a/backend/cmd/crm-api/wire_whatsapp_integration_test.go
+++ b/backend/cmd/crm-api/wire_whatsapp_integration_test.go
@@ -91,14 +91,21 @@ func TestWireWhatsApp_TurnsTheFeatureOn(t *testing.T) {
 		c.Features.EnableWhatsAppSync = true
 	})
 
-	// The real ingestor, built the way run() builds it — so the gate the
+	// The real ingestor, built through run()'s own builder — so the gate the
 	// drainer is handed is the same instance SetIngestor binds.
+	//
+	// The enricher and the aggregation engine are both nil, which the matcher
+	// tolerates: this test drives readiness and the drain gate, never a peer
+	// link, so neither is reachable from anything it asserts. Constructing a
+	// real engine would mean standing up a contact service, an event bus and a
+	// river client for dependencies nothing here calls.
 	ingestor := buildWhatsAppIngestor(
 		h.cfg,
 		h.database,
 		repository.NewCommsMessageRepository(h.database.Queries),
 		service.NewIdentityService(repository.NewIdentityRepository(h.database.Queries)),
 		repository.NewExternalContactRepository(h.database.Queries),
+		nil,
 		nil,
 	)
 

--- a/backend/internal/synthetic/replay/harness_setup.go
+++ b/backend/internal/synthetic/replay/harness_setup.go
@@ -305,8 +305,15 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 	)
 	// WhatsApp: the REAL ingest trio (repo → gate → matcher → ingestor),
 	// reproducing buildWhatsAppIngestor, plus its aggregation engine. The
-	// adapter drives the ingestor; the worker drives the engine.
+	// engine is built FIRST — the matcher needs the same instance so a link
+	// aggregates in the same pass rather than waiting on the sweeper — then
+	// reused by the worker that drives it.
 	whatsappRepo := repository.NewWhatsAppRepository(database.Queries)
+	whatsappEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(client)
+	whatsappEngine := whatsapp.NewAggregationEngine(
+		cfg.WhatsApp.BurstWindowHours, cfg.WhatsApp.ReplyBridgeHours,
+		commsRepo, interactionRepo, contactService, contactService, bus, database.Pool, whatsappEnqueuer,
+	)
 	// One reading of the threshold feeds BOTH the matcher and the accessor a
 	// fixture sizes itself by, so the two can never disagree about how many
 	// unmatched messages mint a candidate.
@@ -316,12 +323,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		whatsapp.NewChatGate(whatsappRepo, cfg.WhatsApp.GroupMaxMembers),
 		// enricher nil: EnrichmentService is not constructed in this package and
 		// PeerMatcher tolerates a nil one.
-		whatsapp.NewPeerMatcher(identityService, commsRepo, externalRepo, nil, whatsappDiscoveryMinMsgs),
-	)
-	whatsappEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(client)
-	whatsappEngine := whatsapp.NewAggregationEngine(
-		cfg.WhatsApp.BurstWindowHours, cfg.WhatsApp.ReplyBridgeHours,
-		commsRepo, interactionRepo, contactService, contactService, bus, database.Pool, whatsappEnqueuer,
+		whatsapp.NewPeerMatcher(identityService, commsRepo, externalRepo, nil, whatsappEngine, whatsappDiscoveryMinMsgs),
 	)
 
 	chatListerRegistry := scheduler.NewPerSourceChatListerRegistry(

--- a/backend/internal/whatsapp/matcher.go
+++ b/backend/internal/whatsapp/matcher.go
@@ -49,7 +49,8 @@ type PeerMatcher struct {
 	identityService     identityMatcher
 	commsRepo           commsPeerStore
 	externalContactRepo externalContactUpserter
-	enricher            contactEnricher // may be nil (tests)
+	enricher            contactEnricher   // may be nil (tests)
+	engine              contactAggregator // may be nil (tests)
 	discoveryMinMsgs    int
 }
 
@@ -59,6 +60,7 @@ func NewPeerMatcher(
 	commsRepo commsPeerStore,
 	externalContactRepo externalContactUpserter,
 	enricher contactEnricher,
+	engine contactAggregator,
 	discoveryMinMsgs int,
 ) *PeerMatcher {
 	return &PeerMatcher{
@@ -66,6 +68,7 @@ func NewPeerMatcher(
 		commsRepo:           commsRepo,
 		externalContactRepo: externalContactRepo,
 		enricher:            enricher,
+		engine:              engine,
 		discoveryMinMsgs:    discoveryMinMsgs,
 	}
 }
@@ -158,6 +161,35 @@ func (m *PeerMatcher) OnPeerLinked(ctx context.Context, peerJID string, phoneE16
 		Int64("attached", attached).
 		Int64("deduped", deduped).
 		Msg("whatsapp: peer linked, staged messages attached")
+
+	// Deriving the interactions HERE, rather than leaving them to the periodic
+	// sweeper, is what makes the attach above visible: the user's evidence that
+	// a link worked is the contact's activity, not a row count nobody sees. A
+	// candidate carrying dozens of staged messages that binds instantly but
+	// still shows zero interactions for up to five minutes (the sweeper's
+	// interval) is indistinguishable, at the moment the user acts, from a link
+	// that silently failed. Skipped when nothing was attached — an
+	// already-linked peer's repeat call has nothing new to aggregate — and
+	// guarded on a nil engine for the many test call sites that pass nil.
+	//
+	// A failure here is logged and swallowed rather than returned: the rows ARE
+	// attached, so the link itself succeeded, and returning the error would
+	// report a successful link as failed. The periodic sweeper is the retry for
+	// whatever aggregation could not finish.
+	//
+	// This is the OPPOSITE of what the contact-method rematch path does with the
+	// same error, and deliberately so: that path runs inside a River job, where
+	// returning the error is what schedules the retry and makes the failure
+	// visible as a failed job. A link is a synchronous user action with no job
+	// behind it, so there is nothing for a returned error to retry — only a
+	// success the user would be told had failed.
+	if attached > 0 && m.engine != nil {
+		if err := m.engine.AggregateForContactBatch(ctx, contactID); err != nil {
+			logger.Warn().Err(err).
+				Str("contact_id", contactID.String()).
+				Msg("whatsapp: post-link aggregation failed; the periodic sweeper will retry")
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/whatsapp/matcher_test.go
+++ b/backend/internal/whatsapp/matcher_test.go
@@ -116,7 +116,7 @@ func TestMatchPeer_ResolvedPhoneMatchesContact(t *testing.T) {
 	want := uuid.New()
 	ids := &fakeIdentityMatcher{contactID: &want}
 	ext := &fakeExternalContactUpserter{}
-	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, nil, 3)
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, nil, nil, 3)
 
 	got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), strp("Their Name"))
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestMatchPeer_ResolvedPhoneMatchesContact(t *testing.T) {
 
 func TestMatchPeer_NilPhoneIsUnmatchedWithoutIdentityCall(t *testing.T) {
 	ids := &fakeIdentityMatcher{}
-	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, 3)
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, nil, 3)
 
 	got, err := m.MatchPeer(context.Background(), "88800000002@lid", nil, nil)
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestMatchPeer_NilPhoneIsUnmatchedWithoutIdentityCall(t *testing.T) {
 
 func TestMatchPeer_IdentityErrorIsNonFatal(t *testing.T) {
 	ids := &fakeIdentityMatcher{err: errors.New("identity service down")}
-	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, 3)
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, nil, 3)
 
 	got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
 	require.NoError(t, err, "matching is best-effort; the message still stages")
@@ -160,7 +160,7 @@ func TestMatchPeer_FiresEnricherOnMatch(t *testing.T) {
 		MatchStatus: repository.MatchStatusUnmatched, Metadata: map[string]any{},
 	}}
 	enricher := &fakeEnricher{}
-	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, 3)
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, nil, 3)
 
 	_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestMatchPeer_FiresEnricherOnMatch(t *testing.T) {
 
 func TestMatchPeer_NilEnricherNoPanic(t *testing.T) {
 	want := uuid.New()
-	m := NewPeerMatcher(&fakeIdentityMatcher{contactID: &want}, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{contactID: &want}, &fakeCommsPeerStore{}, &fakeExternalContactUpserter{}, nil, nil, 3)
 
 	got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
 	require.NoError(t, err)
@@ -186,7 +186,7 @@ func TestOnPeerLinked_PassesBothSelectors(t *testing.T) {
 	contactID := uuid.New()
 	comms := &fakeCommsPeerStore{attached: 4, dedupedCount: 1}
 	ids := &fakeIdentityMatcher{contactID: &contactID}
-	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, 3)
+	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, nil, 3)
 
 	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", strp("+15559876543"), contactID))
 
@@ -207,7 +207,7 @@ func TestOnPeerLinked_NilPhoneReproducesTheContractedShape(t *testing.T) {
 	contactID := uuid.New()
 	comms := &fakeCommsPeerStore{}
 	ids := &fakeIdentityMatcher{}
-	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, 3)
+	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, nil, 3)
 
 	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", nil, contactID))
 	assert.Empty(t, ids.requests, "with no phone there is nothing to link the identity by")
@@ -217,20 +217,62 @@ func TestOnPeerLinked_NilPhoneReproducesTheContractedShape(t *testing.T) {
 
 func TestOnPeerLinked_AttachErrorIsFatal(t *testing.T) {
 	comms := &fakeCommsPeerStore{attachErr: errors.New("database down")}
-	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, &fakeExternalContactUpserter{}, nil, 3)
+	engine := &fakeContactAggregator{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, &fakeExternalContactUpserter{}, nil, engine, 3)
 
 	err := m.OnPeerLinked(context.Background(), "88800000002@lid", nil, uuid.New())
 	require.Error(t, err, "the attach IS the user-visible effect of linking; a silent failure loses it")
+	assert.Zero(t, engine.calls, "nothing was attached, so there is nothing new to aggregate")
 }
 
 func TestOnPeerLinked_IdentityLinkFailureIsNonFatal(t *testing.T) {
 	comms := &fakeCommsPeerStore{attached: 2}
 	ids := &fakeIdentityMatcher{err: errors.New("identity service down")}
-	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, 3)
+	m := NewPeerMatcher(ids, comms, &fakeExternalContactUpserter{}, nil, nil, 3)
 
 	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", strp("+15559876543"), uuid.New()),
 		"the identity link is a convenience for future matches; the attach still has to run")
 	assert.Len(t, comms.attachCalls, 1)
+}
+
+// spec: WHA-025.interactions-derived-in-the-same-pass
+func TestOnPeerLinked_AggregatesAfterAttach(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCommsPeerStore{attached: 74}
+	engine := &fakeContactAggregator{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, &fakeExternalContactUpserter{}, nil, engine, 3)
+
+	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", nil, contactID))
+
+	assert.Equal(t, 1, engine.calls, "linking is only visible once the interactions exist; waiting on the sweeper leaves it looking like nothing happened")
+	assert.Equal(t, contactID, engine.gotContactID)
+}
+
+// spec: WHA-025.aggregation-failure-does-not-fail-the-link
+func TestOnPeerLinked_AggregationErrorIsNonFatal(t *testing.T) {
+	comms := &fakeCommsPeerStore{attached: 5}
+	engine := &fakeContactAggregator{err: errors.New("aggregation down")}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, &fakeExternalContactUpserter{}, nil, engine, 3)
+
+	err := m.OnPeerLinked(context.Background(), "88800000002@lid", nil, uuid.New())
+	require.NoError(t, err, "the rows ARE attached, so the link succeeded; the periodic sweeper is the retry")
+	assert.Equal(t, 1, engine.calls)
+}
+
+func TestOnPeerLinked_NoAttachSkipsAggregation(t *testing.T) {
+	comms := &fakeCommsPeerStore{attached: 0}
+	engine := &fakeContactAggregator{}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, &fakeExternalContactUpserter{}, nil, engine, 3)
+
+	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", nil, uuid.New()))
+	assert.Zero(t, engine.calls, "nothing was attached, so there is nothing new to aggregate")
+}
+
+func TestOnPeerLinked_NilEngineNoPanic(t *testing.T) {
+	comms := &fakeCommsPeerStore{attached: 3}
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, &fakeExternalContactUpserter{}, nil, nil, 3)
+
+	require.NoError(t, m.OnPeerLinked(context.Background(), "88800000002@lid", nil, uuid.New()))
 }
 
 // --- discovery --------------------------------------------------------------
@@ -251,7 +293,7 @@ func TestDiscovery_ThresholdIsAppliedByTheQuery(t *testing.T) {
 		peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), strp("Their Name")),
 	}}
 	ext := &fakeExternalContactUpserter{}
-	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, nil, 3)
 
 	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), strp("15559876543@s.whatsapp.net")))
 
@@ -267,7 +309,7 @@ func TestDiscovery_BelowThresholdNoCandidate(t *testing.T) {
 	// invent a candidate from an empty result.
 	comms := &fakeCommsPeerStore{}
 	ext := &fakeExternalContactUpserter{}
-	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, nil, 3)
 
 	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
 	assert.Empty(t, ext.upserts)
@@ -279,7 +321,7 @@ func TestDiscovery_MetadataCarriesCountsAndPhone(t *testing.T) {
 	row.InboundCount = 3
 	comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{row}}
 	ext := &fakeExternalContactUpserter{}
-	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, nil, 3)
 
 	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
 	require.Len(t, ext.upserts, 1)
@@ -318,7 +360,7 @@ func TestDiscovery_AlwaysWritesADisplayName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			comms := &fakeCommsPeerStore{counts: []repository.UnmatchedPeerCount{tt.row}}
 			ext := &fakeExternalContactUpserter{}
-			m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+			m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, nil, 3)
 
 			require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
 			require.Len(t, ext.upserts, 1)
@@ -336,7 +378,7 @@ func TestDiscovery_LaterPushNameUpgradesJIDLabel(t *testing.T) {
 		peerCount("88800000002@lid", 3, nil, nil),
 	}}
 	ext := &fakeExternalContactUpserter{}
-	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, nil, 3)
 
 	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
 	comms.counts = []repository.UnmatchedPeerCount{peerCount("88800000002@lid", 4, nil, strp("Their Name"))}
@@ -355,7 +397,7 @@ func TestDiscovery_EmptyPushNameDoesNotClobberStoredName(t *testing.T) {
 		peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), strp("")),
 	}}
 	ext := &fakeExternalContactUpserter{}
-	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, nil, 3)
 
 	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil))
 	require.Len(t, ext.upserts, 1)
@@ -368,7 +410,7 @@ func TestDiscovery_UpsertErrorIsNonFatal(t *testing.T) {
 		peerCount("15559876543@s.whatsapp.net", 3, strp("+15559876543"), nil),
 	}}
 	ext := &fakeExternalContactUpserter{upsertErrOne: errors.New("database down")}
-	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{}, comms, ext, nil, nil, 3)
 
 	require.NoError(t, m.UpdateDiscoveryCandidates(context.Background(), nil),
 		"discovery is best-effort; it must not withhold an ack for a message already staged")
@@ -426,7 +468,7 @@ func TestMatchPeer_ReconcileIsFirstMatchGated(t *testing.T) {
 				getResult: tt.candidate,
 			}}
 			enricher := &fakeEnricher{}
-			m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, 3)
+			m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, nil, 3)
 
 			got, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
 			require.NoError(t, err)
@@ -447,7 +489,7 @@ func TestMatchPeer_RepeatedMessagesFromAKnownPeerCostNothingExtra(t *testing.T) 
 	ids := &fakeIdentityMatcher{contactID: &want}
 	ext := &countingExternalContactUpserter{}
 	enricher := &fakeEnricher{}
-	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, 3)
+	m := NewPeerMatcher(ids, &fakeCommsPeerStore{}, ext, enricher, nil, 3)
 
 	// First message: the identity is newly bound, so it reconciles once.
 	_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
@@ -474,7 +516,7 @@ func TestMatchPeer_ReconcileRunsOnceForANewCandidate(t *testing.T) {
 		},
 	}}
 	enricher := &fakeEnricher{}
-	m := NewPeerMatcher(&fakeIdentityMatcher{contactID: &want}, &fakeCommsPeerStore{}, ext, enricher, 3)
+	m := NewPeerMatcher(&fakeIdentityMatcher{contactID: &want}, &fakeCommsPeerStore{}, ext, enricher, nil, 3)
 
 	_, err := m.MatchPeer(context.Background(), "15559876543@s.whatsapp.net", strp("+15559876543"), nil)
 	require.NoError(t, err)

--- a/backend/tests/whatsapp_history_drain_test.go
+++ b/backend/tests/whatsapp_history_drain_test.go
@@ -87,6 +87,7 @@ func setupHistoryDrainTest(t *testing.T) *drainEnv {
 		env.comms,
 		repository.NewExternalContactRepository(database.Queries),
 		nil,
+		nil,
 		2,
 	)
 	env.ingestor = whatsapp.NewIngestor(env.comms, gate, matcher)

--- a/backend/tests/whatsapp_ingest_test.go
+++ b/backend/tests/whatsapp_ingest_test.go
@@ -150,7 +150,7 @@ func setupIngestTest(t *testing.T) *ingestEnv {
 func (e *ingestEnv) rebuild(store commsChatStore) {
 	gate := whatsapp.NewChatGate(e.waRepo, 10)
 	gate.BindGroupInfoSource(func() whatsapp.GroupInfoFetcher { return e.group })
-	e.matcher = whatsapp.NewPeerMatcher(e.identity, e.comms, e.externals, nil, 2)
+	e.matcher = whatsapp.NewPeerMatcher(e.identity, e.comms, e.externals, nil, nil, 2)
 	e.ingestor = whatsapp.NewIngestor(store, gate, e.matcher)
 }
 

--- a/spec/whatsapp.yaml
+++ b/spec/whatsapp.yaml
@@ -531,6 +531,10 @@ behaviors:
       - a peer stored before their phone number was known is still found, by either the identifier the messages carry or the recovered number
       - a message already stored against the contact is reconciled rather than duplicated
       - a failure to attach is reported rather than silently swallowed, because attaching is the visible effect of linking
+      - key: interactions-derived-in-the-same-pass
+        text: the attached messages are aggregated in the same pass rather than being left to the next periodic sweep
+      - key: aggregation-failure-does-not-fail-the-link
+        text: a failure to aggregate does not fail or undo the link, because the periodic sweep retries the aggregation
     provenance: [PeerMatcher.OnPeerLinked, AttachUnmatchedByPeer]
 
   - id: WHA-026


### PR DESCRIPTION
Closes #801

`PeerMatcher.OnPeerLinked` bound a linked peer's staged `comms_message` rows to the contact, logged the counts, and returned. It never derived the interactions. Both of its siblings already do: `telegram.TelegramManager.OnPeerLinked` aggregates immediately after the peer-matcher attach, and WhatsApp's own `phoneRematchBase.rematchByPhone` — the contact-method rematch path — does the same. Within the WhatsApp package the link path was the outlier.

The consequence is that linking an import candidate bound its messages instantly but produced no interactions until the periodic `MessagingAggregateSweeperWorker` fired, a five-minute interval. For up to five minutes the contact showed no WhatsApp activity and `last_contacted` stayed stale, which makes a successful link indistinguishable from a failed one at the moment the user performs it — and invites a retry, or a second link against the wrong candidate.

Observed on production: linking a candidate carrying 74 staged messages bound all 74 rows instantly while the contact still reported 0 WhatsApp interactions and an unchanged `last_contacted`. The 23 interactions appeared only on the next sweeper tick.

## The fix

`PeerMatcher` gains the `contactAggregator` its own package already declares for the rematch path, and `OnPeerLinked` calls `AggregateForContactBatch` after a successful attach. Skipped when nothing was attached, since a repeat call on an already-linked peer has nothing new to derive.

The failure is non-fatal: the rows are attached either way, so the link itself succeeded, and returning the error would report a success as a failure. That is deliberately the opposite of what `rematchByPhone` does with the same error — it runs inside a River job, where returning is what schedules the retry and surfaces a failed job. A link is a synchronous user action with no job behind it, so a returned error would retry nothing. The sweeper remains the retry here, and remains the safety net generally; this closes the window rather than replacing it.

## Wiring: why the engine construction moved

`buildWhatsAppIngestor` constructs the `PeerMatcher` at `main.go:279`, but the WhatsApp aggregation engine was not built until `buildAggregationEngines` at `main.go:310` — so the engine did not exist yet when the matcher needed it.

The obvious fix, a `SetAggregationEngine` setter, would reintroduce this bug's exact shape: a setter that is never called yields silent no-aggregation, with nothing to catch it. Instead the engine construction is extracted into `buildWhatsAppAggregationEngine` and called earlier, so injection is a constructor parameter and omitting it is a compile error.

The single instance is threaded into both `buildWhatsAppIngestor` and `buildAggregationEngines`, so the composition root holds exactly one engine rather than two. It is still constructed unconditionally, outside the `EnableWhatsAppSync` gate, preserving the documented property that rows staged under an earlier ON boot must still aggregate after a restart with the flag off.

No wiring-parity test accompanies this. Per the proportionality rule in `.ai/rules/core.md`, constructor injection makes omission a compile error, so the failure such a test would guard is already impossible, and the test plus its own falsification would exceed the code it guards.

## Ephemeral second-order verification

Per `.ai/rules/core.md`, the mutants were run and discarded rather than committed. Each was confirmed to build first (so it could not merely trip a compile error), grepped to confirm the edit landed, run with the exit code read directly rather than through a pipe, then reverted.

| Mutation | Exit | Turned red |
| --- | --- | --- |
| Aggregation block deleted entirely | 1 | `TestOnPeerLinked_AggregatesAfterAttach`, `TestOnPeerLinked_AggregationErrorIsNonFatal` |
| `attached > 0` guard removed | 1 | `TestOnPeerLinked_NoAttachSkipsAggregation` |
| Error returned instead of swallowed | 1 | `TestOnPeerLinked_AggregationErrorIsNonFatal` |
| `m.engine != nil` guard removed | 1 | Nil-pointer panic at the call site, taking the binary down before the nil-engine test even runs |

The first mutation is the one that matters: it fails on a runtime assertion (`engine.calls` stays 0), not a build break, which is what establishes the test actually catches a missing call rather than merely a changed signature. Under each mutation the tests belonging to the other guards stayed green.

The typed-nil hazard was traced rather than assumed: `NewAggregationEngine` unconditionally returns a non-nil pointer, it is called once outside the feature gate over unconditionally-built dependencies, and neither of the two test call sites constructs a `PeerMatcher` at all — so `m.engine` is never a typed nil wearing a non-nil interface.

The synthetic replay harness reorder was checked against this repo's PRNG-shift hazard, where inserting a call mid-sequence can shift shared random state into peer-id collisions and a silent timeout. Only two struct-literal constructors moved, crossing a plain field read and one constructor call; nothing crossed a generator call or any consumer of shared random state.

## Spec

`WHA-025` ("Linking a peer retroactively attaches their stored messages") extended in place with two keyed then-items — `interactions-derived-in-the-same-pass` and `aggregation-failure-does-not-fail-the-link` — cited from the two tests that prove them. The refusal set grew and nothing was reversed, which is the extend-in-place case in `spec/README.md`; the four pre-existing plain-string then-items are left as they were, which the schema permits.

## A regression this branch caught on itself

The first push failed on a build error the local `go build ./...` could not see: `cmd/crm-api/wire_whatsapp_integration_test.go` calls `buildWhatsAppIngestor` and sits behind the `integration_testdb` tag, so neither `go build` (which skips test files) nor `make test-unit` (which does not set the tag) compiled it against the new signature.

It is fixed here, and the check that actually covers this is `go vet -tags integration_testdb ./...`, which compiles test files under the tag — exit 0, no output. The engine is nil at that call site by design: the test drives readiness and the drain gate, never a peer link, so an engine is not reachable from anything it asserts, and standing one up would mean constructing a contact service, event bus and river client for dependencies nothing there calls.
