### PR TITLE
feat(imports): combined Gmail source filter on the People tab

### DIFF
--- a/backend/internal/api/handlers/import_routes_test.go
+++ b/backend/internal/api/handlers/import_routes_test.go
@@ -28,6 +28,9 @@ func (emptySuggestionDeps) GetByID(ctx context.Context, id uuid.UUID) (*reposito
 func (emptySuggestionDeps) ListUnmatched(ctx context.Context, source string, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error) {
 	return nil, nil
 }
+func (emptySuggestionDeps) ListUnmatchedBySources(ctx context.Context, sources []string, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error) {
+	return nil, nil
+}
 func (emptySuggestionDeps) ListAllUnmatched(ctx context.Context, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error) {
 	return nil, nil
 }

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -1330,6 +1330,93 @@ func (q *Queries) ListUnmatchedExternalContacts(ctx context.Context, arg ListUnm
 	return items, nil
 }
 
+const ListUnmatchedExternalContactsBySources = `-- name: ListUnmatchedExternalContactsBySources :many
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at, host_id, last_content_hash, pending_method_suggestions, dismissed_method_suggestions FROM external_contact
+WHERE source = ANY($1::text[])
+  AND source != 'anarlog_title'
+  AND match_status = 'unmatched'
+  AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
+  AND (
+    $2::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
+ORDER BY display_name
+LIMIT $4 OFFSET $3
+`
+
+type ListUnmatchedExternalContactsBySourcesParams struct {
+	Sources                   []string `json:"sources"`
+	IncludeUnresolvedTelegram bool     `json:"include_unresolved_telegram"`
+	PageOffset                int32    `json:"page_offset"`
+	PageLimit                 int32    `json:"page_limit"`
+}
+
+// Multi-source variant of ListUnmatchedExternalContacts for combined UI
+// filters (a filter value that groups several real sources, e.g. the two
+// Gmail discovery sources). Same anarlog_title defense and unresolved-
+// telegram gate as the single-source query.
+func (q *Queries) ListUnmatchedExternalContactsBySources(ctx context.Context, arg ListUnmatchedExternalContactsBySourcesParams) ([]*ExternalContact, error) {
+	rows, err := q.db.Query(ctx, ListUnmatchedExternalContactsBySources,
+		arg.Sources,
+		arg.IncludeUnresolvedTelegram,
+		arg.PageOffset,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ExternalContact{}
+	for rows.Next() {
+		var i ExternalContact
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.SourceID,
+			&i.AccountID,
+			&i.DisplayName,
+			&i.FirstName,
+			&i.LastName,
+			&i.Emails,
+			&i.Phones,
+			&i.Addresses,
+			&i.Organization,
+			&i.JobTitle,
+			&i.Birthday,
+			&i.PhotoUrl,
+			&i.CrmContactID,
+			&i.MatchStatus,
+			&i.DuplicateOfID,
+			&i.Etag,
+			&i.Metadata,
+			&i.SyncedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.HostID,
+			&i.LastContentHash,
+			&i.PendingMethodSuggestions,
+			&i.DismissedMethodSuggestions,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const MarkAnarlogTitleSiblingsIgnoredByToken = `-- name: MarkAnarlogTitleSiblingsIgnoredByToken :exec
 UPDATE external_contact SET
     match_status = 'ignored',

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1435,6 +1435,11 @@ type Querier interface {
 	// injection), this query returns empty rather than leaking weak
 	// discovery rows into the per-source UI.
 	ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error)
+	// Multi-source variant of ListUnmatchedExternalContacts for combined UI
+	// filters (a filter value that groups several real sources, e.g. the two
+	// Gmail discovery sources). Same anarlog_title defense and unresolved-
+	// telegram gate as the single-source query.
+	ListUnmatchedExternalContactsBySources(ctx context.Context, arg ListUnmatchedExternalContactsBySourcesParams) ([]*ExternalContact, error)
 	ListUnmatchedIdentities(ctx context.Context, arg ListUnmatchedIdentitiesParams) ([]*ExternalIdentity, error)
 	// Eligible rows for a contact within one source. Orders by thread_id then
 	// sent_at — thread_id carries the chat scope, mirroring messages' ORDER BY

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -168,6 +168,32 @@ WHERE source = sqlc.arg('source')
 ORDER BY display_name
 LIMIT sqlc.arg('page_limit') OFFSET sqlc.arg('page_offset');
 
+-- name: ListUnmatchedExternalContactsBySources :many
+-- Multi-source variant of ListUnmatchedExternalContacts for combined UI
+-- filters (a filter value that groups several real sources, e.g. the two
+-- Gmail discovery sources). Same anarlog_title defense and unresolved-
+-- telegram gate as the single-source query.
+SELECT * FROM external_contact
+WHERE source = ANY(sqlc.arg('sources')::text[])
+  AND source != 'anarlog_title'
+  AND match_status = 'unmatched'
+  AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
+  AND (
+    sqlc.arg('include_unresolved_telegram')::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
+ORDER BY display_name
+LIMIT sqlc.arg('page_limit') OFFSET sqlc.arg('page_offset');
+
 -- name: ListAllUnmatchedExternalContacts :many
 SELECT * FROM external_contact
 WHERE match_status = 'unmatched'

--- a/backend/internal/repository/external_contact.go
+++ b/backend/internal/repository/external_contact.go
@@ -599,6 +599,31 @@ func (r *ExternalContactRepository) ListUnmatched(ctx context.Context, source st
 	return contacts, nil
 }
 
+// ListUnmatchedBySources returns unmatched candidates whose source is any of
+// the given set — the read behind combined UI filter values that group
+// several real sources (e.g. the Gmail pair).
+func (r *ExternalContactRepository) ListUnmatchedBySources(ctx context.Context, sources []string, limit, offset int32, includeUnresolvedTelegram bool) ([]ExternalContact, error) {
+	dbContacts, err := r.queries.ListUnmatchedExternalContactsBySources(ctx, db.ListUnmatchedExternalContactsBySourcesParams{
+		Sources:                   sources,
+		IncludeUnresolvedTelegram: includeUnresolvedTelegram,
+		PageLimit:                 limit,
+		PageOffset:                offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	contacts := make([]ExternalContact, 0, len(dbContacts))
+	for _, dbContact := range dbContacts {
+		contact, err := convertDbExternalContact(dbContact)
+		if err != nil {
+			continue
+		}
+		contacts = append(contacts, *contact)
+	}
+	return contacts, nil
+}
+
 // ListAllUnmatched returns all unmatched external contacts across sources.
 func (r *ExternalContactRepository) ListAllUnmatched(ctx context.Context, limit, offset int32, includeUnresolvedTelegram bool) ([]ExternalContact, error) {
 	dbContacts, err := r.queries.ListAllUnmatchedExternalContacts(ctx, db.ListAllUnmatchedExternalContactsParams{

--- a/backend/internal/service/import_suggestions.go
+++ b/backend/internal/service/import_suggestions.go
@@ -58,6 +58,15 @@ func IsLinkOnlySource(source string) bool {
 	return linkOnlySources[source]
 }
 
+// sourceFilterGroups maps virtual UI filter values to the set of real
+// sources they cover. "gmail" combines the two Gmail discovery sources
+// (link-only correspondence + trust-anchored participant) so the imports
+// queue can filter all mail-derived candidates at once. A virtual value
+// never collides with a real source tag.
+var sourceFilterGroups = map[string][]string{
+	"gmail": {"gmail_correspondence", "gmail_participant"},
+}
+
 // CandidateWithMatch pairs an unmatched external_contact with its
 // pre-computed suggested match, in the confidence-sorted order the
 // candidate surface renders. Both the existing /imports/candidates handler
@@ -125,6 +134,7 @@ type DismissResult struct {
 type suggestionExternalRepo interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*repository.ExternalContact, error)
 	ListUnmatched(ctx context.Context, source string, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error)
+	ListUnmatchedBySources(ctx context.Context, sources []string, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error)
 	ListAllUnmatched(ctx context.Context, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error)
 	CountHiddenUnresolvedTelegram(ctx context.Context, source string) (int64, error)
 	ListPendingMethodSuggestionRows(ctx context.Context, sourceFilter string) ([]repository.PendingMethodSuggestionRow, error)
@@ -205,7 +215,9 @@ func NewSuggestionService(
 func (s *SuggestionService) BuildSortedCandidates(ctx context.Context, source string, maxCandidates int32, includeUnresolvedTelegram bool) ([]CandidateWithMatch, error) {
 	var contacts []repository.ExternalContact
 	var err error
-	if source != "" {
+	if sources, ok := sourceFilterGroups[source]; ok {
+		contacts, err = s.externalRepo.ListUnmatchedBySources(ctx, sources, maxCandidates, 0, includeUnresolvedTelegram)
+	} else if source != "" {
 		contacts, err = s.externalRepo.ListUnmatched(ctx, source, maxCandidates, 0, includeUnresolvedTelegram)
 	} else {
 		contacts, err = s.externalRepo.ListAllUnmatched(ctx, maxCandidates, 0, includeUnresolvedTelegram)

--- a/backend/tests/api/import_participant_actions_test.go
+++ b/backend/tests/api/import_participant_actions_test.go
@@ -240,3 +240,38 @@ func TestParticipantCandidate_ImportWithoutNameRejected(t *testing.T) {
 	assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
 	assert.Equal(t, "Cannot import contact without a name", response.Error.Message)
 }
+
+// The combined "gmail" filter value covers BOTH Gmail discovery sources —
+// the link-only correspondence rows and the trust-anchored participant rows
+// — and nothing else. The isolated database clone makes the absence
+// assertion deterministic (no other test's rows exist here).
+func TestSuggestions_GmailCombinedFilter(t *testing.T) {
+	t.Parallel()
+	router, database, ctx, _ := newParticipantTestRouter(t)
+
+	participantWorld, err := declare.Run(ctx, database, "IMP-048", declaredAPINS(t), factory.DefaultSeed)
+	require.NoError(t, err)
+	participantID := participantWorld.Entities["participant"].ID
+
+	correspondenceWorld, err := declare.Run(ctx, database, "IMP-037", declaredAPINS(t), factory.DefaultSeed)
+	require.NoError(t, err)
+	correspondenceID := correspondenceWorld.Entities["corr"].ID
+
+	gcontactsWorld, err := declare.Run(ctx, database, "IMP-007", declaredAPINS(t), factory.DefaultSeed)
+	require.NoError(t, err)
+	gcontactsID := gcontactsWorld.Entities["cand"].ID
+
+	gmailItems, _ := getSuggestions(t, router, "source=gmail&limit=10000")
+	assert.GreaterOrEqual(t, findSuggestionItemIndex(gmailItems, "contact", participantID), 0,
+		"gmail filter must include the gmail_participant candidate")
+	assert.GreaterOrEqual(t, findSuggestionItemIndex(gmailItems, "contact", correspondenceID), 0,
+		"gmail filter must include the gmail_correspondence candidate")
+	assert.Equal(t, -1, findSuggestionItemIndex(gmailItems, "contact", gcontactsID),
+		"gmail filter must exclude non-gmail sources")
+
+	gcItems, _ := getSuggestions(t, router, "source=gcontacts&limit=10000")
+	assert.GreaterOrEqual(t, findSuggestionItemIndex(gcItems, "contact", gcontactsID), 0,
+		"single-source filtering is unchanged by the group mechanism")
+	assert.Equal(t, -1, findSuggestionItemIndex(gcItems, "contact", participantID),
+		"a real-source filter must not leak group members")
+}

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -62,6 +62,7 @@ const SOURCE_FILTERS = [
   { value: 'gcontacts', label: 'Google Contacts' },
   { value: 'gcal_attendee', label: 'Calendar' },
   { value: 'icloud_contacts', label: 'iCloud Contacts' },
+  { value: 'gmail', label: 'Gmail' },
   { value: 'telegram', label: 'Telegram' },
   { value: 'whatsapp', label: 'WhatsApp' },
   { value: 'anarlog_humans', label: 'Anarlog' },

--- a/frontend/tests/e2e/imports-participant.spec.ts
+++ b/frontend/tests/e2e/imports-participant.spec.ts
@@ -5,6 +5,7 @@ import {
   candidateCardByName,
   expectModalCandidate,
   findCandidateByName,
+  findCandidateByNameNoReload,
   resolverDialog,
 } from './helpers/imports-helpers'
 
@@ -245,5 +246,39 @@ test.describe('Imports gmail_participant @area:imports', () => {
       card.getByText(`${messageCount} ${messageCount === 1 ? 'message' : 'messages'}`)
     ).toBeVisible()
     await expect(card.getByText(/Last: [A-Za-z]{3} \d{1,2}, \d{4}/)).toBeVisible()
+  })
+
+  test('the combined Gmail filter surfaces both Gmail sources', async ({ page }) => {
+    const participantWorld = await testApi.seedBehavior('IMP-048')
+    const participantName = participantWorld.entities['participant'].name
+    const correspondenceWorld = await testApi.seedBehavior('IMP-037')
+    const correspondenceName = correspondenceWorld.entities['corr'].name
+
+    await page.goto('/imports')
+    // The pill drives a server-side source-group filter; a fresh request
+    // always fires because the filter changes the query key. Exclusion
+    // semantics (non-gmail sources filtered out, single-source filters
+    // unchanged) are pinned deterministically by the API integration test —
+    // this test proves the UI wiring sends the COMBINED virtual value and
+    // renders rows from BOTH member sources. The param is parsed exactly:
+    // a substring check would also match a broken single-source value like
+    // source=gmail_participant, passing while correspondence rows vanish.
+    const filtered = page.waitForResponse(
+      res =>
+        res.request().method() === 'GET' &&
+        new URL(res.url()).searchParams.get('source') === 'gmail'
+    )
+    await page.getByRole('button', { name: 'Gmail', exact: true }).click()
+    await filtered
+    await expect(page.getByRole('button', { name: 'Gmail', exact: true })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    // No-reload walks: the source filter is client state, and
+    // findCandidateByName's reload recovery would silently reset it to All —
+    // the walk would then "find" the cards under no filter at all. One card
+    // from EACH Gmail source proves the group, not just a member.
+    await findCandidateByNameNoReload(page, participantName)
+    await findCandidateByNameNoReload(page, correspondenceName)
   })
 })


### PR DESCRIPTION
Follow-up to #813 (user-requested): the People tab had no way to filter to Gmail-derived candidates — neither `gmail_correspondence` (a pre-existing gap) nor the new `gmail_participant` appeared in the source filter, so mail-discovered cards were findable only under "All".

## What

One combined **Gmail** filter pill covering both Gmail discovery sources, per the user's ruling (single filter, not two entries).

- Service-level `sourceFilterGroups` maps the virtual filter value `gmail` → `{gmail_correspondence, gmail_participant}`; a new `ListUnmatchedExternalContactsBySources` sqlc query (`source = ANY(...)`, same anarlog defense + unresolved-telegram gate as the single-source query) + repository wrapper serve the group. Real single-source filters are untouched; the method-suggestion group correctly renders empty under the Gmail filter (address-book-scoped); the hidden-unresolved-telegram count correctly reads zero.
- Frontend: `{ value: 'gmail', label: 'Gmail' }` in `SOURCE_FILTERS`.

## Verification

- API integration test `TestSuggestions_GmailCombinedFilter` (isolated DB clone, so exclusion assertions are deterministic): gmail filter includes both Gmail sources and excludes gcontacts; single-source filtering unchanged.
- E2E (`imports-participant.spec.ts`, run live): pill click → `source=gmail` request → seeded participant card found via the no-reload paging walk (the filter is client state; the reloading walk would silently reset it to All — noted in the test).
- Full pre-push gates green (lint, unit, integration, frontend, E2E-diff).

## Ephemeral second-order proof (reverted, nothing committed)

Emptied the `sourceFilterGroups` map (grep-confirmed the mutant landed) → `make test-integration INTEGRATION_RUN='TestSuggestions_GmailCombinedFilter'` exit 2, `--- FAIL: TestSuggestions_GmailCombinedFilter`; reverted (grep count 0), re-run green.

No spec change: IMP-026's "source filters" then-item stays true as written; filter-list membership is not per-source spec'd (matching whatsapp/anarlog precedent).