### PR TITLE
fix(imports): keep the unresolved toggle on the source filter row

### DIFF
--- a/frontend/src/app/imports/__tests__/page.test.tsx
+++ b/frontend/src/app/imports/__tests__/page.test.tsx
@@ -543,7 +543,7 @@ describe('ImportsPage - Source Filter', () => {
   it('displays source filter buttons', () => {
     render(<ImportsPage />, { wrapper: createWrapper() })
 
-    expect(screen.getByText('Filter:')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Filter by source' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Google Contacts' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument()
@@ -636,6 +636,29 @@ describe('ImportsPage - Source Filter', () => {
 
     // Should reset page to 1 when changing filter
     expect(useSuggestions).toHaveBeenCalledWith(expect.objectContaining({ page: 1 }))
+  })
+
+  it('speaks to every connected source in the empty state when no filter is active', () => {
+    render(<ImportsPage />, { wrapper: createWrapper() })
+
+    expect(
+      screen.getByText(
+        'Everything from your connected sources has been imported or is already linked.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('names the active source in the empty state when a filter is applied', async () => {
+    const user = userEvent.setup()
+    render(<ImportsPage />, { wrapper: createWrapper() })
+
+    await user.click(screen.getByRole('button', { name: 'Gmail' }))
+
+    // A filtered empty list must not claim every source is exhausted.
+    expect(
+      screen.getByText('Everything from Gmail has been imported or is already linked.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/your connected sources/)).not.toBeInTheDocument()
   })
 })
 
@@ -785,7 +808,7 @@ describe('ImportsPage - Sub-tabs and name candidates', () => {
   it('defaults to the People tab and shows the source filter', () => {
     render(<ImportsPage />, { wrapper: createWrapper() })
     expect(screen.getByRole('tab', { name: /People/ })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByText('Filter:')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Filter by source' })).toBeInTheDocument()
   })
 
   it('shows the amber badge with the conflict + orphan count (name candidates excluded)', () => {
@@ -816,7 +839,7 @@ describe('ImportsPage - Sub-tabs and name candidates', () => {
     // Conflict candidate + orphan affordances are present; source filter is hidden.
     expect(screen.getByText('Project sync')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Open Anarlog/ })).toBeInTheDocument()
-    expect(screen.queryByText('Filter:')).not.toBeInTheDocument()
+    expect(screen.queryByRole('group', { name: 'Filter by source' })).not.toBeInTheDocument()
   })
 
   it('shows the empty state on Interactions when the queue is empty', () => {

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -68,6 +68,16 @@ const SOURCE_FILTERS = [
   { value: 'anarlog_humans', label: 'Anarlog' },
 ] as const
 
+/** Empty-state copy for the candidate list. Names the active source when one
+ * is selected, so a filtered empty list does not claim every source is
+ * exhausted; otherwise speaks to the connected sources as a whole. */
+function emptyCandidatesMessage(source: string | undefined): string {
+  const active = SOURCE_FILTERS.find(filter => filter.value === (source || ''))
+  return active && active.value !== ''
+    ? `Everything from ${active.label} has been imported or is already linked.`
+    : 'Everything from your connected sources has been imported or is already linked.'
+}
+
 /** Normalize the inbound `?tab` param to a canonical tab. `needs-attention`
  * is a transitional alias for `interactions`; everything else (including
  * `people` and unknown values) resolves to People. */
@@ -345,7 +355,7 @@ function ImportsPageFallback() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Navigation />
-      <div className="max-w-5xl mx-auto py-6 sm:px-6 lg:px-8">
+      <div className="max-w-6xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="space-y-4">
           {[...Array(5)].map((_, i) => (
             <div key={i} className="h-24 bg-gray-200 rounded-lg animate-pulse"></div>
@@ -719,9 +729,9 @@ function ImportsPageInner() {
     <div className="min-h-screen bg-gray-50">
       <Navigation />
 
-      <div className="max-w-5xl mx-auto py-6 sm:px-6 lg:px-8">
+      <div className="max-w-6xl mx-auto py-6 sm:px-6 lg:px-8">
         {/* Header */}
-        <div className="md:flex md:items-center md:justify-between mb-6">
+        <div className="mb-6">
           <div className="flex-1 min-w-0">
             <div className="flex items-center space-x-3">
               <CloudDownload className="w-8 h-8 text-blue-600" />
@@ -736,16 +746,6 @@ function ImportsPageInner() {
                   ? headerSummary(methodSuggestions.length, data?.total ?? 0)
                   : 'Nothing to review'}
             </p>
-          </div>
-          <div className="mt-4 flex md:mt-0 md:ml-4 space-x-2">
-            <Button variant="outline" onClick={handleSyncContacts} loading={syncMutation.isPending}>
-              <RefreshCw className="w-4 h-4 mr-2" />
-              Sync Contacts
-            </Button>
-            <Button variant="outline" onClick={handleSyncCalendar} loading={syncMutation.isPending}>
-              <Calendar className="w-4 h-4 mr-2" />
-              Sync Calendar
-            </Button>
           </div>
         </div>
 
@@ -775,21 +775,30 @@ function ImportsPageInner() {
           <>
             {/* Source filter (People tab only) */}
             <div className="mb-6 flex flex-wrap items-center gap-2">
-              <span className="text-sm text-gray-500">Filter:</span>
-              {SOURCE_FILTERS.map(filter => (
-                <button
-                  key={filter.value}
-                  onClick={() => handleSourceFilter(filter.value)}
-                  aria-pressed={(params.source || '') === filter.value}
-                  className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
-                    (params.source || '') === filter.value
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  }`}
-                >
-                  {filter.label}
-                </button>
-              ))}
+              {/* The pills carry their own group label so the row does not
+                  spend horizontal space on a visible "Filter:" caption — the
+                  source list is wide enough that the caption pushed the
+                  unresolved toggle onto a second line. */}
+              <div
+                role="group"
+                aria-label="Filter by source"
+                className="flex flex-wrap items-center gap-2"
+              >
+                {SOURCE_FILTERS.map(filter => (
+                  <button
+                    key={filter.value}
+                    onClick={() => handleSourceFilter(filter.value)}
+                    aria-pressed={(params.source || '') === filter.value}
+                    className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                      (params.source || '') === filter.value
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    {filter.label}
+                  </button>
+                ))}
+              </div>
               {((data?.hidden_unresolved_telegram_count ?? 0) > 0 ||
                 params.include_unresolved_telegram) && (
                 <button
@@ -857,7 +866,7 @@ function ImportsPageInner() {
                   <CloudDownload className="mx-auto h-12 w-12 text-gray-400" />
                   <h3 className="mt-2 text-sm font-medium text-gray-900">No import candidates</h3>
                   <p className="mt-1 text-sm text-gray-500">
-                    All contacts from Google have been imported or are already linked.
+                    {emptyCandidatesMessage(params.source)}
                   </p>
                   <div className="mt-6 flex justify-center space-x-2">
                     <Button

--- a/frontend/tests/e2e/imports-page.spec.ts
+++ b/frontend/tests/e2e/imports-page.spec.ts
@@ -167,6 +167,15 @@ test.describe('Imports Page @area:imports', () => {
       }
       return corsFulfill(route, { success: true, data: null })
     })
+    // The triggers live in the candidate list's empty state, so force an empty
+    // list rather than depending on whatever the shared E2E database holds.
+    await page.route('**/api/v1/imports/suggestions*', route =>
+      corsFulfill(route, {
+        success: true,
+        data: [],
+        meta: { pagination: { total: 0, page: 1, limit: 20, pages: 0 } },
+      })
+    )
 
     // The triggers act only once the account list has loaded — wait for it
     // before clicking, else the click lands on the no-accounts branch.
@@ -177,10 +186,9 @@ test.describe('Imports Page @area:imports', () => {
     await page.waitForLoadState('domcontentloaded')
     await accountsLoaded
 
-    // Both per-source triggers are offered. (.first(): an empty candidate
-    // list renders a second contacts-sync affordance in the empty state.)
-    const syncContacts = page.getByRole('button', { name: /Sync Contacts/i }).first()
-    const syncCalendar = page.getByRole('button', { name: /Sync Calendar/i }).first()
+    // Both per-source triggers are offered, in the candidate list's empty state.
+    const syncContacts = page.getByRole('button', { name: /Sync Contacts/i })
+    const syncCalendar = page.getByRole('button', { name: /Sync Calendar/i })
     await expect(syncContacts).toBeVisible()
     await expect(syncCalendar).toBeVisible()
 

--- a/spec/imports-matching.yaml
+++ b/spec/imports-matching.yaml
@@ -402,7 +402,7 @@ behaviors:
       - key: interactions-tab-holds-conflicts
         text: an Interactions tab holds conflicts and orphans, with an attention badge counting only those (discovery items excluded)
       - key: manual-sync-triggers-offered
-        text: manual sync triggers are offered for contact and calendar sources
+        text: manual sync triggers are offered for contact and calendar sources when the candidate list is empty
       - key: low-confidence-names-section
         text: a low-confidence names section appears at the bottom only when title-derived tokens exist
     provenance: [imports/page.tsx, SubTabs, NameCandidateSection]


### PR DESCRIPTION
## What

Adding the Gmail source filter (#815) pushed the People tab's filter row past its container, wrapping the "Show unresolved" toggle onto a second line where `ml-auto` stranded it alone at the right edge. The row missed fitting by tens of pixels, so this reclaims that space rather than restructuring the row into columns (which would cost vertical space) or shortening the pill labels (which would lose real meaning — "Google" is not "Google Contacts").

- **Widen the page container** from `max-w-5xl` to `max-w-6xl` (+128px), on both the page and its loading fallback. This also brings Imports in line with Contacts and Dashboard, which are already `max-w-7xl`.
- **Drop the visible "Filter:" caption** (+~48px) and move its meaning onto a `role="group" aria-label="Filter by source"` wrapper, so screen readers keep the context the caption carried.
- **Remove the Sync Contacts / Sync Calendar buttons from the page header.** They only ever covered Google, and Settings' Google accounts section already offers per-account triggers for contacts, calendar, email, and chat. The candidate list's empty state keeps its copies.
- **Generalize the empty-state copy** for the multi-source world. It named Google unconditionally; it now names the active source filter and falls back to "your connected sources" when unfiltered, so a filtered empty list no longer claims every source is exhausted.

## Result

Measured in the browser at a 1280px viewport: the pill group ends at 819px, the toggle starts at 997px, the row is a single 32px line, content width 1088px. All eight pills plus the toggle share one row with ~178px of slack.

Empty-state copy, verified by driving the real page:

| Filter | Copy |
| --- | --- |
| (none) | Everything from your connected sources has been imported or is already linked. |
| Google Contacts | Everything from Google Contacts has been imported or is already linked. |
| Gmail | Everything from Gmail has been imported or is already linked. |
| Anarlog | Everything from Anarlog has been imported or is already linked. |

## Behavior change worth knowing

The candidate list's empty state is now the only sync trigger on the Imports page, so you cannot kick off a sync while candidates are listed. The capability is not lost — Settings › Google accounts has per-account triggers for contacts, calendar, email, and chat via `sync-badge.tsx`, which is the more correct home (per-account, and covering more sources than these two buttons did).

That location change made `IMP-026.manual-sync-triggers-offered` inaccurate, so the then-item is extended in place to "…when the candidate list is empty", and its citing E2E test now serves an empty suggestions list to reach that state instead of relying on `.first()` matching the header button.

## Ephemeral falsification

Both new tests were proven able to fail, against the final saved tree at HEAD. Command in each case, run from `frontend/`: `./node_modules/.bin/vitest run src/app/imports/__tests__/page.test.tsx`. Each mutation was applied by a script that asserts its anchor string is present, and the post-mutation source was printed to confirm the injection landed rather than silently no-opping. Mutations were reverted with `git checkout --`; nothing was committed.

| # | State | Exit | Result |
| --- | --- | --- | --- |
| 1 | baseline | 0 | 28 passed |
| 2 | filtered branch returns the unfiltered sentence | 1 | 1 failed — "names the active source in the empty state when a filter is applied" |
| 3 | unfiltered branch names a single source | 1 | 1 failed — "speaks to every connected source in the empty state when no filter is active" |
| 4 | restored | 0 | 28 passed |

Each defect turns red exactly the one test targeting that branch and no other, so neither test is a tautology and neither coincidentally covers the other's branch.

## Testing

- `make lint` — 0 issues
- Full frontend suite — 72 files, 1034 tests passing (1032 before this commit)
- `PLAYWRIGHT_GREP="manual sync triggers" make test-e2e-local` — 1 passed
- Visual verification against a local dev server on this branch, at a 1280px viewport

Not run locally: `make test-e2e-diff` and the backend suites. No backend code changed; the pre-push hook and CI cover them.
