### PR TITLE
refactor(api): delete pass-through service methods; rewrite the layer rule

### DIFF
--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -70,7 +70,7 @@ graph TB
 
 ### Why Layered?
 
-The backend follows a strict layered architecture to maintain separation of concerns and testability:
+The backend follows a layered architecture to maintain separation of concerns and testability. The service layer is present where it earns its keep (transactions, cross-repository writes, business logic); read-heavy handlers may bind directly to a repository surface:
 
 ```mermaid
 sequenceDiagram

--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -113,7 +113,7 @@ sequenceDiagram
 
 **Trade-offs:**
 - More boilerplate than using an ORM directly from handlers
-- Requires discipline to not skip layers
+- A layer exists where it earns its keep: a service is required wherever there is business logic, multi-repository orchestration, or a transaction; a handler may call a repository directly when the call would add nothing but a rename (see `.ai/rules/core.md` rule 3)
 
 ---
 

--- a/.ai/patterns/backend.md
+++ b/.ai/patterns/backend.md
@@ -123,7 +123,8 @@ func (h *ContactHandler) CreateContact(c *gin.Context) {
         return
     }
 
-    // 3. Call repository/service
+    // 3. Call the repository directly — simple CRUD adds nothing but a
+    //    rename through a service (rule 3, .ai/rules/core.md)
     contact, err := h.repo.CreateContact(c.Request.Context(), repository.CreateContactRequest{
         FullName: req.FullName,
         Email:    req.Email,

--- a/.ai/rules/core.md
+++ b/.ai/rules/core.md
@@ -97,7 +97,7 @@ See `.ai/rules/code-review.md` for details
 
 ## Layered Architecture
 
-See [Request Flow Diagram](../guides/architecture.md#why-layered) for the full sequence (`Handler → Service → Repository → sqlc → PostgreSQL`).
+See [Request Flow Diagram](../guides/architecture.md#why-layered) for the write-path sequence (`Handler → Service → Repository → sqlc → PostgreSQL`). Read-heavy handlers may bind directly to a repository surface when the service layer would only forward (rule: a layer exists where it earns its keep).
 
 ## Common Gotchas
 

--- a/.ai/rules/core.md
+++ b/.ai/rules/core.md
@@ -6,7 +6,7 @@ These rules apply to all AI agents working on this project.
 
 1. **Never use `time.Now()`** → Use `accelerated.GetCurrentTime()`
 2. **Never write raw SQL in Go** → Use sqlc-generated queries (`make sqlc`). Applies to ALL Go code: production code, integration tests, test fixtures, and helper scripts — add a test-only sqlc query + repository wrapper rather than inlining `pool.Exec(ctx, "INSERT ...", ...)` in a test file.
-3. **Never skip layers** → Handler → Service → Repository → DB
+3. **A layer exists where it earns its keep** → handlers never call sqlc (see rule 5); anything with business logic, multi-repository orchestration, or a transaction goes in a service; a handler may call a repository directly when the call adds nothing but a rename. See `.ai/guides/feature-development.md` "When NOT to create a service".
 4. **Never use npm/npx** → Use bun/bunx
 5. **Never call queries from handlers** → Go through repository
 6. **Always sign commits** → `git commit -S -m "..."`

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
       value: |
         ## Before You Start
         - Read [AGENTS.md](../AGENTS.md) for development guidelines
-        - Follow the layered architecture: Handler → Service → Repository → DB
+        - Follow the layered architecture: a layer exists where it earns its keep (Handler → [Service →] Repository → DB; handlers never call sqlc)
         - Write tests for all new features
         
   - type: input

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -1552,7 +1552,7 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 
 	deps := adminDeps{
 		tokens:     hostService,
-		hosts:      hostService,
+		hosts:      hostRepo,
 		revoker:    hostService,
 		rematch:    rematch,
 		reconcile:  addressBookReconcile,

--- a/backend/cmd/crm-api/wire_machost.go
+++ b/backend/cmd/crm-api/wire_machost.go
@@ -47,7 +47,7 @@ func buildMacHost(reg *riverRegistrar, database *db.Database, core coreRepos, in
 		0, // default bcrypt cost
 	)
 	pairingIPLimiter := auth.NewPairingIPRateLimiter()
-	macHostHandler := handlers.NewMacHostHandler(macHostService, pairingIPLimiter)
+	macHostHandler := handlers.NewMacHostHandler(macHostService, macHostRepo, pairingIPLimiter)
 
 	// Register the pairing-token janitor periodic job (5 min). Worker
 	// registered unconditionally; the periodic-job inserter triggers it

--- a/backend/cmd/crm-api/wire_sync.go
+++ b/backend/cmd/crm-api/wire_sync.go
@@ -199,8 +199,8 @@ func buildExternalSync(
 		}
 	}
 
-	stack.SyncHandler = handlers.NewSyncHandler(syncService)
-	stack.IdentityHandler = handlers.NewIdentityHandler(identityService)
+	stack.SyncHandler = handlers.NewSyncHandler(syncService, syncRepo)
+	stack.IdentityHandler = handlers.NewIdentityHandler(identityService, identityRepo)
 
 	// Suggestion service composes the method-suggestion group with the
 	// confidence-ranked candidate list and runs resolve/dismiss. Shared

--- a/backend/internal/api/handlers/identity.go
+++ b/backend/internal/api/handlers/identity.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -15,13 +16,15 @@ import (
 // IdentityHandler handles identity-related HTTP requests
 type IdentityHandler struct {
 	identityService *service.IdentityService
+	identityRepo    *repository.IdentityRepository
 	validator       *validator.Validate
 }
 
 // NewIdentityHandler creates a new identity handler
-func NewIdentityHandler(identityService *service.IdentityService) *IdentityHandler {
+func NewIdentityHandler(identityService *service.IdentityService, identityRepo *repository.IdentityRepository) *IdentityHandler {
 	return &IdentityHandler{
 		identityService: identityService,
+		identityRepo:    identityRepo,
 		validator:       sharedValidator,
 	}
 }
@@ -55,13 +58,13 @@ func (h *IdentityHandler) ListUnmatchedIdentities(c *gin.Context) {
 
 	offset := int32((page - 1) * limit)
 
-	identities, err := h.identityService.ListUnmatchedIdentities(c.Request.Context(), int32(limit), offset)
+	identities, err := h.identityRepo.ListUnmatched(c.Request.Context(), int32(limit), offset)
 	if err != nil {
 		api.RespondInternal(c, err)
 		return
 	}
 
-	total, err := h.identityService.CountUnmatchedIdentities(c.Request.Context())
+	total, err := h.identityRepo.CountUnmatched(c.Request.Context())
 	if err != nil {
 		api.RespondInternal(c, err)
 		return
@@ -89,7 +92,7 @@ func (h *IdentityHandler) GetIdentity(c *gin.Context) {
 		return
 	}
 
-	identity, err := h.identityService.GetIdentity(c.Request.Context(), id)
+	identity, err := h.identityRepo.GetByID(c.Request.Context(), id)
 	if err != nil {
 		api.RespondError(c, err, "Identity")
 		return
@@ -155,7 +158,7 @@ func (h *IdentityHandler) UnlinkIdentity(c *gin.Context) {
 		return
 	}
 
-	identity, err := h.identityService.UnlinkIdentity(c.Request.Context(), identityID)
+	identity, err := h.identityRepo.UnlinkFromContact(c.Request.Context(), identityID)
 	if err != nil {
 		api.RespondError(c, err, "Identity")
 		return
@@ -180,7 +183,7 @@ func (h *IdentityHandler) DeleteIdentity(c *gin.Context) {
 		return
 	}
 
-	if err := h.identityService.DeleteIdentity(c.Request.Context(), id); err != nil {
+	if err := h.identityRepo.Delete(c.Request.Context(), id); err != nil {
 		api.RespondInternal(c, err)
 		return
 	}
@@ -204,7 +207,7 @@ func (h *IdentityHandler) ListIdentitiesForContact(c *gin.Context) {
 		return
 	}
 
-	identities, err := h.identityService.ListIdentitiesForContact(c.Request.Context(), contactID)
+	identities, err := h.identityRepo.ListForContact(c.Request.Context(), contactID)
 	if err != nil {
 		api.RespondInternal(c, err)
 		return

--- a/backend/internal/api/handlers/mac_host.go
+++ b/backend/internal/api/handlers/mac_host.go
@@ -26,15 +26,19 @@ type MacHostService interface {
 	CreatePairingToken(ctx context.Context) (plaintext string, expiresAt time.Time, err error)
 	PairWithToken(ctx context.Context, plaintextToken, hostname, daemonVersion string, protocolVersion int32) (*service.PairResult, error)
 	RotateAPIKey(ctx context.Context, hostID uuid.UUID, expectedCurrentHash string, plaintextToken string) (*service.RotateAPIKeyResult, error)
-	Heartbeat(ctx context.Context, hostID uuid.UUID, payload repository.HeartbeatPayload) (*repository.MacHost, error)
 	CommitCursor(ctx context.Context, params repository.CommitMacHostCursorParams) error
 	GetCursor(ctx context.Context, source string, hostID uuid.UUID) (*repository.MacHostCursor, error)
-	ListActiveHosts(ctx context.Context) ([]*repository.MacHost, error)
-	GetHost(ctx context.Context, id uuid.UUID) (*repository.MacHost, error)
 	RevokeHost(ctx context.Context, id uuid.UUID) error
 	KnownIdentifiers(ctx context.Context) (*service.KnownIdentifiersResult, error)
 	KnownIDsForSource(ctx context.Context, hostID uuid.UUID, source string) ([]service.KnownExternalContactID, error)
 	GetSourceCounts(ctx context.Context, hostID uuid.UUID) (map[string]int, error)
+}
+
+// MacHostStore is the repository surface the mac-host handler reads directly.
+type MacHostStore interface {
+	UpdateHeartbeat(ctx context.Context, id uuid.UUID, payload repository.HeartbeatPayload) (*repository.MacHost, error)
+	ListActiveHosts(ctx context.Context) ([]*repository.MacHost, error)
+	GetHost(ctx context.Context, id uuid.UUID) (*repository.MacHost, error)
 }
 
 // MacHostHandler handles Mac-daemon HTTP requests + admin UI requests
@@ -47,13 +51,14 @@ type MacHostService interface {
 //     middleware. Reached from the UI.
 type MacHostHandler struct {
 	svc            MacHostService
+	store          MacHostStore
 	pairingLimiter *auth.PairingIPRateLimiter
 }
 
 // NewMacHostHandler constructs the handler. pairingLimiter is REQUIRED
 // for the Pair endpoint; pass auth.NewPairingIPRateLimiter() at wire-up.
-func NewMacHostHandler(svc MacHostService, pairingLimiter *auth.PairingIPRateLimiter) *MacHostHandler {
-	return &MacHostHandler{svc: svc, pairingLimiter: pairingLimiter}
+func NewMacHostHandler(svc MacHostService, store MacHostStore, pairingLimiter *auth.PairingIPRateLimiter) *MacHostHandler {
+	return &MacHostHandler{svc: svc, store: store, pairingLimiter: pairingLimiter}
 }
 
 // MacHostView is the JSON shape returned to the admin UI. Pointer fields
@@ -237,7 +242,7 @@ func (h *MacHostHandler) Heartbeat(c *gin.Context) {
 		return
 	}
 
-	host, err := h.svc.Heartbeat(c.Request.Context(), hostID, repository.HeartbeatPayload{
+	host, err := h.store.UpdateHeartbeat(c.Request.Context(), hostID, repository.HeartbeatPayload{
 		DaemonVersion:   req.DaemonVersion,
 		ProtocolVersion: req.ProtocolVersion,
 		Permissions:     req.Permissions,
@@ -537,7 +542,7 @@ func (h *MacHostHandler) KnownIdentifiers(c *gin.Context) {
 
 // ListHosts is the admin list view.
 func (h *MacHostHandler) ListHosts(c *gin.Context) {
-	hosts, err := h.svc.ListActiveHosts(c.Request.Context())
+	hosts, err := h.store.ListActiveHosts(c.Request.Context())
 	if err != nil {
 		api.RespondInternal(c, err)
 		return
@@ -555,7 +560,7 @@ func (h *MacHostHandler) GetHostAdmin(c *gin.Context) {
 	if !ok {
 		return
 	}
-	host, err := h.svc.GetHost(c.Request.Context(), id)
+	host, err := h.store.GetHost(c.Request.Context(), id)
 	if err != nil {
 		api.RespondError(c, err, "Mac host")
 		return

--- a/backend/internal/api/handlers/mac_host_test.go
+++ b/backend/internal/api/handlers/mac_host_test.go
@@ -28,10 +28,6 @@ type stubMacHostService struct {
 	rotateResult *service.RotateAPIKeyResult
 	rotateErr    error
 	rotateCalls  int
-
-	heartbeatResult *repository.MacHost
-	heartbeatErr    error
-	heartbeatCalls  int
 }
 
 func (s *stubMacHostService) RotateAPIKey(_ context.Context, _ uuid.UUID, _ string, _ string) (*service.RotateAPIKeyResult, error) {
@@ -45,24 +41,11 @@ func (s *stubMacHostService) CreatePairingToken(_ context.Context) (string, time
 func (s *stubMacHostService) PairWithToken(_ context.Context, _ string, _ string, _ string, _ int32) (*service.PairResult, error) {
 	panic("PairWithToken not expected in this test")
 }
-func (s *stubMacHostService) Heartbeat(_ context.Context, _ uuid.UUID, _ repository.HeartbeatPayload) (*repository.MacHost, error) {
-	s.heartbeatCalls++
-	if s.heartbeatResult != nil || s.heartbeatErr != nil {
-		return s.heartbeatResult, s.heartbeatErr
-	}
-	panic("Heartbeat not expected in this test")
-}
 func (s *stubMacHostService) CommitCursor(_ context.Context, _ repository.CommitMacHostCursorParams) error {
 	panic("CommitCursor not expected in this test")
 }
 func (s *stubMacHostService) GetCursor(_ context.Context, _ string, _ uuid.UUID) (*repository.MacHostCursor, error) {
 	panic("GetCursor not expected in this test")
-}
-func (s *stubMacHostService) ListActiveHosts(_ context.Context) ([]*repository.MacHost, error) {
-	panic("ListActiveHosts not expected in this test")
-}
-func (s *stubMacHostService) GetHost(_ context.Context, _ uuid.UUID) (*repository.MacHost, error) {
-	panic("GetHost not expected in this test")
 }
 func (s *stubMacHostService) RevokeHost(_ context.Context, _ uuid.UUID) error {
 	panic("RevokeHost not expected in this test")
@@ -75,6 +58,31 @@ func (s *stubMacHostService) KnownIDsForSource(_ context.Context, _ uuid.UUID, _
 }
 func (s *stubMacHostService) GetSourceCounts(_ context.Context, _ uuid.UUID) (map[string]int, error) {
 	panic("GetSourceCounts not expected in this test")
+}
+
+// stubMacHostStore satisfies the handler's MacHostStore interface
+// (the repository surface the handler now reads directly for
+// heartbeat/list/get). Only UpdateHeartbeat is exercised by this
+// file; the other methods panic on call so a stray invocation is
+// surfaced as a test failure rather than masked as success.
+type stubMacHostStore struct {
+	heartbeatResult *repository.MacHost
+	heartbeatErr    error
+	heartbeatCalls  int
+}
+
+func (s *stubMacHostStore) UpdateHeartbeat(_ context.Context, _ uuid.UUID, _ repository.HeartbeatPayload) (*repository.MacHost, error) {
+	s.heartbeatCalls++
+	if s.heartbeatResult != nil || s.heartbeatErr != nil {
+		return s.heartbeatResult, s.heartbeatErr
+	}
+	panic("UpdateHeartbeat not expected in this test")
+}
+func (s *stubMacHostStore) ListActiveHosts(_ context.Context) ([]*repository.MacHost, error) {
+	panic("ListActiveHosts not expected in this test")
+}
+func (s *stubMacHostStore) GetHost(_ context.Context, _ uuid.UUID) (*repository.MacHost, error) {
+	panic("GetHost not expected in this test")
 }
 
 // fakeHostRepo is a deterministic MacHostKeyValidator that returns a
@@ -113,7 +121,7 @@ func TestRotateKey_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 		APIKeyHash: "test-hash",
 	}
 	stub := &stubMacHostService{rotateErr: db.ErrNotFound}
-	handler := NewMacHostHandler(stub, nil)
+	handler := NewMacHostHandler(stub, nil, nil)
 
 	r := gin.New()
 	r.Use(auth.MacHostAuthMiddleware(
@@ -166,7 +174,7 @@ func TestRotateKey_ConcurrentRotationLoser_MapsStaleAuthTo401(t *testing.T) {
 		APIKeyHash: "test-hash",
 	}
 	stub := &stubMacHostService{rotateErr: service.ErrAPIKeyStaleAuth}
-	handler := NewMacHostHandler(stub, nil)
+	handler := NewMacHostHandler(stub, nil, nil)
 
 	r := gin.New()
 	r.Use(auth.MacHostAuthMiddleware(
@@ -213,8 +221,9 @@ func TestHeartbeat_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 		Hostname:   "test-host",
 		APIKeyHash: "test-hash",
 	}
-	stub := &stubMacHostService{heartbeatErr: db.ErrNotFound}
-	handler := NewMacHostHandler(stub, nil)
+	stub := &stubMacHostService{}
+	store := &stubMacHostStore{heartbeatErr: db.ErrNotFound}
+	handler := NewMacHostHandler(stub, store, nil)
 
 	r := gin.New()
 	r.Use(auth.MacHostAuthMiddleware(
@@ -239,7 +248,7 @@ func TestHeartbeat_HostRevokedBetweenMiddlewareAndTx(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
-	require.Equal(t, 1, stub.heartbeatCalls, "service must be invoked exactly once")
+	require.Equal(t, 1, store.heartbeatCalls, "store must be invoked exactly once")
 
 	var body2 map[string]any
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&body2))
@@ -261,7 +270,7 @@ func TestRotateKey_MissingPairingToken(t *testing.T) {
 		APIKeyHash: "test-hash",
 	}
 	stub := &stubMacHostService{}
-	handler := NewMacHostHandler(stub, nil)
+	handler := NewMacHostHandler(stub, nil, nil)
 
 	r := gin.New()
 	r.Use(auth.MacHostAuthMiddleware(

--- a/backend/internal/api/handlers/sync.go
+++ b/backend/internal/api/handlers/sync.go
@@ -21,25 +21,31 @@ import (
 // This allows for easier testing with mock implementations.
 type SyncService interface {
 	TriggerSync(ctx context.Context, source string, accountID *string) error
-	GetSyncStatus(ctx context.Context) ([]repository.SyncState, error)
-	GetSyncStateBySource(ctx context.Context, source string, accountID *string) (*repository.SyncState, error)
-	EnableSync(ctx context.Context, id uuid.UUID, enabled bool) (*repository.SyncState, error)
-	GetSyncLogs(ctx context.Context, syncStateID uuid.UUID, limit, offset int32) ([]repository.SyncLog, error)
-	CountSyncLogs(ctx context.Context, syncStateID uuid.UUID) (int64, error)
-	GetRecentSyncLogs(ctx context.Context, limit int32) ([]repository.SyncLog, error)
 	GetAvailableProviders() []sync.SourceConfig
+}
+
+// SyncStateStore is the repository surface the sync handler reads directly.
+type SyncStateStore interface {
+	ListSyncStates(ctx context.Context) ([]repository.SyncState, error)
+	GetSyncStateBySource(ctx context.Context, source string, accountID *string) (*repository.SyncState, error)
+	UpdateSyncStateEnabled(ctx context.Context, id uuid.UUID, enabled bool) (*repository.SyncState, error)
+	ListSyncLogsByState(ctx context.Context, stateID uuid.UUID, limit, offset int32) ([]repository.SyncLog, error)
+	CountSyncLogsByState(ctx context.Context, stateID uuid.UUID) (int64, error)
+	ListRecentSyncLogs(ctx context.Context, limit int32) ([]repository.SyncLog, error)
 }
 
 // SyncHandler handles sync-related HTTP requests
 type SyncHandler struct {
 	syncService SyncService
+	syncStore   SyncStateStore
 	validator   *validator.Validate
 }
 
 // NewSyncHandler creates a new sync handler
-func NewSyncHandler(syncService SyncService) *SyncHandler {
+func NewSyncHandler(syncService SyncService, syncStore SyncStateStore) *SyncHandler {
 	return &SyncHandler{
 		syncService: syncService,
+		syncStore:   syncStore,
 		validator:   sharedValidator,
 	}
 }
@@ -59,7 +65,7 @@ type TriggerSyncRequest struct {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /sync/status [get]
 func (h *SyncHandler) GetSyncStatus(c *gin.Context) {
-	states, err := h.syncService.GetSyncStatus(c.Request.Context())
+	states, err := h.syncStore.ListSyncStates(c.Request.Context())
 	if err != nil {
 		api.RespondInternal(c, err)
 		return
@@ -104,7 +110,7 @@ func (h *SyncHandler) GetSyncState(c *gin.Context) {
 		accountIDPtr = &accountID
 	}
 
-	state, err := h.syncService.GetSyncStateBySource(c.Request.Context(), source, accountIDPtr)
+	state, err := h.syncStore.GetSyncStateBySource(c.Request.Context(), source, accountIDPtr)
 	if err != nil {
 		api.RespondError(c, err, "Sync state")
 		return
@@ -207,7 +213,7 @@ func (h *SyncHandler) EnableSync(c *gin.Context) {
 		return
 	}
 
-	state, err := h.syncService.EnableSync(c.Request.Context(), id, enabled)
+	state, err := h.syncStore.UpdateSyncStateEnabled(c.Request.Context(), id, enabled)
 	if err != nil {
 		api.RespondError(c, err, "Sync state")
 		return
@@ -246,14 +252,14 @@ func (h *SyncHandler) GetSyncLogs(c *gin.Context) {
 
 	offset := int32((page - 1) * limit)
 
-	logs, err := h.syncService.GetSyncLogs(c.Request.Context(), id, int32(limit), offset)
+	logs, err := h.syncStore.ListSyncLogsByState(c.Request.Context(), id, int32(limit), offset)
 	if err != nil {
 		api.RespondInternal(c, err)
 		return
 	}
 
 	// Get total count for pagination
-	total, err := h.syncService.CountSyncLogs(c.Request.Context(), id)
+	total, err := h.syncStore.CountSyncLogsByState(c.Request.Context(), id)
 	if err != nil {
 		api.RespondInternal(c, err)
 		return
@@ -280,7 +286,7 @@ func (h *SyncHandler) GetRecentSyncLogs(c *gin.Context) {
 		limit = 20
 	}
 
-	logs, err := h.syncService.GetRecentSyncLogs(c.Request.Context(), int32(limit))
+	logs, err := h.syncStore.ListRecentSyncLogs(c.Request.Context(), int32(limit))
 	if err != nil {
 		api.RespondInternal(c, err)
 		return

--- a/backend/internal/api/handlers/sync_test.go
+++ b/backend/internal/api/handlers/sync_test.go
@@ -27,38 +27,45 @@ func (f *fakeSyncService) TriggerSync(_ context.Context, _ string, _ *string) er
 	return f.err
 }
 
-func (f *fakeSyncService) GetSyncStatus(_ context.Context) ([]repository.SyncState, error) {
-	return nil, f.err
-}
-
-func (f *fakeSyncService) GetSyncStateBySource(_ context.Context, _ string, _ *string) (*repository.SyncState, error) {
-	return nil, f.err
-}
-
-func (f *fakeSyncService) EnableSync(_ context.Context, _ uuid.UUID, _ bool) (*repository.SyncState, error) {
-	return nil, f.err
-}
-
-func (f *fakeSyncService) GetSyncLogs(_ context.Context, _ uuid.UUID, _, _ int32) ([]repository.SyncLog, error) {
-	return nil, f.err
-}
-
-func (f *fakeSyncService) CountSyncLogs(_ context.Context, _ uuid.UUID) (int64, error) {
-	return 0, f.err
-}
-
-func (f *fakeSyncService) GetRecentSyncLogs(_ context.Context, _ int32) ([]repository.SyncLog, error) {
-	return nil, f.err
-}
-
 func (f *fakeSyncService) GetAvailableProviders() []sync.SourceConfig {
 	return nil
 }
 
-func newSyncTestRouter(svc SyncService) *gin.Engine {
+// fakeSyncStateStore implements SyncStateStore, returning configurable errors
+// so the migrated RespondError / RespondInternal paths can be exercised
+// without a DB.
+type fakeSyncStateStore struct {
+	err error
+}
+
+func (f *fakeSyncStateStore) ListSyncStates(_ context.Context) ([]repository.SyncState, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncStateStore) GetSyncStateBySource(_ context.Context, _ string, _ *string) (*repository.SyncState, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncStateStore) UpdateSyncStateEnabled(_ context.Context, _ uuid.UUID, _ bool) (*repository.SyncState, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncStateStore) ListSyncLogsByState(_ context.Context, _ uuid.UUID, _, _ int32) ([]repository.SyncLog, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncStateStore) CountSyncLogsByState(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, f.err
+}
+
+func (f *fakeSyncStateStore) ListRecentSyncLogs(_ context.Context, _ int32) ([]repository.SyncLog, error) {
+	return nil, f.err
+}
+
+func newSyncTestRouter(svc SyncService, store SyncStateStore) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	h := NewSyncHandler(svc)
+	h := NewSyncHandler(svc, store)
 	r.GET("/sync/status", h.GetSyncStatus)
 	r.GET("/sync/:source/status", h.GetSyncState)
 	return r
@@ -67,7 +74,7 @@ func newSyncTestRouter(svc SyncService) *gin.Engine {
 // TestSyncHandler_GetSyncState_NotFound proves RespondError keeps the
 // db.ErrNotFound → 404 mapping on a real migrated interface-backed handler.
 func TestSyncHandler_GetSyncState_NotFound(t *testing.T) {
-	r := newSyncTestRouter(&fakeSyncService{err: db.ErrNotFound})
+	r := newSyncTestRouter(&fakeSyncService{}, &fakeSyncStateStore{err: db.ErrNotFound})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/sync/gmail/status", nil)
@@ -80,7 +87,7 @@ func TestSyncHandler_GetSyncState_NotFound(t *testing.T) {
 // TestSyncHandler_GetSyncState_GenericError proves a non-not-found error still
 // 500s (no drift to 404) with no raw cause leaking into the body.
 func TestSyncHandler_GetSyncState_GenericError(t *testing.T) {
-	r := newSyncTestRouter(&fakeSyncService{err: errors.New("connection reset secret")})
+	r := newSyncTestRouter(&fakeSyncService{}, &fakeSyncStateStore{err: errors.New("connection reset secret")})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/sync/gmail/status", nil)
@@ -92,7 +99,7 @@ func TestSyncHandler_GetSyncState_GenericError(t *testing.T) {
 }
 
 func TestSyncHandler_GetSyncStatus_GenericError(t *testing.T) {
-	r := newSyncTestRouter(&fakeSyncService{err: errors.New("db offline secret")})
+	r := newSyncTestRouter(&fakeSyncService{}, &fakeSyncStateStore{err: errors.New("db offline secret")})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/sync/status", nil)

--- a/backend/internal/service/identity.go
+++ b/backend/internal/service/identity.go
@@ -480,36 +480,6 @@ func (s *IdentityService) LinkIdentity(ctx context.Context, identityID, contactI
 	})
 }
 
-// UnlinkIdentity unlinks an identity from its contact
-func (s *IdentityService) UnlinkIdentity(ctx context.Context, identityID uuid.UUID) (*repository.ExternalIdentity, error) {
-	return s.identityRepo.UnlinkFromContact(ctx, identityID)
-}
-
-// GetIdentity retrieves an identity by ID
-func (s *IdentityService) GetIdentity(ctx context.Context, id uuid.UUID) (*repository.ExternalIdentity, error) {
-	return s.identityRepo.GetByID(ctx, id)
-}
-
-// ListUnmatchedIdentities returns unmatched identities with pagination
-func (s *IdentityService) ListUnmatchedIdentities(ctx context.Context, limit, offset int32) ([]repository.ExternalIdentity, error) {
-	return s.identityRepo.ListUnmatched(ctx, limit, offset)
-}
-
-// CountUnmatchedIdentities returns the count of unmatched identities
-func (s *IdentityService) CountUnmatchedIdentities(ctx context.Context) (int64, error) {
-	return s.identityRepo.CountUnmatched(ctx)
-}
-
-// ListIdentitiesForContact returns all identities linked to a contact
-func (s *IdentityService) ListIdentitiesForContact(ctx context.Context, contactID uuid.UUID) ([]repository.ExternalIdentity, error) {
-	return s.identityRepo.ListForContact(ctx, contactID)
-}
-
-// DeleteIdentity removes an identity
-func (s *IdentityService) DeleteIdentity(ctx context.Context, id uuid.UUID) error {
-	return s.identityRepo.Delete(ctx, id)
-}
-
 // BulkLinkIdentities links multiple identities to a contact
 func (s *IdentityService) BulkLinkIdentities(ctx context.Context, identityIDs []uuid.UUID, contactID uuid.UUID) error {
 	confidence := 1.0

--- a/backend/internal/service/mac_host.go
+++ b/backend/internal/service/mac_host.go
@@ -484,13 +484,6 @@ func (s *MacHostService) RotateAPIKey(
 	}, nil
 }
 
-// Heartbeat updates the host's heartbeat fields. Returns the updated
-// host (so the handler can echo cursor_epoch back to the daemon) or
-// db.ErrNotFound if the host has been revoked.
-func (s *MacHostService) Heartbeat(ctx context.Context, hostID uuid.UUID, payload repository.HeartbeatPayload) (*repository.MacHost, error) {
-	return s.hostRepo.UpdateHeartbeat(ctx, hostID, payload)
-}
-
 // CommitCursor wraps SyncRepository.CommitMacHostCursor. Returns the
 // repository's typed errors directly so handlers can map them to
 // status codes. Defence-in-depth: rejects sources outside the
@@ -512,19 +505,6 @@ func (s *MacHostService) GetCursor(ctx context.Context, source string, hostID uu
 		return nil, fmt.Errorf("%w: unknown push source %q", ErrUnknownPushSource, source)
 	}
 	return s.syncRepo.GetMacHostSyncCursor(ctx, source, hostID)
-}
-
-// ListActiveHosts returns the admin-view list. Returned slice may be
-// empty (no host paired yet).
-func (s *MacHostService) ListActiveHosts(ctx context.Context) ([]*repository.MacHost, error) {
-	return s.hostRepo.ListActiveHosts(ctx)
-}
-
-// GetHost is the admin-view detail. Returns db.ErrNotFound for an
-// unknown UUID; revoked hosts are returned (the UI may want to show
-// historical detail).
-func (s *MacHostService) GetHost(ctx context.Context, id uuid.UUID) (*repository.MacHost, error) {
-	return s.hostRepo.GetHost(ctx, id)
 }
 
 // RevokeHost marks the host revoked AND cascades: deletes the host's

--- a/backend/internal/service/sync.go
+++ b/backend/internal/service/sync.go
@@ -403,44 +403,9 @@ func (s *SyncService) completeSyncWithError(ctx context.Context, state *reposito
 	}
 }
 
-// GetSyncStatus returns sync status for all sources
-func (s *SyncService) GetSyncStatus(ctx context.Context) ([]repository.SyncState, error) {
-	return s.syncRepo.ListSyncStates(ctx)
-}
-
-// GetSyncStateBySource returns sync state for a specific source
-func (s *SyncService) GetSyncStateBySource(ctx context.Context, source string, accountID *string) (*repository.SyncState, error) {
-	return s.syncRepo.GetSyncStateBySource(ctx, source, accountID)
-}
-
-// GetSyncState returns sync state by ID
-func (s *SyncService) GetSyncState(ctx context.Context, id uuid.UUID) (*repository.SyncState, error) {
-	return s.syncRepo.GetSyncState(ctx, id)
-}
-
-// EnableSync enables/disables sync for a source
-func (s *SyncService) EnableSync(ctx context.Context, id uuid.UUID, enabled bool) (*repository.SyncState, error) {
-	return s.syncRepo.UpdateSyncStateEnabled(ctx, id, enabled)
-}
-
-// GetSyncLogs returns sync logs for a specific state
-func (s *SyncService) GetSyncLogs(ctx context.Context, stateID uuid.UUID, limit, offset int32) ([]repository.SyncLog, error) {
-	return s.syncRepo.ListSyncLogsByState(ctx, stateID, limit, offset)
-}
-
-// GetRecentSyncLogs returns the most recent sync logs across all sources
-func (s *SyncService) GetRecentSyncLogs(ctx context.Context, limit int32) ([]repository.SyncLog, error) {
-	return s.syncRepo.ListRecentSyncLogs(ctx, limit)
-}
-
 // GetAvailableProviders returns list of registered sync providers
 func (s *SyncService) GetAvailableProviders() []sync.SourceConfig {
 	return s.registry.List()
-}
-
-// CountSyncLogs returns the count of sync logs for a specific state
-func (s *SyncService) CountSyncLogs(ctx context.Context, stateID uuid.UUID) (int64, error) {
-	return s.syncRepo.CountSyncLogsByState(ctx, stateID)
 }
 
 // DeleteOldSyncLogs removes sync logs older than the specified duration

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -126,7 +126,7 @@ func setupExtContactIngestEnv(t *testing.T) *extContactIngestEnv {
 	router.Use(api.CORSMiddleware(cfg.CORS))
 
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/external_contact_known_ids_test.go
+++ b/backend/tests/api/external_contact_known_ids_test.go
@@ -72,7 +72,7 @@ func setupKnownIDsByHostEnv(t *testing.T) *knownIDsByHostEnv {
 	router.Use(api.CORSMiddleware(cfg.CORS))
 
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/external_contact_savepoint_rollback_test.go
+++ b/backend/tests/api/external_contact_savepoint_rollback_test.go
@@ -109,7 +109,7 @@ func TestIngestExternalContact_SavepointRollback_OnMatchFailure(t *testing.T) {
 	router.Use(api.LoggingMiddleware())
 	router.Use(api.CORSMiddleware(cfg.CORS))
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/identity_routes_test.go
+++ b/backend/tests/api/identity_routes_test.go
@@ -5,10 +5,9 @@
 // drove the repository and service directly, so a rewrite of a handler call
 // site to a wrong-but-signature-compatible repository method (e.g.
 // identityRepo.GetByID standing in for identityRepo.UnlinkFromContact) would
-// have shipped green. This suite exercises the five registered identity
-// routes that PR1-E1 rewrote from service calls to repository calls, through
-// the real router, asserting status plus a discriminating field of the
-// response shape rather than just 200.
+// have shipped green. This suite exercises the five identity routes that
+// bind directly to the repository, through the real router, asserting status
+// plus a discriminating field of the response shape rather than just 200.
 package api
 
 import (
@@ -107,10 +106,10 @@ func seedIdentity(t *testing.T, ctx context.Context, identityRepo *repository.Id
 	return ident
 }
 
-// TestIdentityRoutes covers the five identity routes PR1-E1 rewrote from
-// IdentityService calls to IdentityRepository calls. POST /identities/:id/link
-// is excluded: it reaches IdentityService.LinkIdentity, a near-pass-through
-// that this element does not touch.
+// TestIdentityRoutes covers the five identity routes that call
+// IdentityRepository directly. POST /identities/:id/link is excluded: it
+// reaches IdentityService.LinkIdentity, which carries real logic and keeps
+// its service call.
 func TestIdentityRoutes(t *testing.T) {
 	t.Parallel()
 

--- a/backend/tests/api/identity_routes_test.go
+++ b/backend/tests/api/identity_routes_test.go
@@ -1,0 +1,219 @@
+//go:build integration_testdb
+
+// Package api's identity_routes_test.go is the first handler-level coverage
+// of IdentityHandler over HTTP. Before this file, backend/tests/identity_integration_test.go
+// drove the repository and service directly, so a rewrite of a handler call
+// site to a wrong-but-signature-compatible repository method (e.g.
+// identityRepo.GetByID standing in for identityRepo.UnlinkFromContact) would
+// have shipped green. This suite exercises the five registered identity
+// routes that PR1-E1 rewrote from service calls to repository calls, through
+// the real router, asserting status plus a discriminating field of the
+// response shape rather than just 200.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newIdentityRoutesTest builds a fresh, empty isolated DB clone, wires the
+// production identity route surface (RegisterIdentityRoutes) over the real
+// IdentityHandler -> repository.IdentityRepository stack, and returns the
+// pieces subtests need to seed state and assert against the repository
+// directly. Every subtest MUST call this as its first line: ListUnmatchedIdentities
+// counts contact_id IS NULL rows DB-wide with no source/account filter, so a
+// shared clone would let one subtest's seeded rows leak into a sibling's
+// exact-count assertion.
+func newIdentityRoutesTest(t *testing.T) (router *gin.Engine, identityRepo *repository.IdentityRepository, contactRepo *repository.ContactRepository, ctx context.Context) {
+	t.Helper()
+	ctx = context.Background()
+	database, _ := newIsolatedRiverTestDB(t, ctx)
+
+	identityRepo = repository.NewIdentityRepository(database.Queries)
+	contactRepo = repository.NewContactRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	handler := handlers.NewIdentityHandler(identityService, identityRepo)
+
+	router = gin.New()
+	v1 := router.Group("/api/v1")
+	handlers.RegisterIdentityRoutes(v1, handler)
+
+	return router, identityRepo, contactRepo, ctx
+}
+
+// doIdentityRequest serves a bodyless HTTP request against the router and
+// returns the recorder.
+func doIdentityRequest(router *gin.Engine, method, path string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// identityResponse mirrors the JSON fields of repository.ExternalIdentity
+// this suite asserts on.
+type identityResponse struct {
+	ID        string  `json:"id"`
+	ContactID *string `json:"contact_id"`
+}
+
+// identityEnvelope unwraps api.APIResponse around a single identity.
+type identityEnvelope struct {
+	Success bool             `json:"success"`
+	Data    identityResponse `json:"data"`
+}
+
+// identityListEnvelope unwraps api.APIResponse around a list of identities
+// plus meta.pagination.
+type identityListEnvelope struct {
+	Success bool               `json:"success"`
+	Data    []identityResponse `json:"data"`
+	Meta    struct {
+		Pagination struct {
+			Total int64 `json:"total"`
+		} `json:"pagination"`
+	} `json:"meta"`
+}
+
+// seedIdentity upserts an external identity for the given contact (nil for
+// unmatched) with a per-call-unique identifier so parallel subtests never
+// collide on the (identifier, identifier_type, source) unique constraint.
+func seedIdentity(t *testing.T, ctx context.Context, identityRepo *repository.IdentityRepository, contactID *uuid.UUID) *repository.ExternalIdentity {
+	t.Helper()
+	req := repository.UpsertIdentityRequest{
+		Identifier:     "identity-" + uuid.NewString(),
+		IdentifierType: identity.IdentifierTypeEmail,
+		Source:         "gmail",
+		ContactID:      contactID,
+	}
+	if contactID != nil {
+		req.MatchType = repository.MatchTypeManual
+	}
+	ident, err := identityRepo.Upsert(ctx, req)
+	require.NoError(t, err)
+	return ident
+}
+
+// TestIdentityRoutes covers the five identity routes PR1-E1 rewrote from
+// IdentityService calls to IdentityRepository calls. POST /identities/:id/link
+// is excluded: it reaches IdentityService.LinkIdentity, a near-pass-through
+// that this element does not touch.
+func TestIdentityRoutes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmatched list and count", func(t *testing.T) {
+		router, identityRepo, contactRepo, ctx := newIdentityRoutesTest(t)
+
+		unmatched := seedIdentity(t, ctx, identityRepo, nil)
+
+		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Linked Contact"})
+		require.NoError(t, err)
+		linked := seedIdentity(t, ctx, identityRepo, &contact.ID)
+
+		w := doIdentityRequest(router, http.MethodGet, "/api/v1/identities/unmatched")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var env identityListEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+
+		ids := make([]string, 0, len(env.Data))
+		for _, d := range env.Data {
+			ids = append(ids, d.ID)
+		}
+		assert.Contains(t, ids, unmatched.ID.String())
+		assert.NotContains(t, ids, linked.ID.String())
+		// This is the only coverage CountUnmatched gets, so a rebind of
+		// identityRepo.CountUnmatched shows up here or nowhere.
+		assert.EqualValues(t, 1, env.Meta.Pagination.Total)
+	})
+
+	t.Run("get by id", func(t *testing.T) {
+		router, identityRepo, _, ctx := newIdentityRoutesTest(t)
+
+		seeded := seedIdentity(t, ctx, identityRepo, nil)
+
+		w := doIdentityRequest(router, http.MethodGet, "/api/v1/identities/"+seeded.ID.String())
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var env identityEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+		assert.Equal(t, seeded.ID.String(), env.Data.ID)
+
+		w = doIdentityRequest(router, http.MethodGet, "/api/v1/identities/"+uuid.NewString())
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		router, identityRepo, _, ctx := newIdentityRoutesTest(t)
+
+		seeded := seedIdentity(t, ctx, identityRepo, nil)
+
+		w := doIdentityRequest(router, http.MethodDelete, "/api/v1/identities/"+seeded.ID.String())
+		require.Equal(t, http.StatusNoContent, w.Code)
+		assert.Empty(t, w.Body.Bytes())
+
+		w = doIdentityRequest(router, http.MethodGet, "/api/v1/identities/"+seeded.ID.String())
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("unlink", func(t *testing.T) {
+		router, identityRepo, contactRepo, ctx := newIdentityRoutesTest(t)
+
+		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Unlink Contact"})
+		require.NoError(t, err)
+		seeded := seedIdentity(t, ctx, identityRepo, &contact.ID)
+
+		w := doIdentityRequest(router, http.MethodPost, "/api/v1/identities/"+seeded.ID.String()+"/unlink")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var env identityEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+		assert.Equal(t, seeded.ID.String(), env.Data.ID)
+
+		// The row survives with its link cleared — this is what distinguishes
+		// UnlinkFromContact from every signature-compatible neighbour.
+		w = doIdentityRequest(router, http.MethodGet, "/api/v1/identities/"+seeded.ID.String())
+		require.Equal(t, http.StatusOK, w.Code)
+		var getEnv identityEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &getEnv))
+		assert.Nil(t, getEnv.Data.ContactID)
+	})
+
+	t.Run("identities for contact", func(t *testing.T) {
+		router, identityRepo, contactRepo, ctx := newIdentityRoutesTest(t)
+
+		contactA, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Contact A"})
+		require.NoError(t, err)
+		contactB, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Contact B"})
+		require.NoError(t, err)
+
+		identA := seedIdentity(t, ctx, identityRepo, &contactA.ID)
+		identB := seedIdentity(t, ctx, identityRepo, &contactB.ID)
+
+		w := doIdentityRequest(router, http.MethodGet, "/api/v1/contacts/"+contactA.ID.String()+"/identities")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var env identityListEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+
+		ids := make([]string, 0, len(env.Data))
+		for _, d := range env.Data {
+			ids = append(ids, d.ID)
+		}
+		assert.Contains(t, ids, identA.ID.String())
+		assert.NotContains(t, ids, identB.ID.String())
+	})
+}

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -150,7 +150,7 @@ func setupRawMessageE2E(t *testing.T) *rawMessageE2EEnv {
 	router.Use(api.CORSMiddleware(cfg.CORS))
 
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -137,7 +137,7 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 
 	// Mac host routes (pairing + heartbeat etc).
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/known_identifiers_test.go
+++ b/backend/tests/api/known_identifiers_test.go
@@ -67,7 +67,7 @@ func setupKnownIDsEnv(t *testing.T) *knownIDsEnv {
 	router.Use(api.CORSMiddleware(cfg.CORS))
 
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -67,7 +67,7 @@ func setupMacHostEnv(t *testing.T) *macHostTestEnv {
 	// real bcrypt path.
 	macService := service.NewMacHostService(hostRepo, tokenRepo, syncRepo, nil, externalRepo, nil, database.Pool, 4)
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -188,7 +188,7 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	router.Use(api.CORSMiddleware(cfg.CORS))
 
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/phone_call_ingest_integration_test.go
+++ b/backend/tests/api/phone_call_ingest_integration_test.go
@@ -231,7 +231,7 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 	router.Use(api.CORSMiddleware(cfg.CORS))
 
 	limiter := auth.NewPairingIPRateLimiter()
-	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	macHandler := handlers.NewMacHostHandler(macService, hostRepo, limiter)
 	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
 		HostRepo:    hostRepo,
 		Handler:     macHandler,

--- a/backend/tests/api/sync_api_test.go
+++ b/backend/tests/api/sync_api_test.go
@@ -74,7 +74,7 @@ func newSyncAPITest(t *testing.T) (router *gin.Engine, syncRepo *repository.Sync
 	registry = sync.NewProviderRegistry()
 
 	svc := service.NewSyncService(syncRepo, contactRepo, registry)
-	handler := handlers.NewSyncHandler(svc)
+	handler := handlers.NewSyncHandler(svc, syncRepo)
 
 	router = gin.New()
 	v1 := router.Group("/api/v1")

--- a/backend/tests/gchat_enablement_reconcile_test.go
+++ b/backend/tests/gchat_enablement_reconcile_test.go
@@ -385,7 +385,7 @@ func TestReconcileGChat_StatusSurfacesGChatState(t *testing.T) {
 	// state must surface there with the generic SyncState shape (no new fields)
 	// once reconciliation enables it — this is what "mirror Gmail's status
 	// shape" means (DD-5): GChat surfaces through the identical generic row.
-	states, err := e.service.GetSyncStatus(e.ctx)
+	states, err := e.syncRepo.ListSyncStates(e.ctx)
 	require.NoError(t, err)
 
 	var found *repository.SyncState

--- a/backend/tests/identity_integration_test.go
+++ b/backend/tests/identity_integration_test.go
@@ -542,7 +542,7 @@ func TestIdentityService_Integration(t *testing.T) {
 		assert.Equal(t, repository.MatchTypeManual, linked.MatchType)
 
 		// Unlink
-		unlinked, err := identityService.UnlinkIdentity(ctx, result.Identity.ID)
+		unlinked, err := identityRepo.UnlinkFromContact(ctx, result.Identity.ID)
 		require.NoError(t, err)
 		assert.Nil(t, unlinked.ContactID)
 		assert.Equal(t, repository.MatchTypeUnmatched, unlinked.MatchType)

--- a/backend/tests/unit/sync_handler_test.go
+++ b/backend/tests/unit/sync_handler_test.go
@@ -71,37 +71,46 @@ func (m *mockSyncService) TriggerSync(ctx context.Context, source string, accoun
 	return nil
 }
 
-func (m *mockSyncService) GetSyncStatus(ctx context.Context) ([]repository.SyncState, error) {
-	return nil, nil
-}
-
-func (m *mockSyncService) GetSyncStateBySource(ctx context.Context, source string, accountID *string) (*repository.SyncState, error) {
-	return nil, nil
-}
-
-func (m *mockSyncService) EnableSync(ctx context.Context, id uuid.UUID, enabled bool) (*repository.SyncState, error) {
-	return nil, nil
-}
-
-func (m *mockSyncService) GetSyncLogs(ctx context.Context, syncStateID uuid.UUID, limit, offset int32) ([]repository.SyncLog, error) {
-	return nil, nil
-}
-
-func (m *mockSyncService) CountSyncLogs(ctx context.Context, syncStateID uuid.UUID) (int64, error) {
-	return 0, nil
-}
-
-func (m *mockSyncService) GetRecentSyncLogs(ctx context.Context, limit int32) ([]repository.SyncLog, error) {
-	return nil, nil
-}
-
 func (m *mockSyncService) GetAvailableProviders() []psync.SourceConfig {
 	return m.availableProviders
 }
 
+// stubSyncStateStore implements handlers.SyncStateStore with no-op returns.
+// This suite only exercises the TriggerSync route, which never reaches the
+// store, so the stub exists solely to satisfy NewSyncHandler's second
+// parameter.
+type stubSyncStateStore struct{}
+
+// Verify stubSyncStateStore implements handlers.SyncStateStore
+var _ handlers.SyncStateStore = (*stubSyncStateStore)(nil)
+
+func (s *stubSyncStateStore) ListSyncStates(ctx context.Context) ([]repository.SyncState, error) {
+	return nil, nil
+}
+
+func (s *stubSyncStateStore) GetSyncStateBySource(ctx context.Context, source string, accountID *string) (*repository.SyncState, error) {
+	return nil, nil
+}
+
+func (s *stubSyncStateStore) UpdateSyncStateEnabled(ctx context.Context, id uuid.UUID, enabled bool) (*repository.SyncState, error) {
+	return nil, nil
+}
+
+func (s *stubSyncStateStore) ListSyncLogsByState(ctx context.Context, stateID uuid.UUID, limit, offset int32) ([]repository.SyncLog, error) {
+	return nil, nil
+}
+
+func (s *stubSyncStateStore) CountSyncLogsByState(ctx context.Context, stateID uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (s *stubSyncStateStore) ListRecentSyncLogs(ctx context.Context, limit int32) ([]repository.SyncLog, error) {
+	return nil, nil
+}
+
 func setupSyncHandlerTestRouter(mockService *mockSyncService) *gin.Engine {
 	// Create handler with mock service
-	handler := handlers.NewSyncHandler(mockService)
+	handler := handlers.NewSyncHandler(mockService, &stubSyncStateStore{})
 
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())


### PR DESCRIPTION
## What

Deletes the 16 strict pass-through service methods (13 across sync/identity, 3 in mac-host) and binds their handlers to repository surfaces: `SyncStateStore` and `MacHostStore` interfaces whose signatures mirror the actual repository methods, plus the identity handler holding `IdentityRepository` directly. `GetSyncState` is deleted without replacement (dead code; every caller resolves to the repository method). Rewrites the "Never skip layers" rule in `.ai/rules/core.md` to "a layer exists where it earns its keep" and aligns the architecture guide, backend patterns, and feature issue template. No behavior change; spec/ and `backend/AGENTS.md` untouched (verified empty diff).

## Test coverage added

`backend/tests/api/identity_routes_test.go` — first handler-level coverage of the five identity routes that now bind to the repository, with discriminating assertions (the unlink subtest asserts `contact_id` null on a follow-up GET while the row survives).

## Falsification record

- Defect injected: `identityRepo.UnlinkFromContact` → `identityRepo.GetByID` (signature-identical rebind) in `handlers/identity.go`. Command: `INTEGRATION_RUN='SyncHandler|TestIdentity|GchatEnablement|TestWireGolden|TestKnowledgeRouteAbsence' make test-integration-fast`. Observed: exit 2, `TestIdentityRoutes/unlink` failed on `Expected nil` for `contact_id`. Reverted; lane re-run green (exit 0). The mutant was found live in the working tree during acceptance — the test caught a real wrong-but-compatible rebind before it shipped.
- The plan's `MacHost` unit regex matched no handler-package test name (vacuous); substituted `RotateKey|Heartbeat`, which runs the tests that exercise the rewired heartbeat path. The tagged `INTEGRATION_RUN='MacHost|TestRunListHosts|TestIdentityRoutes'` lane ran the mac-host API suite and crm-admin hostLister tests non-vacuously (all pass).

## Rule-5 audit (one-time, per Proportionality)

`grep -rn "db\.Queries\|db\.Querier" backend/internal/api/handlers/*.go` → no hits. Handlers importing `internal/db` for the `db.ErrNotFound` sentinel are the prescribed idiom, not violations.

## Fixture note

The new route test seeds via repository methods rather than the synthetic harness: `NewHarnessForNamespace` starts a live River client, disproportionate for a five-subtest route test seeding two contacts. No raw SQL.

## Review trail

Element reviews: E1 PASS (0 findings), E2 PASS (1 P3 — plan-doc arithmetic, fixed in the plan). PR-level Codex round: 2 P1 / 1 P2 / 1 P3, all addressed in 671750e8 (doc alignment, comment scrub, corrected acceptance regex). Native gate review of 671750e8: PASS, 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyBhn6w1rKWLDYMLijKGZt