### PR TITLE
feat(imports): generalize candidate evidence across sources (#803)

### DIFF
--- a/.ai/spec/2026-08-11-gmail-participant-discovery.md
+++ b/.ai/spec/2026-08-11-gmail-participant-discovery.md
@@ -1,0 +1,124 @@
+# Gmail Participant Discovery — Propose New Contacts from Trusted Senders' Mail
+
+**Status:** Draft v1 — user-confirmed exploration, ready for planning (spec-pinned TDD workflow)
+**Date:** 2026-08-11
+**GH:** #789 (primary), folds in #803; #390 closed as stale during grounding; #391 narrowed (see Relations)
+**Behavior items:** IMP-042 … IMP-049 in `spec/imports-matching.yaml` (all `status: proposed`)
+
+## Context & problem
+
+Email is the only major sync source that cannot propose a **new** contact. Gmail's single producer, `gmail_correspondence`, is deliberately link-only: it surfaces an observed address only when its display name trigram-matches an existing contact (sim ≥ 0.60, ≥2-token name). On a real group thread started by an existing contact, three participants who were genuinely new people were silently dropped — nothing in the product ever showed them. The pipeline works as specified; the gap is structural: no mechanism exists to propose a brand-new contact from an email participant.
+
+Loosening the existing gate is not an option: every fetched message already touches a known contact by construction of the fetch query, so "co-occurs with a known contact" is nearly free and would admit newsletters, vendors, recruiters, and cold outreach — burying the imports tab.
+
+The idea (user's conviction): **filter on who is already trusted, not on properties of the unknown address.** A participant qualifies only when the message's sender is already trusted — an existing CRM contact, or the user themself.
+
+## What matters (priority order)
+
+1. **Discovery must never break sync.** Errors stay best-effort and logged; they never rewind the cursor, fail a sweep, or fail the rematch backfill.
+2. **No real person silently missed** within the ruled gates. This is why the recipient cap applies to the create path only.
+3. **No firehose.** The acceptance bar from production measurement: on the order of 40 cards over the whole backfill window, zero automated-looking senders.
+4. **One card per address.** Duplicate cards for the same address are a low-medium defect.
+5. **Misclassification (link vs create) is cheap.** The user picks the action in the UI; no migration machinery is warranted.
+
+## Severity grading context (for every reviewer)
+
+Calibrate P-levels to this feature's actual cost structure, not generic severity:
+
+- **Worst:** discovery breaking the sync path — a cursor rewind, a failed sweep, or blocked message ingest. Silent and compounding.
+- **Expensive:** a qualifying real person never surfaced (silent over-suppression). The user cannot know what they never saw.
+- **Bad (the acceptance bar):** noise/firehose — visible and recoverable via ignore, but defeats the feature's purpose.
+- **Low-medium:** a duplicate card for one address.
+- **Cheap:** link-vs-create misclassification; evidence/observability gaps. Not worth complexity to prevent.
+
+## Goals
+
+- A second Gmail candidate source, `gmail_participant`, that proposes **create** candidates from To ∪ Cc participants of trust-anchored messages, surfaced through the existing imports queue with import / link / ignore.
+- Nameless (address-only) candidates are first-class: they surface, and can be imported after the user types a name.
+- Candidate evidence (trusted sender, anchor message subject, message count) is stored and rendered — and the queue's evidence line is generalized across all discovery sources (#803).
+- The historical backlog is harvested via the existing one-time cursor-reset runbook step; steady state is automatic thereafter.
+
+## Non-Goals
+
+- No auto-import — every proposal remains a manual review.
+- No change to bystander interaction attribution (separate issue territory).
+- No Bcc recovery (structurally impossible from Gmail's stored copies).
+- No re-classification migration: first classification is sticky until the user resolves the card.
+- No extension of the own-domain rule beyond discovery (message storage / inbound-outbound classification unchanged).
+- Not the full #391 form-state-hygiene refactor — only the narrow guarantee this feature needs (see Relations).
+- No new Gmail fetching and no History API work (#399 is separate).
+- No backfill beyond what the cursor-reset replay covers.
+
+## Ruled behavior (user-confirmed)
+
+| Rule | Decision |
+| --- | --- |
+| Trust anchor | `From` is an existing contact, **or** one of the user's own accounts, **or** an address at a configured **own domain** (see below) |
+| Own-domain rule | Per-account configuration listing domains that count as "me" (the user runs several aliases on a personal domain). Applies to **discovery only**: anchors trust, and excludes those addresses from the candidate pool. The actual domain value is deployment configuration — never hardcoded in code, spec, or tests (repo PII rule) |
+| Participant pool | To ∪ Cc; Bcc excluded |
+| Recipient cap | To ∪ Cc > 20 → no **create** candidates from that message; link discovery for the same message is unaffected (it stays uncapped, gated by its trigram match as today) |
+| Display name | Not required; address-only participants qualify |
+| Repetition | First sighting proposes; no minimum message count |
+| Exclusions | Known addresses (any contact method), own addresses (incl. own-domain), sticky-ignored addresses |
+| Precedence | Link gate evaluated first: strong name match (≥ 0.60) → `gmail_correspondence` link candidate as today; otherwise trust anchor → `gmail_participant` create candidate |
+| Mutual exclusion | One card per address: an address with an existing candidate row under either Gmail source is never proposed under the other; first classification sticky |
+| Actions | `gmail_participant` is **not** in `linkOnlySources` → import / link / ignore; frontend allowed-actions helper mirrored in lock-step |
+| Evidence | Trusted-sender identity, an anchor message subject, and message count ride the existing candidate metadata channel |
+| Nameless UX | Card/modal heading falls back to the address (never the literal "Unknown"); editable name field seeds **empty** (nothing to delete); Import disabled until a name is typed; a typed name survives a background refetch |
+| Seams | Both discovery seams produce identically: the live sync window loop and the rematch backfill scan |
+| Idempotency | Re-syncing the same mail produces no duplicate candidates |
+
+## Relation to existing & planned work
+
+- **`.ai/spec/2026-06-03-gmail-correspondence-discovery-on-fetched-set.md`** — established the in-sync discovery hook, aggregate fold, best-effort error posture, and the cursor-reset runbook. This feature extends that machinery (new gate + flag on the aggregate), it does not add a parallel path.
+- **#803 (folded in):** the queue's evidence line is hard-gated to `gmail_correspondence`; we must touch that gate anyway for `gmail_participant`, so it is generalized to render each discovery source's evidence metadata (message count, recency, counterpart) — frontend-only, per the issue. Its motivating failure (indistinguishable rows → mis-link → hand SQL against prod) aligns with this spec's severity ranking.
+- **#390 (closed as stale during grounding):** written against a modal that no longer exists; the current modal already tracks candidates by stable id.
+- **#391 (narrowed):** the full refetch-hygiene refactor stays out; the one guarantee this feature needs — a typed name for a nameless candidate survives a background refetch — is in scope (IMP-047).
+- **IMP-014** (link-only invariant) is unchanged and still true: `gmail_correspondence` stays link-only; `gmail_participant` is deliberately not link-only.
+- **IMP-006 / IMP-007** (per-source dedup, sticky ignore) are relied on; the cross-source one-card-per-address rule is *new* and minted as IMP-045.
+- **IMP-023** is the chat-side analog (repetition-gated where this is sender-gated); no interaction.
+- **#399 (History API)** is orthogonal; this feature must not assume anything beyond the current windowed fetch.
+
+## Hard constraints
+
+- Discovery remains best-effort: errors logged, never returned to the sync/backfill paths.
+- No new Gmail API calls; piggyback the existing fetch exactly as the current discovery does.
+- No raw SQL in Go; sqlc only. Handler → Service → Repository layering. `accelerated.GetCurrentTime()`.
+- The Gmail message **fakes used in tests must present headers the way real Gmail does** — address-only participants, missing display names, absent Subject — so the no-name and no-subject paths are genuinely exercised (workflow rule: fakes must reject/omit what the real system rejects/omits). No external write endpoints exist in this feature, so the verbatim-write-schema rule does not apply.
+- Same-PR repo obligations: synthetic factory + replay + profile coverage for the new source; `spec/imports-matching.yaml` proposed items flipped to `current` with citing tests (ui + api surfaces are both settled — E2E cites for `ui`, Go tests for `api`); test-map entries for any new frontend files; `make api-types` / `make api-docs` if DTOs or annotations change.
+- Repo PII rule: the user's real domain/addresses never appear in committed code, fixtures, spec text, or tests; the own-domain list is runtime configuration.
+
+## Architectural direction
+
+- **Constraint — extend, don't fork:** the new gate rides the existing fold machinery (`foldDiscovery` / `aggregateParticipants` / the per-address aggregate), adding a per-address "trust-anchored message seen" flag plus sender/subject evidence capture. No parallel discovery pipeline.
+- **Constraint — discovery-only own-domain rule:** the own-domain set must not leak into the storage gate's inbound/outbound classification.
+- **Constraint — server is the source of truth for allowed actions** (existing `AllowedActionsForSource` pattern), frontend mirrors.
+- **Leaning — anchor subject choice:** most-recent trust-anchored message's subject seems right; the planner may pick first-seen if materially simpler. Either is acceptable (evidence gaps are cheap).
+- **Leaning — own-domain config mechanism:** per-account configuration (shape left to planning — settings column, env, or config file), so long as it is not hardcoded and works for exactly-one-account setups without ceremony.
+
+## Success criteria
+
+- All eight acceptance criteria on #789 hold (they map onto IMP-042 … IMP-047).
+- After deploy plus the one-time `crm-admin --reset-gmail-backfill-cursors` runbook step, the backfill replay surfaces on the order of the measured volume (~tens of cards, not hundreds), with no automated-looking senders — verified against the live instance, per the workflow's live-verification discipline.
+- The imports queue renders evidence for chat-source candidates (#803's table), not just Gmail's.
+- Re-running sync over the same mail adds nothing.
+
+## Desired behavior
+
+Normative statements live as behavior items IMP-042 … IMP-049 (`spec/imports-matching.yaml`, `status: proposed`), minted in this session:
+
+- IMP-042 — trusted-sender participants become create candidates (incl. nameless, evidence, exclusions)
+- IMP-043 — untrusted senders never produce create candidates (negative)
+- IMP-044 — the recipient cap suppresses create proposals only (negative + boundary)
+- IMP-045 — link precedence and one-card-per-address mutual exclusion
+- IMP-046 — the server declares import / link / ignore for `gmail_participant`
+- IMP-047 — nameless candidates are importable after naming (UI)
+- IMP-048 — the evidence line renders for every discovery source (UI, #803)
+- IMP-049 — own-domain addresses count as the user, in discovery only
+
+## Assumptions & deferred questions
+
+- Volume figures (30 + ~9 addresses over the backfill window) were measured against production before this spec; treated as the calibration for the firehose bar, not re-verified here.
+- The own-domain configuration mechanism and the exact anchor-subject choice are left to planning (leanings above).
+- Whether the evidence line's generalized rendering needs per-source field mapping beyond message count / recency / counterpart is left to planning within #803's table.
+- Single PR vs small arc (e.g. #803 rendering as its own PR) is a planning decision; the spec is indifferent.

--- a/backend/internal/synthetic/declare/imports_domain.go
+++ b/backend/internal/synthetic/declare/imports_domain.go
@@ -24,6 +24,10 @@ import "fmt"
 func init() {
 	RegisterNone("IMP-031", "every citing test rides the fixture of the behavior whose surface it exercises (IMP-012/013/026/027/030/037); the claim is that resolving an item invalidates dependent surfaces, which needs no fixture of its own")
 
+	RegisterNone("IMP-047", "proposed behavior whose gmail_participant source has no implementation yet, so there is nothing to seed; the implementing change replaces this entry with a real declaration")
+
+	RegisterNone("IMP-048", "its citing E2E renders evidence metadata already written and seeded by other behaviors' declarations (IMP-036's telegram candidate, IMP-037's correspondence candidate); the rendering provisions no data of its own")
+
 	// One unmatched candidate: the row awaiting review, and the row the ignore
 	// action turns terminal.
 	Register(Declaration{

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -42,6 +42,7 @@ import {
 import { useGoogleAccounts } from '@/hooks/use-google-accounts'
 import { getCandidateDisplayName, isUnresolvedTelegramCandidate } from '@/lib/candidate-display'
 import { sourceAllowsImport } from '@/lib/candidate-actions'
+import { candidateEvidenceLabel } from '@/lib/candidate-evidence'
 import { importsApi } from '@/lib/imports-api'
 import { importKeys } from '@/lib/query-invalidation'
 import type {
@@ -166,22 +167,10 @@ function CandidateCard({
     ? meetingContext.meeting_link
     : null
 
-  // Gmail-correspondence evidence: the co-occurring contact and how many
-  // messages this address was seen in.
-  const correspondence =
-    candidate.source === 'gmail_correspondence' && candidate.metadata ? candidate.metadata : null
-  const correspondenceLabel = correspondence
-    ? [
-        correspondence.co_occurring_contact?.name
-          ? `Seen with ${correspondence.co_occurring_contact.name}`
-          : null,
-        correspondence.message_count
-          ? `${correspondence.message_count} ${correspondence.message_count === 1 ? 'message' : 'messages'}`
-          : null,
-      ]
-        .filter(Boolean)
-        .join(' · ')
-    : null
+  // Evidence line: counterpart + message count + recency, generalized across
+  // every discovery source that writes evidence metadata (gmail_correspondence,
+  // whatsapp, telegram, gmail_participant).
+  const evidenceLabel = candidateEvidenceLabel(candidate)
 
   return (
     <div className="p-4 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
@@ -227,12 +216,12 @@ function CandidateCard({
                     From: {meetingContext.meeting_title}
                   </span>
                 ))}
-              {/* Inline correspondence-evidence badge for gmail_correspondence
-                  candidates: who this address co-appeared with + message count. */}
-              {correspondenceLabel && (
+              {/* Inline evidence badge: counterpart + message count + recency,
+                  for any discovery source that recorded evidence metadata. */}
+              {evidenceLabel && (
                 <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
                   <Users className="w-3 h-3 mr-1" />
-                  {correspondenceLabel}
+                  {evidenceLabel}
                 </span>
               )}
               {unresolvedTelegram && (

--- a/frontend/src/lib/__tests__/candidate-evidence.test.ts
+++ b/frontend/src/lib/__tests__/candidate-evidence.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import { candidateEvidenceLabel } from '../candidate-evidence'
+import type { ImportCandidate } from '@/types/import'
+
+function candidate(overrides: Partial<ImportCandidate> = {}): ImportCandidate {
+  return {
+    id: '1',
+    source: 'test',
+    emails: [],
+    phones: [],
+    ...overrides,
+  }
+}
+
+describe('candidateEvidenceLabel', () => {
+  it('renders the co-occurring contact and message count for gmail_correspondence', () => {
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'gmail_correspondence',
+          metadata: {
+            co_occurring_contact: { id: 'c1', name: 'Alex Rivera' },
+            message_count: 4,
+          },
+        })
+      )
+    ).toBe('Seen with Alex Rivera · 4 messages')
+  })
+
+  it('renders count, recency and counterpart for telegram metadata', () => {
+    // Handle-only telegram candidates have no name fields, so
+    // getCandidateDisplayName falls back to the username itself — the exact
+    // case where the card's existing username chip is suppressed as
+    // redundant with the heading, and the evidence line picks up the
+    // counterpart instead (no duplicate rendering with the chip).
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'telegram',
+          metadata: {
+            username: '@dalepeer5',
+            message_count: 12,
+            last_message_at: '2026-08-01T10:00:00Z',
+          },
+        })
+      )
+    ).toBe('@dalepeer5 · 12 messages · Last: Aug 1, 2026')
+  })
+
+  it('omits the counterpart segment for telegram when a chip already shows it', () => {
+    // A named candidate (display_name != username) is exactly when the
+    // existing username chip in page.tsx renders — the evidence line must
+    // not repeat it.
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'telegram',
+          display_name: 'Dale Peer',
+          metadata: {
+            username: '@dalepeer5',
+            message_count: 12,
+          },
+        })
+      )
+    ).toBe('12 messages')
+  })
+
+  it('renders whatsapp push_name and counts', () => {
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'whatsapp',
+          metadata: {
+            push_name: 'Sam Okafor',
+            message_count: 74,
+            last_message_at: '2026-02-14T09:30:00Z',
+          },
+        })
+      )
+    ).toBe('Sam Okafor · 74 messages · Last: Feb 14, 2026')
+  })
+
+  it('renders trusted_sender counterpart and self variant', () => {
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'gmail_participant',
+          metadata: {
+            trusted_sender: { address: 'pat@example.com', name: 'Pat Nguyen' },
+            message_count: 1,
+          },
+        })
+      )
+    ).toBe('From Pat Nguyen · 1 message')
+
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'gmail_participant',
+          metadata: {
+            trusted_sender: { address: 'me@own-domain.example', self: true },
+            message_count: 2,
+          },
+        })
+      )
+    ).toBe('Sent by you · 2 messages')
+
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'gmail_participant',
+          metadata: {
+            trusted_sender: { address: 'unknown@example.com' },
+            message_count: 3,
+          },
+        })
+      )
+    ).toBe('From unknown@example.com · 3 messages')
+  })
+
+  it('renders nothing for an unparseable last_message_at', () => {
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'gmail_correspondence',
+          metadata: {
+            co_occurring_contact: { id: 'c1', name: 'Alex Rivera' },
+            last_message_at: 'not-a-date',
+          },
+        })
+      )
+    ).toBe('Seen with Alex Rivera')
+  })
+
+  it('returns null when metadata carries no evidence keys', () => {
+    expect(candidateEvidenceLabel(candidate({ source: 'gcontacts', metadata: {} }))).toBeNull()
+  })
+
+  it('returns null when the candidate carries no metadata at all', () => {
+    expect(candidateEvidenceLabel(candidate({ source: 'gcontacts' }))).toBeNull()
+  })
+
+  it('returns null for gcal_attendee meeting metadata (no evidence keys)', () => {
+    expect(
+      candidateEvidenceLabel(
+        candidate({
+          source: 'gcal_attendee',
+          metadata: { meeting_title: 'Weekly sync', meeting_date: '2026-08-01' },
+        })
+      )
+    ).toBeNull()
+  })
+})

--- a/frontend/src/lib/candidate-evidence.ts
+++ b/frontend/src/lib/candidate-evidence.ts
@@ -1,0 +1,65 @@
+import type { ImportCandidate } from '@/types/import'
+import { getCandidateDisplayName } from '@/lib/candidate-display'
+
+function formatMessageCount(count: number): string {
+  return `${count} ${count === 1 ? 'message' : 'messages'}`
+}
+
+function formatLastMessageAt(timestamp: string): string | null {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return null
+  return `Last: ${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+}
+
+/**
+ * The counterpart segment: who or what this address's evidence is anchored
+ * to, per source. Telegram's username is shown here only when the card's
+ * existing username chip (imports/page.tsx) would be suppressed — i.e. when
+ * the candidate has no name fields and the display name already fell back to
+ * the username itself — so the chip and the evidence line never repeat the
+ * same identity.
+ */
+function counterpartSegment(candidate: ImportCandidate): string | null {
+  const metadata = candidate.metadata
+  if (!metadata) return null
+
+  if (metadata.co_occurring_contact?.name) {
+    return `Seen with ${metadata.co_occurring_contact.name}`
+  }
+
+  if (metadata.trusted_sender) {
+    if (metadata.trusted_sender.self) return 'Sent by you'
+    const label = metadata.trusted_sender.name ?? metadata.trusted_sender.address
+    return label ? `From ${label}` : null
+  }
+
+  if (candidate.source === 'whatsapp' && metadata.push_name) {
+    return metadata.push_name
+  }
+
+  if (candidate.source === 'telegram' && metadata.username) {
+    const displayName = getCandidateDisplayName(candidate)
+    return metadata.username === displayName ? metadata.username : null
+  }
+
+  return null
+}
+
+/**
+ * The queue's generic evidence line: up to three segments (counterpart,
+ * message count, recency) joined with ' · '. Returns null when the
+ * candidate's metadata carries none of the recognized evidence keys, so
+ * cards with nothing to show render no pill.
+ */
+export function candidateEvidenceLabel(candidate: ImportCandidate): string | null {
+  const metadata = candidate.metadata
+  if (!metadata) return null
+
+  const segments = [
+    counterpartSegment(candidate),
+    metadata.message_count ? formatMessageCount(metadata.message_count) : null,
+    metadata.last_message_at ? formatLastMessageAt(metadata.last_message_at) : null,
+  ].filter((segment): segment is string => Boolean(segment))
+
+  return segments.length > 0 ? segments.join(' · ') : null
+}

--- a/frontend/src/types/import.ts
+++ b/frontend/src/types/import.ts
@@ -20,6 +20,17 @@ export interface ImportCandidateMetadata {
   display_names_seen?: string[]
   co_occurring_contact?: { id: string; name?: string }
   message_count?: number
+  // Shared discovery evidence (whatsapp, telegram, gmail_participant).
+  last_message_at?: string
+  inbound_count?: number
+  outbound_count?: number
+  // WhatsApp peer metadata (source: 'whatsapp').
+  push_name?: string
+  phone_e164?: string
+  peer_jid?: string
+  // Gmail participant evidence (source: 'gmail_participant').
+  trusted_sender?: { address: string; name?: string; self?: boolean }
+  anchor_subject?: string
 }
 
 export interface ImportCandidate {

--- a/frontend/tests/e2e/imports-evidence.spec.ts
+++ b/frontend/tests/e2e/imports-evidence.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from './fixtures'
+import type { APIRequestContext } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+import { candidateCardByName } from './helpers/imports-helpers'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
+const API_HEADERS = {
+  'X-API-Key': API_KEY,
+  'Content-Type': 'application/json',
+}
+
+/**
+ * The '@handle' a declared telegram candidate actually carries, read back
+ * from the candidate endpoint (the generator owns the handle, so a test that
+ * rebuilt it from the namespace would be asserting against a string it
+ * invented).
+ */
+async function telegramHandleOf(request: APIRequestContext, candidateId: string): Promise<string> {
+  const res = await request.get(`${API_BASE_URL}/api/v1/imports/${candidateId}`, {
+    headers: API_HEADERS,
+  })
+  expect(res.ok()).toBe(true)
+  const handle: string = (await res.json())?.data?.metadata?.username
+  expect(handle, 'the declared telegram candidate must carry a handle').toBeTruthy()
+  return handle
+}
+
+/**
+ * The declared telegram candidate's message_count, read back from the API —
+ * the generator's message-count constant is internal, so a test asserting an
+ * exact rendered count reads it back rather than hardcoding it.
+ */
+async function messageCountOf(request: APIRequestContext, candidateId: string): Promise<number> {
+  const res = await request.get(`${API_BASE_URL}/api/v1/imports/${candidateId}`, {
+    headers: API_HEADERS,
+  })
+  expect(res.ok()).toBe(true)
+  const count: number = (await res.json())?.data?.metadata?.message_count
+  expect(count, 'the declared telegram candidate must carry a message count').toBeTruthy()
+  return count
+}
+
+// The evidence line generalized across discovery sources (#803): a chat-source
+// candidate (telegram) and a Gmail candidate both render count/recency/counterpart
+// evidence, not just gmail_correspondence.
+test.describe('Imports evidence line @area:imports', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  // spec: IMP-048.count-recency-visible-any-source, IMP-048.counterpart-visible
+  test('evidence renders for chat and gmail sources alike', async ({ page, request }) => {
+    // IMP-036's "named" telegram candidate carries a display name distinct
+    // from its username, so the card's existing username chip renders — the
+    // evidence line must not repeat that identity, only count + recency.
+    const telegramWorld = await testApi.seedBehavior('IMP-036')
+    const telegramName = telegramWorld.entities['named'].name
+    const telegramHandle = await telegramHandleOf(request, telegramWorld.entities['named'].id)
+    const telegramMessageCount = await messageCountOf(request, telegramWorld.entities['named'].id)
+
+    // IMP-037's fixture is the existing correspondence evidence badge, whose
+    // rendered text this element must NOT change.
+    const correspondenceWorld = await testApi.seedBehavior('IMP-037')
+    const correspondenceName = correspondenceWorld.entities['corr'].name
+    const coOccurringName = correspondenceWorld.entities['cooccur'].name
+
+    await page.goto('/imports')
+    await page.waitForLoadState('domcontentloaded')
+
+    // --- Telegram (chat source): count + recency evidence line, peer
+    // identity visible via the existing username chip on the card. ---
+    const telegramCard = candidateCardByName(page, telegramName)
+    await expect(telegramCard).toBeVisible({ timeout: 10000 })
+    await expect(
+      telegramCard.getByText(
+        `${telegramMessageCount} ${telegramMessageCount === 1 ? 'message' : 'messages'}`
+      )
+    ).toBeVisible()
+    await expect(telegramCard.getByText(/Last: [A-Za-z]{3} \d{1,2}, \d{4}/)).toBeVisible()
+    await expect(telegramCard.getByRole('link', { name: telegramHandle })).toBeVisible()
+
+    // --- Gmail correspondence: unchanged "Seen with X · N messages" text. ---
+    const correspondenceCard = candidateCardByName(page, correspondenceName)
+    await expect(correspondenceCard).toBeVisible()
+    await expect(correspondenceCard.getByText(`Seen with ${coOccurringName}`)).toBeVisible()
+    await expect(correspondenceCard.getByText('4 messages')).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -291,6 +291,10 @@
     "tags": ["@area:imports"]
   },
   {
+    "pattern": "^frontend/src/lib/candidate-evidence\\.ts$",
+    "tags": ["@area:imports"]
+  },
+  {
     "pattern": "^frontend/src/lib/calendar-api\\.ts$",
     "tags": ["@area:meetings"]
   },

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -718,13 +718,15 @@ behaviors:
   - id: IMP-048
     title: The evidence line renders for every discovery source
     type: ux
-    status: proposed
+    status: current
     surface: ui
     given: a discovery candidate whose row carries evidence metadata
     when: the imports queue renders it
     then:
-      - message count and recency evidence are visible regardless of the candidate's source
-      - the counterpart evidence the source recorded (co-occurring contact, trusted sender, or chat peer identity) is visible
+      - key: count-recency-visible-any-source
+        text: message count and recency evidence are visible regardless of the candidate's source
+      - key: counterpart-visible
+        text: the counterpart evidence the source recorded (co-occurring contact, trusted sender, or chat peer identity) is visible
     provenance: ['#803', 2026-08-11-gmail-participant-discovery.md]
     notes: Generalizes the line previously hard-gated to gmail_correspondence; motivated by a real prod mis-link between two rows rendered as bare phone numbers.
 

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -631,3 +631,113 @@ behaviors:
       - the person is represented in the queue only by the canonical row
     provenance: [MarkAsDuplicate, external_contact.sql unmatched queries, duplicate_of_id]
     notes: Reconciliation-side duplicate precedence is IMP-017.
+
+  # --- Gmail participant discovery (trusted-sender create candidates) ---
+
+  - id: IMP-042
+    title: Trusted-sender participants become create candidates
+    type: business-logic
+    status: proposed
+    surface: none
+    given: a fetched Gmail message whose sender is an existing contact or one of the user's own accounts
+    when: discovery evaluates the message's To and Cc participants
+    then:
+      - an unknown participant is upserted as a gmail_participant create candidate on first sighting, with no minimum message count
+      - a participant with no display name still qualifies
+      - the candidate records the trusted sender's identity and an anchor message subject as evidence, alongside message count
+      - known addresses, the user's own addresses, and sticky-ignored addresses are never proposed
+    provenance: ['#789', 2026-08-11-gmail-participant-discovery.md]
+
+  - id: IMP-043
+    title: Untrusted senders never produce create candidates
+    type: business-logic
+    status: proposed
+    surface: none
+    given: a fetched Gmail message whose sender is neither an existing contact nor one of the user's own accounts
+    when: discovery evaluates the message's participants
+    then:
+      - no gmail_participant candidate is produced, even when known contacts appear among the recipients
+    provenance: ['#789', 2026-08-11-gmail-participant-discovery.md]
+    notes: The whole design anchors on sender trust — co-occurrence with a known contact is nearly free by construction of the fetch query and must never qualify on its own.
+
+  - id: IMP-044
+    title: The recipient cap suppresses create proposals only
+    type: business-logic
+    status: proposed
+    surface: none
+    given: a fetched Gmail message whose To and Cc together exceed 20 recipients
+    when: discovery evaluates the message
+    then:
+      - no gmail_participant candidate is produced from that message
+      - link-candidate discovery for the same message is unaffected
+    provenance: ['#789', 2026-08-11-gmail-participant-discovery.md]
+    notes: The cap exists so a mass announcement cannot flood the ungated create path; the link path stays uncapped because its trigram gate already filters.
+
+  - id: IMP-045
+    title: Link precedence and one card per address across Gmail sources
+    type: business-logic
+    status: proposed
+    surface: none
+    given: an unknown address observed by Gmail discovery
+    when: both the name-match link gate and the trusted-sender gate could apply
+    then:
+      - a strong name match to an existing contact takes precedence and yields a gmail_correspondence link candidate
+      - otherwise a trust-anchored sighting yields a gmail_participant create candidate
+      - an address with an existing candidate row under either Gmail source is never proposed under the other
+      - the first classification is sticky until the user resolves the card
+    provenance: ['#789', 2026-08-11-gmail-participant-discovery.md]
+    notes: Mutual exclusion is cross-source and therefore not covered by the per-source dedup of IMP-006. No migration machinery — misclassification is cheap, the user picks link or import in the UI.
+
+  - id: IMP-046
+    title: The server declares import, link, and ignore for gmail_participant
+    type: api
+    status: proposed
+    surface: api
+    given: a gmail_participant candidate
+    when: the candidate is served or acted on
+    then:
+      - the declared allowed actions are import, link, and ignore
+      - an import with a user-supplied name succeeds; the link-only rejection never applies to this source
+    provenance: ['#789', AllowedActionsForSource, 2026-08-11-gmail-participant-discovery.md]
+    notes: Deliberately absent from linkOnlySources — the counterpart of IMP-014.
+
+  - id: IMP-047
+    title: Nameless candidates are importable after naming
+    type: ux
+    status: proposed
+    surface: ui
+    given: a gmail_participant candidate with no observed display name
+    when: the user reviews it in the imports queue
+    then:
+      - the queue row and the modal identify the candidate by its address, never as a generic unknown label
+      - the editable name starts empty
+      - import is unavailable until the user supplies a name
+      - a name the user has typed survives a background data refresh
+    provenance: ['#789', 2026-08-11-gmail-participant-discovery.md]
+
+  - id: IMP-048
+    title: The evidence line renders for every discovery source
+    type: ux
+    status: proposed
+    surface: ui
+    given: a discovery candidate whose row carries evidence metadata
+    when: the imports queue renders it
+    then:
+      - message count and recency evidence are visible regardless of the candidate's source
+      - the counterpart evidence the source recorded (co-occurring contact, trusted sender, or chat peer identity) is visible
+    provenance: ['#803', 2026-08-11-gmail-participant-discovery.md]
+    notes: Generalizes the line previously hard-gated to gmail_correspondence; motivated by a real prod mis-link between two rows rendered as bare phone numbers.
+
+  - id: IMP-049
+    title: Own-domain addresses count as the user in discovery only
+    type: business-logic
+    status: proposed
+    surface: none
+    given: a Gmail account configured with one or more own domains
+    when: discovery evaluates fetched messages
+    then:
+      - a sender address at an own domain anchors trust like a connected account address
+      - participant addresses at own domains are never proposed as candidates
+      - message storage and inbound-outbound classification are unchanged by the own-domain list
+    provenance: ['#789', 2026-08-11-gmail-participant-discovery.md]
+    notes: The user operates aliases on a personal domain; the domain list is per-account runtime configuration and is never hardcoded in code, fixtures, or tests (repo PII rule).


### PR DESCRIPTION
Closes #803. PR1 of 2 for #789 (the `gmail_participant` discovery feature follows in PR2; this PR also carries the #789 spec/behavior minting commit).

## What

The imports queue's evidence line ("Seen with X · N messages") was hard-gated to `gmail_correspondence`. Chat-source candidates rendered as bare labels — on prod this made two phone-number-only rows indistinguishable and caused a real mis-link. This PR generalizes the line: a new `candidateEvidenceLabel` helper renders counterpart + message count + recency for any discovery source that recorded evidence metadata (`gmail_correspondence`, `telegram`, `whatsapp`, and PR2's `gmail_participant`, pre-wired).

- The existing `gmail_correspondence` output is preserved byte-for-byte (the untouched `imports-correspondence.spec.ts` passes unmodified).
- Telegram's username renders as the evidence counterpart only when the existing username chip would be suppressed (handle-only candidates), so the same identity is never shown twice; the named-candidate case keeps the chip.
- WhatsApp mapping is unit-tested only (not synthetically declarable today — a known, cheap evidence gap; PR2's E2E adds a third live source).
- `spec/imports-matching.yaml`: IMP-048 flipped proposed→current with keys `count-recency-visible-any-source` / `counterpart-visible`, cited by the new `imports-evidence.spec.ts`.
- Declare-completeness accounting: `RegisterNone` entries for IMP-048 (renders data seeded by IMP-036/037 declarations) and IMP-047 (proposed, unimplemented until PR2 — PR2's real declaration replaces the entry; the completeness gate mechanically rejects declared+none so the placeholder cannot go stale).

## Verification

- vitest: 9/9 (`candidate-evidence.test.ts`); full frontend suite 1020/1020; tsc + eslint clean.
- E2E (live lane): `imports-evidence.spec.ts` green; regression: IMP-036 (3 tests) + IMP-037 (1) green with zero edits.
- `make spec-lint` / `make spec-coverage` / declare completeness tests: green.

## Ephemeral second-order proofs (nothing committed)

1. TDD red: test file written before `candidate-evidence.ts` existed → vitest module-not-found failure, then green after implementation.
2. Spec-coverage red: IMP-048 flipped current before the citing test existed → `make spec-coverage` exit 1 naming `ORPHAN (blocking) IMP-048.count-recency-visible-any-source`.
3. Citation-deletion probe: removed `IMP-048.counterpart-visible` from the E2E `// spec:` line → `make spec-coverage` exit 2 naming the orphaned key; restored → exit 0.
4. Renderer mutation: injected `if (candidate.source === 'telegram') return null` into `candidateEvidenceLabel` (grep-confirmed) → cited E2E exit 2 on the missing pill; reverted (grep-confirmed absent), suite green. Independently re-run by the pair reviewer.

Both the implementation and this assembly were pair-reviewed (implementer + independent reviewer re-running tests and mutations); the cross-model codex merge-gate review runs alongside CI.