### PR TITLE
fix(aggregation): scope comms claim and event keys per contact

### DIFF
--- a/backend/cmd/crm-api/whatsapp_wiring_test.go
+++ b/backend/cmd/crm-api/whatsapp_wiring_test.go
@@ -172,7 +172,7 @@ func TestWhatsAppWiring_ProductionRegistriesDispatchWhatsApp(t *testing.T) {
 	require.NotNil(t, engine, "site 6: no ChatAwareAggregator registered for whatsapp")
 	require.NoError(t, engine.AggregateForContact(ctx, fx.contactID, fx.chatC))
 
-	wantRefC := repository.InteractionSourceWhatsApp + ":" + fx.chatC + ":" + fx.firstC
+	wantRefC := repository.InteractionSourceWhatsApp + ":" + fx.chatC + ":" + fx.firstC + ":" + fx.contactID.String()
 	envC, err := chain.eventRepo.FindEventBySource(ctx, repository.InteractionSourceWhatsApp, wantRefC)
 	require.NoError(t, err, "sites 3+6: the whatsapp engine published no event for %s", wantRefC)
 	require.NotNil(t, envC)
@@ -249,7 +249,7 @@ func TestWhatsAppWiring_ProductionRegistriesDispatchWhatsApp(t *testing.T) {
 	envD := envelopeWithPeerRef(t, repository.InteractionSourceWhatsApp+":"+fx.chatD)
 	require.NoError(t, reenqueuer.Reenqueue(ctx, envD, fx.contactID))
 
-	wantRefD := repository.InteractionSourceWhatsApp + ":" + fx.chatD + ":" + fx.firstD
+	wantRefD := repository.InteractionSourceWhatsApp + ":" + fx.chatD + ":" + fx.firstD + ":" + fx.contactID.String()
 	envDOut, err := chain.eventRepo.FindEventBySource(ctx, repository.InteractionSourceWhatsApp, wantRefD)
 	require.NoError(t, err, "site 4: the whatsapp reenqueuer aggregated nothing for %s", wantRefD)
 	require.NotNil(t, envDOut)

--- a/backend/internal/messaging/aggregation/engine.go
+++ b/backend/internal/messaging/aggregation/engine.go
@@ -338,8 +338,9 @@ func (e *Engine) createInteractionForSession(ctx context.Context, contactID uuid
 		return fmt.Errorf("aggregation: cutover wiring requires publisher; refusing to drop interaction (mode=off/shadow is post-cutover broken per spec §3.9)")
 	}
 	sourceRef := sess.sourceRef(e.adapter)
+	key := claimKey(sourceRef, contactID)
 	desc := sess.description(e.adapter)
-	env, err := e.buildEnvelope(contactID, sess, sourceRef, &desc)
+	env, err := e.buildEnvelope(contactID, sess, sourceRef, key, &desc)
 	if err != nil {
 		return err
 	}
@@ -357,12 +358,12 @@ func (e *Engine) createInteractionForSession(ctx context.Context, contactID uuid
 	}
 
 	// Gate 2: recovery pass. Any row whose ClaimedSessionRef matches
-	// the just-computed sourceRef tells us the session was previously
+	// the just-computed claim key tells us the session was previously
 	// claimed but Stage 3 never completed. Look up the existing event
 	// and re-enqueue a consumer job — re-publishing would be
 	// dedup-rejected by the event-log unique index.
-	if sess.isStaleRecovery(sourceRef) {
-		return e.handleStaleRecovery(ctx, sess, sourceRef)
+	if sess.isStaleRecovery(key) {
+		return e.handleStaleRecovery(ctx, sess, key)
 	}
 
 	// Gates 1 + 3: open one tx that wraps both the boundary-shift
@@ -373,7 +374,7 @@ func (e *Engine) createInteractionForSession(ctx context.Context, contactID uuid
 	// so an uncommitted-clear-then-failed-claim window would let the
 	// stale consumer mark the rows under the old interaction.
 	requested := sess.messageIDs()
-	staleRefs := sess.staleBoundaryShiftRefs(sourceRef)
+	staleRefs := sess.staleBoundaryShiftRefs(key)
 
 	tx, err := e.txBeginner.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
@@ -396,7 +397,7 @@ func (e *Engine) createInteractionForSession(ctx context.Context, contactID uuid
 	}
 
 	// Gate 1: conditional claim against the (possibly just-cleared) rows.
-	claimed, err := e.store.ClaimRowsTx(ctx, tx, requested, sourceRef)
+	claimed, err := e.store.ClaimRowsTx(ctx, tx, requested, key)
 	if err != nil {
 		return fmt.Errorf("aggregation: claim rows: %w", err)
 	}
@@ -406,7 +407,7 @@ func (e *Engine) createInteractionForSession(ctx context.Context, contactID uuid
 		// eligible.
 		log.Info().
 			Str("source", e.adapter.SourceName()).
-			Str("source_ref", sourceRef).
+			Str("claim_key", key).
 			Int("requested", len(requested)).
 			Int("claimed", len(claimed)).
 			Msg("aggregation: partial claim; rolling back and yielding to racing worker")
@@ -423,19 +424,19 @@ func (e *Engine) createInteractionForSession(ctx context.Context, contactID uuid
 }
 
 // handleStaleRecovery is taken when the session's rows show a prior
-// claim for the same sourceRef. Per spec §3, do NOT re-publish (event-
+// claim for the same claim key. Per spec §3, do NOT re-publish (event-
 // log dedup would suppress); look up the existing event and re-enqueue
 // a consumer job against it. The recovery enqueue is bounded by River
 // UniqueOpts so repeated stale passes coalesce into one in-flight job.
-func (e *Engine) handleStaleRecovery(ctx context.Context, sess msgSession, sourceRef string) error {
+func (e *Engine) handleStaleRecovery(ctx context.Context, sess msgSession, key string) error {
 	if e.eventLookup == nil || e.consumerEnqueuer == nil {
 		log.Warn().
 			Str("source", e.adapter.SourceName()).
-			Str("source_ref", sourceRef).
+			Str("claim_key", key).
 			Msg("aggregation: stale-claim recovery skipped; lookup/enqueuer not wired")
 		return nil
 	}
-	eventID, found, err := e.eventLookup.FindEventBySourceRef(ctx, e.adapter.SourceName(), sourceRef)
+	eventID, found, err := e.eventLookup.FindEventBySourceRef(ctx, e.adapter.SourceName(), key)
 	if err != nil {
 		return fmt.Errorf("aggregation: event lookup for stale-claim recovery: %w", err)
 	}
@@ -443,11 +444,11 @@ func (e *Engine) handleStaleRecovery(ctx context.Context, sess msgSession, sourc
 		// Spec §3 defensive: claim_session_ref exists but no event
 		// matches. Treat as unclaimed — clear the stale claim columns
 		// and let the next pass re-publish.
-		return e.clearStaleClaimAndYield(ctx, sess, sourceRef)
+		return e.clearStaleClaimAndYield(ctx, sess, key)
 	}
 	log.Warn().
 		Str("source", e.adapter.SourceName()).
-		Str("source_ref", sourceRef).
+		Str("claim_key", key).
 		Str("event_id", eventID.String()).
 		Msg("aggregation: stale-claim recovery — re-enqueuing consumer job")
 	if err := e.consumerEnqueuer.EnqueueInteractionRecorderJob(ctx, eventID); err != nil {
@@ -457,17 +458,17 @@ func (e *Engine) handleStaleRecovery(ctx context.Context, sess msgSession, sourc
 }
 
 // clearStaleClaimAndYield clears the claim columns for rows whose
-// ClaimedSessionRef still equals the supplied stale ref. Used by the
+// ClaimedSessionRef still equals the supplied stale key. Used by the
 // defensive recovery branch (FindEventBySource returned no row). The
 // next aggregator pass will see rows as unclaimed and proceed normally.
-func (e *Engine) clearStaleClaimAndYield(ctx context.Context, sess msgSession, staleRef string) error {
+func (e *Engine) clearStaleClaimAndYield(ctx context.Context, sess msgSession, staleKey string) error {
 	tx, err := e.txBeginner.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("aggregation: begin tx for stale-claim clear: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if err := e.store.ClearStaleClaimTx(ctx, tx, sess.messageIDs(), staleRef); err != nil {
+	if err := e.store.ClearStaleClaimTx(ctx, tx, sess.messageIDs(), staleKey); err != nil {
 		return fmt.Errorf("aggregation: clear stale claim: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -486,11 +487,17 @@ func (e *Engine) clearStaleClaimAndYield(ctx context.Context, sess msgSession, s
 //   - outbound session → KindMessageSent (Direction="")
 //   - mutual session   → KindMessageReceived (Direction="mutual")
 //
-// SourceID = sourceRef so publisher-idempotency dedupes retries.
+// SourceID = eventKey (the contact-scoped claim key, not sourceRef) so
+// publisher-idempotency dedupes retries per contact rather than
+// colliding across every contact fanned into the same chat message.
+// The payload's ExternalMessageID stays sourceRef — interaction dedup
+// keys off (contact_id, source, source_ref), which is already
+// contact-scoped via contact_id, so that string must not change here.
 func (e *Engine) buildEnvelope(
 	contactID uuid.UUID,
 	sess msgSession,
 	sourceRef string,
+	eventKey string,
 	description *string,
 ) (*events.Envelope, error) {
 	cid := contactID
@@ -548,11 +555,25 @@ func (e *Engine) buildEnvelope(
 
 	return &events.Envelope{
 		Source:     e.adapter.SourceName(),
-		SourceID:   sourceRef,
+		SourceID:   eventKey,
 		Kind:       kind,
 		Payload:    raw,
 		ObservedAt: messageAt,
 	}, nil
+}
+
+// claimKey scopes the aggregation claim + event-log identity to the
+// contact being aggregated. sourceRef alone is shared by every contact
+// a message fans out to (e.g. every matched member of a group chat),
+// so using it bare as comms_message.claimed_session_ref / event.source_id
+// collides: the first contact to aggregate wins the claim and the event,
+// and every other contact's claim commits with no event to record an
+// interaction against. Appending the contact id splits the claim/event
+// identity per contact while leaving interaction.source_ref (still
+// sourceRef, via the payload's ExternalMessageID) untouched — its dedup
+// index is already (contact_id, source, source_ref)-scoped.
+func claimKey(sourceRef string, contactID uuid.UUID) string {
+	return sourceRef + ":" + contactID.String()
 }
 
 // sameIDSet reports whether a and b contain the same UUIDs

--- a/backend/internal/messaging/aggregation/engine_test.go
+++ b/backend/internal/messaging/aggregation/engine_test.go
@@ -75,6 +75,7 @@ type fakeStore struct {
 	markProcessedCalls    []markProcessedCall
 	markProcessedTxCalls  []markProcessedTxCall
 	clearStaleClaimCalls  []clearStaleClaimCall
+	claimRowsTxCalls      []claimRowsTxCall
 
 	// listUnprocessedByContactErr controls injection points for negative tests.
 	listUnprocessedByContactErr error
@@ -100,6 +101,11 @@ type markProcessedTxCall struct {
 type clearStaleClaimCall struct {
 	messageIDs         []uuid.UUID
 	expectedSessionRef string
+}
+
+type claimRowsTxCall struct {
+	messageIDs []uuid.UUID
+	sessionRef string
 }
 
 func newFakeStore() *fakeStore {
@@ -140,7 +146,13 @@ func (s *fakeStore) MarkProcessed(_ context.Context, messageIDs []uuid.UUID, int
 
 // ClaimRowsTx default: full claim success (returns the requested IDs).
 // Tests can override by replacing the field below or wrapping the store.
-func (s *fakeStore) ClaimRowsTx(_ context.Context, _ pgx.Tx, messageIDs []uuid.UUID, _ string) ([]uuid.UUID, error) {
+// The sessionRef argument is captured so tests can assert the engine
+// derived the contact-scoped claim key correctly.
+func (s *fakeStore) ClaimRowsTx(_ context.Context, _ pgx.Tx, messageIDs []uuid.UUID, sessionRef string) ([]uuid.UUID, error) {
+	s.claimRowsTxCalls = append(s.claimRowsTxCalls, claimRowsTxCall{
+		messageIDs: append([]uuid.UUID(nil), messageIDs...),
+		sessionRef: sessionRef,
+	})
 	if s.claimRowsTxErr != nil {
 		return nil, s.claimRowsTxErr
 	}
@@ -540,7 +552,7 @@ func TestEngine_FakeSource_AggregateForContactBatch_CreatesEvents(t *testing.T) 
 	require.Len(t, publisher.envelopes, 1)
 	env := publisher.envelopes[0]
 	assert.Equal(t, "fakesrc", env.Source)
-	assert.Equal(t, "fakesrc:chatA:m1", env.SourceID)
+	assert.Equal(t, "fakesrc:chatA:m1:"+contactID.String(), env.SourceID)
 	assert.Equal(t, events.KindMessageReceived, env.Kind)
 }
 
@@ -769,7 +781,7 @@ func TestEngine_FakeSource_NoMatch_PublishesCreateEvent(t *testing.T) {
 	require.Len(t, publisher.envelopes, 1)
 	assert.Equal(t, events.KindMessageReceived, publisher.envelopes[0].Kind)
 	assert.Equal(t, "fakesrc", publisher.envelopes[0].Source)
-	assert.Equal(t, "fakesrc:chatA:i1", publisher.envelopes[0].SourceID)
+	assert.Equal(t, "fakesrc:chatA:i1:"+contactID.String(), publisher.envelopes[0].SourceID)
 	// No staging-row mark — the consumer's tx does that in the create path.
 	assert.Empty(t, store.markProcessedCalls)
 }
@@ -820,7 +832,7 @@ func TestEngine_TelegramShape_SourceRefMatchesLegacyFormat(t *testing.T) {
 
 	require.NoError(t, engine.AggregateForContactBatch(ctx, contactID))
 	require.Len(t, publisher.envelopes, 1)
-	assert.Equal(t, "tg:12345:50001", publisher.envelopes[0].SourceID)
+	assert.Equal(t, "tg:12345:50001:"+contactID.String(), publisher.envelopes[0].SourceID)
 	assert.Equal(t, repository.InteractionSourceTelegram, publisher.envelopes[0].Source)
 }
 
@@ -1063,9 +1075,9 @@ func TestEngine_ClaimPath_PartialClaimRollsBack(t *testing.T) {
 
 // TestEngine_StaleRecovery_LooksUpEventAndEnqueues exercises gate 2:
 // when at least one row's ClaimedSessionRef matches the computed
-// sourceRef, the engine consults EventLookup and (on hit) enqueues an
-// InteractionRecorder job via ConsumerJobEnqueuer — without publishing
-// a duplicate event.
+// contact-scoped claim key, the engine consults EventLookup and (on
+// hit) enqueues an InteractionRecorder job via ConsumerJobEnqueuer —
+// without publishing a duplicate event.
 func TestEngine_StaleRecovery_LooksUpEventAndEnqueues(t *testing.T) {
 	ctx := context.Background()
 	base := accelerated.GetCurrentTime()
@@ -1074,8 +1086,9 @@ func TestEngine_StaleRecovery_LooksUpEventAndEnqueues(t *testing.T) {
 
 	adapter := fakeAdapter{name: "fakesrc"}
 	store := newFakeStore()
-	// SourceRef the adapter will compute for this session: "fakesrc:chatA:m1".
-	staleRef := "fakesrc:chatA:m1"
+	// The claim key the engine will compute for this session+contact:
+	// sourceRef ("fakesrc:chatA:m1") + ":" + contactID.
+	staleRef := "fakesrc:chatA:m1:" + contactID.String()
 	staleTime := base.Add(-10 * time.Minute)
 	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{
 		{
@@ -1113,7 +1126,9 @@ func TestEngine_StaleRecovery_NoEventClearsClaim(t *testing.T) {
 
 	adapter := fakeAdapter{name: "fakesrc"}
 	store := newFakeStore()
-	staleRef := "fakesrc:chatA:m1"
+	// The claim key the engine will compute for this session+contact:
+	// sourceRef ("fakesrc:chatA:m1") + ":" + contactID.
+	staleRef := "fakesrc:chatA:m1:" + contactID.String()
 	staleTime := base.Add(-10 * time.Minute)
 	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{
 		{
@@ -1163,6 +1178,109 @@ func TestEngine_NoTxBeginnerFallsBackToNonTxPublish(t *testing.T) {
 	engine := NewEngine(adapter, store, finder, &fakePromoter{}, &fakeExtender{}, publisher, 2, 48, nil, nil, nil)
 	require.NoError(t, engine.AggregateForContact(ctx, contactID, "chatA"))
 	require.Len(t, publisher.envelopes, 1, "non-tx Publish path produced one envelope")
+}
+
+// TestCreateInteractionForSession_ClaimAndEventKeyAreContactScoped is the
+// direct regression test for the fanned-out collision: two different
+// contacts aggregating the identical (chatID, firstExternalID) session
+// share the same sourceRef but must NOT collide on claim or event
+// identity. Asserts the exact key format (sourceRef + ":" +
+// contactID.String()) rather than mere inequality — an implementation
+// that derives the key from contactID alone (dropping sourceRef) would
+// pass an inequality check here while still colliding two different
+// sessions of the SAME contact on the event unique key.
+func TestCreateInteractionForSession_ClaimAndEventKeyAreContactScoped(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactA := uuid.New()
+	contactB := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	publisher := &fakePublisher{}
+	beginner := &fakeTxBeginner{}
+
+	sourceRef := adapter.SourceRef("chatA", "m1")
+	sess := msgSession{
+		direction:       repository.InteractionDirectionInbound,
+		chatID:          "chatA",
+		firstExternalID: "m1",
+		messages: []Message{
+			{ID: uuid.New(), ChatID: "chatA", ExternalID: "m1", IsOutgoing: false, SentAt: base},
+		},
+	}
+
+	engine := NewEngine(adapter, store, &fakeFinder{}, &fakePromoter{}, &fakeExtender{}, publisher, 2, 48, beginner, nil, nil)
+
+	require.NoError(t, engine.createInteractionForSession(ctx, contactA, sess))
+	require.NoError(t, engine.createInteractionForSession(ctx, contactB, sess))
+
+	wantKeyA := sourceRef + ":" + contactA.String()
+	wantKeyB := sourceRef + ":" + contactB.String()
+
+	require.Len(t, store.claimRowsTxCalls, 2)
+	assert.Equal(t, wantKeyA, store.claimRowsTxCalls[0].sessionRef)
+	assert.Equal(t, wantKeyB, store.claimRowsTxCalls[1].sessionRef)
+
+	require.Len(t, publisher.envelopes, 2)
+	assert.Equal(t, wantKeyA, publisher.envelopes[0].SourceID)
+	assert.Equal(t, wantKeyB, publisher.envelopes[1].SourceID)
+
+	var payloadA, payloadB events.MessageReceivedPayload
+	require.NoError(t, events.Unmarshal(&publisher.envelopes[0], &payloadA))
+	require.NoError(t, events.Unmarshal(&publisher.envelopes[1], &payloadB))
+	assert.Equal(t, sourceRef, payloadA.ExternalMessageID, "interaction.source_ref stays contact-free")
+	assert.Equal(t, sourceRef, payloadB.ExternalMessageID, "interaction.source_ref stays contact-free")
+}
+
+// TestCreateInteractionForSession_ContactFreeClaimIsBoundaryShift proves
+// the backlog self-heals: a staging row still carrying the pre-fix
+// contact-free claimed_session_ref must be read as a boundary-shift (the
+// old claim is cleared and the rows re-claimed under the new
+// contact-scoped key), not as stale-recovery for a completed session —
+// which would look up an event, find none matching, and yield without
+// publishing, leaving the row stranded forever.
+func TestCreateInteractionForSession_ContactFreeClaimIsBoundaryShift(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	publisher := &fakePublisher{}
+	beginner := &fakeTxBeginner{}
+	lookup := &fakeEventLookup{}        // must not be consulted
+	enqueuer := &fakeConsumerEnqueuer{} // must not be called
+
+	sourceRef := adapter.SourceRef("chatA", "m1")
+	staleTime := base.Add(-10 * time.Minute)
+	sess := msgSession{
+		direction:       repository.InteractionDirectionInbound,
+		chatID:          "chatA",
+		firstExternalID: "m1",
+		messages: []Message{
+			{
+				ID: uuid.New(), ChatID: "chatA", ExternalID: "m1", IsOutgoing: false, SentAt: base,
+				ClaimedAt: &staleTime, ClaimedSessionRef: &sourceRef, // pre-fix, contact-free claim
+			},
+		},
+	}
+
+	engine := NewEngine(adapter, store, &fakeFinder{}, &fakePromoter{}, &fakeExtender{}, publisher, 2, 48, beginner, lookup, enqueuer)
+	require.NoError(t, engine.createInteractionForSession(ctx, contactID, sess))
+
+	assert.Equal(t, 0, lookup.calls, "boundary-shift path must not consult EventLookup")
+	assert.Equal(t, 0, enqueuer.calls, "boundary-shift path must not re-enqueue a recovery job")
+
+	require.Len(t, store.clearStaleClaimCalls, 1)
+	assert.Equal(t, sourceRef, store.clearStaleClaimCalls[0].expectedSessionRef, "clears the OLD contact-free ref")
+
+	wantKey := sourceRef + ":" + contactID.String()
+	require.Len(t, store.claimRowsTxCalls, 1)
+	assert.Equal(t, wantKey, store.claimRowsTxCalls[0].sessionRef, "re-claims under the new contact-scoped key")
+
+	require.Len(t, publisher.envelopes, 1, "publishes a fresh event rather than silently yielding")
+	assert.Equal(t, wantKey, publisher.envelopes[0].SourceID)
 }
 
 // TestSameIDSet covers the partial-claim helper.

--- a/backend/internal/messaging/aggregation/interfaces.go
+++ b/backend/internal/messaging/aggregation/interfaces.go
@@ -26,6 +26,8 @@ import (
 // Race Mechanics). The engine reads these to detect stale-claim
 // recovery / boundary-shift scenarios without re-querying the staging
 // table. Per-source adapters populate them from the underlying row.
+// ClaimedSessionRef holds the contact-scoped claim key (sourceRef +
+// ":" + contactID), not the bare sourceRef — see claimKey in engine.go.
 type Message struct {
 	ID                uuid.UUID
 	ChatID            string     // source-neutral chat scope key (numeric stringified for sources with numeric chat IDs, opaque guid for sources like Apple Messages)
@@ -128,18 +130,22 @@ type MessageStore interface {
 	// ClaimRowsTx writes claimed_at = NOW() and claimed_session_ref =
 	// sessionRef on rows that are STILL eligible at write time
 	// (unprocessed AND unclaimed-or-stale AND not soft-deleted).
-	// Returns the IDs actually claimed; caller MUST compare against the
-	// requested set to detect partial claims and roll back the tx when
-	// the sets differ. Called inside the engine's create-path tx;
-	// commits atomically with the event publish via the same tx.
+	// sessionRef is the engine's contact-scoped claim key (see claimKey
+	// in engine.go), not the bare sourceRef — this is what keeps a
+	// fanned-out message's per-contact staging rows from colliding on
+	// the same claim. Returns the IDs actually claimed; caller MUST
+	// compare against the requested set to detect partial claims and
+	// roll back the tx when the sets differ. Called inside the engine's
+	// create-path tx; commits atomically with the event publish via the
+	// same tx.
 	ClaimRowsTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, sessionRef string) (claimed []uuid.UUID, err error)
 
 	// ClearStaleClaimTx is the recovery-defensive branch. Clears claim
 	// columns for rows whose claimed_session_ref still matches the
-	// expected stale ref but for which no event-log row could be found
-	// (spec §3 defensive case), and for the boundary-shift case (rows
-	// claimed for an older session under a new computed sourceRef).
-	// Called inside a tx opened by the engine.
+	// expected stale claim key but for which no event-log row could be
+	// found (spec §3 defensive case), and for the boundary-shift case
+	// (rows claimed for an older session under a newly computed claim
+	// key). Called inside a tx opened by the engine.
 	ClearStaleClaimTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, expectedSessionRef string) error
 }
 
@@ -152,7 +158,10 @@ type TxBeginner interface {
 
 // EventLookup finds an existing event by (source, source_id) so the
 // engine can decide whether to re-publish vs. re-enqueue against an
-// existing event during stale-claim recovery.
+// existing event during stale-claim recovery. sourceID here is the
+// engine's contact-scoped claim key (see claimKey in engine.go), matching
+// what the create path wrote as the envelope's SourceID — not the bare
+// sourceRef.
 //
 // Returns (uuid.Nil, false, nil) when no row matches; (id, true, nil)
 // on hit; non-nil error only on infrastructure failure.

--- a/backend/tests/comms_group_space_fanout_test.go
+++ b/backend/tests/comms_group_space_fanout_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommsGroupSpaceFanout_SecondContactAlsoGetsInteraction pins the
+// multi-contact chat fan-out regression: a single outbound gchat message
+// fanned out to two matched contacts in the same space must aggregate into
+// one interaction PER CONTACT. Before the claim/event key is contact-scoped,
+// both contacts derive the identical (source, chatID, firstExternalID)
+// sourceRef; the second contact to aggregate claims its staging row but its
+// event publish silently no-ops against the first contact's already-published
+// event (event.source_id is globally unique), so the recorder job never runs
+// for it and its row is stranded processed_at IS NULL forever.
+//
+// spec: ING-026.fanout-claim-and-event-key-is-per-contact
+func TestCommsGroupSpaceFanout_SecondContactAlsoGetsInteraction(t *testing.T) {
+	t.Parallel()
+	e := setupGChatEngineTest(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
+
+	contactA := e.newGChatContact(t, "GChat Fanout A "+suffix)
+	contactB := e.newGChatContact(t, "GChat Fanout B "+suffix)
+	space := "spaces/FANOUT-" + suffix
+	externalID := "gchat-fanout1-" + suffix
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	// One outbound message, fanned out as two comms_message rows: identical
+	// source/external_id/thread_id/sent_at/direction, different
+	// matched_contact_id — mirrors what the gchat provider writes for a
+	// group-space message with more than one matched participant.
+	rowA := e.seedGChatRow(t, contactA.ID, space, externalID, repository.InteractionDirectionOutbound, sentAt)
+	rowB := e.seedGChatRow(t, contactB.ID, space, externalID, repository.InteractionDirectionOutbound, sentAt)
+
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contactA.ID, space))
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contactB.ID, space))
+
+	interactionsA := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contactA.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactionsA, 1)
+	// Required failure mode: pre-fix, contact B never gets an interaction —
+	// this call times out with 0 interactions observed.
+	interactionsB := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contactB.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactionsB, 1)
+
+	waitForGChatRowsProcessed(t, e, []uuid.UUID{rowA.ID}, interactionsA[0].ID)
+	waitForGChatRowsProcessed(t, e, []uuid.UUID{rowB.ID}, interactionsB[0].ID)
+
+	assert.NotEqual(t, interactionsA[0].ID, interactionsB[0].ID, "each contact gets its own interaction")
+
+	// interaction.source_ref stays contact-free and SHARED between the two
+	// contacts' interactions — proves the fix split the claim/event key from
+	// interaction.source_ref rather than mangling the latter to dodge the
+	// collision (that would break the (contact_id, source, source_ref) dedup
+	// index this same value is used for).
+	require.NotNil(t, interactionsA[0].SourceRef)
+	require.NotNil(t, interactionsB[0].SourceRef)
+	assert.Equal(t, *interactionsA[0].SourceRef, *interactionsB[0].SourceRef)
+	assert.Equal(t, "gchat:"+space+":"+externalID, *interactionsA[0].SourceRef)
+
+	// Idempotency: a second aggregation pass for both contacts adds no
+	// further interactions — the staging rows are already processed.
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contactA.ID, space))
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contactB.ID, space))
+	time.Sleep(500 * time.Millisecond) // settle any (unexpected) async write
+	countA, err := e.interactionRepo.CountContactInteractions(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), countA, "re-aggregating contact A must not create a second interaction")
+	countB, err := e.interactionRepo.CountContactInteractions(e.ctx, contactB.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), countB, "re-aggregating contact B must not create a second interaction")
+}

--- a/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
+++ b/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
@@ -144,9 +144,10 @@ func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 	assert.Equal(t, outboundInteractionID, *inboundRow.InteractionID)
 
 	// And no message.received event was published for the inbound's
-	// would-be source_ref (the promote path consumes the message
-	// rather than going through the publisher).
-	wouldBeRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase+1)
+	// would-be claim/event key (the promote path consumes the message
+	// rather than going through the publisher). The key is scoped to
+	// this contact the same way the engine derives its claim key.
+	wouldBeRef := fmt.Sprintf("tg:%d:%d:%s", chatID, msgIDBase+1, contact.ID.String())
 	_, err = eventRepo.FindEventBySource(ctx, repository.InteractionSourceTelegram, wouldBeRef)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound for the would-be inbound event, got %v", err)

--- a/backend/tests/telegram_aggregation_inbound_coalesce_test.go
+++ b/backend/tests/telegram_aggregation_inbound_coalesce_test.go
@@ -119,10 +119,11 @@ func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 		"extend path must link the staging row to the baseline interaction")
 
 	// The extend path must NOT publish a message.received event for
-	// the extending message's source_ref (would-be source_ref is based
-	// on msgIDBase+1). Use FindEventBySource for a targeted query —
-	// avoids cross-query counts on the shared DB.
-	wouldBeRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase+1)
+	// the extending message's claim/event key (would-be source_ref is
+	// based on msgIDBase+1, scoped to this contact the same way the
+	// engine derives its claim key). Use FindEventBySource for a
+	// targeted query — avoids cross-query counts on the shared DB.
+	wouldBeRef := fmt.Sprintf("tg:%d:%d:%s", chatID, msgIDBase+1, contact.ID.String())
 	_, err = eventRepo.FindEventBySource(ctx, repository.InteractionSourceTelegram, wouldBeRef)
 	require.Error(t, err, "extend path must not publish a create event for the inbound extension")
 	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound for the missing extend event, got %v", err)

--- a/spec/ingest.yaml
+++ b/spec/ingest.yaml
@@ -337,7 +337,9 @@ behaviors:
       - an explicit or time-based reply to a prior outbound message promotes that interaction to mutual
       - same-direction messages within the burst window extend the existing interaction rather than creating a new one
       - otherwise a new interaction is created by publishing a message event
-    provenance: [Engine.AggregateForContact, tryExplicitReplyBridge]
+      - key: fanout-claim-and-event-key-is-per-contact
+        text: when one staged message fans out to several contacts in the same chat, each contact claims and publishes under its own contact-scoped key, so every contact's session aggregates into its own interaction instead of colliding on a key shared across contacts
+    provenance: [Engine.AggregateForContact, Engine.createInteractionForSession, tryExplicitReplyBridge]
     notes: Batch/backfill aggregation is create-only (no extend or bridge); provider-specific staging adapters are CAL/TGM/MAC scope.
 
   - id: ING-027


### PR DESCRIPTION
## What

In a chat with more than one matched contact, only one contact ever got an interaction for a shared (fanned-out) message. The others' staging rows were claimed, never processed, and re-entered a stale-recovery loop forever.

`Adapter.SourceRef` returns `source:chatID:firstExternalID` — no contact identity — and the aggregation engine used that one string for three different jobs: `interaction.source_ref`, `comms_message.claimed_session_ref`, and `event.source_id`. Only the first is safe, because interaction dedup is already contact-scoped via `(contact_id, source, source_ref)`. `event` is `UNIQUE (source, source_id)` with an `ON CONFLICT DO NOTHING` insert, so it is global.

An outbound message in a multi-participant chat fans out to one staging row per matched contact, and every one of those contacts derives a session starting at the same `firstExternalID`. First contact to aggregate publishes the event and gets its interaction. The second claims its rows, its publish silently no-ops, and its transaction commits with a claim but no event — so no `interaction_recorder` job ever runs for it.

It then wedges permanently: those rows satisfy `isStaleRecovery` on every later pass, so the engine looks up the *other* contact's event, re-enqueues that already-completed job, and yields.

This splits the overloaded string in two. `interaction.source_ref` stays exactly as it was; the claim and event-log key become `sourceRef + ":" + contactID`.

| Consumer | Before | After |
| --- | --- | --- |
| `interaction.source_ref` (payload `ExternalMessageID`) | `sourceRef` | `sourceRef` — unchanged |
| `comms_message.claimed_session_ref` | `sourceRef` | `claimKey` |
| `event.source_id` (`env.SourceID`) | `sourceRef` | `claimKey` |
| `FindEventBySourceRef` lookup | `sourceRef` | `claimKey` |

The email ingest path already keys its events `externalID:contactID`, so this brings comms aggregation in line with existing precedent.

## Impact

Measured on the live database before the fix: 301 staging rows stuck unprocessed (261 gchat, 40 whatsapp). **Every one of them is in a thread with more than one matched contact; zero unprocessed rows in single-contact threads.** One affected contact had 197 unaggregated messages going back four months, with a visible timeline months short of its actual last message. The 5-minute sweeper was burning all 50 of its loop iterations re-enqueuing dead recoveries, logging `messaging_aggregate: hit loop bound` 288 times a day per affected contact.

## Expected self-heal

Stranded rows carry the old contact-free `claimed_session_ref`. Post-fix the engine computes a different key, so they land in `staleBoundaryShiftRefs` rather than `isStaleRecovery`: the claim is cleared in-tx, re-claimed under the new key, and published — no event exists there yet. No backfill script or migration.

For the contact that previously won, a re-publish under the new key dedups on the unchanged `interaction.source_ref` and takes the `IsReplay` path, so no duplicate interactions. Old contact-free event rows are left inert (retention is #452's scope).

This is an expectation to verify on staging, not a guarantee. If stranded rows do not drain within a few sweeps, a one-time claim-clearing repair is the fallback.

## TDD evidence

The regression test was written and proven red before any production code moved (commit `b9c1638e`, parent `69ecfab7`).

```
INTEGRATION_RUN='TestCommsGroupSpaceFanout' make test-integration-fast >/tmp/red.txt 2>&1; echo "EXIT:$?"
EXIT:2

=== RUN   TestCommsGroupSpaceFanout_SecondContactAlsoGetsInteraction
    comms_group_space_fanout_test.go:52: timed out waiting for exactly 1 interactions for contact=<redacted> (got 0)
--- FAIL: TestCommsGroupSpaceFanout_SecondContactAlsoGetsInteraction (30.49s)
```

The failure is on the *second* wait call. The first wait (contact A, same code path, same fixture) succeeded, which rules out a seeding or wiring fault: contact A aggregates, contact B ends the 30s poll at zero interactions. That is the defect itself.

After the fix (`3f61546d`), same command: `EXIT:0`, `--- PASS ... (0.83s)`.

## Commits

- `b9c1638e` — regression test pinning the fan-out defect, plus `spec/ingest.yaml` ING-026 extended in place with a keyed then-item
- `3f61546d` — the engine fix
- `714eac27` — existing-suite alignment

## Review notes

Two things a reviewer should check specifically:

**The unit test pins the exact key format**, not merely that two contacts' keys differ. Inequality alone would pass an implementation that dropped `firstExternalID` from the key — which would collide two different sessions of the *same* contact, recreating the bug one axis over.

**Two telegram tests would otherwise have gone vacuous.** They assert `FindEventBySource` returns `ErrNotFound` for a would-be ref, to prove an extend/bridge path published nothing. Once events moved to the contact-scoped key, the old-key lookup returns `ErrNotFound` whether or not the path wrongly published — green while proving nothing. Both now derive the contact-scoped key. These were found by grep, not by a red run, and no acceptance command would have surfaced them.

## Out of scope

- Retention of the now-inert contact-free event rows (#452)
- The discarded `interaction_recorder` jobs failing with `record interaction tx: record not found` — a separate, older defect from a stale contact id in an event payload
- The sweeper's 50-iteration loop bound. Once the collision is fixed the backlog drains and the bound stops being hit; tuning it now would mask the signal.
