### PR TITLE
refactor(accelerated): process-local clock state, not per-call env reads

### DIFF
--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -291,8 +291,10 @@ lock, so the pre-check cannot race with a concurrent insert.
 
 **Solution:** `accelerated.GetCurrentTime()` instead of `time.Now()`
 
+At boot, `TIME_ACCELERATION`/`TIME_BASE` are read once into `config.RuntimeConfig` and handed to `accelerated.ConfigureAtBoot`, which becomes the package's only process-global clock state (an `atomic.Pointer`, not env reads on every call). `TIME_BASE` accepts either Unix seconds or an RFC3339 timestamp. A factor above 1 with no usable base does not activate acceleration — the clock stays on wall time and boot logs a warning; the settings endpoint's `POST /system/time/acceleration` always anchors a base together with the factor, so that case is reachable only through boot config, never through the API.
+
 ```go
-// Environment variables control time
+// Environment variables control time at boot
 TIME_ACCELERATION=1440  // 1 minute = 1 day
 TIME_BASE=2024-01-01T00:00:00Z
 
@@ -786,9 +788,10 @@ Interaction, cadence, and follow-up consumers each have an `EVENT_BUS_*_MODE` fl
 
 ### Time-Accelerated Testing
 
-Use `.env.example.testing` for fast cadence testing:
+Use `.env.example.testing` for fast cadence testing. `TIME_ACCELERATION` requires a `TIME_BASE` to activate — a factor with no base leaves the clock on wall time:
 ```bash
 TIME_ACCELERATION=1440  # 1 min = 1 day
+TIME_BASE=2024-01-01T00:00:00Z
 # Weekly cadence = 2 minutes
 # Monthly cadence = 8 minutes
 ```

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,5 @@ linters:
       # Legitimate exceptions use inline //nolint:forbidigo comments:
       # - backend/internal/accelerated/time.go (wrapper implementation)
       # - backend/internal/api/middleware.go (latency measurement)
-      # - backend/internal/api/handlers/system.go:83 (TIME_BASE setting)
       # - backend/internal/synthetic/replay/replay.go (Stopwatch: seed/settle
       #   duration measurement — infrastructure timing, not domain time)

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -483,6 +483,16 @@ func runMain(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+
+	// Boot the process clock from config. Never fatal: a bad acceleration
+	// setting must not abort every crm-admin subcommand, only leave the
+	// clock on wall time. crm-admin has no structured logger, so this uses
+	// the file's own non-fatal stderr idiom (see main()'s exitErr branch)
+	// rather than adding a logger dependency for one warning.
+	if err := accelerated.ConfigureAtBoot(cfg.Runtime.TimeAcceleration, cfg.Runtime.TimeBase); err != nil {
+		fmt.Fprintln(os.Stderr, "crm-admin:", "time acceleration not applied:", err)
+	}
+
 	ctx := context.Background()
 
 	// Migration subcommands run PRE-DB: they need only the database URL +

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -488,7 +488,11 @@ func runMain(args []string) error {
 	// setting must not abort every crm-admin subcommand, only leave the
 	// clock on wall time. crm-admin has no structured logger, so this uses
 	// the file's own non-fatal stderr idiom (see main()'s exitErr branch)
-	// rather than adding a logger dependency for one warning.
+	// rather than adding a logger dependency for one warning. This exact call
+	// site (not just the accelerated.ConfigureAtBoot function it calls) is
+	// covered by TestRunMain_AppliesAccelerationBoot in main_test.go, which
+	// drives runMain end to end through a PRE-DB rejection path so it needs
+	// no database.
 	if err := accelerated.ConfigureAtBoot(cfg.Runtime.TimeAcceleration, cfg.Runtime.TimeBase); err != nil {
 		fmt.Fprintln(os.Stderr, "crm-admin:", "time acceleration not applied:", err)
 	}

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -2106,6 +2106,13 @@ func TestRunMain_AppliesAccelerationBoot(t *testing.T) {
 	t.Cleanup(accelerated.Reset)
 	t.Setenv("DATABASE_URL", "postgres://unused-never-connected-to")
 	t.Setenv("CRM_ENV", "production") // trips SeedAllowed's PRE-DB rejection
+	// NODE_ENV pinned to non-production explicitly: config.Validate's
+	// IsProduction() checks NODE_ENV, not CRM_ENV, and requires
+	// SESSION_SECRET/API_KEY when it's "production". Without this, an
+	// ambient NODE_ENV=production in the test's environment would fail
+	// config.Load() before this test ever reaches the boot line, reporting a
+	// false regression.
+	t.Setenv("NODE_ENV", "development")
 	t.Setenv("TIME_ACCELERATION", "60")
 	t.Setenv("TIME_BASE", "1700000000")
 

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -2084,3 +2084,44 @@ func TestSetEmailOwnDomains_WritesPreservedMetadata(t *testing.T) {
 		t.Fatalf("expected the resulting domain list in the summary, got %q", stdout.String())
 	}
 }
+
+// TestRunMain_AppliesAccelerationBoot proves the ACTUAL wiring in runMain —
+// not just accelerated.ConfigureAtBoot, the function it calls — reads
+// TIME_ACCELERATION/TIME_BASE off the process environment via config.Load()
+// and applies them before subcommand dispatch. Every other test in this file
+// drives run() directly, deliberately bypassing runMain to avoid
+// config.Load()'s production-shaped validation requirements (main_test.go's
+// header comment), so none of them exercises this call site: deleting the
+// two lines that wire it would leave every other test in this file green.
+//
+// This routes through --seed under CRM_ENV=production, which
+// synthetic.SeedAllowed rejects PRE-DB (main.go's seed/reset gate runs before
+// db.NewDatabase), so the boot line executes and the process fails fast
+// afterward without ever needing a real database connection. NODE_ENV is
+// left at its "development" default so config.Validate's production-only
+// SESSION_SECRET/API_KEY requirements (keyed off NODE_ENV, not CRM_ENV) don't
+// also need stubbing.
+func TestRunMain_AppliesAccelerationBoot(t *testing.T) {
+	accelerated.Reset()
+	t.Cleanup(accelerated.Reset)
+	t.Setenv("DATABASE_URL", "postgres://unused-never-connected-to")
+	t.Setenv("CRM_ENV", "production") // trips SeedAllowed's PRE-DB rejection
+	t.Setenv("TIME_ACCELERATION", "60")
+	t.Setenv("TIME_BASE", "1700000000")
+
+	err := runMain([]string{"--seed"})
+	if err == nil {
+		t.Fatal("runMain returned nil error, want the CRM_ENV=production seed-refused error")
+	}
+	if !strings.Contains(err.Error(), "production") {
+		t.Fatalf("runMain error = %q, want it to name the production refusal (confirms we reached the seed gate, not some earlier failure)", err.Error())
+	}
+
+	factor, _, active := accelerated.Snapshot()
+	if !active {
+		t.Fatal("accelerated.Snapshot() active = false, want true — runMain must have applied TIME_ACCELERATION/TIME_BASE from config before dispatching, not merely have accelerated.ConfigureAtBoot exist and pass in isolation")
+	}
+	if factor != 60 {
+		t.Fatalf("accelerated.Snapshot() factor = %d, want 60", factor)
+	}
+}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -78,13 +78,21 @@ func run() int {
 	logger.Init(cfg.Logger)
 
 	// Boot the process clock from config. Never fatal: a bad acceleration
-	// setting must not stop the process, only leave the clock on wall time.
-	// This call site runs for real in E2E — Playwright's webServer launches
-	// this binary via `go run ./cmd/crm-api` (frontend/playwright.config.ts),
-	// no test env sets TIME_ACCELERATION, and dashboard.spec.ts's "marking
-	// contact as contacted updates dashboard immediately without navigation"
-	// asserts the server clock IS the wall clock — which only holds if this
-	// line ran and left acceleration inactive by default.
+	// setting must not stop the process, only leave the clock on wall time —
+	// the logged warning below is the entire failure handling this needs, no
+	// further machinery.
+	//
+	// E2E runs this call for real (Playwright's webServer launches this
+	// binary via `go run ./cmd/crm-api`), but that does NOT discriminate
+	// whether the line ran: no E2E env sets TIME_ACCELERATION, so a correct
+	// boot and an accidentally deleted call both leave the package at its
+	// inactive default, and dashboard.spec.ts's server-clock-is-wall-clock
+	// assertion holds either way. What actually proves this wiring executes
+	// and applies a configured value is TestRunMain_AppliesAccelerationBoot
+	// (backend/cmd/crm-admin/main_test.go), which drives crm-admin's runMain
+	// through the same shared accelerated.ConfigureAtBoot call this line
+	// makes — the two binaries wire it identically, differing only in how
+	// they report a non-fatal failure (logger here, stderr there).
 	if err := accelerated.ConfigureAtBoot(cfg.Runtime.TimeAcceleration, cfg.Runtime.TimeBase); err != nil {
 		logger.Warn().Err(err).Msg("time acceleration not applied")
 	}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -79,6 +79,12 @@ func run() int {
 
 	// Boot the process clock from config. Never fatal: a bad acceleration
 	// setting must not stop the process, only leave the clock on wall time.
+	// This call site runs for real in E2E — Playwright's webServer launches
+	// this binary via `go run ./cmd/crm-api` (frontend/playwright.config.ts),
+	// no test env sets TIME_ACCELERATION, and dashboard.spec.ts's "marking
+	// contact as contacted updates dashboard immediately without navigation"
+	// asserts the server clock IS the wall clock — which only holds if this
+	// line ran and left acceleration inactive by default.
 	if err := accelerated.ConfigureAtBoot(cfg.Runtime.TimeAcceleration, cfg.Runtime.TimeBase); err != nil {
 		logger.Warn().Err(err).Msg("time acceleration not applied")
 	}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -33,6 +33,7 @@ import (
 	"syscall"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
@@ -75,6 +76,12 @@ func run() int {
 
 	// Initialize structured logger with configuration
 	logger.Init(cfg.Logger)
+
+	// Boot the process clock from config. Never fatal: a bad acceleration
+	// setting must not stop the process, only leave the clock on wall time.
+	if err := accelerated.ConfigureAtBoot(cfg.Runtime.TimeAcceleration, cfg.Runtime.TimeBase); err != nil {
+		logger.Warn().Err(err).Msg("time acceleration not applied")
+	}
 
 	// Record the serving build (stamped via -ldflags at build time). In prod this
 	// lands in `podman logs crm-backend`, a log-side record of which commit is live.

--- a/backend/internal/accelerated/time.go
+++ b/backend/internal/accelerated/time.go
@@ -1,41 +1,142 @@
 package accelerated
 
 import (
-	"os"
+	"fmt"
 	"strconv"
+	"sync/atomic"
 	"time"
 )
 
-// GetCurrentTime returns the current time, potentially accelerated for testing
+// settings is immutable once published; the atomic pointer swap is the only
+// mutation, so a reader can never see a factor paired with the other base.
+type settings struct {
+	factor int       // the last factor supplied, verbatim — may be <= 1
+	base   time.Time // meaningful only when active
+	active bool      // factor > 1 AND base usable
+}
+
+var current atomic.Pointer[settings] // nil ⇒ never configured: factor 1, inactive
+
+// nowFn is the package's single wall-clock seam and the only time.Now in the
+// repository. SetNowForTest swaps it; production never does.
+var nowFn = time.Now //nolint:forbidigo // the one wrapper implementation
+
+// load is the single atomic read. Every exported reader calls it exactly once
+// per invocation, so no caller can observe two different configurations.
+func load() *settings {
+	return current.Load()
+}
+
+// GetCurrentTime returns the app clock: wall time, or base + factor×(now-base).
 func GetCurrentTime() time.Time {
-	now := time.Now() //nolint:forbidigo // This is the wrapper implementation
-
-	// Check for acceleration settings
-	accelerationStr := os.Getenv("TIME_ACCELERATION")
-	if accelerationStr == "" {
+	s := load()
+	now := nowFn()
+	if s == nil || !s.active {
 		return now
 	}
+	return s.base.Add(now.Sub(s.base) * time.Duration(s.factor))
+}
 
-	acceleration, err := strconv.Atoi(accelerationStr)
-	if err != nil || acceleration <= 1 {
-		return now
+// Configure sets the process clock from an explicit base. The base is
+// TRUNCATED TO WHOLE SECONDS (D2-6). factor <= 1 disables acceleration but is
+// still recorded verbatim for Snapshot. Safe from any goroutine.
+func Configure(factor int, base time.Time) {
+	current.Store(&settings{
+		factor: factor,
+		base:   base.Truncate(time.Second),
+		active: factor > 1,
+	})
+}
+
+// ConfigureNow anchors the base at the current wall clock TRUNCATED TO WHOLE
+// SECONDS (D2-6) and sets the factor, returning the new base. The package owns
+// the wall clock (rule 1), so the settings handler must not capture its own.
+func ConfigureNow(factor int) time.Time {
+	base := nowFn().Truncate(time.Second)
+	current.Store(&settings{
+		factor: factor,
+		base:   base,
+		active: factor > 1,
+	})
+	return base
+}
+
+// ConfigureAtBoot applies settings from configuration. baseStr accepts Unix
+// seconds or RFC3339; either way the base is truncated to whole seconds
+// (D2-6). A missing or unparseable base with factor > 1 records the factor,
+// leaves the clock inactive, and returns an error describing why. Parameter
+// types match config.RuntimeConfig exactly (int, string).
+func ConfigureAtBoot(factor int, baseStr string) error {
+	if factor <= 1 {
+		current.Store(&settings{factor: factor})
+		return nil
 	}
-
-	// Get base time from environment (stored as Unix timestamp)
-	baseTimeStr := os.Getenv("TIME_BASE")
-	if baseTimeStr == "" {
-		return now
-	}
-
-	// Parse as Unix timestamp (set by SetTimeAcceleration in system handler)
-	baseUnix, err := strconv.ParseInt(baseTimeStr, 10, 64)
+	base, err := parseBase(baseStr)
 	if err != nil {
-		return now
+		current.Store(&settings{factor: factor})
+		return fmt.Errorf("time acceleration factor %d supplied with no usable base: %w", factor, err)
 	}
-	baseTime := time.Unix(baseUnix, 0)
+	current.Store(&settings{
+		factor: factor,
+		base:   base.Truncate(time.Second),
+		active: true,
+	})
+	return nil
+}
 
-	// Calculate accelerated time
-	elapsed := now.Sub(baseTime)
-	acceleratedElapsed := time.Duration(int64(elapsed) * int64(acceleration))
-	return baseTime.Add(acceleratedElapsed)
+// parseBase tries Unix seconds first (what SetTimeAcceleration/ConfigureNow
+// produce), then falls back to RFC3339 (what the docs additionally promise).
+func parseBase(baseStr string) (time.Time, error) {
+	if baseStr == "" {
+		return time.Time{}, fmt.Errorf("TIME_BASE is empty")
+	}
+	if unixSec, err := strconv.ParseInt(baseStr, 10, 64); err == nil {
+		return time.Unix(unixSec, 0), nil
+	}
+	if t, err := time.Parse(time.RFC3339, baseStr); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("TIME_BASE %q is neither Unix seconds nor RFC3339", baseStr)
+}
+
+// Snapshot reports the last accepted factor VERBATIM (including values <= 1),
+// the base, and whether the clock is actually accelerated. Never configured ⇒
+// (1, time.Time{}, false). One atomic load.
+func Snapshot() (factor int, base time.Time, active bool) {
+	s := load()
+	if s == nil {
+		return 1, time.Time{}, false
+	}
+	return s.factor, s.base, s.active
+}
+
+// SnapshotWithTime reports the app clock AND the settings that produced it,
+// from ONE atomic load, so an HTTP response can never pair a current_time
+// computed under one configuration with a factor/base/active from another
+// (D2-7). This is the only reader GetSystemTime may use.
+func SnapshotWithTime() (now time.Time, factor int, base time.Time, active bool) {
+	s := load()
+	n := nowFn()
+	if s == nil {
+		return n, 1, time.Time{}, false
+	}
+	if !s.active {
+		return n, s.factor, s.base, s.active
+	}
+	return s.base.Add(n.Sub(s.base) * time.Duration(s.factor)), s.factor, s.base, s.active
+}
+
+// Reset disables acceleration and clears the recorded factor.
+func Reset() {
+	current.Store(nil)
+}
+
+// SetNowForTest replaces the package wall clock and returns a restore func.
+// Exported because handler tests in other packages must advance the clock
+// deterministically; there is no other way to test re-anchoring without a
+// sleep. Production code must never call it.
+func SetNowForTest(fn func() time.Time) (restore func()) {
+	prev := nowFn
+	nowFn = fn
+	return func() { nowFn = prev }
 }

--- a/backend/internal/accelerated/time.go
+++ b/backend/internal/accelerated/time.go
@@ -41,28 +41,36 @@ func GetCurrentTime() time.Time {
 // TRUNCATED TO WHOLE SECONDS, so the RFC3339 timestamp this package later
 // echoes is a lossless encoding of the exact value it computes from and a
 // client's second-resolution copy of it never drifts. factor <= 1 disables
-// acceleration but is still recorded verbatim for Snapshot. Safe from any
-// goroutine.
+// acceleration AND clears the stored base to the zero value — Snapshot must
+// never report a base left over from a prior active configuration once the
+// clock is disabled, even though GetCurrentTime already ignores it via the
+// active flag. The factor itself is still recorded verbatim for Snapshot.
+// Safe from any goroutine.
 func Configure(factor int, base time.Time) {
-	current.Store(&settings{
-		factor: factor,
-		base:   base.Truncate(time.Second),
-		active: factor > 1,
-	})
+	s := &settings{factor: factor}
+	if factor > 1 {
+		s.base = base.Truncate(time.Second)
+		s.active = true
+	}
+	current.Store(s)
 }
 
 // ConfigureNow anchors the base at the current wall clock, TRUNCATED TO WHOLE
-// SECONDS for the same reason as Configure, and sets the factor, returning the
-// new base. The package owns the wall clock (rule 1), so the settings handler
-// must not capture its own.
+// SECONDS for the same reason as Configure, and sets the factor, always
+// returning that anchor instant regardless of whether the factor activates
+// acceleration (the caller uses it to report when the setting was applied).
+// The STORED base follows the same clear-on-disable rule as Configure: only
+// factor > 1 persists a base for Snapshot to report. The package owns the
+// wall clock (rule 1), so the settings handler must not capture its own.
 func ConfigureNow(factor int) time.Time {
-	base := nowFn().Truncate(time.Second)
-	current.Store(&settings{
-		factor: factor,
-		base:   base,
-		active: factor > 1,
-	})
-	return base
+	anchor := nowFn().Truncate(time.Second)
+	s := &settings{factor: factor}
+	if factor > 1 {
+		s.base = anchor
+		s.active = true
+	}
+	current.Store(s)
+	return anchor
 }
 
 // ConfigureAtBoot applies settings from configuration. baseStr accepts Unix

--- a/backend/internal/accelerated/time.go
+++ b/backend/internal/accelerated/time.go
@@ -38,8 +38,11 @@ func GetCurrentTime() time.Time {
 }
 
 // Configure sets the process clock from an explicit base. The base is
-// TRUNCATED TO WHOLE SECONDS (D2-6). factor <= 1 disables acceleration but is
-// still recorded verbatim for Snapshot. Safe from any goroutine.
+// TRUNCATED TO WHOLE SECONDS, so the RFC3339 timestamp this package later
+// echoes is a lossless encoding of the exact value it computes from and a
+// client's second-resolution copy of it never drifts. factor <= 1 disables
+// acceleration but is still recorded verbatim for Snapshot. Safe from any
+// goroutine.
 func Configure(factor int, base time.Time) {
 	current.Store(&settings{
 		factor: factor,
@@ -48,9 +51,10 @@ func Configure(factor int, base time.Time) {
 	})
 }
 
-// ConfigureNow anchors the base at the current wall clock TRUNCATED TO WHOLE
-// SECONDS (D2-6) and sets the factor, returning the new base. The package owns
-// the wall clock (rule 1), so the settings handler must not capture its own.
+// ConfigureNow anchors the base at the current wall clock, TRUNCATED TO WHOLE
+// SECONDS for the same reason as Configure, and sets the factor, returning the
+// new base. The package owns the wall clock (rule 1), so the settings handler
+// must not capture its own.
 func ConfigureNow(factor int) time.Time {
 	base := nowFn().Truncate(time.Second)
 	current.Store(&settings{
@@ -62,10 +66,11 @@ func ConfigureNow(factor int) time.Time {
 }
 
 // ConfigureAtBoot applies settings from configuration. baseStr accepts Unix
-// seconds or RFC3339; either way the base is truncated to whole seconds
-// (D2-6). A missing or unparseable base with factor > 1 records the factor,
-// leaves the clock inactive, and returns an error describing why. Parameter
-// types match config.RuntimeConfig exactly (int, string).
+// seconds or RFC3339; either way the base is truncated to whole seconds for
+// the same reason as Configure. A missing or unparseable base with factor > 1
+// records the factor, leaves the clock inactive, and returns an error
+// describing why. Parameter types match config.RuntimeConfig exactly (int,
+// string).
 func ConfigureAtBoot(factor int, baseStr string) error {
 	if factor <= 1 {
 		current.Store(&settings{factor: factor})
@@ -112,8 +117,8 @@ func Snapshot() (factor int, base time.Time, active bool) {
 
 // SnapshotWithTime reports the app clock AND the settings that produced it,
 // from ONE atomic load, so an HTTP response can never pair a current_time
-// computed under one configuration with a factor/base/active from another
-// (D2-7). This is the only reader GetSystemTime may use.
+// computed under one configuration with a factor/base/active from another.
+// This is the only reader GetSystemTime may use.
 func SnapshotWithTime() (now time.Time, factor int, base time.Time, active bool) {
 	s := load()
 	n := nowFn()

--- a/backend/internal/accelerated/time_test.go
+++ b/backend/internal/accelerated/time_test.go
@@ -2,6 +2,7 @@ package accelerated
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -35,8 +36,12 @@ func TestGetCurrentTime_ProcessState(t *testing.T) {
 		if got := GetCurrentTime(); !got.Equal(fakeNow) {
 			t.Fatalf("GetCurrentTime() = %v, want wall clock %v", got, fakeNow)
 		}
-		if _, _, active := Snapshot(); active {
+		_, base, active := Snapshot()
+		if active {
 			t.Fatal("Snapshot() active = true, want false for factor 1")
+		}
+		if !base.IsZero() {
+			t.Fatalf("Snapshot() base = %v, want the zero value — a disabling Configure must clear the stored base, not just gate it behind active", base)
 		}
 	})
 
@@ -123,12 +128,15 @@ func TestGetCurrentTime_ProcessState(t *testing.T) {
 
 		Configure(-5, fakeNow.Add(-time.Hour))
 
-		factor, _, active := Snapshot()
+		factor, base, active := Snapshot()
 		if factor != -5 {
 			t.Fatalf("Snapshot() factor = %d, want -5", factor)
 		}
 		if active {
 			t.Fatal("Snapshot() active = true, want false for a non-positive factor")
+		}
+		if !base.IsZero() {
+			t.Fatalf("Snapshot() base = %v, want the zero value even though a base argument was supplied — a disabling Configure clears it", base)
 		}
 		if got := GetCurrentTime(); !got.Equal(fakeNow) {
 			t.Fatalf("GetCurrentTime() = %v, want wall clock %v", got, fakeNow)
@@ -219,6 +227,48 @@ func TestConfigureNow_TruncatesBaseToSecond(t *testing.T) {
 	})
 }
 
+// TestConfigure_DisablingClearsTheBase pins that every entry point clears the
+// STORED base to the zero value when the supplied factor disables
+// acceleration (<= 1), not merely that GetCurrentTime ignores it via the
+// active flag. A direct Snapshot caller — anything other than the HTTP
+// handler, which happens to gate base_time behind is_accelerated — must not
+// see a base left over from a prior active configuration.
+func TestConfigure_DisablingClearsTheBase(t *testing.T) {
+	fakeNow := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("Configure", func(t *testing.T) {
+		t.Cleanup(Reset)
+		Configure(10, fakeNow.Add(-time.Hour))
+		Configure(1, fakeNow.Add(-time.Hour)) // re-configure to disable
+		_, base, active := Snapshot()
+		if active {
+			t.Fatal("Snapshot() active = true, want false")
+		}
+		if !base.IsZero() {
+			t.Fatalf("Snapshot() base = %v, want the zero value after disabling", base)
+		}
+	})
+
+	t.Run("ConfigureNow", func(t *testing.T) {
+		t.Cleanup(Reset)
+		restore := SetNowForTest(func() time.Time { return fakeNow })
+		t.Cleanup(restore)
+
+		ConfigureNow(60)          // activate first, anchoring a real base
+		anchor := ConfigureNow(1) // then disable via the handler's own call path
+		if !anchor.Equal(fakeNow) {
+			t.Fatalf("ConfigureNow(1) returned anchor %v, want %v — it always reports the instant it was called, even when disabling", anchor, fakeNow)
+		}
+		_, base, active := Snapshot()
+		if active {
+			t.Fatal("Snapshot() active = true, want false")
+		}
+		if !base.IsZero() {
+			t.Fatalf("Snapshot() base = %v, want the zero value after ConfigureNow(1) disables — the prior active base must not leak through Snapshot", base)
+		}
+	})
+}
+
 // TestConfigureAtBoot_AppliesAndWarns pins the contract crm-api's and
 // crm-admin's boot wiring both depend on: a good boot config activates, a
 // missing or unparseable base echoes the factor but stays inactive and
@@ -251,6 +301,9 @@ func TestConfigureAtBoot_AppliesAndWarns(t *testing.T) {
 		if err == nil {
 			t.Fatal("ConfigureAtBoot returned nil error, want non-nil naming the missing base")
 		}
+		if !strings.Contains(err.Error(), "empty") {
+			t.Fatalf("ConfigureAtBoot error = %q, want it to name the missing base (contain \"empty\")", err.Error())
+		}
 		factor, _, active := Snapshot()
 		if active {
 			t.Fatal("Snapshot() active = true, want false")
@@ -265,6 +318,9 @@ func TestConfigureAtBoot_AppliesAndWarns(t *testing.T) {
 		err := ConfigureAtBoot(60, "not-a-timestamp")
 		if err == nil {
 			t.Fatal("ConfigureAtBoot returned nil error, want non-nil naming the unparseable base")
+		}
+		if !strings.Contains(err.Error(), "not-a-timestamp") {
+			t.Fatalf("ConfigureAtBoot error = %q, want it to name the unparseable base value", err.Error())
 		}
 		factor, _, active := Snapshot()
 		if active {

--- a/backend/internal/accelerated/time_test.go
+++ b/backend/internal/accelerated/time_test.go
@@ -1,0 +1,368 @@
+package accelerated
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestGetCurrentTime_ProcessState pins the package's read path against
+// injected process state instead of environment variables. No subtest here
+// calls time.Now() — every clock read comes from the injected nowFn, which is
+// the rule this PR exists to make true of the package itself, not just its
+// callers.
+func TestGetCurrentTime_ProcessState(t *testing.T) {
+	fakeNow := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("unconfigured returns wall clock", func(t *testing.T) {
+		t.Cleanup(Reset)
+		restore := SetNowForTest(func() time.Time { return fakeNow })
+		t.Cleanup(restore)
+
+		if got := GetCurrentTime(); !got.Equal(fakeNow) {
+			t.Fatalf("GetCurrentTime() = %v, want %v", got, fakeNow)
+		}
+	})
+
+	t.Run("factor of one is inactive", func(t *testing.T) {
+		t.Cleanup(Reset)
+		restore := SetNowForTest(func() time.Time { return fakeNow })
+		t.Cleanup(restore)
+
+		Configure(1, fakeNow.Add(-time.Hour))
+
+		if got := GetCurrentTime(); !got.Equal(fakeNow) {
+			t.Fatalf("GetCurrentTime() = %v, want wall clock %v", got, fakeNow)
+		}
+		if _, _, active := Snapshot(); active {
+			t.Fatal("Snapshot() active = true, want false for factor 1")
+		}
+	})
+
+	t.Run("accelerates elapsed time", func(t *testing.T) {
+		t.Cleanup(Reset)
+		base := fakeNow
+		now := fakeNow
+		restore := SetNowForTest(func() time.Time { return now })
+		t.Cleanup(restore)
+
+		Configure(10, base)
+		now = now.Add(60 * time.Second)
+
+		want := base.Add(600 * time.Second)
+		if got := GetCurrentTime(); !got.Equal(want) {
+			t.Fatalf("GetCurrentTime() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("re-anchoring the base jumps the clock", func(t *testing.T) {
+		t.Cleanup(Reset)
+		now := fakeNow
+		restore := SetNowForTest(func() time.Time { return now })
+		t.Cleanup(restore)
+
+		base := fakeNow.Add(-1000 * time.Second)
+		Configure(60, base)
+		first := GetCurrentTime()
+
+		Configure(60, base.Add(-1000*time.Second))
+		second := GetCurrentTime()
+
+		wantDelta := 59 * 1000 * time.Second // (factor-1) * shift
+		if gotDelta := second.Sub(first); gotDelta != wantDelta {
+			t.Fatalf("second - first = %v, want %v", gotDelta, wantDelta)
+		}
+	})
+
+	t.Run("boot accepts unix seconds and rfc3339", func(t *testing.T) {
+		t.Cleanup(Reset)
+		restore := SetNowForTest(func() time.Time { return fakeNow })
+		t.Cleanup(restore)
+
+		unixBase := fakeNow.Add(-500 * time.Second)
+		if err := ConfigureAtBoot(60, fmt.Sprintf("%d", unixBase.Unix())); err != nil {
+			t.Fatalf("ConfigureAtBoot(unix) returned error: %v", err)
+		}
+		if _, _, active := Snapshot(); !active {
+			t.Fatal("Snapshot() active = false after unix-seconds boot config")
+		}
+
+		Reset()
+		rfcBase := fakeNow.Add(-500 * time.Second)
+		if err := ConfigureAtBoot(60, rfcBase.Format(time.RFC3339)); err != nil {
+			t.Fatalf("ConfigureAtBoot(rfc3339) returned error: %v", err)
+		}
+		if _, _, active := Snapshot(); !active {
+			t.Fatal("Snapshot() active = false after rfc3339 boot config")
+		}
+	})
+
+	t.Run("boot without a base is inactive and errors", func(t *testing.T) {
+		t.Cleanup(Reset)
+		restore := SetNowForTest(func() time.Time { return fakeNow })
+		t.Cleanup(restore)
+
+		err := ConfigureAtBoot(60, "")
+		if err == nil {
+			t.Fatal("ConfigureAtBoot(60, \"\") returned nil error, want non-nil")
+		}
+		factor, _, active := Snapshot()
+		if active {
+			t.Fatal("Snapshot() active = true, want false")
+		}
+		if factor != 60 {
+			t.Fatalf("Snapshot() factor = %d, want 60 (echoed verbatim)", factor)
+		}
+	})
+
+	t.Run("snapshot echoes a non-positive factor", func(t *testing.T) {
+		t.Cleanup(Reset)
+		restore := SetNowForTest(func() time.Time { return fakeNow })
+		t.Cleanup(restore)
+
+		Configure(-5, fakeNow.Add(-time.Hour))
+
+		factor, _, active := Snapshot()
+		if factor != -5 {
+			t.Fatalf("Snapshot() factor = %d, want -5", factor)
+		}
+		if active {
+			t.Fatal("Snapshot() active = true, want false for a non-positive factor")
+		}
+		if got := GetCurrentTime(); !got.Equal(fakeNow) {
+			t.Fatalf("GetCurrentTime() = %v, want wall clock %v", got, fakeNow)
+		}
+	})
+
+	t.Run("snapshot agrees with the clock", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			configure  func()
+			wantActive bool
+		}{
+			{"unconfigured", func() {}, false},
+			{"factor one", func() { Configure(1, fakeNow.Add(-time.Hour)) }, false},
+			{"accelerated", func() { Configure(10, fakeNow.Add(-time.Hour)) }, true},
+			{"negative factor", func() { Configure(-5, fakeNow.Add(-time.Hour)) }, false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Cleanup(Reset)
+				restore := SetNowForTest(func() time.Time { return fakeNow })
+				t.Cleanup(restore)
+
+				tc.configure()
+				_, _, active := Snapshot()
+				if active != tc.wantActive {
+					t.Fatalf("Snapshot() active = %v, want %v", active, tc.wantActive)
+				}
+				differsFromWall := !GetCurrentTime().Equal(fakeNow)
+				if differsFromWall != active {
+					t.Fatalf("GetCurrentTime() differs from wall clock = %v, want it to match active = %v", differsFromWall, active)
+				}
+			})
+		}
+	})
+}
+
+// TestConfigureNow_TruncatesBaseToSecond pins D2-6: every entry point stores
+// a whole-second base so the server's RFC3339 echo is a lossless encoding of
+// the value it actually computes from, and the browser's second-resolution
+// copy never drifts from it.
+func TestConfigureNow_TruncatesBaseToSecond(t *testing.T) {
+	fractional := time.Date(2026, 3, 1, 12, 0, 0, 750_000_000, time.UTC)
+	want := fractional.Truncate(time.Second)
+
+	t.Run("ConfigureNow", func(t *testing.T) {
+		t.Cleanup(Reset)
+		restore := SetNowForTest(func() time.Time { return fractional })
+		t.Cleanup(restore)
+
+		got := ConfigureNow(60)
+		if got.Nanosecond() != 0 {
+			t.Fatalf("ConfigureNow returned base with Nanosecond() = %d, want 0", got.Nanosecond())
+		}
+		if !got.Equal(want) {
+			t.Fatalf("ConfigureNow returned %v, want %v", got, want)
+		}
+		_, base, _ := Snapshot()
+		if !base.Equal(want) {
+			t.Fatalf("Snapshot() base = %v, want %v", base, want)
+		}
+	})
+
+	t.Run("Configure", func(t *testing.T) {
+		t.Cleanup(Reset)
+		Configure(60, fractional)
+		_, base, _ := Snapshot()
+		if base.Nanosecond() != 0 {
+			t.Fatalf("Snapshot() base Nanosecond() = %d, want 0", base.Nanosecond())
+		}
+		if !base.Equal(want) {
+			t.Fatalf("Snapshot() base = %v, want %v", base, want)
+		}
+	})
+
+	t.Run("ConfigureAtBoot", func(t *testing.T) {
+		t.Cleanup(Reset)
+		if err := ConfigureAtBoot(60, fractional.Format(time.RFC3339Nano)); err != nil {
+			t.Fatalf("ConfigureAtBoot returned error: %v", err)
+		}
+		_, base, _ := Snapshot()
+		if base.Nanosecond() != 0 {
+			t.Fatalf("Snapshot() base Nanosecond() = %d, want 0", base.Nanosecond())
+		}
+		if !base.Equal(want) {
+			t.Fatalf("Snapshot() base = %v, want %v", base, want)
+		}
+	})
+}
+
+// TestConfigureAtBoot_AppliesAndWarns pins the contract crm-api's and
+// crm-admin's boot wiring both depend on: a good boot config activates, a
+// missing or unparseable base echoes the factor but stays inactive and
+// returns a non-nil error, and a factor <= 1 with no base is a silent no-op
+// (nothing to warn about).
+func TestConfigureAtBoot_AppliesAndWarns(t *testing.T) {
+	fakeNow := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("good config activates", func(t *testing.T) {
+		t.Cleanup(Reset)
+		base := fakeNow.Add(-500 * time.Second)
+		if err := ConfigureAtBoot(60, fmt.Sprintf("%d", base.Unix())); err != nil {
+			t.Fatalf("ConfigureAtBoot returned error: %v", err)
+		}
+		factor, gotBase, active := Snapshot()
+		if !active {
+			t.Fatal("Snapshot() active = false, want true")
+		}
+		if factor != 60 {
+			t.Fatalf("Snapshot() factor = %d, want 60", factor)
+		}
+		if !gotBase.Equal(base.Truncate(time.Second)) {
+			t.Fatalf("Snapshot() base = %v, want %v", gotBase, base.Truncate(time.Second))
+		}
+	})
+
+	t.Run("empty base errors and stays inactive", func(t *testing.T) {
+		t.Cleanup(Reset)
+		err := ConfigureAtBoot(60, "")
+		if err == nil {
+			t.Fatal("ConfigureAtBoot returned nil error, want non-nil naming the missing base")
+		}
+		factor, _, active := Snapshot()
+		if active {
+			t.Fatal("Snapshot() active = true, want false")
+		}
+		if factor != 60 {
+			t.Fatalf("Snapshot() factor = %d, want 60 (echoed verbatim)", factor)
+		}
+	})
+
+	t.Run("unparseable base errors and stays inactive", func(t *testing.T) {
+		t.Cleanup(Reset)
+		err := ConfigureAtBoot(60, "not-a-timestamp")
+		if err == nil {
+			t.Fatal("ConfigureAtBoot returned nil error, want non-nil naming the unparseable base")
+		}
+		factor, _, active := Snapshot()
+		if active {
+			t.Fatal("Snapshot() active = true, want false")
+		}
+		if factor != 60 {
+			t.Fatalf("Snapshot() factor = %d, want 60 (echoed verbatim)", factor)
+		}
+	})
+
+	t.Run("factor at or below one with no base is a silent no-op", func(t *testing.T) {
+		t.Cleanup(Reset)
+		if err := ConfigureAtBoot(1, ""); err != nil {
+			t.Fatalf("ConfigureAtBoot(1, \"\") returned error: %v, want nil", err)
+		}
+		_, _, active := Snapshot()
+		if active {
+			t.Fatal("Snapshot() active = true, want false")
+		}
+	})
+}
+
+// TestGetCurrentTime_ConcurrentReconfigure is the proof this PR exists to
+// make possible: under the old two-os.Getenv implementation, a reader
+// landing between the factor write and the base write could pair a new
+// factor with a stale base. The atomic.Pointer[settings] swap makes that
+// structurally impossible, because every reader does exactly one load and
+// therefore observes one configuration in full or the other in full, never a
+// mix. The wall clock is held fixed (via the injected nowFn, per the
+// package's no-time.Now()-in-tests rule) so each configuration produces one
+// exact, precomputed value; any read that is neither value is a torn read.
+// Run with -race so a regression to non-atomic package state is caught as a
+// data race too, not just as a wrong value.
+func TestGetCurrentTime_ConcurrentReconfigure(t *testing.T) {
+	t.Cleanup(Reset)
+	fixedNow := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	restore := SetNowForTest(func() time.Time { return fixedNow })
+	t.Cleanup(restore)
+
+	const factorA, factorB = 2, 1000
+	baseA := fixedNow.Add(-100 * time.Second)
+	baseB := fixedNow.Add(-500 * time.Second)
+	valueA := baseA.Add(fixedNow.Sub(baseA) * time.Duration(factorA))
+	valueB := baseB.Add(fixedNow.Sub(baseB) * time.Duration(factorB))
+
+	// Seed synchronously so no reader can start before the package holds
+	// either configuration — otherwise an early read legitimately observes
+	// the unconfigured wall clock, which is a false positive for this test,
+	// not the torn read it exists to catch.
+	Configure(factorA, baseA)
+
+	stop := make(chan struct{})
+	var writerWG sync.WaitGroup
+	writerWG.Add(1)
+	go func() {
+		defer writerWG.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if i%2 == 0 {
+				Configure(factorA, baseA)
+			} else {
+				Configure(factorB, baseB)
+			}
+		}
+	}()
+
+	const readers = 8
+	const iterations = 5000
+	errCh := make(chan error, readers)
+	var readerWG sync.WaitGroup
+	readerWG.Add(readers)
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer readerWG.Done()
+			for i := 0; i < iterations; i++ {
+				got := GetCurrentTime()
+				if !got.Equal(valueA) && !got.Equal(valueB) {
+					select {
+					case errCh <- fmt.Errorf("torn read: got %v, want %v or %v", got, valueA, valueB):
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+
+	readerWG.Wait()
+	close(stop)
+	writerWG.Wait()
+
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+}

--- a/backend/internal/accelerated/time_test.go
+++ b/backend/internal/accelerated/time_test.go
@@ -166,7 +166,7 @@ func TestGetCurrentTime_ProcessState(t *testing.T) {
 	})
 }
 
-// TestConfigureNow_TruncatesBaseToSecond pins D2-6: every entry point stores
+// TestConfigureNow_TruncatesBaseToSecond pins that every entry point stores
 // a whole-second base so the server's RFC3339 echo is a lossless encoding of
 // the value it actually computes from, and the browser's second-resolution
 // copy never drifts from it.

--- a/backend/internal/api/handlers/oauth_test.go
+++ b/backend/internal/api/handlers/oauth_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sort"
-	"strconv"
 	"testing"
 	"time"
 
@@ -388,8 +387,8 @@ func TestGoogleCallback_ExpiredStateAbortsBeforeExchange(t *testing.T) {
 	}
 	handler := NewOAuthHandler(mock, "http://localhost:3000")
 
-	t.Setenv("TIME_ACCELERATION", "60")
-	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix, 10))
+	accelerated.Configure(60, time.Unix(fixedOAuthTestBaseUnix, 0))
+	t.Cleanup(accelerated.Reset)
 
 	state := "expiring-state-" + uuid.New().String()[:8]
 	handler.storeState(state)
@@ -399,7 +398,7 @@ func TestGoogleCallback_ExpiredStateAbortsBeforeExchange(t *testing.T) {
 	// (a 1000s base shift * 60x acceleration = 60,000 accelerated seconds,
 	// which dwarfs both the 600s TTL and any real-wall-clock jitter between
 	// the two GetCurrentTime() calls involved).
-	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix-1000, 10))
+	accelerated.Configure(60, time.Unix(fixedOAuthTestBaseUnix-1000, 0))
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -880,13 +879,13 @@ func validateStateAfterShift(t *testing.T, shiftSeconds int64) bool {
 	t.Helper()
 	handler := NewOAuthHandler(&MockOAuthService{}, "http://localhost:3000")
 
-	t.Setenv("TIME_ACCELERATION", "2")
-	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix, 10))
+	accelerated.Configure(2, time.Unix(fixedOAuthTestBaseUnix, 0))
+	t.Cleanup(accelerated.Reset)
 
 	state := "ttl-state-" + uuid.New().String()[:8]
 	handler.storeState(state)
 
-	t.Setenv("TIME_BASE", strconv.FormatInt(fixedOAuthTestBaseUnix-shiftSeconds, 10))
+	accelerated.Configure(2, time.Unix(fixedOAuthTestBaseUnix-shiftSeconds, 0))
 	return handler.validateState(state)
 }
 

--- a/backend/internal/api/handlers/system.go
+++ b/backend/internal/api/handlers/system.go
@@ -2,8 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"os"
-	"strconv"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
@@ -40,26 +38,16 @@ type AccelerationSettings struct {
 
 // GetSystemTime returns the current accelerated time and settings
 func (h *SystemHandler) GetSystemTime(c *gin.Context) {
-	currentTime := accelerated.GetCurrentTime()
-	accelerationStr := os.Getenv("TIME_ACCELERATION")
-	accelerationFactor := 1
-	isAccelerated := false
+	// One atomic load (D2-7): current_time and the factor/base/active that
+	// produced it can never straddle a concurrent reconfiguration. Do not
+	// replace this with accelerated.GetCurrentTime() + accelerated.Snapshot()
+	// — that is two loads and reintroduces the torn response this call
+	// exists to prevent.
+	currentTime, accelerationFactor, base, isAccelerated := accelerated.SnapshotWithTime()
 
-	if accelerationStr != "" {
-		if factor, err := strconv.Atoi(accelerationStr); err == nil {
-			accelerationFactor = factor
-			isAccelerated = factor > 1
-		}
-	}
-
-	// Get base_time for client-side acceleration calculation
 	baseTime := ""
 	if isAccelerated {
-		if baseUnix := os.Getenv("TIME_BASE"); baseUnix != "" {
-			if unixSec, err := strconv.ParseInt(baseUnix, 10, 64); err == nil {
-				baseTime = time.Unix(unixSec, 0).Format(time.RFC3339) //nolint:forbidigo // Need wall-clock conversion
-			}
-		}
+		baseTime = base.Format(time.RFC3339)
 	}
 
 	response := TimeResponse{
@@ -87,39 +75,16 @@ func (h *SystemHandler) SetTimeAcceleration(c *gin.Context) {
 		return
 	}
 
-	// Set environment variables (note: this only affects current process)
-	if err := os.Setenv("TIME_ACCELERATION", strconv.Itoa(settings.Factor)); err != nil {
-		// Preserve the existing non-standard body (system.go is E2E-selected); just
-		// add the logged cause + c.Error revival.
-		api.LogServerError(c, err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Failed to set TIME_ACCELERATION environment variable",
-		})
-		return
-	}
-	if settings.Factor > 1 {
-		if err := os.Setenv("TIME_BASE", strconv.FormatInt(time.Now().Unix(), 10)); err != nil { //nolint:forbidigo // Need wall-clock base for acceleration
-			api.LogServerError(c, err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to set TIME_BASE environment variable",
-			})
-			return
-		}
-	} else {
-		if err := os.Unsetenv("TIME_BASE"); err != nil {
-			api.LogServerError(c, err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to unset TIME_BASE environment variable",
-			})
-			return
-		}
-	}
+	// The package owns the wall clock (rule 1); the handler captures none of
+	// its own. Setting process state cannot fail, so there is nothing left to
+	// 500 on.
+	appliedAt := accelerated.ConfigureNow(settings.Factor)
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data": gin.H{
 			"acceleration_factor": settings.Factor,
-			"applied_at":          accelerated.GetCurrentTime(),
+			"applied_at":          appliedAt,
 		},
 	})
 }

--- a/backend/internal/api/handlers/system.go
+++ b/backend/internal/api/handlers/system.go
@@ -38,11 +38,13 @@ type AccelerationSettings struct {
 
 // GetSystemTime returns the current accelerated time and settings
 func (h *SystemHandler) GetSystemTime(c *gin.Context) {
-	// One atomic load (D2-7): current_time and the factor/base/active that
-	// produced it can never straddle a concurrent reconfiguration. Do not
-	// replace this with accelerated.GetCurrentTime() + accelerated.Snapshot()
-	// — that is two loads and reintroduces the torn response this call
-	// exists to prevent.
+	// One atomic load: current_time and the factor/base/active that produced
+	// it can never straddle a concurrent reconfiguration. Do not replace this
+	// with accelerated.GetCurrentTime() + accelerated.Snapshot() — that is two
+	// loads, and a reconfiguration landing between them would report a
+	// current_time computed under the old settings alongside the new
+	// factor/base/active, an inconsistent response this call exists to
+	// prevent.
 	currentTime, accelerationFactor, base, isAccelerated := accelerated.SnapshotWithTime()
 
 	baseTime := ""

--- a/backend/internal/api/handlers/system_time_test.go
+++ b/backend/internal/api/handlers/system_time_test.go
@@ -20,10 +20,9 @@ import (
 // newSystemTimeTestRouter builds the two system-time routes on a real gin
 // engine, through the same RegisterSystemRoutes call site production uses so
 // the test cannot drift from the real path shape. SystemHandler's contactRepo
-// is nil deliberately: neither GetSystemTime nor SetTimeAcceleration touches
-// it (system.go:42, :77), and a nil pointer makes an accidental repository
-// read panic loudly instead of silently succeeding against a database this
-// test does not have.
+// is nil deliberately: neither GetSystemTime nor SetTimeAcceleration reads
+// it, and a nil pointer makes an accidental repository read panic loudly
+// instead of silently succeeding against a database this test does not have.
 func newSystemTimeTestRouter(t *testing.T, env string) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -55,7 +54,8 @@ type envelopeError struct {
 }
 
 // setAccelerationData decodes POST /system/time/acceleration's ad-hoc success
-// body (system.go:118-124), which is not the api.SendSuccess envelope shape.
+// body, built inline in SetTimeAcceleration rather than through
+// api.SendSuccess, so it is not that envelope's shape.
 type setAccelerationData struct {
 	AccelerationFactor int       `json:"acceleration_factor"`
 	AppliedAt          time.Time `json:"applied_at"`
@@ -103,7 +103,7 @@ func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
 
 	r := newSystemTimeTestRouter(t, "test")
 
-	// Step 1: boot state.
+	// Boot state: unconfigured, wall clock.
 	code, env := getSystemTime(t, r)
 	assert.Equal(t, http.StatusOK, code)
 	assert.False(t, env.Data.IsAccelerated)
@@ -112,13 +112,15 @@ func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
 	assert.True(t, env.Data.CurrentTime.Equal(now), "current_time = %v, want %v", env.Data.CurrentTime, now)
 	assert.Equal(t, "test", env.Data.Environment)
 
-	// Step 2: enable.
+	// Enable acceleration: the base anchors at the current instant.
 	postCode, postEnv := postAcceleration(t, r, `{"factor": 60}`)
 	assert.Equal(t, http.StatusOK, postCode)
 	assert.Equal(t, 60, postEnv.Data.AccelerationFactor)
-	// applied_at is the anchored base ConfigureNow returns, truncated to a
-	// whole second (zero nanoseconds) — not a fresh, possibly-fractional
-	// current-time read taken after the anchor.
+	// applied_at is the anchored base ConfigureNow returns. This fixture's
+	// fake clock is whole-second already, so this check alone can't tell that
+	// implementation apart from a rejected one (a fresh GetCurrentTime() read
+	// taken after the anchor) — TestSetTimeAcceleration_AppliedAtIsTheAnchoredBase
+	// below uses a fractional-second clock specifically so the two diverge.
 	assert.True(t, postEnv.Data.AppliedAt.Equal(now), "applied_at = %v, want the anchored base %v", postEnv.Data.AppliedAt, now)
 	assert.Zero(t, postEnv.Data.AppliedAt.Nanosecond(), "applied_at must be truncated to a whole second")
 
@@ -132,7 +134,7 @@ func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
 	assert.True(t, baseTime.Equal(now), "base_time = %v, want %v", baseTime, now)
 	assert.True(t, env.Data.CurrentTime.Equal(now), "current_time = %v, want %v (zero elapsed since anchor)", env.Data.CurrentTime, now)
 
-	// Step 3: advance then re-anchor.
+	// Advance the wall clock, then re-anchor at the new instant.
 	now = now.Add(60 * time.Second)
 	code, env = getSystemTime(t, r)
 	assert.Equal(t, http.StatusOK, code)
@@ -150,7 +152,7 @@ func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
 	assert.True(t, reanchoredBase.Equal(now), "base_time after re-anchor = %v, want the advanced now %v", reanchoredBase, now)
 	assert.True(t, env.Data.CurrentTime.Equal(reanchoredBase), "current_time after re-anchor = %v, want the new base %v exactly", env.Data.CurrentTime, reanchoredBase)
 
-	// Step 4: disable.
+	// Disable acceleration: the accumulated offset is discarded, base cleared.
 	postCode, postEnv = postAcceleration(t, r, `{"factor": 1}`)
 	assert.Equal(t, http.StatusOK, postCode)
 	assert.Equal(t, 1, postEnv.Data.AccelerationFactor)
@@ -161,6 +163,34 @@ func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
 	assert.Equal(t, 1, env.Data.AccelerationFactor)
 	assert.Equal(t, "", env.Data.BaseTime)
 	assert.True(t, env.Data.CurrentTime.Equal(now), "current_time after disable = %v, want the fake wall clock %v (accelerated offset discarded)", env.Data.CurrentTime, now)
+}
+
+// TestSetTimeAcceleration_AppliedAtIsTheAnchoredBase pins that applied_at is
+// ConfigureNow's own anchored, whole-second-truncated base, not a value
+// freshly recomputed by calling GetCurrentTime() again after anchoring. The
+// fake clock deliberately carries a non-zero sub-second component: under
+// acceleration, a fresh post-anchor GetCurrentTime() read would scale that
+// discarded fraction by the factor and land somewhere else entirely, so a
+// whole-second fixture (as used elsewhere in this file) cannot tell the two
+// implementations apart — this one can.
+//
+// spec: SET-037.enabling-anchors-base-atomically
+func TestSetTimeAcceleration_AppliedAtIsTheAnchoredBase(t *testing.T) {
+	accelerated.Reset()
+	t.Cleanup(accelerated.Reset)
+
+	fractional := time.Date(2026, 3, 1, 12, 0, 0, 750_000_000, time.UTC)
+	restore := accelerated.SetNowForTest(func() time.Time { return fractional })
+	t.Cleanup(restore)
+
+	r := newSystemTimeTestRouter(t, "test")
+
+	postCode, postEnv := postAcceleration(t, r, `{"factor": 60}`)
+	require.Equal(t, http.StatusOK, postCode)
+
+	want := fractional.Truncate(time.Second)
+	assert.True(t, postEnv.Data.AppliedAt.Equal(want), "applied_at = %v, want the anchored, truncated base %v — a fresh post-anchor GetCurrentTime() read would instead land at roughly %v (the discarded 750ms scaled by factor 60)", postEnv.Data.AppliedAt, want, want.Add(45*time.Second))
+	assert.Zero(t, postEnv.Data.AppliedAt.Nanosecond(), "applied_at must be truncated to a whole second")
 }
 
 // TestSystemTime_FactorEdgeCases pins the factor contract across the entire
@@ -277,13 +307,23 @@ func TestSetTimeAcceleration_MissingFactorIsBadRequest(t *testing.T) {
 	t.Run("malformed json against an active clock", func(t *testing.T) {
 		accelerated.Reset()
 		t.Cleanup(accelerated.Reset)
-		restore := accelerated.SetNowForTest(func() time.Time { return now })
+		cur := now
+		restore := accelerated.SetNowForTest(func() time.Time { return cur })
 		t.Cleanup(restore)
 		r := newSystemTimeTestRouter(t, "test")
 
 		setCode, setEnv := postAcceleration(t, r, `{"factor": 60}`)
 		require.Equal(t, http.StatusOK, setCode)
 		require.Equal(t, 60, setEnv.Data.AccelerationFactor)
+
+		beforeCode, beforeEnv := getSystemTime(t, r)
+		require.Equal(t, http.StatusOK, beforeCode)
+		require.NotEmpty(t, beforeEnv.Data.BaseTime)
+
+		// Advance the clock before the rejected request: if a bug silently
+		// re-anchored the base on rejection, the base_time comparison below
+		// would only catch it if the anchor instant actually moved.
+		cur = cur.Add(10 * time.Second)
 
 		code, env := postAcceleration(t, r, `{"factor":`)
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -293,11 +333,15 @@ func TestSetTimeAcceleration_MissingFactorIsBadRequest(t *testing.T) {
 
 		// The unchanged-clock assertion checked against an ACTIVE clock, not
 		// only the reset state: the rejected malformed request must not have
-		// disturbed the factor 60 configured just above.
+		// disturbed the factor 60 configured just above. Pin the base too, not
+		// just factor/is_accelerated — a regression that re-anchored the base
+		// on a rejected request while leaving the factor untouched would pass
+		// factor/is_accelerated-only assertions.
 		getCode, getEnv := getSystemTime(t, r)
 		assert.Equal(t, http.StatusOK, getCode)
 		assert.True(t, getEnv.Data.IsAccelerated)
 		assert.Equal(t, 60, getEnv.Data.AccelerationFactor)
+		assert.Equal(t, beforeEnv.Data.BaseTime, getEnv.Data.BaseTime, "base_time must be unchanged by a rejected request")
 	})
 }
 

--- a/backend/internal/api/handlers/system_time_test.go
+++ b/backend/internal/api/handlers/system_time_test.go
@@ -116,6 +116,11 @@ func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
 	postCode, postEnv := postAcceleration(t, r, `{"factor": 60}`)
 	assert.Equal(t, http.StatusOK, postCode)
 	assert.Equal(t, 60, postEnv.Data.AccelerationFactor)
+	// applied_at is the anchored base ConfigureNow returns, truncated to a
+	// whole second (zero nanoseconds) — not a fresh, possibly-fractional
+	// current-time read taken after the anchor.
+	assert.True(t, postEnv.Data.AppliedAt.Equal(now), "applied_at = %v, want the anchored base %v", postEnv.Data.AppliedAt, now)
+	assert.Zero(t, postEnv.Data.AppliedAt.Nanosecond(), "applied_at must be truncated to a whole second")
 
 	code, env = getSystemTime(t, r)
 	assert.Equal(t, http.StatusOK, code)
@@ -158,9 +163,10 @@ func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
 	assert.True(t, env.Data.CurrentTime.Equal(now), "current_time after disable = %v, want the fake wall clock %v (accelerated offset discarded)", env.Data.CurrentTime, now)
 }
 
-// TestSystemTime_FactorEdgeCases pins D2-5b/D2-5c across the integer range:
-// any factor <= 1, negative included, disables acceleration and clears the
-// base, while the factor itself is always echoed verbatim.
+// TestSystemTime_FactorEdgeCases pins the factor contract across the entire
+// integer range: any factor <= 1, negative included, disables acceleration
+// and clears the base, while the factor itself is always echoed back exactly
+// as supplied.
 //
 // spec: SET-037.factor-echoed-verbatim, SET-037.non-positive-factor-disables-acceleration
 func TestSystemTime_FactorEdgeCases(t *testing.T) {
@@ -295,12 +301,13 @@ func TestSetTimeAcceleration_MissingFactorIsBadRequest(t *testing.T) {
 	})
 }
 
-// TestSystemTime_FactorWithoutBaseReportsInactive pins the one declared HTTP
-// delta (D2-3): today's handler reports is_accelerated: true here
-// (system.go:51); after this PR it reports false, because activation
-// requires a factor > 1 AND a usable base. This state is unreachable through
-// the setter (ConfigureNow always anchors a base) and reachable only through
-// boot config, so it is driven via accelerated.ConfigureAtBoot directly.
+// TestSystemTime_FactorWithoutBaseReportsInactive pins that activation
+// requires a factor > 1 AND a usable base: a factor with no parseable base
+// reports is_accelerated: false rather than true with an unusable empty
+// base_time, because a client cannot compute a clock from a base it never
+// received. This state is unreachable through the setter (ConfigureNow
+// always anchors a base) and reachable only through boot config, so it is
+// driven via accelerated.ConfigureAtBoot directly.
 //
 // spec: SET-037.factor-without-usable-base-reports-inactive
 func TestSystemTime_FactorWithoutBaseReportsInactive(t *testing.T) {
@@ -343,7 +350,9 @@ func TestSystemTime_FactorWithoutBaseReportsInactive(t *testing.T) {
 	})
 }
 
-// TestSystemTime_SingleLoadSnapshot is the D2-7 proof. It forces a
+// TestSystemTime_SingleLoadSnapshot proves the response GetSystemTime returns
+// is always self-consistent — current_time and the factor/base/is_accelerated
+// beside it always describe the same configuration. It forces a
 // reconfiguration to land BETWEEN a two-load handler's two loads by hooking
 // the package clock: the hook reconfigures the package the first time it is
 // called (guarded by sync.Once) and then returns a fixed instant on every

--- a/backend/internal/api/handlers/system_time_test.go
+++ b/backend/internal/api/handlers/system_time_test.go
@@ -1,0 +1,410 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSystemTimeTestRouter builds the two system-time routes on a real gin
+// engine, through the same RegisterSystemRoutes call site production uses so
+// the test cannot drift from the real path shape. SystemHandler's contactRepo
+// is nil deliberately: neither GetSystemTime nor SetTimeAcceleration touches
+// it (system.go:42, :77), and a nil pointer makes an accidental repository
+// read panic loudly instead of silently succeeding against a database this
+// test does not have.
+func newSystemTimeTestRouter(t *testing.T, env string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	cfg := config.RuntimeConfig{CRMEnvironment: env}
+	h := NewSystemHandler(nil, cfg)
+	r := gin.New()
+	RegisterSystemRoutes(&r.RouterGroup, h)
+	return r
+}
+
+// systemTimeData decodes GET /system/time's data payload.
+type systemTimeData struct {
+	CurrentTime        time.Time `json:"current_time"`
+	IsAccelerated      bool      `json:"is_accelerated"`
+	AccelerationFactor int       `json:"acceleration_factor"`
+	Environment        string    `json:"environment"`
+	BaseTime           string    `json:"base_time"`
+}
+
+type systemTimeEnvelope struct {
+	Success bool           `json:"success"`
+	Data    systemTimeData `json:"data"`
+	Error   *envelopeError `json:"error"`
+}
+
+type envelopeError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// setAccelerationData decodes POST /system/time/acceleration's ad-hoc success
+// body (system.go:118-124), which is not the api.SendSuccess envelope shape.
+type setAccelerationData struct {
+	AccelerationFactor int       `json:"acceleration_factor"`
+	AppliedAt          time.Time `json:"applied_at"`
+}
+
+type setAccelerationEnvelope struct {
+	Success bool                `json:"success"`
+	Data    setAccelerationData `json:"data"`
+	Error   *envelopeError      `json:"error"`
+}
+
+func getSystemTime(t *testing.T, r *gin.Engine) (int, systemTimeEnvelope) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/system/time", nil)
+	r.ServeHTTP(w, req)
+	var env systemTimeEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	return w.Code, env
+}
+
+func postAcceleration(t *testing.T, r *gin.Engine, body string) (int, setAccelerationEnvelope) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/system/time/acceleration", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	var env setAccelerationEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	return w.Code, env
+}
+
+// TestSystemTime_BootEnableReanchorDisableCycle drives the full lifecycle
+// over HTTP in one ordered sequence, because each step's assertions depend on
+// state the previous step left behind.
+//
+// spec: SET-037.enabling-anchors-base-atomically, SET-037.disabling-discards-accumulated-offset
+func TestSystemTime_BootEnableReanchorDisableCycle(t *testing.T) {
+	accelerated.Reset()
+	t.Cleanup(accelerated.Reset)
+
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	restore := accelerated.SetNowForTest(func() time.Time { return now })
+	t.Cleanup(restore)
+
+	r := newSystemTimeTestRouter(t, "test")
+
+	// Step 1: boot state.
+	code, env := getSystemTime(t, r)
+	assert.Equal(t, http.StatusOK, code)
+	assert.False(t, env.Data.IsAccelerated)
+	assert.Equal(t, 1, env.Data.AccelerationFactor)
+	assert.Equal(t, "", env.Data.BaseTime)
+	assert.True(t, env.Data.CurrentTime.Equal(now), "current_time = %v, want %v", env.Data.CurrentTime, now)
+	assert.Equal(t, "test", env.Data.Environment)
+
+	// Step 2: enable.
+	postCode, postEnv := postAcceleration(t, r, `{"factor": 60}`)
+	assert.Equal(t, http.StatusOK, postCode)
+	assert.Equal(t, 60, postEnv.Data.AccelerationFactor)
+
+	code, env = getSystemTime(t, r)
+	assert.Equal(t, http.StatusOK, code)
+	assert.True(t, env.Data.IsAccelerated)
+	assert.Equal(t, 60, env.Data.AccelerationFactor)
+	require.NotEmpty(t, env.Data.BaseTime)
+	baseTime, err := time.Parse(time.RFC3339, env.Data.BaseTime)
+	require.NoError(t, err)
+	assert.True(t, baseTime.Equal(now), "base_time = %v, want %v", baseTime, now)
+	assert.True(t, env.Data.CurrentTime.Equal(now), "current_time = %v, want %v (zero elapsed since anchor)", env.Data.CurrentTime, now)
+
+	// Step 3: advance then re-anchor.
+	now = now.Add(60 * time.Second)
+	code, env = getSystemTime(t, r)
+	assert.Equal(t, http.StatusOK, code)
+	wantBeforeReanchor := baseTime.Add(3600 * time.Second) // 60 real seconds * factor 60
+	assert.True(t, env.Data.CurrentTime.Equal(wantBeforeReanchor), "current_time = %v, want %v", env.Data.CurrentTime, wantBeforeReanchor)
+
+	postCode, postEnv = postAcceleration(t, r, `{"factor": 60}`)
+	assert.Equal(t, http.StatusOK, postCode)
+	assert.Equal(t, 60, postEnv.Data.AccelerationFactor)
+
+	code, env = getSystemTime(t, r)
+	assert.Equal(t, http.StatusOK, code)
+	reanchoredBase, err := time.Parse(time.RFC3339, env.Data.BaseTime)
+	require.NoError(t, err)
+	assert.True(t, reanchoredBase.Equal(now), "base_time after re-anchor = %v, want the advanced now %v", reanchoredBase, now)
+	assert.True(t, env.Data.CurrentTime.Equal(reanchoredBase), "current_time after re-anchor = %v, want the new base %v exactly", env.Data.CurrentTime, reanchoredBase)
+
+	// Step 4: disable.
+	postCode, postEnv = postAcceleration(t, r, `{"factor": 1}`)
+	assert.Equal(t, http.StatusOK, postCode)
+	assert.Equal(t, 1, postEnv.Data.AccelerationFactor)
+
+	code, env = getSystemTime(t, r)
+	assert.Equal(t, http.StatusOK, code)
+	assert.False(t, env.Data.IsAccelerated)
+	assert.Equal(t, 1, env.Data.AccelerationFactor)
+	assert.Equal(t, "", env.Data.BaseTime)
+	assert.True(t, env.Data.CurrentTime.Equal(now), "current_time after disable = %v, want the fake wall clock %v (accelerated offset discarded)", env.Data.CurrentTime, now)
+}
+
+// TestSystemTime_FactorEdgeCases pins D2-5b/D2-5c across the integer range:
+// any factor <= 1, negative included, disables acceleration and clears the
+// base, while the factor itself is always echoed verbatim.
+//
+// spec: SET-037.factor-echoed-verbatim, SET-037.non-positive-factor-disables-acceleration
+func TestSystemTime_FactorEdgeCases(t *testing.T) {
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name          string
+		factor        int
+		wantActive    bool
+		wantBaseEmpty bool
+	}{
+		{"negative", -5, false, true},
+		{"one", 1, false, true},
+		{"two", 2, true, false},
+		{"max widget factor", 1440, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			accelerated.Reset()
+			t.Cleanup(accelerated.Reset)
+			cur := now
+			restore := accelerated.SetNowForTest(func() time.Time { return cur })
+			t.Cleanup(restore)
+
+			r := newSystemTimeTestRouter(t, "test")
+
+			postCode, postEnv := postAcceleration(t, r, jsonFactorBody(tc.factor))
+			assert.Equal(t, http.StatusOK, postCode)
+			assert.Equal(t, tc.factor, postEnv.Data.AccelerationFactor)
+
+			code, env := getSystemTime(t, r)
+			assert.Equal(t, http.StatusOK, code)
+			assert.Equal(t, tc.factor, env.Data.AccelerationFactor)
+			assert.Equal(t, tc.wantActive, env.Data.IsAccelerated)
+			if tc.wantBaseEmpty {
+				assert.Equal(t, "", env.Data.BaseTime)
+			} else {
+				require.NotEmpty(t, env.Data.BaseTime)
+				baseTime, err := time.Parse(time.RFC3339, env.Data.BaseTime)
+				require.NoError(t, err)
+				assert.True(t, baseTime.Equal(now), "base_time = %v, want %v", baseTime, now)
+			}
+
+			if tc.name == "max widget factor" {
+				cur = cur.Add(1 * time.Second)
+				code, env = getSystemTime(t, r)
+				assert.Equal(t, http.StatusOK, code)
+				want := now.Add(1440 * time.Second)
+				assert.True(t, env.Data.CurrentTime.Equal(want), "current_time = %v, want %v (exact, no drift)", env.Data.CurrentTime, want)
+			}
+		})
+	}
+}
+
+func jsonFactorBody(factor int) string {
+	b, _ := json.Marshal(map[string]int{"factor": factor})
+	return string(b)
+}
+
+// TestSetTimeAcceleration_MissingFactorIsBadRequest pins that AccelerationSettings.Factor's
+// binding:"required" rejects Go's zero value, and that a rejected request never mutates the
+// process clock.
+//
+// spec: SET-037.missing-factor-rejected-without-mutation
+func TestSetTimeAcceleration_MissingFactorIsBadRequest(t *testing.T) {
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty object", func(t *testing.T) {
+		accelerated.Reset()
+		t.Cleanup(accelerated.Reset)
+		restore := accelerated.SetNowForTest(func() time.Time { return now })
+		t.Cleanup(restore)
+		r := newSystemTimeTestRouter(t, "test")
+
+		code, env := postAcceleration(t, r, `{}`)
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.False(t, env.Success)
+		require.NotNil(t, env.Error)
+		assert.Equal(t, "VALIDATION_ERROR", env.Error.Code)
+		assert.NotEmpty(t, env.Error.Message)
+
+		getCode, getEnv := getSystemTime(t, r)
+		assert.Equal(t, http.StatusOK, getCode)
+		assert.False(t, getEnv.Data.IsAccelerated)
+		assert.Equal(t, 1, getEnv.Data.AccelerationFactor)
+	})
+
+	t.Run("explicit zero", func(t *testing.T) {
+		accelerated.Reset()
+		t.Cleanup(accelerated.Reset)
+		restore := accelerated.SetNowForTest(func() time.Time { return now })
+		t.Cleanup(restore)
+		r := newSystemTimeTestRouter(t, "test")
+
+		code, env := postAcceleration(t, r, `{"factor": 0}`)
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.False(t, env.Success)
+		require.NotNil(t, env.Error)
+		assert.Equal(t, "VALIDATION_ERROR", env.Error.Code)
+
+		getCode, getEnv := getSystemTime(t, r)
+		assert.Equal(t, http.StatusOK, getCode)
+		assert.False(t, getEnv.Data.IsAccelerated)
+		assert.Equal(t, 1, getEnv.Data.AccelerationFactor)
+	})
+
+	t.Run("malformed json against an active clock", func(t *testing.T) {
+		accelerated.Reset()
+		t.Cleanup(accelerated.Reset)
+		restore := accelerated.SetNowForTest(func() time.Time { return now })
+		t.Cleanup(restore)
+		r := newSystemTimeTestRouter(t, "test")
+
+		setCode, setEnv := postAcceleration(t, r, `{"factor": 60}`)
+		require.Equal(t, http.StatusOK, setCode)
+		require.Equal(t, 60, setEnv.Data.AccelerationFactor)
+
+		code, env := postAcceleration(t, r, `{"factor":`)
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.False(t, env.Success)
+		require.NotNil(t, env.Error)
+		assert.Equal(t, "VALIDATION_ERROR", env.Error.Code)
+
+		// The unchanged-clock assertion checked against an ACTIVE clock, not
+		// only the reset state: the rejected malformed request must not have
+		// disturbed the factor 60 configured just above.
+		getCode, getEnv := getSystemTime(t, r)
+		assert.Equal(t, http.StatusOK, getCode)
+		assert.True(t, getEnv.Data.IsAccelerated)
+		assert.Equal(t, 60, getEnv.Data.AccelerationFactor)
+	})
+}
+
+// TestSystemTime_FactorWithoutBaseReportsInactive pins the one declared HTTP
+// delta (D2-3): today's handler reports is_accelerated: true here
+// (system.go:51); after this PR it reports false, because activation
+// requires a factor > 1 AND a usable base. This state is unreachable through
+// the setter (ConfigureNow always anchors a base) and reachable only through
+// boot config, so it is driven via accelerated.ConfigureAtBoot directly.
+//
+// spec: SET-037.factor-without-usable-base-reports-inactive
+func TestSystemTime_FactorWithoutBaseReportsInactive(t *testing.T) {
+	now := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("no base", func(t *testing.T) {
+		accelerated.Reset()
+		t.Cleanup(accelerated.Reset)
+		restore := accelerated.SetNowForTest(func() time.Time { return now })
+		t.Cleanup(restore)
+
+		err := accelerated.ConfigureAtBoot(60, "")
+		require.Error(t, err)
+
+		r := newSystemTimeTestRouter(t, "test")
+		code, env := getSystemTime(t, r)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, 60, env.Data.AccelerationFactor)
+		assert.False(t, env.Data.IsAccelerated, "delta: today's handler reports true here")
+		assert.Equal(t, "", env.Data.BaseTime)
+		assert.True(t, env.Data.CurrentTime.Equal(now), "current_time = %v, want the wall clock %v", env.Data.CurrentTime, now)
+	})
+
+	t.Run("unparseable base", func(t *testing.T) {
+		accelerated.Reset()
+		t.Cleanup(accelerated.Reset)
+		restore := accelerated.SetNowForTest(func() time.Time { return now })
+		t.Cleanup(restore)
+
+		err := accelerated.ConfigureAtBoot(60, "not-a-timestamp")
+		require.Error(t, err)
+
+		r := newSystemTimeTestRouter(t, "test")
+		code, env := getSystemTime(t, r)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, 60, env.Data.AccelerationFactor)
+		assert.False(t, env.Data.IsAccelerated)
+		assert.Equal(t, "", env.Data.BaseTime)
+		assert.True(t, env.Data.CurrentTime.Equal(now))
+	})
+}
+
+// TestSystemTime_SingleLoadSnapshot is the D2-7 proof. It forces a
+// reconfiguration to land BETWEEN a two-load handler's two loads by hooking
+// the package clock: the hook reconfigures the package the first time it is
+// called (guarded by sync.Once) and then returns a fixed instant on every
+// call thereafter. A single-load handler (SnapshotWithTime) captures its
+// settings before ever calling nowFn, so the reconfiguration lands after the
+// response is already determined and the response stays self-consistent. A
+// two-load handler (GetCurrentTime() then Snapshot()) computes current_time
+// under the pre-hook configuration but reads factor/base/active under the
+// post-hook one, producing a torn response. The assertion recomputes the
+// clock from the response's OWN factor/base/is_accelerated and requires
+// exact equality against the response's current_time — a self-consistent
+// response satisfies this by construction; a torn one cannot.
+//
+// spec: SET-037.response-reflects-one-configuration
+func TestSystemTime_SingleLoadSnapshot(t *testing.T) {
+	fixed := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		configureA func()
+		configureB func()
+	}{
+		{
+			name:       "slow_to_fast",
+			configureA: func() { accelerated.Configure(2, fixed.Add(-1000*time.Second)) },
+			configureB: func() { accelerated.Configure(1000, fixed.Add(-500*time.Second)) },
+		},
+		{
+			name:       "fast_to_slow",
+			configureA: func() { accelerated.Configure(1000, fixed.Add(-1000*time.Second)) },
+			configureB: func() { accelerated.Configure(2, fixed.Add(-500*time.Second)) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			accelerated.Reset()
+			t.Cleanup(accelerated.Reset)
+
+			tc.configureA()
+
+			var once sync.Once
+			restore := accelerated.SetNowForTest(func() time.Time {
+				once.Do(tc.configureB)
+				return fixed
+			})
+			t.Cleanup(restore)
+
+			r := newSystemTimeTestRouter(t, "test")
+			code, env := getSystemTime(t, r)
+			assert.Equal(t, http.StatusOK, code)
+
+			var want time.Time
+			if env.Data.IsAccelerated {
+				baseTime, err := time.Parse(time.RFC3339, env.Data.BaseTime)
+				require.NoError(t, err)
+				want = baseTime.Add(fixed.Sub(baseTime) * time.Duration(env.Data.AccelerationFactor))
+			} else {
+				want = fixed
+			}
+			assert.True(t, env.Data.CurrentTime.Equal(want), "current_time = %v, want %v recomputed from the response's own factor/base/is_accelerated (a torn response fails this)", env.Data.CurrentTime, want)
+		})
+	}
+}

--- a/backend/internal/api/handlers/system_time_test.go
+++ b/backend/internal/api/handlers/system_time_test.go
@@ -191,6 +191,19 @@ func TestSetTimeAcceleration_AppliedAtIsTheAnchoredBase(t *testing.T) {
 	want := fractional.Truncate(time.Second)
 	assert.True(t, postEnv.Data.AppliedAt.Equal(want), "applied_at = %v, want the anchored, truncated base %v — a fresh post-anchor GetCurrentTime() read would instead land at roughly %v (the discarded 750ms scaled by factor 60)", postEnv.Data.AppliedAt, want, want.Add(45*time.Second))
 	assert.Zero(t, postEnv.Data.AppliedAt.Nanosecond(), "applied_at must be truncated to a whole second")
+
+	// applied_at reporting the right value is not enough on its own — a
+	// mutant that reports applied_at correctly while installing a DIFFERENT
+	// factor or base (e.g. leaving the clock at factor 1) would still pass
+	// the two assertions above. Confirm the installed clock itself: factor
+	// 60 anchored at the SAME truncated instant applied_at reports.
+	getCode, getEnv := getSystemTime(t, r)
+	require.Equal(t, http.StatusOK, getCode)
+	assert.True(t, getEnv.Data.IsAccelerated)
+	assert.Equal(t, 60, getEnv.Data.AccelerationFactor)
+	installedBase, err := time.Parse(time.RFC3339, getEnv.Data.BaseTime)
+	require.NoError(t, err)
+	assert.True(t, installedBase.Equal(want), "installed base = %v, want the same anchored base %v applied_at reported", installedBase, want)
 }
 
 // TestSystemTime_FactorEdgeCases pins the factor contract across the entire

--- a/backend/internal/cadence/cadence_config.go
+++ b/backend/internal/cadence/cadence_config.go
@@ -2,8 +2,9 @@ package cadence
 
 import (
 	"os"
-	"strconv"
 	"time"
+
+	"personal-crm/backend/internal/accelerated"
 )
 
 // CadenceConfig manages different cadence mappings for testing vs production
@@ -201,10 +202,6 @@ func GetOverdueDaysWithConfig(cadenceType CadenceType, lastContacted *time.Time,
 
 // isAccelerationActive checks if time acceleration is currently enabled
 func isAccelerationActive() bool {
-	accelerationStr := os.Getenv("TIME_ACCELERATION")
-	if accelerationStr == "" {
-		return false
-	}
-	acceleration, err := strconv.Atoi(accelerationStr)
-	return err == nil && acceleration > 1
+	_, _, active := accelerated.Snapshot()
+	return active
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -77,7 +77,7 @@ type FeatureFlags struct {
 type RuntimeConfig struct {
 	CRMEnvironment   string // production|staging|test|accelerated (staging shares production cadence durations; test/accelerated run compressed cadences)
 	TimeAcceleration int    // Default: 1 (no acceleration)
-	TimeBase         string // RFC3339 timestamp for acceleration base
+	TimeBase         string // Unix seconds or RFC3339 timestamp for acceleration base
 }
 
 // ExternalConfig holds external service credentials

--- a/backend/tests/unit/cadence_test.go
+++ b/backend/tests/unit/cadence_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/cadence"
 
 	"github.com/stretchr/testify/assert"
@@ -538,14 +539,15 @@ func TestGetOverdueDaysWithConfig(t *testing.T) {
 // TestGetOverdueDaysWithConfig_Accelerated covers the CRM_ENV=accelerated scaled-day
 // branch (1 "day" = 10 minutes / 7), which the table test above does not reach. That
 // branch is guarded: GetOverdueDaysWithConfig returns real 24h days whenever
-// TIME_ACCELERATION is active, so the test neutralizes TIME_ACCELERATION (empty →
+// TIME_ACCELERATION is active, so the test neutralizes the process clock state (reset →
 // isAccelerationActive() false) to fall through to the CRM_ENV switch. checkTime is
 // placed exactly overdueDays scaled-days past the due point, so the branch's truncating
-// division yields exactly overdueDays. Serial (t.Setenv mutates process env) so it does
-// not race sibling cadence tests; deliberately does NOT touch IsTestingMode (#645).
+// division yields exactly overdueDays. Serial (the clock is package-global state) so it
+// does not race sibling cadence tests; deliberately does NOT touch IsTestingMode (#645).
 func TestGetOverdueDaysWithConfig_Accelerated(t *testing.T) {
 	t.Setenv("CRM_ENV", "accelerated")
-	t.Setenv("TIME_ACCELERATION", "")
+	accelerated.Reset()
+	t.Cleanup(accelerated.Reset)
 
 	const overdueDays = 5
 	scaledDay := 10 * time.Minute / 7 // the accelerated branch's "1 day"

--- a/backend/tests/unit/cadence_test.go
+++ b/backend/tests/unit/cadence_test.go
@@ -563,6 +563,35 @@ func TestGetOverdueDaysWithConfig_Accelerated(t *testing.T) {
 	assert.Equal(t, overdueDays, result)
 }
 
+// TestGetOverdueDaysWithConfig_AccelerationActive covers the branch the test
+// above deliberately neutralizes: when the process clock IS active,
+// GetOverdueDaysWithConfig must take the real-24h-days branch and skip the
+// CRM_ENV scaled-day switch entirely — even with CRM_ENV set to "accelerated",
+// which would otherwise select the compressed 10-minutes-per-week "day". An
+// isAccelerationActive implementation that never actually observes the
+// process clock (e.g. a body that unconditionally returns false) would fall
+// through to the scaled-day branch instead and produce a count off by three
+// orders of magnitude, so this test — not just its inactive/scaled sibling
+// above — is what proves the active branch is reachable and correct.
+func TestGetOverdueDaysWithConfig_AccelerationActive(t *testing.T) {
+	t.Setenv("CRM_ENV", "accelerated")
+	accelerated.Configure(60, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	t.Cleanup(accelerated.Reset)
+
+	const overdueDays = 5
+	lastContact := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	created := time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC)
+	// nextContactDue = lastContact + the accelerated weekly duration
+	// (GetCadenceDuration itself still reads CRM_ENV regardless of process
+	// acceleration state); checkTime sits exactly overdueDays REAL 24h days
+	// past it, since that's the unit the active branch must use.
+	nextDue := lastContact.Add(cadence.GetCadenceDuration(cadence.CadenceWeekly))
+	checkTime := nextDue.Add(overdueDays * 24 * time.Hour)
+
+	result := cadence.GetOverdueDaysWithConfig(cadence.CadenceWeekly, &lastContact, created, checkTime)
+	assert.Equal(t, overdueDays, result)
+}
+
 // TestBiweeklyCadenceComprehensive tests biweekly cadence across all functions
 func TestBiweeklyCadenceComprehensive(t *testing.T) {
 	t.Parallel()

--- a/spec/settings.yaml
+++ b/spec/settings.yaml
@@ -547,9 +547,9 @@ behaviors:
     when: the clock is read or the acceleration factor is set
     then:
       - key: factor-echoed-verbatim
-        text: the acceleration factor is echoed back exactly as supplied, including values at or below one and negative values
+        text: an accepted acceleration factor is echoed back exactly as supplied, including negative values and a factor of exactly one (zero is not an accepted factor — see missing-factor-rejected-without-mutation)
       - key: non-positive-factor-disables-acceleration
-        text: any factor at or below one, negative included, disables acceleration and clears the reported base
+        text: any accepted factor at or below one — negative values and exactly one, zero being rejected before reaching this logic — disables acceleration and clears the reported base
       - key: enabling-anchors-base-atomically
         text: enabling acceleration anchors a new base at the current instant, and setting the factor again re-anchors the base without an intervening moment where the factor and base disagree
       - key: disabling-discards-accumulated-offset

--- a/spec/settings.yaml
+++ b/spec/settings.yaml
@@ -535,3 +535,30 @@ behaviors:
         text: a non-empty application version is shown
     provenance: [settings/page.tsx System Information section]
     notes: The version string is build-stamped (NEXT_PUBLIC_BUILD_VERSION, with a dev fallback when unstamped); the backend build stamp is covered separately by TestHealthEndpoint_StampedBuildInfo. Pinning the exact fallback copy is deliberately avoided.
+
+  # --- Time acceleration clock state ---
+
+  - id: SET-037
+    title: The system clock reports one atomically consistent view of acceleration state
+    type: business-logic
+    status: current
+    surface: api
+    given: the system time and manual acceleration control (GET /system/time, POST /system/time/acceleration)
+    when: the clock is read or the acceleration factor is set
+    then:
+      - key: factor-echoed-verbatim
+        text: the acceleration factor is echoed back exactly as supplied, including values at or below one and negative values
+      - key: non-positive-factor-disables-acceleration
+        text: any factor at or below one, negative included, disables acceleration and clears the reported base
+      - key: enabling-anchors-base-atomically
+        text: enabling acceleration anchors a new base at the current instant, and setting the factor again re-anchors the base without an intervening moment where the factor and base disagree
+      - key: disabling-discards-accumulated-offset
+        text: disabling acceleration discards any accumulated accelerated offset rather than carrying it forward, and reports no base
+      - key: missing-factor-rejected-without-mutation
+        text: a request with no factor field, an explicit factor of zero, or malformed JSON is rejected with a 400 validation error and does not change the clock's current configuration
+      - key: factor-without-usable-base-reports-inactive
+        text: a factor above one with no usable base (unset or unparseable) reports the clock as not accelerated, even though the factor itself is still echoed
+      - key: response-reflects-one-configuration
+        text: current_time and the factor/base/is_accelerated reported alongside it always describe the same configuration, never a current_time computed under one configuration paired with settings from another
+    provenance: [accelerated.ConfigureNow, accelerated.Snapshot, accelerated.SnapshotWithTime, SystemHandler.SetTimeAcceleration, SystemHandler.GetSystemTime]
+    notes: 'Delta from prior behavior: before this behavior was minted, a factor above one with no usable base reported is_accelerated true (with an empty, unusable base_time) rather than false. That case is unreachable through the setter, which always anchors a base together with the factor; it is reachable only through boot configuration.'


### PR DESCRIPTION
Part of the arch-hygiene arc (stack #820: this PR ← #818 ← #819). Replaces per-call `os.Getenv` reads in the `accelerated` package with process-local state behind a single `atomic.Pointer[settings]`, so factor and base are always read as a consistent pair.

## What changed

- `accelerated` holds one immutable settings struct behind `atomic.Pointer`; nil means not accelerated. New API: `Configure`, `ConfigureNow`, `ConfigureAtBoot`, `Snapshot`, `SnapshotWithTime`, `Reset`, `SetNowForTest`. Exactly one `time.Now` remains in the repository, inside the package's `nowFn` seam.
- Boot reads env through `config` (`RuntimeConfig.TimeAcceleration`/`.TimeBase`), reviving the dead config fields; both binaries call `ConfigureAtBoot` before anything reads the clock, and a factor-without-base warns loudly instead of silently no-opping.
- One activation predicate (factor > 1 AND valid base) unifies the three former readers (`time.go`, `cadence_config.isAccelerationActive`, `system.go`). Disabling clears the base — `Snapshot` cannot expose a stale one.
- `GET /system/time` reads clock + settings from ONE atomic load (`SnapshotWithTime`), making the torn two-load response structurally impossible.
- Every base is truncated to whole seconds at every entry point, so RFC3339 stays a lossless encoding and server/browser clocks agree exactly (at factor 1440 the alternative is up to ~24 minutes of permanent skew).
- `SetTimeAcceleration` loses its two 500 branches (process state cannot fail) and sources `applied_at` from `ConfigureNow`'s returned anchored base.

## Declared behavior deltas

1. Factor-without-base now reports `is_accelerated: false` (previously `true` with an empty, unusable `base_time`). Pinned by `TestSystemTime_FactorWithoutBaseReportsInactive`; declared in spec SET-037. Reachable only via boot env, never via the HTTP setter.
2. `applied_at` in the POST 200 body is now the anchored whole-second base rather than a fresh clock read moments later. Pinned by `TestSetTimeAcceleration_AppliedAtIsTheAnchoredBase` (fractional-second fake clock); no frontend consumer reads the field.

## Spec

Minted SET-037 (the plan pre-allocated SET-036, but merged PR #794 claimed it first; renumbered with all citations updated). Note: the middle commit's message says "SET-036" in one sentence — a typo in the message only; every code and spec artifact says SET-037.

## Falsification record (mutants injected, observed red, reverted; nothing committed)

1. Two-load handler mutant (`GetCurrentTime()` + `Snapshot()` composition): `TestSystemTime_SingleLoadSnapshot` failed both subtests, exit 1 read directly — a torn response with `current_time` from one config beside factor/base from another.
2. Split-atomics mutant (two independently-swapped pointers): `TestGetCurrentTime_ConcurrentReconfigure` failed under `-race` via its value-equality assertion (not merely the race detector), exit 1.
3. Always-store-base mutant (disable keeps the base): 4 assertions failed naming the leaked base, exit 1.
4. `isAccelerationActive` replaced with `return false`: `TestGetOverdueDaysWithConfig_AccelerationActive` failed through the tagged lane, exit 2, expected 5 got 5040.
5. Deleted crm-admin's boot wiring call: `TestRunMain_AppliesAccelerationBoot` failed exit 1 while every other `TestRun*` stayed green — no other test covers the line.
6. Fresh-clock-read `applied_at` mutant: the dedicated test failed exit 1 (got 12:00:45, want 12:00:00 — the discarded 750 ms × factor 60); the pre-existing coarse assertion stayed green under the same mutant, proving the dedicated test was needed.
7. Re-anchor-on-bind-failure mutant: the malformed-JSON subtest failed exit 1 on the base_time delta (12:00:00 vs 12:00:10).

## Review trail

Sonnet pair review PASS → Codex round 1 FAIL (1 P1: stale base on disable; fixed) → Codex round 2 PASS → polish round (comment overclaim corrected, citation-bearing test strengthened, `NODE_ENV` pinned). Merge gate review + CI follow on this PR.
