### PR TITLE
fix(contacts): transfer automated merge tasks that can transfer

### DIFF
--- a/backend/internal/db/contact_task.sql.go
+++ b/backend/internal/db/contact_task.sql.go
@@ -81,13 +81,15 @@ type CompleteLiveContactTasksForContactRow struct {
 }
 
 // Merge-time close of the source contact's live AUTOMATED tasks (cadence_due
-// + followup_loop). Manual-lifecycle rows are deliberately excluded — they
-// are user content and are REPOINTED to the merge target instead (see
-// RepointManualContactTasksToContact). Automated rows cannot be repointed:
-// unique_contact_provider_cadence has no state filter, so a repoint collides
-// whenever the target has ANY cadence_due row, and the target's own automated
-// rows already cover the survivor. Returns the closed rows' identifying
-// fields plus the pending_temp_id metadata key so the service can decide
+// + followup_loop) that TransferAutomatedContactTasksToContact could not
+// move. Manual-lifecycle rows are deliberately excluded — they are user
+// content and are REPOINTED to the merge target instead (see
+// RepointManualContactTasksToContact). Automated rows cannot always be
+// repointed: unique_contact_provider_cadence has no state filter, so a
+// transfer collides whenever the target has ANY cadence_due row, and a
+// follow-up collides on a live target row or a shared idempotency key. This
+// query is the fallback for exactly those blocked rows. Returns the closed
+// rows' identifying fields plus the pending_temp_id metadata key so the service can decide
 // remote-close enqueue eligibility (real external id only — never a pending
 // temp id, mirroring todoist.isPendingTempID).
 func (q *Queries) CompleteLiveContactTasksForContact(ctx context.Context, arg CompleteLiveContactTasksForContactParams) ([]*CompleteLiveContactTasksForContactRow, error) {
@@ -940,6 +942,73 @@ type SetContactTaskExternalIDOnlyParams struct {
 func (q *Queries) SetContactTaskExternalIDOnly(ctx context.Context, arg SetContactTaskExternalIDOnlyParams) error {
 	_, err := q.db.Exec(ctx, SetContactTaskExternalIDOnly, arg.ID, arg.ExternalTaskID)
 	return err
+}
+
+const TransferAutomatedContactTasksToContact = `-- name: TransferAutomatedContactTasksToContact :many
+UPDATE contact_task AS src
+SET contact_id = $1,
+    updated_at = NOW()
+WHERE src.contact_id = $2
+  AND src.lifecycle IN ('cadence_due', 'followup_loop')
+  AND src.state IN ('managed', 'pending_remote_create')
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_task tgt
+      WHERE tgt.contact_id = $1
+        AND tgt.provider = src.provider
+        AND tgt.lifecycle = src.lifecycle
+        AND (src.lifecycle = 'cadence_due'
+             OR tgt.state IN ('managed', 'pending_remote_create'))
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_task idem
+      WHERE idem.contact_id = $1
+        AND idem.lifecycle = 'followup_loop'
+        AND idem.idempotency_key IS NOT NULL
+        AND idem.idempotency_key = src.idempotency_key
+  )
+RETURNING id, lifecycle
+`
+
+type TransferAutomatedContactTasksToContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+type TransferAutomatedContactTasksToContactRow struct {
+	ID        pgtype.UUID `json:"id"`
+	Lifecycle string      `json:"lifecycle"`
+}
+
+// Merge-time transfer of the source's LIVE automated rows to the target, for
+// the rows where the move is legal under the existing partial unique indexes.
+// A row moves only when the target has no colliding row:
+//
+//	cadence_due    — unique_contact_provider_cadence is state-agnostic, so the
+//	                 target must have NO cadence_due row in any state.
+//	followup_loop  — idx_contact_task_followup_unique_live covers live states
+//	                 only, so the target must have no LIVE follow-up; and
+//	                 idx_contact_task_followup_idempotency covers
+//	                 (contact_id, idempotency_key), so the key must be free.
+//
+// Rows that cannot move are left for CompleteLiveContactTasksForContact.
+func (q *Queries) TransferAutomatedContactTasksToContact(ctx context.Context, arg TransferAutomatedContactTasksToContactParams) ([]*TransferAutomatedContactTasksToContactRow, error) {
+	rows, err := q.db.Query(ctx, TransferAutomatedContactTasksToContact, arg.TargetContactID, arg.SourceContactID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TransferAutomatedContactTasksToContactRow{}
+	for rows.Next() {
+		var i TransferAutomatedContactTasksToContactRow
+		if err := rows.Scan(&i.ID, &i.Lifecycle); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const UpdateContactTaskExternalID = `-- name: UpdateContactTaskExternalID :one

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -473,6 +473,13 @@ type PgIndex struct {
 	Indexdef   string `json:"indexdef"`
 }
 
+type PgStatActivity struct {
+	Pid           int32       `json:"pid"`
+	State         pgtype.Text `json:"state"`
+	WaitEventType pgtype.Text `json:"wait_event_type"`
+	Datname       pgtype.Text `json:"datname"`
+}
+
 type PhoneCall struct {
 	ID               pgtype.UUID        `json:"id"`
 	CallUniqueID     string             `json:"call_unique_id"`

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -180,13 +180,15 @@ type Querier interface {
 	// transitions the row to completed.
 	CompleteFollowUpForContact(ctx context.Context, contactID pgtype.UUID) ([]*ContactTask, error)
 	// Merge-time close of the source contact's live AUTOMATED tasks (cadence_due
-	// + followup_loop). Manual-lifecycle rows are deliberately excluded — they
-	// are user content and are REPOINTED to the merge target instead (see
-	// RepointManualContactTasksToContact). Automated rows cannot be repointed:
-	// unique_contact_provider_cadence has no state filter, so a repoint collides
-	// whenever the target has ANY cadence_due row, and the target's own automated
-	// rows already cover the survivor. Returns the closed rows' identifying
-	// fields plus the pending_temp_id metadata key so the service can decide
+	// + followup_loop) that TransferAutomatedContactTasksToContact could not
+	// move. Manual-lifecycle rows are deliberately excluded — they are user
+	// content and are REPOINTED to the merge target instead (see
+	// RepointManualContactTasksToContact). Automated rows cannot always be
+	// repointed: unique_contact_provider_cadence has no state filter, so a
+	// transfer collides whenever the target has ANY cadence_due row, and a
+	// follow-up collides on a live target row or a shared idempotency key. This
+	// query is the fallback for exactly those blocked rows. Returns the closed
+	// rows' identifying fields plus the pending_temp_id metadata key so the service can decide
 	// remote-close enqueue eligibility (real external id only — never a pending
 	// temp id, mirroring todoist.isPendingTempID).
 	CompleteLiveContactTasksForContact(ctx context.Context, arg CompleteLiveContactTasksForContactParams) ([]*CompleteLiveContactTasksForContactRow, error)
@@ -2526,12 +2528,19 @@ type Querier interface {
 	// be executed on a dedicated pooled connection — session advisory locks belong
 	// to the connection that took them.
 	SyntheticTryAdvisoryLock(ctx context.Context, lockKey int64) (bool, error)
+	// Race-test only: the PostgreSQL backend pid serving THIS connection. Run on
+	// the blocking transaction so a sibling can ask who is waiting on it.
+	TestBackendPID(ctx context.Context) (int32, error)
 	// Reset integration test only: count ALL rows in a single table by name. Used by
 	// the clone-DB reset test to assert each wiped table is empty after the reset and
 	// that schema_migrations survives. The table name is validated against the wiped
 	// list by the test before it reaches here; format() with %I quotes the
 	// identifier so it can never be an injection vector.
 	TestCountAllRows(ctx context.Context, tableName string) (int64, error)
+	// Race-test only: how many active backends are waiting on a lock held by the
+	// given backend. Scoped to one blocker, so a parallel sibling waiting on an
+	// unrelated lock cannot satisfy the poll.
+	TestCountBackendsBlockedBy(ctx context.Context, blockerPid int32) (int64, error)
 	// Test-only: counts venue-type nodes that no live interaction references via
 	// venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
 	TestCountOrphanVenueNodes(ctx context.Context) (int64, error)
@@ -2752,6 +2761,17 @@ type Querier interface {
 	// NOT compare it numerically to the Tier-1 queue_wait_ms metric, which is
 	// River's exact QueueWaitDuration.
 	Tier0RiverJobStatsByKind(ctx context.Context, cutoff pgtype.Timestamptz) ([]*Tier0RiverJobStatsByKindRow, error)
+	// Merge-time transfer of the source's LIVE automated rows to the target, for
+	// the rows where the move is legal under the existing partial unique indexes.
+	// A row moves only when the target has no colliding row:
+	//   cadence_due    — unique_contact_provider_cadence is state-agnostic, so the
+	//                    target must have NO cadence_due row in any state.
+	//   followup_loop  — idx_contact_task_followup_unique_live covers live states
+	//                    only, so the target must have no LIVE follow-up; and
+	//                    idx_contact_task_followup_idempotency covers
+	//                    (contact_id, idempotency_key), so the key must be free.
+	// Rows that cannot move are left for CompleteLiveContactTasksForContact.
+	TransferAutomatedContactTasksToContact(ctx context.Context, arg TransferAutomatedContactTasksToContactParams) ([]*TransferAutomatedContactTasksToContactRow, error)
 	// Contact merge queries
 	// These queries support merging one contact (source) into another (target)
 	// Transfer contact methods from source to target contact

--- a/backend/internal/db/queries/contact_task.sql
+++ b/backend/internal/db/queries/contact_task.sql
@@ -253,13 +253,15 @@ RETURNING *;
 
 -- name: CompleteLiveContactTasksForContact :many
 -- Merge-time close of the source contact's live AUTOMATED tasks (cadence_due
--- + followup_loop). Manual-lifecycle rows are deliberately excluded — they
--- are user content and are REPOINTED to the merge target instead (see
--- RepointManualContactTasksToContact). Automated rows cannot be repointed:
--- unique_contact_provider_cadence has no state filter, so a repoint collides
--- whenever the target has ANY cadence_due row, and the target's own automated
--- rows already cover the survivor. Returns the closed rows' identifying
--- fields plus the pending_temp_id metadata key so the service can decide
+-- + followup_loop) that TransferAutomatedContactTasksToContact could not
+-- move. Manual-lifecycle rows are deliberately excluded — they are user
+-- content and are REPOINTED to the merge target instead (see
+-- RepointManualContactTasksToContact). Automated rows cannot always be
+-- repointed: unique_contact_provider_cadence has no state filter, so a
+-- transfer collides whenever the target has ANY cadence_due row, and a
+-- follow-up collides on a live target row or a shared idempotency key. This
+-- query is the fallback for exactly those blocked rows. Returns the closed
+-- rows' identifying fields plus the pending_temp_id metadata key so the service can decide
 -- remote-close enqueue eligibility (real external id only — never a pending
 -- temp id, mirroring todoist.isPendingTempID).
 UPDATE contact_task
@@ -270,6 +272,40 @@ WHERE contact_id = @contact_id
   AND state IN ('managed', 'pending_remote_create')
 RETURNING id, external_task_id, provider,
     COALESCE(metadata->>sqlc.arg(pending_temp_id_key)::text, '')::text AS pending_temp_id;
+
+-- name: TransferAutomatedContactTasksToContact :many
+-- Merge-time transfer of the source's LIVE automated rows to the target, for
+-- the rows where the move is legal under the existing partial unique indexes.
+-- A row moves only when the target has no colliding row:
+--   cadence_due    — unique_contact_provider_cadence is state-agnostic, so the
+--                    target must have NO cadence_due row in any state.
+--   followup_loop  — idx_contact_task_followup_unique_live covers live states
+--                    only, so the target must have no LIVE follow-up; and
+--                    idx_contact_task_followup_idempotency covers
+--                    (contact_id, idempotency_key), so the key must be free.
+-- Rows that cannot move are left for CompleteLiveContactTasksForContact.
+UPDATE contact_task AS src
+SET contact_id = sqlc.arg(target_contact_id),
+    updated_at = NOW()
+WHERE src.contact_id = sqlc.arg(source_contact_id)
+  AND src.lifecycle IN ('cadence_due', 'followup_loop')
+  AND src.state IN ('managed', 'pending_remote_create')
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_task tgt
+      WHERE tgt.contact_id = sqlc.arg(target_contact_id)
+        AND tgt.provider = src.provider
+        AND tgt.lifecycle = src.lifecycle
+        AND (src.lifecycle = 'cadence_due'
+             OR tgt.state IN ('managed', 'pending_remote_create'))
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_task idem
+      WHERE idem.contact_id = sqlc.arg(target_contact_id)
+        AND idem.lifecycle = 'followup_loop'
+        AND idem.idempotency_key IS NOT NULL
+        AND idem.idempotency_key = src.idempotency_key
+  )
+RETURNING id, lifecycle;
 
 -- name: RepointManualContactTasksToContact :exec
 -- Merge-time repoint of the source contact's MANUAL tasks (user to-dos) to

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1084,6 +1084,21 @@ SELECT indexname::text, indexdef::text FROM pg_indexes
 WHERE schemaname = 'public' AND tablename = @table_name
 ORDER BY indexname;
 
+-- name: TestBackendPID :one
+-- Race-test only: the PostgreSQL backend pid serving THIS connection. Run on
+-- the blocking transaction so a sibling can ask who is waiting on it.
+SELECT pg_backend_pid()::int;
+
+-- name: TestCountBackendsBlockedBy :one
+-- Race-test only: how many active backends are waiting on a lock held by the
+-- given backend. Scoped to one blocker, so a parallel sibling waiting on an
+-- unrelated lock cannot satisfy the poll.
+SELECT count(*)::bigint
+FROM pg_stat_activity
+WHERE state = 'active'
+  AND pid <> sqlc.arg(blocker_pid)::int
+  AND pg_blocking_pids(pid) @> ARRAY[sqlc.arg(blocker_pid)::int];
+
 -- name: TestInsertNonFinalRiverJob :exec
 -- Reset/additive-seed test only: plant ONE queued (non-finalized) river_job so a
 -- test can assert the additive --seed preflight REFUSES while --reset-and-seed

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2680,6 +2680,19 @@ func (q *Queries) SyntheticTryAdvisoryLock(ctx context.Context, lockKey int64) (
 	return pg_try_advisory_lock, err
 }
 
+const TestBackendPID = `-- name: TestBackendPID :one
+SELECT pg_backend_pid()::int
+`
+
+// Race-test only: the PostgreSQL backend pid serving THIS connection. Run on
+// the blocking transaction so a sibling can ask who is waiting on it.
+func (q *Queries) TestBackendPID(ctx context.Context) (int32, error) {
+	row := q.db.QueryRow(ctx, TestBackendPID)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const TestCountAllRows = `-- name: TestCountAllRows :one
 SELECT (xpath('/row/c/text()',
     query_to_xml(format('SELECT COUNT(*) AS c FROM %I', $1::text), false, true, '')))[1]::text::bigint
@@ -2692,6 +2705,24 @@ SELECT (xpath('/row/c/text()',
 // identifier so it can never be an injection vector.
 func (q *Queries) TestCountAllRows(ctx context.Context, tableName string) (int64, error) {
 	row := q.db.QueryRow(ctx, TestCountAllRows, tableName)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const TestCountBackendsBlockedBy = `-- name: TestCountBackendsBlockedBy :one
+SELECT count(*)::bigint
+FROM pg_stat_activity
+WHERE state = 'active'
+  AND pid <> $1::int
+  AND pg_blocking_pids(pid) @> ARRAY[$1::int]
+`
+
+// Race-test only: how many active backends are waiting on a lock held by the
+// given backend. Scoped to one blocker, so a parallel sibling waiting on an
+// unrelated lock cannot satisfy the poll.
+func (q *Queries) TestCountBackendsBlockedBy(ctx context.Context, blockerPid int32) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountBackendsBlockedBy, blockerPid)
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err

--- a/backend/internal/repository/contact_task.go
+++ b/backend/internal/repository/contact_task.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/logger"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -829,6 +833,77 @@ func (r *ContactTaskRepository) CompleteLiveTasksForContactTx(ctx context.Contex
 			Provider:       row.Provider,
 			PendingTempID:  row.PendingTempID,
 		}
+		if row.ID.Valid {
+			ref.ID = uuid.UUID(row.ID.Bytes)
+		}
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+// transferAutomatedTaskConstraints are the partial unique indexes
+// TransferAutomatedTasksForMergeTx's query guards against with its NOT
+// EXISTS clauses. A unique-violation on any other constraint is an
+// unexpected integrity defect, not a lost race, and must not be swallowed.
+var transferAutomatedTaskConstraints = map[string]bool{
+	"unique_contact_provider_cadence":       true,
+	"idx_contact_task_followup_unique_live": true,
+	"idx_contact_task_followup_idempotency": true,
+}
+
+// TransferredTaskRef identifies a contact_task row
+// TransferAutomatedTasksForMergeTx moved onto the target.
+type TransferredTaskRef struct {
+	ID        uuid.UUID
+	Lifecycle string
+}
+
+// TransferAutomatedTasksForMergeTx moves the source's transferable automated
+// rows onto the target inside a savepoint. A concurrent reconcile insert can
+// win the race between the query's NOT EXISTS guard and its UPDATE; the
+// resulting 23505 would abort the caller's whole merge tx, so it is absorbed
+// here and the rows are left for the close path instead.
+func (r *ContactTaskRepository) TransferAutomatedTasksForMergeTx(
+	ctx context.Context, tx pgx.Tx, sourceID, targetID uuid.UUID,
+) ([]TransferredTaskRef, error) {
+	sp, err := tx.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open automated task transfer savepoint: %w", err)
+	}
+
+	rows, err := db.New(sp).TransferAutomatedContactTasksToContact(ctx, db.TransferAutomatedContactTasksToContactParams{
+		SourceContactID: uuidToPgUUID(sourceID),
+		TargetContactID: uuidToPgUUID(targetID),
+	})
+	if err != nil {
+		var pgErr *pgconn.PgError
+		recoverable := errors.As(err, &pgErr) &&
+			pgErr.Code == pgerrcode.UniqueViolation &&
+			transferAutomatedTaskConstraints[pgErr.ConstraintName]
+
+		if rbErr := sp.Rollback(ctx); rbErr != nil {
+			return nil, fmt.Errorf("rollback automated task transfer savepoint: %w (transfer: %w)", rbErr, err)
+		}
+
+		if !recoverable {
+			return nil, fmt.Errorf("transfer automated tasks for merge: %w", err)
+		}
+
+		logger.Warn().
+			Str("source_contact_id", sourceID.String()).
+			Str("target_contact_id", targetID.String()).
+			Str("constraint", pgErr.ConstraintName).
+			Msg("merge: automated task transfer lost a race; falling back to close")
+		return nil, nil
+	}
+
+	if err := sp.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit automated task transfer savepoint: %w", err)
+	}
+
+	refs := make([]TransferredTaskRef, 0, len(rows))
+	for _, row := range rows {
+		ref := TransferredTaskRef{Lifecycle: row.Lifecycle}
 		if row.ID.Valid {
 			ref.ID = uuid.UUID(row.ID.Bytes)
 		}

--- a/backend/internal/repository/contact_task.go
+++ b/backend/internal/repository/contact_task.go
@@ -851,6 +851,22 @@ var transferAutomatedTaskConstraints = map[string]bool{
 	"idx_contact_task_followup_idempotency": true,
 }
 
+// classifyTransferConflict decides whether an error from the transfer query
+// is a recoverable race — a concurrent insert winning against one of the
+// three indexes the query's own NOT EXISTS clauses guard — or an unexpected
+// integrity defect that must propagate. Matching on the SQLSTATE alone would
+// swallow an unrelated integrity defect and silently degrade every merge to
+// close-everything, which is why ConstraintName is checked too. Extracted
+// from TransferAutomatedTasksForMergeTx so the classification can be unit
+// tested without a database.
+func classifyTransferConflict(err error) (pgErr *pgconn.PgError, recoverable bool) {
+	if !errors.As(err, &pgErr) {
+		return nil, false
+	}
+	recoverable = pgErr.Code == pgerrcode.UniqueViolation && transferAutomatedTaskConstraints[pgErr.ConstraintName]
+	return pgErr, recoverable
+}
+
 // TransferredTaskRef identifies a contact_task row
 // TransferAutomatedTasksForMergeTx moved onto the target.
 type TransferredTaskRef struct {
@@ -876,10 +892,7 @@ func (r *ContactTaskRepository) TransferAutomatedTasksForMergeTx(
 		TargetContactID: uuidToPgUUID(targetID),
 	})
 	if err != nil {
-		var pgErr *pgconn.PgError
-		recoverable := errors.As(err, &pgErr) &&
-			pgErr.Code == pgerrcode.UniqueViolation &&
-			transferAutomatedTaskConstraints[pgErr.ConstraintName]
+		pgErr, recoverable := classifyTransferConflict(err)
 
 		if rbErr := sp.Rollback(ctx); rbErr != nil {
 			return nil, fmt.Errorf("rollback automated task transfer savepoint: %w (transfer: %w)", rbErr, err)

--- a/backend/internal/repository/contact_task_transfer_test.go
+++ b/backend/internal/repository/contact_task_transfer_test.go
@@ -1,0 +1,69 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClassifyTransferConflict pins the recoverability decision
+// TransferAutomatedTasksForMergeTx makes on a failed transfer: recoverable
+// only for a unique_violation on exactly one of the three indexes the
+// transfer query's own NOT EXISTS clauses guard. Anything else — an
+// unrelated constraint, or a non-pg error entirely — must propagate rather
+// than be silently absorbed into "the transfer lost a race".
+func TestClassifyTransferConflict(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		err             error
+		wantRecoverable bool
+	}{
+		{
+			name:            "unique_contact_provider_cadence violation is recoverable",
+			err:             &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "unique_contact_provider_cadence"},
+			wantRecoverable: true,
+		},
+		{
+			name:            "idx_contact_task_followup_unique_live violation is recoverable",
+			err:             &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "idx_contact_task_followup_unique_live"},
+			wantRecoverable: true,
+		},
+		{
+			name:            "idx_contact_task_followup_idempotency violation is recoverable",
+			err:             &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "idx_contact_task_followup_idempotency"},
+			wantRecoverable: true,
+		},
+		{
+			name:            "unique_violation on an unrelated constraint propagates",
+			err:             &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "idx_note_contact_notepad_unique"},
+			wantRecoverable: false,
+		},
+		{
+			name:            "a non-23505 pg error propagates even on a guarded constraint name",
+			err:             &pgconn.PgError{Code: pgerrcode.NotNullViolation, ConstraintName: "unique_contact_provider_cadence"},
+			wantRecoverable: false,
+		},
+		{
+			name:            "a non-pg error propagates",
+			err:             errors.New("connection reset"),
+			wantRecoverable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pgErr, recoverable := classifyTransferConflict(tc.err)
+			assert.Equal(t, tc.wantRecoverable, recoverable)
+			if tc.wantRecoverable {
+				require.NotNil(t, pgErr)
+			}
+		})
+	}
+}

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -1340,18 +1340,30 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 		return nil, fmt.Errorf("repoint comms_message staging rows: %w", err)
 	}
 
-	// 6c. contact_task, split by lifecycle: manual rows are USER CONTENT and
-	// follow the survivor (collision-free — no unique index covers
-	// lifecycle='manual'); automated rows (cadence_due/followup_loop) are
-	// CLOSED instead, because repointing them collides with the target's own
-	// automated rows (unique_contact_provider_cadence has no state filter)
-	// and the target's rows already cover the survivor.
+	// 6c. contact_task, split by lifecycle: manual rows (user content) follow
+	// the survivor in every state (collision-free — no unique index covers
+	// lifecycle='manual'). Automated rows (cadence_due/followup_loop)
+	// transfer to the survivor whenever no unique index blocks the move; a
+	// transfer that loses a race to a concurrent insert falls back to
+	// closing rather than failing the merge. The rest close, with a durable
+	// remote close only for rows carrying a real external id. No row is ever
+	// deleted by a merge — orphan cleanup of merge-closed automated tasks is
+	// tracked separately (issue #811).
 	if err := txQueries.RepointManualContactTasksToContact(ctx, db.RepointManualContactTasksToContactParams{
 		SourceContactID: sourceUUID,
 		TargetContactID: targetUUID,
 	}); err != nil {
 		return nil, fmt.Errorf("repoint manual contact tasks: %w", err)
 	}
+	transferredRefs, err := s.contactTaskRepo.TransferAutomatedTasksForMergeTx(ctx, tx, req.SourceContactID, req.TargetContactID)
+	if err != nil {
+		return nil, fmt.Errorf("transfer automated contact tasks: %w", err)
+	}
+	logger.Debug().
+		Str("source_contact_id", req.SourceContactID.String()).
+		Str("target_contact_id", req.TargetContactID.String()).
+		Int("transferred_tasks", len(transferredRefs)).
+		Msg("merge: transferred automated contact tasks to survivor")
 	closedRefs, err := s.contactTaskRepo.CompleteLiveTasksForContactTx(ctx, tx, req.SourceContactID, todoist.MetadataKeyPendingTempID)
 	if err != nil {
 		return nil, fmt.Errorf("close live contact tasks: %w", err)

--- a/backend/sqlc_schema/pg_catalog.sql
+++ b/backend/sqlc_schema/pg_catalog.sql
@@ -30,3 +30,24 @@ CREATE TABLE pg_indexes (
     indexname  text NOT NULL,
     indexdef   text NOT NULL
 );
+
+-- pg_stat_activity, pg_blocking_pids(), and pg_backend_pid() back the merge
+-- transfer race test's blocking probe (TestBackendPID, TestCountBackendsBlockedBy
+-- in internal/db/queries/test.sql); sqlc v1.30.0 does not model any of them.
+-- As above, only the columns/signatures those queries touch are declared, and
+-- the live catalog is the source of truth at runtime — the stub function
+-- bodies are placeholders sqlc only type-checks against.
+CREATE TABLE pg_stat_activity (
+    pid             integer NOT NULL,
+    state           text,
+    wait_event_type text,
+    datname         text
+);
+
+CREATE FUNCTION pg_blocking_pids(pid integer) RETURNS integer[] AS $$
+    SELECT ARRAY[]::integer[];
+$$ LANGUAGE sql;
+
+CREATE FUNCTION pg_backend_pid() RETURNS integer AS $$
+    SELECT 0;
+$$ LANGUAGE sql;

--- a/backend/tests/contact_merge_identity_attribution_integration_test.go
+++ b/backend/tests/contact_merge_identity_attribution_integration_test.go
@@ -3,8 +3,10 @@
 package tests
 
 import (
+	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
@@ -14,6 +16,7 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/todoist"
@@ -569,6 +572,28 @@ func (h *mergeAttrHarness) closeJobCount(t *testing.T, ctx context.Context, task
 	return n
 }
 
+// seedTaskWithIdempotencyKey seeds a contact_task carrying an idempotency_key,
+// which the plain CreateContactTask path (seedTask) cannot set. Used only by
+// the transfer idempotency-guard subtest.
+func (h *mergeAttrHarness) seedTaskWithIdempotencyKey(t *testing.T, ctx context.Context, contactID uuid.UUID, lifecycle, state, externalID, idempotencyKey string) *repository.ContactTask {
+	t.Helper()
+	tx, err := h.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	task, err := h.taskRepo.CreateContactTaskTx(ctx, tx, repository.CreateContactTaskRequest{
+		ContactID:      contactID,
+		Provider:       todoist.SourceName,
+		Kind:           contacttask.KindReachOut,
+		Lifecycle:      lifecycle,
+		ExternalTaskID: externalID,
+		State:          state,
+	}, &idempotencyKey)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+	return task
+}
+
 // TestMergeContacts_ClosesLiveContactTasks covers the D4 lifecycle split:
 // automated rows (cadence_due / followup_loop) close (with a durable remote
 // close job only for real external ids), manual rows repoint to the survivor.
@@ -605,6 +630,13 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 	t.Run("pending shapes close locally without a close job", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task close survivor 2")
 		b := h.createContact(t, ctx, "task close loser 2")
+		// A holds a live row in EACH automated lifecycle so the transfer
+		// guard blocks both of B's rows below and they fall back to the
+		// close path — this subtest is about the close path's no-close-job
+		// guarantee for pending/temp shapes, not the transfer guard itself
+		// (which the transfer subtests below cover on their own).
+		h.seedTask(t, ctx, a.ID, contacttask.LifecycleCadenceDue, "managed", "tsk-blocker-cad-a2", nil)
+		h.seedTask(t, ctx, a.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-blocker-fu-a2", nil)
 		// pending_remote_create follow-up: no external id yet.
 		pendingTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "pending_remote_create", "", nil)
 		// cadence row still carrying its Todoist temp id.
@@ -643,6 +675,121 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		h.requireTaskState(t, ctx, aManual.ID, repository.ContactTaskStateManaged, a.ID)
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bManual.ID), "manual tasks are never remotely closed by merge")
 	})
+
+	t.Run("transfers live cadence row when target has no cadence row", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task transfer survivor 4")
+		b := h.createContact(t, ctx, "task transfer loser 4")
+		// A has no cadence_due row at all, so the transfer's state-agnostic
+		// NOT EXISTS guard on unique_contact_provider_cadence is satisfied.
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleCadenceDue, "managed", "tsk-xfer-cad-b4", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateManaged, a.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
+	})
+
+	t.Run("closes live cadence row when target holds a completed cadence row", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task transfer survivor 5")
+		b := h.createContact(t, ctx, "task transfer loser 5")
+		// A's cadence_due row is TERMINAL, but unique_contact_provider_cadence
+		// has no state filter — the transfer guard sees ANY row and refuses.
+		aTask := h.seedTask(t, ctx, a.ID, contacttask.LifecycleCadenceDue, "completed", "tsk-xfer-cad-a5", nil)
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleCadenceDue, "managed", "tsk-xfer-cad-b5", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateCompleted, b.ID)
+		h.requireTaskState(t, ctx, aTask.ID, repository.ContactTaskStateCompleted, a.ID)
+		assert.EqualValues(t, 1, h.closeJobCount(t, ctx, bTask.ID), "blocked transfer falls back to the close path")
+	})
+
+	t.Run("transfers live follow-up when target holds only a terminal follow-up", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task transfer survivor 6")
+		b := h.createContact(t, ctx, "task transfer loser 6")
+		// A's follow-up is TERMINAL: idx_contact_task_followup_unique_live only
+		// covers live states, so a terminal target row does not block transfer.
+		aTask := h.seedTask(t, ctx, a.ID, contacttask.LifecycleFollowUpLoop, "completed", "tsk-xfer-fu-a6", nil)
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-xfer-fu-b6", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateManaged, a.ID)
+		h.requireTaskState(t, ctx, aTask.ID, repository.ContactTaskStateCompleted, a.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
+	})
+
+	t.Run("does not transfer follow-up with a colliding idempotency key", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task transfer survivor 7")
+		b := h.createContact(t, ctx, "task transfer loser 7")
+		// A's follow-up is TERMINAL (would not block on the live-state guard
+		// alone) but shares B's idempotency_key: the second NOT EXISTS must
+		// still refuse the transfer. B ALSO carries an unrelated, cleanly
+		// transferable cadence_due row in the SAME UPDATE statement — this
+		// is what makes the guard's presence observable: the transfer query
+		// is one statement per merge, so if the idempotency guard did not
+		// exclude the colliding row from the row-set, the whole statement
+		// would abort on the first constraint hit and the savepoint
+		// fallback would sweep the innocent cadence row into the close path
+		// too, even though nothing blocks it on its own.
+		const key = "shared-idem-key-7"
+		aTask := h.seedTaskWithIdempotencyKey(t, ctx, a.ID, contacttask.LifecycleFollowUpLoop, "completed", "tsk-xfer-idem-a7", key)
+		bFollowUp := h.seedTaskWithIdempotencyKey(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-xfer-idem-b7", key)
+		bCadence := h.seedTask(t, ctx, b.ID, contacttask.LifecycleCadenceDue, "managed", "tsk-xfer-idem-cad-b7", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		h.requireTaskState(t, ctx, bFollowUp.ID, repository.ContactTaskStateCompleted, b.ID)
+		h.requireTaskState(t, ctx, aTask.ID, repository.ContactTaskStateCompleted, a.ID)
+		assert.EqualValues(t, 1, h.closeJobCount(t, ctx, bFollowUp.ID), "idempotency-blocked transfer falls back to the close path")
+
+		// The unrelated cadence row must transfer cleanly, unaffected by its
+		// sibling's idempotency collision in the same UPDATE statement.
+		h.requireTaskState(t, ctx, bCadence.ID, repository.ContactTaskStateManaged, a.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bCadence.ID), "the unblocked sibling row is never closed")
+	})
+
+	t.Run("no task row is deleted by a merge", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task transfer survivor 8")
+		b := h.createContact(t, ctx, "task transfer loser 8")
+		// A mix of transferable, blocked, and manual rows on the source —
+		// the point is that every one of B's row ids must survive the merge
+		// SOMEWHERE, whether it moved to A or stayed on B closed.
+		h.seedTask(t, ctx, b.ID, contacttask.LifecycleCadenceDue, "managed", "tsk-nodelete-cad-8", nil)
+		h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-nodelete-fu-8", nil)
+		h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "managed", "tsk-nodelete-man-8", nil)
+
+		preIDs, err := h.taskRepo.ListContactTasksByContact(ctx, b.ID)
+		require.NoError(t, err)
+		require.Len(t, preIDs, 3, "fixture sanity: three rows seeded on the source")
+
+		_, err = h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		for _, pre := range preIDs {
+			_, err := h.taskRepo.GetContactTask(ctx, pre.ID)
+			require.NoError(t, err, "row %s must still exist after the merge, transferred or not", pre.ID)
+		}
+	})
 }
 
 // TestMergeContacts_EnqueuerNotWired_Errors pins the D9 wiring contract:
@@ -661,6 +808,9 @@ func TestMergeContacts_EnqueuerNotWired_Errors(t *testing.T) {
 		h := newMergeAttrHarnessWith(t, ctx, false, false)
 		a := h.createContact(t, ctx, "enqueuer survivor 1")
 		b := h.createContact(t, ctx, "enqueuer loser 1")
+		// A holds a live follow-up so B's row below is blocked from
+		// transfer and reaches the close path this subtest exercises.
+		h.seedTask(t, ctx, a.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-wire-blocker-a1", nil)
 		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-wire-b1", nil)
 
 		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
@@ -681,6 +831,9 @@ func TestMergeContacts_EnqueuerNotWired_Errors(t *testing.T) {
 		h := newMergeAttrHarnessWith(t, ctx, true, false)
 		a := h.createContact(t, ctx, "enqueuer survivor 2")
 		b := h.createContact(t, ctx, "enqueuer loser 2")
+		// A holds a live follow-up so B's row below is blocked from
+		// transfer and reaches the close path this subtest exercises.
+		h.seedTask(t, ctx, a.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-wire-blocker-a2", nil)
 		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-wire-b2", nil)
 
 		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
@@ -692,6 +845,91 @@ func TestMergeContacts_EnqueuerNotWired_Errors(t *testing.T) {
 		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateCompleted, b.ID)
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "no close job in mode off")
 	})
+}
+
+// TestMergeContacts_TransferRaceFallsBackToClose is the D4-5 proof: a
+// concurrent insert on the target can win the race between the transfer
+// query's NOT EXISTS guard and its UPDATE, raising a 23505 that the
+// savepoint must absorb rather than let abort the whole merge. Sequenced
+// green-after-code (not red-first) — before the transfer statement exists
+// there is nothing for tx B to block, so a red here would be invented, not
+// observed.
+//
+// Uses logger.SetOutput, process-global mutable state, so this test does
+// NOT run t.Parallel() (see internal/logger/logger.go SetOutput doc).
+func TestMergeContacts_TransferRaceFallsBackToClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+	a := h.createContact(t, ctx, "race survivor")
+	b := h.createContact(t, ctx, "race loser")
+	bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleCadenceDue, "managed", "tsk-race-b", nil)
+
+	var logBuf bytes.Buffer
+	restore := logger.SetOutput(&logBuf)
+	defer restore()
+
+	// Tx B: insert a live cadence_due row for the TARGET, deliberately left
+	// uncommitted. Under READ COMMITTED, tx A's NOT EXISTS guard cannot see
+	// this row (not yet committed), so the guard passes and A's UPDATE then
+	// blocks on unique_contact_provider_cadence, held by B.
+	txB, err := h.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = txB.Rollback(ctx) }()
+
+	_, err = h.taskRepo.CreateContactTaskTx(ctx, txB, repository.CreateContactTaskRequest{
+		ContactID:      a.ID,
+		Provider:       todoist.SourceName,
+		Kind:           contacttask.KindReachOut,
+		Lifecycle:      contacttask.LifecycleCadenceDue,
+		ExternalTaskID: "tsk-race-a",
+		State:          "managed",
+	}, nil)
+	require.NoError(t, err)
+
+	// Read B's own backend pid ON tx B — a pool checkout is a different
+	// backend and would identify the wrong session.
+	bPID, err := db.New(txB).TestBackendPID(ctx)
+	require.NoError(t, err)
+
+	// Tx A: run the merge in a goroutine. It will block inside the
+	// transfer's UPDATE once it reaches the lock B holds.
+	mergeDone := make(chan error, 1)
+	go func() {
+		_, mergeErr := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		mergeDone <- mergeErr
+	}()
+
+	// Poll from a THIRD connection (off the pool, via h.database.Queries —
+	// neither tx A nor tx B) until exactly one backend is blocked by B's
+	// pid. Scoped to B's own backend so a parallel sibling test waiting on
+	// an unrelated lock cannot satisfy the poll. A timeout here means A
+	// never reached the lock, and everything after it would be theatre —
+	// require.Eventually fails the test rather than falling through.
+	require.Eventually(t, func() bool {
+		n, countErr := h.database.Queries.TestCountBackendsBlockedBy(ctx, bPID)
+		return countErr == nil && n == 1
+	}, 5*time.Second, 10*time.Millisecond, "merge transaction never blocked on tx B's lock")
+
+	require.NoError(t, txB.Commit(ctx))
+
+	require.NoError(t, <-mergeDone, "the savepoint must absorb the 23505 and let the merge commit")
+
+	// The transfer lost the race; the row fell back to the close path.
+	h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateCompleted, b.ID)
+	assert.EqualValues(t, 1, h.closeJobCount(t, ctx, bTask.ID), "blocked-by-race transfer falls back to close")
+
+	logged := logBuf.String()
+	assert.Contains(t, logged, "merge: automated task transfer lost a race; falling back to close")
+	assert.Contains(t, logged, b.ID.String(), "source_contact_id must be logged")
+	assert.Contains(t, logged, a.ID.String(), "target_contact_id must be logged")
+	assert.Contains(t, logged, "unique_contact_provider_cadence", "constraint must be logged")
 }
 
 // TestMatchOrCreate_TombstonedCacheFallsThroughToSurvivor isolates the
@@ -820,6 +1058,10 @@ func TestMergeContacts_CloseEnqueue_ExecutesThroughAdapter(t *testing.T) {
 	h := newMergeAttrHarness(t, ctx)
 	a := h.createContact(t, ctx, "adapter survivor")
 	b := h.createContact(t, ctx, "adapter loser")
+	// A holds a live follow-up so B's row below is blocked from transfer
+	// and reaches the close path — this test is about the close path's
+	// adapter execution, not the transfer guard.
+	h.seedTask(t, ctx, a.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-adapter-blocker-a", nil)
 	// B carries a real-external-id follow-up so the merge enqueues a close.
 	bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-adapter-b", nil)
 

--- a/backend/tests/contact_merge_identity_attribution_integration_test.go
+++ b/backend/tests/contact_merge_identity_attribution_integration_test.go
@@ -5,6 +5,8 @@ package tests
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -542,9 +544,20 @@ func TestMergeContacts_SecondPassRepointsRacedRows(t *testing.T) {
 // explicit (kind, lifecycle, state, external id, metadata) shape.
 func (h *mergeAttrHarness) seedTask(t *testing.T, ctx context.Context, contactID uuid.UUID, lifecycle, state, externalID string, metadata map[string]any) *repository.ContactTask {
 	t.Helper()
+	return h.seedTaskForProvider(t, ctx, contactID, todoist.SourceName, lifecycle, state, externalID, metadata)
+}
+
+// seedTaskForProvider is seedTask with an explicit provider, used only by
+// the provider-scoping transfer subtest: the transfer query's NOT EXISTS
+// guards are scoped by tgt.provider = src.provider, so a fixture needs a
+// second provider value to prove a colliding row for provider X does not
+// block a transfer for provider Y. The provider column is free-text (no
+// CHECK constraint), so any non-todoist string is a legal fixture value.
+func (h *mergeAttrHarness) seedTaskForProvider(t *testing.T, ctx context.Context, contactID uuid.UUID, provider, lifecycle, state, externalID string, metadata map[string]any) *repository.ContactTask {
+	t.Helper()
 	task, err := h.taskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 		ContactID:      contactID,
-		Provider:       todoist.SourceName,
+		Provider:       provider,
 		Kind:           contacttask.KindReachOut,
 		Lifecycle:      lifecycle,
 		ExternalTaskID: externalID,
@@ -594,9 +607,11 @@ func (h *mergeAttrHarness) seedTaskWithIdempotencyKey(t *testing.T, ctx context.
 	return task
 }
 
-// TestMergeContacts_ClosesLiveContactTasks covers the D4 lifecycle split:
-// automated rows (cadence_due / followup_loop) close (with a durable remote
-// close job only for real external ids), manual rows repoint to the survivor.
+// TestMergeContacts_ClosesLiveContactTasks covers the merge-time contact_task
+// split: automated rows (cadence_due / followup_loop) transfer to the
+// survivor whenever no unique index blocks the move, and otherwise close
+// (with a durable remote close job only for real external ids); manual rows
+// repoint to the survivor in every state.
 func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -606,6 +621,7 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 
 	h := newMergeAttrHarness(t, ctx)
 
+	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("real external id closes and enqueues, colliding target row survives", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task close survivor 1")
 		b := h.createContact(t, ctx, "task close loser 1")
@@ -627,6 +643,7 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, aTask.ID), "no close job for the survivor's own follow-up")
 	})
 
+	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("pending shapes close locally without a close job", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task close survivor 2")
 		b := h.createContact(t, ctx, "task close loser 2")
@@ -656,13 +673,21 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, tempTask.ID), "no close job for a pending temp id")
 	})
 
-	t.Run("manual tasks repoint to the survivor", func(t *testing.T) {
+	// spec: CON-067.manual-repoints-every-state
+	t.Run("manual tasks repoint to the survivor in every state", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task close survivor 3")
 		b := h.createContact(t, ctx, "task close loser 3")
 		// Both sides have a live manual task — no unique index covers
 		// lifecycle='manual', so the repoint must be collision-free.
 		aManual := h.seedTask(t, ctx, a.ID, contacttask.LifecycleManual, "managed", "tsk-man-a3", nil)
 		bManual := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "managed", "tsk-man-b3", nil)
+		// CON-067 claims manual tasks repoint "in every state", not just
+		// live ones. Seed the terminal/dismissed states on the source too,
+		// so that claim is proven by a passing assertion rather than merely
+		// exercised by a single managed row.
+		bCompleted := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "completed", "tsk-man-b3-completed", nil)
+		bDismissed := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "dismissed", "tsk-man-b3-dismissed", nil)
+		bUnmanaged := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "unmanaged", "tsk-man-b3-unmanaged", nil)
 
 		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
 			SourceContactID: b.ID,
@@ -674,8 +699,15 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		h.requireTaskState(t, ctx, bManual.ID, repository.ContactTaskStateManaged, a.ID)
 		h.requireTaskState(t, ctx, aManual.ID, repository.ContactTaskStateManaged, a.ID)
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bManual.ID), "manual tasks are never remotely closed by merge")
+
+		// Terminal/dismissed manual rows repoint too, state untouched —
+		// RepointManualContactTasksToContact has no state filter.
+		h.requireTaskState(t, ctx, bCompleted.ID, repository.ContactTaskStateCompleted, a.ID)
+		h.requireTaskState(t, ctx, bDismissed.ID, repository.ContactTaskStateDismissed, a.ID)
+		h.requireTaskState(t, ctx, bUnmanaged.ID, repository.ContactTaskStateUnmanaged, a.ID)
 	})
 
+	// spec: CON-067.automated-transfers-when-unblocked
 	t.Run("transfers live cadence row when target has no cadence row", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task transfer survivor 4")
 		b := h.createContact(t, ctx, "task transfer loser 4")
@@ -693,6 +725,51 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
 	})
 
+	// spec: CON-067.automated-transfers-when-unblocked
+	t.Run("transfers a pending_remote_create row awaiting its real id", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task transfer survivor 9")
+		b := h.createContact(t, ctx, "task transfer loser 9")
+		// No blocking row on A. src.state IN ('managed', 'pending_remote_create')
+		// deliberately includes the two-step create's in-flight state — the
+		// service's Risks section verifies this is safe because
+		// finalizeTempIDMappingTx resolves the row by id, never by
+		// contact_id, so a transfer mid-flight is a mere ownership change.
+		// Every other transfer subtest in this file seeds "managed"; this
+		// one is the dedicated proof for the other live state.
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "pending_remote_create", "", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStatePendingRemoteCreate, a.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
+	})
+
+	// spec: CON-067.automated-transfers-when-unblocked
+	t.Run("a colliding row for a different provider does not block transfer", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task transfer survivor 10")
+		b := h.createContact(t, ctx, "task transfer loser 10")
+		// A's blocking cadence_due row is for a DIFFERENT provider. The
+		// transfer query's NOT EXISTS guard is scoped by tgt.provider =
+		// src.provider, so a same-lifecycle collision on another provider
+		// must not be treated as a collision.
+		h.seedTaskForProvider(t, ctx, a.ID, "other-provider", contacttask.LifecycleCadenceDue, "managed", "tsk-other-a10", nil)
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleCadenceDue, "managed", "tsk-xfer-cad-b10", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateManaged, a.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
+	})
+
+	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("closes live cadence row when target holds a completed cadence row", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task transfer survivor 5")
 		b := h.createContact(t, ctx, "task transfer loser 5")
@@ -712,6 +789,7 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 1, h.closeJobCount(t, ctx, bTask.ID), "blocked transfer falls back to the close path")
 	})
 
+	// spec: CON-067.automated-transfers-when-unblocked
 	t.Run("transfers live follow-up when target holds only a terminal follow-up", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task transfer survivor 6")
 		b := h.createContact(t, ctx, "task transfer loser 6")
@@ -731,6 +809,7 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
 	})
 
+	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("does not transfer follow-up with a colliding idempotency key", func(t *testing.T) {
 		a := h.createContact(t, ctx, "task transfer survivor 7")
 		b := h.createContact(t, ctx, "task transfer loser 7")
@@ -847,16 +926,18 @@ func TestMergeContacts_EnqueuerNotWired_Errors(t *testing.T) {
 	})
 }
 
-// TestMergeContacts_TransferRaceFallsBackToClose is the D4-5 proof: a
-// concurrent insert on the target can win the race between the transfer
-// query's NOT EXISTS guard and its UPDATE, raising a 23505 that the
-// savepoint must absorb rather than let abort the whole merge. Sequenced
-// green-after-code (not red-first) — before the transfer statement exists
-// there is nothing for tx B to block, so a red here would be invented, not
-// observed.
+// TestMergeContacts_TransferRaceFallsBackToClose proves the savepoint
+// recovers a concurrent insert winning the race between the transfer
+// query's NOT EXISTS guard and its UPDATE: under READ COMMITTED, a
+// concurrent insert on the target can commit between the guard's read and
+// the UPDATE's write, raising a 23505 that would otherwise abort the whole
+// merge transaction. The savepoint absorbs it and the row falls back to the
+// close path instead.
 //
 // Uses logger.SetOutput, process-global mutable state, so this test does
 // NOT run t.Parallel() (see internal/logger/logger.go SetOutput doc).
+//
+// spec: CON-067.race-falls-back-to-close
 func TestMergeContacts_TransferRaceFallsBackToClose(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -925,11 +1006,36 @@ func TestMergeContacts_TransferRaceFallsBackToClose(t *testing.T) {
 	h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateCompleted, b.ID)
 	assert.EqualValues(t, 1, h.closeJobCount(t, ctx, bTask.ID), "blocked-by-race transfer falls back to close")
 
-	logged := logBuf.String()
-	assert.Contains(t, logged, "merge: automated task transfer lost a race; falling back to close")
-	assert.Contains(t, logged, b.ID.String(), "source_contact_id must be logged")
-	assert.Contains(t, logged, a.ID.String(), "target_contact_id must be logged")
-	assert.Contains(t, logged, "unique_contact_provider_cadence", "constraint must be logged")
+	// Parse the captured log as structured JSON records and assert on the
+	// specific record's field NAMES and values, rather than substring-
+	// searching the whole buffer — a substring match would still pass if
+	// the field names were renamed out from under the assertion (only the
+	// values would then differ), silently losing coverage of the contract.
+	type transferWarnRecord struct {
+		Level           string `json:"level"`
+		Message         string `json:"message"`
+		SourceContactID string `json:"source_contact_id"`
+		TargetContactID string `json:"target_contact_id"`
+		Constraint      string `json:"constraint"`
+	}
+	var warnRecord *transferWarnRecord
+	for _, line := range strings.Split(strings.TrimSpace(logBuf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec transferWarnRecord
+		require.NoError(t, json.Unmarshal([]byte(line), &rec), "each captured log line must be valid JSON")
+		if rec.Message == "merge: automated task transfer lost a race; falling back to close" {
+			require.Nil(t, warnRecord, "expected exactly one fallback warning record")
+			recCopy := rec
+			warnRecord = &recCopy
+		}
+	}
+	require.NotNil(t, warnRecord, "fallback warning was never logged")
+	assert.Equal(t, "warn", warnRecord.Level, "logged at warn level")
+	assert.Equal(t, b.ID.String(), warnRecord.SourceContactID, "source_contact_id field")
+	assert.Equal(t, a.ID.String(), warnRecord.TargetContactID, "target_contact_id field")
+	assert.Equal(t, "unique_contact_provider_cadence", warnRecord.Constraint, "constraint field")
 }
 
 // TestMatchOrCreate_TombstonedCacheFallsThroughToSurvivor isolates the

--- a/backend/tests/contact_merge_identity_attribution_integration_test.go
+++ b/backend/tests/contact_merge_identity_attribution_integration_test.go
@@ -621,8 +621,8 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 
 	h := newMergeAttrHarness(t, ctx)
 
-	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("real external id closes and enqueues, colliding target row survives", func(t *testing.T) {
+		// spec: CON-067.blocked-tasks-close-real-id-only
 		a := h.createContact(t, ctx, "task close survivor 1")
 		b := h.createContact(t, ctx, "task close loser 1")
 		// COLLISION SHAPE: A and B EACH have a live follow-up. A repoint
@@ -643,8 +643,8 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, aTask.ID), "no close job for the survivor's own follow-up")
 	})
 
-	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("pending shapes close locally without a close job", func(t *testing.T) {
+		// spec: CON-067.blocked-tasks-close-real-id-only
 		a := h.createContact(t, ctx, "task close survivor 2")
 		b := h.createContact(t, ctx, "task close loser 2")
 		// A holds a live row in EACH automated lifecycle so the transfer
@@ -673,8 +673,8 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, tempTask.ID), "no close job for a pending temp id")
 	})
 
-	// spec: CON-067.manual-repoints-every-state
 	t.Run("manual tasks repoint to the survivor in every state", func(t *testing.T) {
+		// spec: CON-067.manual-repoints-every-state
 		a := h.createContact(t, ctx, "task close survivor 3")
 		b := h.createContact(t, ctx, "task close loser 3")
 		// Both sides have a live manual task — no unique index covers
@@ -682,12 +682,15 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		aManual := h.seedTask(t, ctx, a.ID, contacttask.LifecycleManual, "managed", "tsk-man-a3", nil)
 		bManual := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "managed", "tsk-man-b3", nil)
 		// CON-067 claims manual tasks repoint "in every state", not just
-		// live ones. Seed the terminal/dismissed states on the source too,
-		// so that claim is proven by a passing assertion rather than merely
-		// exercised by a single managed row.
+		// live ones. Seed every other state on the source too, so that
+		// claim is proven by a passing assertion rather than merely
+		// exercised by a single managed row. pending_remote_create is
+		// included because migration 041 permits it on any lifecycle, not
+		// just followup_loop — the state CHECK constraint is global.
 		bCompleted := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "completed", "tsk-man-b3-completed", nil)
 		bDismissed := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "dismissed", "tsk-man-b3-dismissed", nil)
 		bUnmanaged := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "unmanaged", "tsk-man-b3-unmanaged", nil)
+		bPendingRemoteCreate := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "pending_remote_create", "tsk-man-b3-pending", nil)
 
 		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
 			SourceContactID: b.ID,
@@ -700,15 +703,16 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		h.requireTaskState(t, ctx, aManual.ID, repository.ContactTaskStateManaged, a.ID)
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bManual.ID), "manual tasks are never remotely closed by merge")
 
-		// Terminal/dismissed manual rows repoint too, state untouched —
+		// Every other state repoints too, state untouched —
 		// RepointManualContactTasksToContact has no state filter.
 		h.requireTaskState(t, ctx, bCompleted.ID, repository.ContactTaskStateCompleted, a.ID)
 		h.requireTaskState(t, ctx, bDismissed.ID, repository.ContactTaskStateDismissed, a.ID)
 		h.requireTaskState(t, ctx, bUnmanaged.ID, repository.ContactTaskStateUnmanaged, a.ID)
+		h.requireTaskState(t, ctx, bPendingRemoteCreate.ID, repository.ContactTaskStatePendingRemoteCreate, a.ID)
 	})
 
-	// spec: CON-067.automated-transfers-when-unblocked
 	t.Run("transfers live cadence row when target has no cadence row", func(t *testing.T) {
+		// spec: CON-067.automated-transfers-when-unblocked
 		a := h.createContact(t, ctx, "task transfer survivor 4")
 		b := h.createContact(t, ctx, "task transfer loser 4")
 		// A has no cadence_due row at all, so the transfer's state-agnostic
@@ -725,13 +729,12 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
 	})
 
-	// spec: CON-067.automated-transfers-when-unblocked
 	t.Run("transfers a pending_remote_create row awaiting its real id", func(t *testing.T) {
+		// spec: CON-067.automated-transfers-when-unblocked
 		a := h.createContact(t, ctx, "task transfer survivor 9")
 		b := h.createContact(t, ctx, "task transfer loser 9")
 		// No blocking row on A. src.state IN ('managed', 'pending_remote_create')
-		// deliberately includes the two-step create's in-flight state — the
-		// service's Risks section verifies this is safe because
+		// deliberately includes the two-step create's in-flight state:
 		// finalizeTempIDMappingTx resolves the row by id, never by
 		// contact_id, so a transfer mid-flight is a mere ownership change.
 		// Every other transfer subtest in this file seeds "managed"; this
@@ -748,8 +751,8 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
 	})
 
-	// spec: CON-067.automated-transfers-when-unblocked
 	t.Run("a colliding row for a different provider does not block transfer", func(t *testing.T) {
+		// spec: CON-067.automated-transfers-when-unblocked
 		a := h.createContact(t, ctx, "task transfer survivor 10")
 		b := h.createContact(t, ctx, "task transfer loser 10")
 		// A's blocking cadence_due row is for a DIFFERENT provider. The
@@ -769,8 +772,8 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
 	})
 
-	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("closes live cadence row when target holds a completed cadence row", func(t *testing.T) {
+		// spec: CON-067.blocked-tasks-close-real-id-only
 		a := h.createContact(t, ctx, "task transfer survivor 5")
 		b := h.createContact(t, ctx, "task transfer loser 5")
 		// A's cadence_due row is TERMINAL, but unique_contact_provider_cadence
@@ -789,8 +792,8 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 1, h.closeJobCount(t, ctx, bTask.ID), "blocked transfer falls back to the close path")
 	})
 
-	// spec: CON-067.automated-transfers-when-unblocked
 	t.Run("transfers live follow-up when target holds only a terminal follow-up", func(t *testing.T) {
+		// spec: CON-067.automated-transfers-when-unblocked
 		a := h.createContact(t, ctx, "task transfer survivor 6")
 		b := h.createContact(t, ctx, "task transfer loser 6")
 		// A's follow-up is TERMINAL: idx_contact_task_followup_unique_live only
@@ -809,8 +812,8 @@ func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
 		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "a transferred row is never closed")
 	})
 
-	// spec: CON-067.blocked-tasks-close-real-id-only
 	t.Run("does not transfer follow-up with a colliding idempotency key", func(t *testing.T) {
+		// spec: CON-067.blocked-tasks-close-real-id-only
 		a := h.createContact(t, ctx, "task transfer survivor 7")
 		b := h.createContact(t, ctx, "task transfer loser 7")
 		// A's follow-up is TERMINAL (would not block on the live-state guard

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -430,7 +430,7 @@ behaviors:
   - id: CON-031
     title: Merge closes automated tasks and repoints manual ones
     type: business-logic
-    status: current
+    status: retired
     surface: none
     given: a source contact with live contact tasks
     when: it is merged into a target
@@ -438,7 +438,7 @@ behaviors:
       - manual tasks (user content) are repointed to the target
       - automated tasks (cadence/follow-up) are closed rather than repointed
     provenance: [RepointManualContactTasksToContact, CompleteLiveTasksForContactTx]
-    notes: Repointing automated tasks would collide with the target's own live automated rows under the per-contact uniqueness rule. Propagating the close to the remote task provider is todoist-domain scope.
+    notes: Repointing automated tasks would collide with the target's own live automated rows under the per-contact uniqueness rule. Propagating the close to the remote task provider is todoist-domain scope. Superseded by CON-067 — automated tasks now transfer to the survivor whenever no unique index blocks the move.
 
   - id: CON-032
     title: Merge applies per-field user selections with the target as default
@@ -1001,6 +1001,21 @@ behaviors:
       - key: list-returns-first-page
         text: the list returns to the first page rather than carrying the prior page position into the new view
     provenance: [contacts page applyContext/handleSearchInput, buildContactListUrl page arg]
+
+  - id: CON-067
+    title: Merge transfers automated tasks when no uniqueness rule blocks the move, and repoints manual ones
+    type: business-logic
+    status: current
+    surface: none
+    given: a source contact with live contact tasks
+    when: it is merged into a target
+    then:
+      - manual tasks (user content) are repointed to the target in every state
+      - automated tasks (cadence/follow-up) transfer to the target whenever no uniqueness rule blocks the move
+      - a transfer that loses a race to a concurrent insert falls back to closing rather than failing the merge
+      - automated tasks that cannot move are closed, with a durable remote close only for those carrying a real provider task id
+    provenance: [TransferAutomatedContactTasksToContact, TransferAutomatedTasksForMergeTx, CompleteLiveTasksForContactTx, RepointManualContactTasksToContact]
+    notes: Supersedes CON-031, retired. Merge deletes no contact_task row — orphan cleanup of merge-closed automated tasks is tracked separately (issue #811).
 
   # --- Intents (judged experience goals — Track B agentic judge only) ---
 

--- a/spec/contacts.yaml
+++ b/spec/contacts.yaml
@@ -1010,10 +1010,14 @@ behaviors:
     given: a source contact with live contact tasks
     when: it is merged into a target
     then:
-      - manual tasks (user content) are repointed to the target in every state
-      - automated tasks (cadence/follow-up) transfer to the target whenever no uniqueness rule blocks the move
-      - a transfer that loses a race to a concurrent insert falls back to closing rather than failing the merge
-      - automated tasks that cannot move are closed, with a durable remote close only for those carrying a real provider task id
+      - key: manual-repoints-every-state
+        text: manual tasks (user content) are repointed to the target in every state
+      - key: automated-transfers-when-unblocked
+        text: automated tasks (cadence/follow-up) transfer to the target whenever no uniqueness rule blocks the move
+      - key: race-falls-back-to-close
+        text: a transfer that loses a race to a concurrent insert falls back to closing rather than failing the merge
+      - key: blocked-tasks-close-real-id-only
+        text: automated tasks that cannot move are closed, with a durable remote close only for those carrying a real provider task id
     provenance: [TransferAutomatedContactTasksToContact, TransferAutomatedTasksForMergeTx, CompleteLiveTasksForContactTx, RepointManualContactTasksToContact]
     notes: Supersedes CON-031, retired. Merge deletes no contact_task row — orphan cleanup of merge-closed automated tasks is tracked separately (issue #811).
 


### PR DESCRIPTION
Part of the arch-hygiene arc (stack #820: #817 ← #818 ← this PR). Contact merge previously closed every automated task (`cadence_due`, `follow_up`) on the losing contact, even when the surviving contact had nothing blocking a transfer. Merges now move automated tasks to the survivor whenever no unique index forbids it, falling back to the old close path only for rows that genuinely collide.

## What changed

- New sqlc query + repository method `TransferAutomatedTasksForMergeTx`: a guarded UPDATE whose NOT EXISTS branches mirror the real index predicates exactly — the cadence branch is state-agnostic (matching `unique_contact_provider_cadence`), the follow-up branch is state-scoped (matching `idx_contact_task_followup_idempotency`).
- The transfer runs inside a savepoint (pgx nested-tx idiom) after the manual repoint and before `CompleteLiveTasksForContactTx`, so the close path sees only rows that could not move. On a unique-violation race (concurrent Todoist reconcile insert), the savepoint rolls back and those rows close as before — the merge itself can never fail because of a transfer race. The error check is scoped by `PgError.ConstraintName` to the three known indexes (table-driven classifier test); any other violation propagates.
- No `contact_task` row is ever deleted. Orphaned source rows whose create-op may be mid-flight in `TodoistTaskOpWorker.executeCreate`'s phase-2 window are deliberately left in place — deleting them loses the remote task id permanently. Cleanup is tracked separately in #811; `no_task_row_is_deleted_by_a_merge` pins the invariant.
- No migration; no change to `unique_contact_provider_cadence`, the Todoist provider, the reconcile ladder, or the remote-close eligibility/wiring gates.
- Spec: CON-031 retired (tombstone + pointer), CON-067 minted with keyed then-items cited from the integration tests.

## Test coverage

`TestMergeContacts_ClosesLiveContactTasks` grew to cover: cadence and follow-up transfers, pending_remote_create transfers, cross-provider isolation (a blocker for one provider does not block another's transfer), blocked-row close fallback, idempotency-guard blast-radius containment (a colliding row must not sweep an innocent transferable sibling into the close path), manual repoint across every task state, and the no-deletion pin. `TestMergeContacts_TransferRaceFallsBackToClose` proves the live race: two transactions, a genuine uncommitted-tuple block observed via `pg_blocking_pids`, structured warn-record assertion (parsed JSON log record with field names, not a buffer grep). Four pre-existing tests whose fixtures had no target-side blocker gained one each, preserving their original close-path/wiring intent under the new transfer-first policy.

## Falsification record (mutants injected, observed red, reverted; nothing committed)

1. Savepoint wrapper removed entirely (the plan's literal `db.New(sp)`→`db.New(tx)` swap is a NO-OP under pgx's nested-tx model — both handles share one connection, so `sp.Rollback` recovers either way; verified and upgraded): race test failed exit 2 with raw 23505 propagating. Grep evidence 1→0→1 across inject/revert.
2. Race-probe vacuity: pointed the blocking transaction's insert at an unrelated third contact — the poll timed out and failed exit 2, proving the probe can report zero.
3. Idempotency guard clause removed + `make sqlc` (grep 2→0): the strengthened sibling-row subtest failed exit 2 with the innocent sibling swept into close — the original single-row fixture was a no-op against this mutant (the DB unique index + savepoint fallback mask it) and was strengthened until it discriminated.
4. Classifier relaxed to code-only matching: the unrelated-constraint case failed; reverted.
5. Warn-record field renamed in production (`source_contact_id`→`src_contact_id`): the structured assertion failed exit 2 naming the field; the previous buffer-grep assertion would have passed.

## Review trail

Sonnet pair review PASS (independently traced the NOT EXISTS branches against the 046/041 index DDL) → Codex round 1 FAIL (4 P1s, all test/spec gaps; production code confirmed correct with pgx/pgconn/Postgres semantics verified against upstream) → round 2 narrowed to 1 P1 (every-state fixture completeness) → all closed, final delta spot-verified. Merge gate review + CI follow on this PR.

Related: #811 (orphaned-row cleanup, deliberately out of scope here).
